### PR TITLE
ghost-reaper: add per-vector CLI flags for each detector

### DIFF
--- a/ghost-core/src/init.cpp
+++ b/ghost-core/src/init.cpp
@@ -717,7 +717,13 @@ void SetupServerArgs(ArgsManager& argsman, bool can_listen_ipc)
     SetupChainParamsBaseOptions(argsman);
 
     argsman.AddArg("-acceptnonstdtxn", strprintf("Relay and mine \"non-standard\" transactions (test networks only; default: %u)", DEFAULT_ACCEPT_NON_STD_TXN), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::NODE_RELAY);
-    argsman.AddArg("-ghostreaper", "Ghost Reaper dead-code filter (default: enabled). Set to 'disabled' to turn off.", ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
+    argsman.AddArg("-ghostreaper", "Ghost Reaper dead-code filter master switch (default: enabled). Sets the default value for every per-vector toggle; individual -ghostreaper-reject* flags override per detector.", ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
+    argsman.AddArg("-ghostreaper-rejectinscription", "Ghost Reaper: reject witness scripts containing OP_FALSE OP_IF ... OP_ENDIF inscription envelopes (default: follows -ghostreaper).", ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
+    argsman.AddArg("-ghostreaper-rejectdropstuffing", "Ghost Reaper: reject witness scripts with a large push followed by OP_DROP/OP_2DROP (default: follows -ghostreaper).", ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
+    argsman.AddArg("-ghostreaper-rejectfakepubkey", "Ghost Reaper: reject bare multisig outputs whose pubkey pushes have invalid prefixes (default: follows -ghostreaper).", ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
+    argsman.AddArg("-ghostreaper-rejectannex", "Ghost Reaper: reject P2TR inputs carrying a witness annex (default: follows -ghostreaper).", ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
+    argsman.AddArg("-ghostreaper-rejectopreturn", "Ghost Reaper: reject outputs whose OP_RETURN payload exceeds -ghostreaper-maxopreturn (default: follows -ghostreaper).", ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
+    argsman.AddArg("-ghostreaper-rejectrunestone", "Ghost Reaper: reject outputs encoding a Runestone (OP_RETURN OP_13 ...) (default: follows -ghostreaper).", ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
     argsman.AddArg("-ghostreaper-maxopreturn=<n>", strprintf("Maximum OP_RETURN data bytes before Reaper rejection (default: %u)", 83), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
     argsman.AddArg("-ghostreaper-mindropsize=<n>", strprintf("Minimum push size for drop stuffing detection (default: %u)", 76), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
     argsman.AddArg("-incrementalrelayfee=<amt>", strprintf("Fee rate (in %s/kvB) used to define cost of relay, used for mempool limiting and replacement policy. (default: %s)", CURRENCY_UNIT, FormatMoney(DEFAULT_INCREMENTAL_RELAY_FEE)), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::NODE_RELAY);

--- a/ghost-core/src/node/mempool_args.cpp
+++ b/ghost-core/src/node/mempool_args.cpp
@@ -104,20 +104,31 @@ util::Result<void> ApplyArgsManOptions(const ArgsManager& argsman, const CChainP
 
     mempool_opts.persist_v1_dat = argsman.GetBoolArg("-persistmempoolv1", mempool_opts.persist_v1_dat);
 
-    // Ghost Reaper configuration
+    // Ghost Reaper configuration.
+    //
+    // The master `-ghostreaper` flag sets the default value for every per-vector
+    // toggle. Each `-ghostreaper-reject*` flag overrides its detector independently:
+    // a detector runs iff its per-vector flag is true (after defaulting from
+    // the master). This lets operators run any subset of detectors, e.g.
+    // `-ghostreaper=disabled -ghostreaper-rejectannex=1` enables only the
+    // annex check.
     {
         const std::string reaper_mode = argsman.GetArg("-ghostreaper", "enabled");
-        if (reaper_mode == "disabled") {
-            mempool_opts.ghost_reaper.mode = GhostReaperMode::Disabled;
-        } else {
-            mempool_opts.ghost_reaper.mode = GhostReaperMode::Enabled;
-        }
+        const bool master_default = (reaper_mode != "disabled");
+
+        auto& reaper = mempool_opts.ghost_reaper;
+        reaper.reject_inscription  = argsman.GetBoolArg("-ghostreaper-rejectinscription",  master_default);
+        reaper.reject_dropstuffing = argsman.GetBoolArg("-ghostreaper-rejectdropstuffing", master_default);
+        reaper.reject_fakepubkey   = argsman.GetBoolArg("-ghostreaper-rejectfakepubkey",   master_default);
+        reaper.reject_annex        = argsman.GetBoolArg("-ghostreaper-rejectannex",        master_default);
+        reaper.reject_opreturn     = argsman.GetBoolArg("-ghostreaper-rejectopreturn",     master_default);
+        reaper.reject_runestone    = argsman.GetBoolArg("-ghostreaper-rejectrunestone",    master_default);
 
         if (argsman.IsArgSet("-ghostreaper-maxopreturn")) {
-            mempool_opts.ghost_reaper.max_op_return_bytes = argsman.GetIntArg("-ghostreaper-maxopreturn", 83);
+            reaper.max_op_return_bytes = argsman.GetIntArg("-ghostreaper-maxopreturn", 83);
         }
         if (argsman.IsArgSet("-ghostreaper-mindropsize")) {
-            mempool_opts.ghost_reaper.min_drop_size = argsman.GetIntArg("-ghostreaper-mindropsize", 76);
+            reaper.min_drop_size = argsman.GetIntArg("-ghostreaper-mindropsize", 76);
         }
     }
 

--- a/ghost-core/src/policy/ghost_reaper.cpp
+++ b/ghost-core/src/policy/ghost_reaper.cpp
@@ -296,33 +296,30 @@ bool CheckRunestone(const CTransaction& tx, std::string& reason)
 
 bool IsGhostReaperClean(const CTransaction& tx, const GhostReaperConfig& config, std::string& reason)
 {
-    if (config.mode == GhostReaperMode::Disabled) {
-        return true;
-    }
+    // Each detector runs only when its per-vector toggle is enabled.
+    // Order: cheapest checks first.
 
-    // Run all six detectors. Order: cheapest checks first.
-
-    if (!CheckOversizedOpReturn(tx, config.max_op_return_bytes, reason)) {
+    if (config.reject_opreturn && !CheckOversizedOpReturn(tx, config.max_op_return_bytes, reason)) {
         return false;
     }
 
-    if (!CheckRunestone(tx, reason)) {
+    if (config.reject_runestone && !CheckRunestone(tx, reason)) {
         return false;
     }
 
-    if (!CheckFakeMultisigPubkeys(tx, reason)) {
+    if (config.reject_fakepubkey && !CheckFakeMultisigPubkeys(tx, reason)) {
         return false;
     }
 
-    if (!CheckAnnexPresence(tx, reason)) {
+    if (config.reject_annex && !CheckAnnexPresence(tx, reason)) {
         return false;
     }
 
-    if (!CheckDropStuffing(tx, config.min_drop_size, reason)) {
+    if (config.reject_dropstuffing && !CheckDropStuffing(tx, config.min_drop_size, reason)) {
         return false;
     }
 
-    if (!CheckInscriptionEnvelope(tx, reason)) {
+    if (config.reject_inscription && !CheckInscriptionEnvelope(tx, reason)) {
         return false;
     }
 

--- a/ghost-core/src/policy/ghost_reaper.h
+++ b/ghost-core/src/policy/ghost_reaper.h
@@ -9,15 +9,26 @@
 
 #include <string>
 
-/** Ghost Reaper operating mode */
-enum class GhostReaperMode {
-    Disabled,   //!< No Reaper filtering
-    Enabled,    //!< Dead-code filtering active (default)
-};
-
-/** Configuration for Ghost Reaper mempool filter */
+/** Configuration for Ghost Reaper mempool filter.
+ *
+ * Each detector is independently toggleable. The master CLI flag
+ * `-ghostreaper=enabled|disabled` sets the default value for every per-vector
+ * toggle at startup, but individual `-ghostreaper-reject*` flags override
+ * per-detector when explicitly set. A detector runs iff its `reject_*` flag
+ * is true. */
 struct GhostReaperConfig {
-    GhostReaperMode mode{GhostReaperMode::Enabled};
+    /** Reject inputs containing OP_FALSE OP_IF ... OP_ENDIF inscription envelopes */
+    bool reject_inscription{true};
+    /** Reject inputs with large push followed by OP_DROP/OP_2DROP */
+    bool reject_dropstuffing{true};
+    /** Reject bare multisig outputs whose pubkey pushes have invalid prefixes */
+    bool reject_fakepubkey{true};
+    /** Reject P2TR inputs carrying a witness annex */
+    bool reject_annex{true};
+    /** Reject outputs with OP_RETURN payloads exceeding max_op_return_bytes */
+    bool reject_opreturn{true};
+    /** Reject outputs encoding a Runestone (OP_RETURN OP_13 ...) */
+    bool reject_runestone{true};
     /** Maximum OP_RETURN data payload in bytes (default 83, matching Bitcoin Core relay default) */
     unsigned int max_op_return_bytes{83};
     /** Minimum push size to trigger drop stuffing detection (default 76) */

--- a/ghost-core/src/test/ghost_reaper_tests.cpp
+++ b/ghost-core/src/test/ghost_reaper_tests.cpp
@@ -432,6 +432,19 @@ BOOST_AUTO_TEST_CASE(normal_opreturn_not_runestone)
 // IsGhostReaperClean (integration)
 // ============================================================================
 
+/** Build a config with every detector disabled. */
+GhostReaperConfig AllDisabled()
+{
+    GhostReaperConfig cfg;
+    cfg.reject_inscription  = false;
+    cfg.reject_dropstuffing = false;
+    cfg.reject_fakepubkey   = false;
+    cfg.reject_annex        = false;
+    cfg.reject_opreturn     = false;
+    cfg.reject_runestone    = false;
+    return cfg;
+}
+
 BOOST_AUTO_TEST_CASE(clean_tx_passes_all)
 {
     CMutableTransaction mtx = MakeBaseTx();
@@ -441,13 +454,12 @@ BOOST_AUTO_TEST_CASE(clean_tx_passes_all)
     mtx.vin[0].scriptWitness.stack.push_back(sig);
 
     CTransaction tx(mtx);
-    GhostReaperConfig config;
-    config.mode = GhostReaperMode::Enabled;
+    GhostReaperConfig config; // default: all detectors enabled
     std::string reason;
     BOOST_CHECK(IsGhostReaperClean(tx, config, reason));
 }
 
-BOOST_AUTO_TEST_CASE(disabled_mode_passes_everything)
+BOOST_AUTO_TEST_CASE(all_detectors_disabled_passes_everything)
 {
     CMutableTransaction mtx = MakeBaseTx();
 
@@ -458,13 +470,12 @@ BOOST_AUTO_TEST_CASE(disabled_mode_passes_everything)
     mtx.vin[0].scriptWitness.stack.push_back(witness_elem);
 
     CTransaction tx(mtx);
-    GhostReaperConfig config;
-    config.mode = GhostReaperMode::Disabled;
+    GhostReaperConfig config = AllDisabled();
     std::string reason;
     BOOST_CHECK(IsGhostReaperClean(tx, config, reason));
 }
 
-BOOST_AUTO_TEST_CASE(strict_mode_rejects_inscription)
+BOOST_AUTO_TEST_CASE(default_config_rejects_inscription)
 {
     CMutableTransaction mtx = MakeBaseTx();
 
@@ -474,8 +485,7 @@ BOOST_AUTO_TEST_CASE(strict_mode_rejects_inscription)
     mtx.vin[0].scriptWitness.stack.push_back(witness_elem);
 
     CTransaction tx(mtx);
-    GhostReaperConfig config;
-    config.mode = GhostReaperMode::Enabled;
+    GhostReaperConfig config; // default: all detectors enabled
     std::string reason;
     BOOST_CHECK(!IsGhostReaperClean(tx, config, reason));
     BOOST_CHECK_EQUAL(reason, "ghost-reaper-inscription-envelope");
@@ -494,7 +504,6 @@ BOOST_AUTO_TEST_CASE(custom_opreturn_limit)
 
     CTransaction tx(mtx);
     GhostReaperConfig config;
-    config.mode = GhostReaperMode::Enabled;
 
     // Default limit (83) — should pass
     std::string reason;
@@ -519,7 +528,6 @@ BOOST_AUTO_TEST_CASE(custom_drop_size_threshold)
 
     CTransaction tx(mtx);
     GhostReaperConfig config;
-    config.mode = GhostReaperMode::Enabled;
 
     // Default min_drop_size (76) — 50-byte push should pass
     std::string reason;
@@ -529,6 +537,81 @@ BOOST_AUTO_TEST_CASE(custom_drop_size_threshold)
     config.min_drop_size = 30;
     BOOST_CHECK(!IsGhostReaperClean(tx, config, reason));
     BOOST_CHECK_EQUAL(reason, "ghost-reaper-drop-stuffing");
+}
+
+// ============================================================================
+// Per-vector toggles
+// ============================================================================
+
+BOOST_AUTO_TEST_CASE(per_vector_inscription_toggle)
+{
+    CMutableTransaction mtx = MakeBaseTx();
+    std::vector<unsigned char> witness_elem = {
+        0x00, 0x63, 0x05, 'h', 'e', 'l', 'l', 'o', 0x68
+    };
+    mtx.vin[0].scriptWitness.stack.push_back(witness_elem);
+    CTransaction tx(mtx);
+
+    GhostReaperConfig config; // defaults: all true
+    std::string reason;
+    BOOST_CHECK(!IsGhostReaperClean(tx, config, reason));
+
+    config.reject_inscription = false;
+    BOOST_CHECK(IsGhostReaperClean(tx, config, reason));
+}
+
+BOOST_AUTO_TEST_CASE(per_vector_runestone_toggle)
+{
+    CMutableTransaction mtx = MakeBaseTx();
+    mtx.vout[0].scriptPubKey = CScript() << OP_RETURN << OP_13
+                                         << std::vector<unsigned char>(10, 0x01);
+    CTransaction tx(mtx);
+
+    GhostReaperConfig config;
+    std::string reason;
+    BOOST_CHECK(!IsGhostReaperClean(tx, config, reason));
+    BOOST_CHECK_EQUAL(reason, "ghost-reaper-runestone");
+
+    config.reject_runestone = false;
+    BOOST_CHECK(IsGhostReaperClean(tx, config, reason));
+}
+
+BOOST_AUTO_TEST_CASE(per_vector_annex_toggle)
+{
+    CMutableTransaction mtx = MakeBaseTx();
+    std::vector<unsigned char> sig(64, 0x30);
+    std::vector<unsigned char> annex = {0x50, 0x01, 0x02};
+    mtx.vin[0].scriptWitness.stack.push_back(sig);
+    mtx.vin[0].scriptWitness.stack.push_back(annex);
+    CTransaction tx(mtx);
+
+    GhostReaperConfig config;
+    std::string reason;
+    BOOST_CHECK(!IsGhostReaperClean(tx, config, reason));
+
+    config.reject_annex = false;
+    BOOST_CHECK(IsGhostReaperClean(tx, config, reason));
+}
+
+BOOST_AUTO_TEST_CASE(per_vector_disable_runestone_still_catches_inscription)
+{
+    // Build a tx with BOTH a runestone output AND an inscription witness.
+    // With reject_runestone=false the runestone is allowed, but the
+    // inscription must still be detected.
+    CMutableTransaction mtx = MakeBaseTx();
+    mtx.vout[0].scriptPubKey = CScript() << OP_RETURN << OP_13
+                                         << std::vector<unsigned char>(4, 0x01);
+    std::vector<unsigned char> witness_elem = {
+        0x00, 0x63, 0x05, 'h', 'e', 'l', 'l', 'o', 0x68
+    };
+    mtx.vin[0].scriptWitness.stack.push_back(witness_elem);
+    CTransaction tx(mtx);
+
+    GhostReaperConfig config;
+    config.reject_runestone = false;
+    std::string reason;
+    BOOST_CHECK(!IsGhostReaperClean(tx, config, reason));
+    BOOST_CHECK_EQUAL(reason, "ghost-reaper-inscription-envelope");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/ghost-core/src/validation.cpp
+++ b/ghost-core/src/validation.cpp
@@ -907,8 +907,10 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
         return state.Invalid(TxValidationResult::TX_WITNESS_MUTATED, "bad-witness-nonstandard");
     }
 
-    // Ghost Reaper: reject dead-code patterns before expensive signature checks
-    if (m_pool.m_opts.ghost_reaper.mode != GhostReaperMode::Disabled) {
+    // Ghost Reaper: reject dead-code patterns before expensive signature checks.
+    // Per-vector toggles inside the config decide which detectors fire; the
+    // call is a fast no-op when all detectors are disabled.
+    {
         std::string reaper_reason;
         if (!IsGhostReaperClean(tx, m_pool.m_opts.ghost_reaper, reaper_reason)) {
             return state.Invalid(TxValidationResult::TX_NOT_STANDARD, reaper_reason);


### PR DESCRIPTION
## Summary
- Replaces the all-or-nothing `-ghostreaper` switch with six independent per-detector toggles: `-ghostreaper-rejectinscription`, `-ghostreaper-rejectdropstuffing`, `-ghostreaper-rejectfakepubkey`, `-ghostreaper-rejectannex`, `-ghostreaper-rejectopreturn`, `-ghostreaper-rejectrunestone`.
- The master `-ghostreaper=enabled|disabled` flag now sets the default for every per-vector toggle; each per-vector flag overrides its detector independently (e.g. `-ghostreaper=disabled -ghostreaper-rejectannex=1` runs only the annex check).
- `GhostReaperConfig` drops the `GhostReaperMode` enum in favour of six `reject_*` booleans; `IsGhostReaperClean` gates each detector on its toggle, and the validation hook always calls it (fast no-op when every detector is off).

## Test plan
- [x] `test_ghost --run_test=ghost_reaper_tests` — 30 cases pass (26 existing + 4 new per-vector tests)
- [x] Regtest end-to-end via `testmempoolaccept` of an oversized-OP_RETURN tx: rejected under default, allowed under `-ghostreaper-rejectopreturn=0`, allowed under `-ghostreaper=disabled`, rejected again under `-ghostreaper=disabled -ghostreaper-rejectopreturn=1` (per-vector overrides master)
- [x] Built `ghostd` and deployed to all four mainnet nodes; default behaviour unchanged (all six detectors remain on)