### PR TITLE
Per-vector Ghost Reaper detector selection (dashboard + both layers)

### DIFF
--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -41,7 +41,7 @@ use tokio::sync::{broadcast, Semaphore};
 use tracing::{debug, error, info, warn, Level};
 use tracing_subscriber::FmtSubscriber;
 
-use ghost_common::config::{MiningMode, NodeConfig};
+use ghost_common::config::{MiningMode, NodeConfig, ReaperSettings};
 use ghost_common::identity::NodeIdentity;
 use ghost_common::metrics::Metrics;
 use ghost_common::rpc::BitcoinRpc;
@@ -749,19 +749,22 @@ async fn main() -> Result<()> {
         policy.highest_allowed_tier().map(|t| t as u8).unwrap_or(0)
     );
 
-    // Setup reaper config for dead code detection
-    let reaper_config = if config.reaper.enabled {
-        ReaperConfig::default()
-    } else {
-        ReaperConfig::disabled()
-    };
+    // Setup reaper config for dead code detection, honouring the operator's
+    // per-vector detector selection (not just the master on/off).
+    let reaper_config = reaper_config_from_settings(&config.reaper);
+    if let Err(e) = reaper_config.validate() {
+        warn!("Reaper config invalid ({e}); falling back to all-on defaults");
+    }
     info!(
-        "Reaper: {}",
-        if reaper_config.enabled {
-            "enabled"
-        } else {
-            "disabled"
-        }
+        "Reaper: {} (inscription={} dropstuffing={} fakepubkey={} annex={} unreachable={} excess_witness={} legacy={})",
+        if reaper_config.enabled { "enabled" } else { "disabled" },
+        reaper_config.reject_inscription_envelope,
+        reaper_config.reject_drop_stuffing,
+        reaper_config.reject_fake_pubkeys,
+        reaper_config.reject_annex,
+        reaper_config.reject_unreachable_code,
+        reaper_config.reject_excess_witness,
+        reaper_config.reject_legacy_data_stuffing,
     );
 
     // Determine effective public_mining from mining_mode
@@ -5323,6 +5326,34 @@ fn expand_path(path: &std::path::Path) -> Result<PathBuf> {
     }
 }
 
+/// Build the pool template-reaper config from the operator's per-vector
+/// settings. When the master switch is off, every detector is disabled.
+/// Otherwise each detector and threshold maps straight through to the
+/// `ghost_reaper::ReaperConfig` field that enforces it. Node-only vectors
+/// (`reject_opreturn`, `reject_runestone`) have no pool-side equivalent and are
+/// intentionally not mapped here — the Rust reaper bounds OP_RETURN via the
+/// `max_op_return_bytes` threshold and has no Runestone detector.
+fn reaper_config_from_settings(s: &ReaperSettings) -> ReaperConfig {
+    if !s.enabled {
+        return ReaperConfig::disabled();
+    }
+    ReaperConfig {
+        enabled: true,
+        reject_inscription_envelope: s.reject_inscription,
+        reject_drop_stuffing: s.reject_dropstuffing,
+        reject_fake_pubkeys: s.reject_fakepubkey,
+        reject_annex: s.reject_annex,
+        reject_unreachable_code: s.reject_unreachable_code,
+        max_op_return_bytes: s.max_op_return_bytes,
+        min_drop_data_size: s.min_drop_size,
+        reject_excess_witness: s.reject_excess_witness,
+        min_excess_witness_bytes: s.min_excess_witness_bytes,
+        reject_legacy_data_stuffing: s.reject_legacy_data_stuffing,
+        legacy_max_push_bytes: s.legacy_max_push_bytes,
+        validate_pubkey_curve_point: s.validate_pubkey_curve_point,
+    }
+}
+
 /// Load configuration from file
 fn load_config(path: &std::path::Path) -> Result<NodeConfig> {
     let config = if path.exists() {
@@ -5416,6 +5447,47 @@ fn resolve_signer_path(
 mod tests {
     use super::*;
     use std::path::Path;
+
+    // ── reaper_config_from_settings ──────────────────────────────────
+
+    #[test]
+    fn test_reaper_config_master_off_disables_all() {
+        let s = ReaperSettings {
+            enabled: false,
+            ..Default::default()
+        };
+        let cfg = reaper_config_from_settings(&s);
+        assert!(!cfg.enabled);
+    }
+
+    #[test]
+    fn test_reaper_config_maps_per_vector() {
+        let s = ReaperSettings {
+            enabled: true,
+            reject_inscription: false,
+            reject_annex: false,
+            reject_legacy_data_stuffing: false,
+            max_op_return_bytes: 40,
+            min_drop_size: 64,
+            ..Default::default()
+        };
+        let cfg = reaper_config_from_settings(&s);
+        assert!(cfg.enabled);
+        // disabled vectors map through
+        assert!(!cfg.reject_inscription_envelope);
+        assert!(!cfg.reject_annex);
+        assert!(!cfg.reject_legacy_data_stuffing);
+        // untouched vectors stay on
+        assert!(cfg.reject_drop_stuffing);
+        assert!(cfg.reject_fake_pubkeys);
+        assert!(cfg.reject_unreachable_code);
+        assert!(cfg.reject_excess_witness);
+        // thresholds map (canonical min_drop_size -> min_drop_data_size)
+        assert_eq!(cfg.max_op_return_bytes, 40);
+        assert_eq!(cfg.min_drop_data_size, 64);
+        // valid for the analyzer
+        assert!(cfg.validate().is_ok());
+    }
 
     // ── expand_path ──────────────────────────────────────────────────
 

--- a/bins/ghost-setup/src/main.rs
+++ b/bins/ghost-setup/src/main.rs
@@ -1,11 +1,36 @@
-use clap::Parser;
+use clap::{Parser, Subcommand};
+use ghost_common::config::NodeConfig;
 use ghost_common::setup::{self, FieldValue};
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::process::Command as ProcCommand;
+
+const DROPIN_DIR: &str = "/etc/systemd/system/ghostd.service.d";
+const DROPIN_PATH: &str = "/etc/systemd/system/ghostd.service.d/reaper.conf";
+
+#[derive(Subcommand)]
+enum Command {
+    /// Apply the `[reaper]` per-vector settings from pool.toml to the ghostd
+    /// mempool reaper: writes a systemd drop-in and restarts ghostd. Needs root
+    /// (run with sudo, or it shells out to sudo for the privileged steps).
+    ApplyReaper {
+        /// Config directory holding pool.toml.
+        #[arg(long, default_value = "/etc/ghost")]
+        config_dir: PathBuf,
+        /// Print the flags + drop-in without writing or restarting.
+        #[arg(long)]
+        dry_run: bool,
+        /// Write the drop-in but do not restart ghostd.
+        #[arg(long)]
+        no_restart: bool,
+    },
+}
 
 #[derive(Parser)]
 #[command(name = "ghost-setup", about = "Ghost Pool node setup (headless)")]
 struct Args {
+    #[command(subcommand)]
+    command: Option<Command>,
     /// Node nickname
     #[arg(long)]
     nickname: Option<String>,
@@ -37,6 +62,19 @@ struct Args {
 
 fn main() {
     let args = Args::parse();
+
+    if let Some(Command::ApplyReaper {
+        config_dir,
+        dry_run,
+        no_restart,
+    }) = &args.command
+    {
+        if let Err(e) = apply_reaper_to_ghostd(config_dir, *dry_run, *no_restart) {
+            eprintln!("apply-reaper failed: {e}");
+            std::process::exit(1);
+        }
+        return;
+    }
 
     // Expand ~ in data_dir
     let data_dir = if args.data_dir.starts_with("~") {
@@ -85,4 +123,104 @@ fn main() {
             std::process::exit(1);
         }
     }
+}
+
+/// Translate pool.toml's `[reaper]` per-vector settings into ghostd's mempool
+/// reaper flags and apply them via a systemd drop-in.
+fn apply_reaper_to_ghostd(
+    config_dir: &Path,
+    dry_run: bool,
+    no_restart: bool,
+) -> Result<(), String> {
+    let pool_toml = config_dir.join("pool.toml");
+    let config = NodeConfig::load(&pool_toml)?;
+    let settings = &config.reaper;
+
+    println!(
+        "Ghost Reaper flags for ghostd (from {}):",
+        pool_toml.display()
+    );
+    for f in settings.ghostd_flags() {
+        println!("  {f}");
+    }
+
+    let exec_argv = read_ghostd_exec_argv()?;
+    let dropin = setup::ghostd_reaper_dropin(&exec_argv, settings);
+
+    if dry_run {
+        println!("\n--- drop-in {DROPIN_PATH} (dry-run, not written) ---\n{dropin}");
+        return Ok(());
+    }
+
+    write_dropin(&dropin)?;
+    run_root(&["systemctl", "daemon-reload"])?;
+    println!("Wrote {DROPIN_PATH} and reloaded systemd.");
+    if no_restart {
+        println!(
+            "ghostd NOT restarted (--no-restart). Run `sudo systemctl restart ghostd` to apply."
+        );
+    } else {
+        run_root(&["systemctl", "restart", "ghostd"])?;
+        println!("Restarted ghostd; per-vector reaper flags are now live.");
+    }
+    Ok(())
+}
+
+/// Read ghostd's resolved command line from systemd (`argv[]` of ExecStart).
+fn read_ghostd_exec_argv() -> Result<String, String> {
+    let out = ProcCommand::new("systemctl")
+        .args(["show", "ghostd", "-p", "ExecStart", "--value"])
+        .output()
+        .map_err(|e| format!("systemctl show ghostd: {e}"))?;
+    let s = String::from_utf8_lossy(&out.stdout);
+    let start = s
+        .find("argv[]=")
+        .ok_or("could not find argv[] in ghostd ExecStart (is ghostd installed?)")?;
+    let rest = &s[start + "argv[]=".len()..];
+    let end = rest.find(" ;").unwrap_or(rest.len());
+    let argv = rest[..end].trim();
+    if argv.is_empty() {
+        return Err("ghostd ExecStart argv[] was empty".into());
+    }
+    Ok(argv.to_string())
+}
+
+/// Run a privileged command via sudo (works whether or not we are already root).
+fn run_root(argv: &[&str]) -> Result<(), String> {
+    let status = ProcCommand::new("sudo")
+        .args(argv)
+        .status()
+        .map_err(|e| format!("run `sudo {}`: {e}", argv.join(" ")))?;
+    if !status.success() {
+        return Err(format!("`sudo {}` failed ({status})", argv.join(" ")));
+    }
+    Ok(())
+}
+
+/// Write the drop-in to its system path via `sudo tee`, backing up any existing one.
+fn write_dropin(dropin: &str) -> Result<(), String> {
+    use std::io::Write;
+    run_root(&["mkdir", "-p", DROPIN_DIR])?;
+    let _ = run_root(&[
+        "sh",
+        "-c",
+        &format!("[ -f {DROPIN_PATH} ] && cp {DROPIN_PATH} {DROPIN_PATH}.bak.$(date +%s) || true"),
+    ]);
+    let mut child = ProcCommand::new("sudo")
+        .args(["tee", DROPIN_PATH])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::null())
+        .spawn()
+        .map_err(|e| format!("spawn `sudo tee`: {e}"))?;
+    child
+        .stdin
+        .as_mut()
+        .ok_or("no stdin for tee")?
+        .write_all(dropin.as_bytes())
+        .map_err(|e| format!("write drop-in: {e}"))?;
+    let status = child.wait().map_err(|e| format!("wait tee: {e}"))?;
+    if !status.success() {
+        return Err(format!("`sudo tee {DROPIN_PATH}` failed ({status})"));
+    }
+    Ok(())
 }

--- a/crates/ghost-common/src/config.rs
+++ b/crates/ghost-common/src/config.rs
@@ -736,6 +736,13 @@ impl NodeConfig {
     /// # Returns
     /// * `Ok(())` on success
     /// * `Err` if serialization, writing, or renaming fails
+    /// Load a `NodeConfig` from a TOML file.
+    pub fn load(path: &std::path::Path) -> Result<Self, String> {
+        let content =
+            std::fs::read_to_string(path).map_err(|e| format!("read {}: {e}", path.display()))?;
+        toml::from_str(&content).map_err(|e| format!("parse {}: {e}", path.display()))
+    }
+
     pub fn save_atomic(&self, path: &std::path::Path) -> std::io::Result<()> {
         use std::io::Write;
 
@@ -1323,13 +1330,130 @@ impl Default for RegistryConfig {
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReaperSettings {
-    /// Enable reaper filtering
+    /// Master switch. When false, every detector is off on both layers.
+    #[serde(default = "default_true")]
     pub enabled: bool,
+
+    // --- Shared detectors (pool template reaper AND ghostd mempool reaper) ---
+    /// Reject OP_FALSE OP_IF ... OP_ENDIF inscription envelopes.
+    #[serde(default = "default_true")]
+    pub reject_inscription: bool,
+    /// Reject a large data push immediately followed by OP_DROP/OP_2DROP.
+    #[serde(default = "default_true")]
+    pub reject_dropstuffing: bool,
+    /// Reject bare multisig outputs whose pubkey pushes have invalid prefixes.
+    #[serde(default = "default_true")]
+    pub reject_fakepubkey: bool,
+    /// Reject P2TR inputs carrying a witness annex.
+    #[serde(default = "default_true")]
+    pub reject_annex: bool,
+
+    // --- Node-only detectors (ghostd mempool reaper) ---
+    /// Reject outputs whose OP_RETURN payload exceeds `max_op_return_bytes`.
+    #[serde(default = "default_true")]
+    pub reject_opreturn: bool,
+    /// Reject Runestone protocol outputs (OP_RETURN OP_13).
+    #[serde(default = "default_true")]
+    pub reject_runestone: bool,
+
+    // --- Pool-only detectors (Rust template reaper) ---
+    /// Reject witness code after an OP_RETURN opcode.
+    #[serde(default = "default_true")]
+    pub reject_unreachable_code: bool,
+    /// Reject witness data beyond what execution requires.
+    #[serde(default = "default_true")]
+    pub reject_excess_witness: bool,
+    /// Reject non-signature/non-pubkey data stuffing in legacy scriptSig.
+    #[serde(default = "default_true")]
+    pub reject_legacy_data_stuffing: bool,
+    /// Also validate that bare-multisig pubkey pushes are on the secp256k1 curve.
+    #[serde(default = "default_true")]
+    pub validate_pubkey_curve_point: bool,
+
+    // --- Thresholds ---
+    /// Max OP_RETURN payload bytes (shared with ghostd).
+    #[serde(default = "default_max_op_return_bytes")]
+    pub max_op_return_bytes: usize,
+    /// Min push size (bytes) that triggers drop-stuffing detection (shared with ghostd).
+    #[serde(default = "default_min_drop_size")]
+    pub min_drop_size: usize,
+    /// Min excess-witness bytes that triggers rejection (pool-only).
+    #[serde(default = "default_min_excess_witness_bytes")]
+    pub min_excess_witness_bytes: usize,
+    /// Max legitimate scriptSig push bytes before legacy stuffing is flagged (pool-only).
+    #[serde(default = "default_legacy_max_push_bytes")]
+    pub legacy_max_push_bytes: usize,
+}
+
+fn default_true() -> bool {
+    true
+}
+fn default_max_op_return_bytes() -> usize {
+    82
+}
+fn default_min_drop_size() -> usize {
+    76
+}
+fn default_min_excess_witness_bytes() -> usize {
+    500
+}
+fn default_legacy_max_push_bytes() -> usize {
+    80
 }
 
 impl Default for ReaperSettings {
     fn default() -> Self {
-        Self { enabled: true }
+        Self {
+            enabled: true,
+            reject_inscription: true,
+            reject_dropstuffing: true,
+            reject_fakepubkey: true,
+            reject_annex: true,
+            reject_opreturn: true,
+            reject_runestone: true,
+            reject_unreachable_code: true,
+            reject_excess_witness: true,
+            reject_legacy_data_stuffing: true,
+            validate_pubkey_curve_point: true,
+            max_op_return_bytes: default_max_op_return_bytes(),
+            min_drop_size: default_min_drop_size(),
+            min_excess_witness_bytes: default_min_excess_witness_bytes(),
+            legacy_max_push_bytes: default_legacy_max_push_bytes(),
+        }
+    }
+}
+
+impl ReaperSettings {
+    /// The ghostd (Bitcoin Core) CLI flags that mirror these settings on the
+    /// node mempool reaper. Only the detectors ghostd implements are emitted —
+    /// pool-only vectors (`reject_unreachable_code`, `reject_excess_witness`,
+    /// `reject_legacy_data_stuffing`, `validate_pubkey_curve_point`) have no
+    /// ghostd equivalent and are omitted. Booleans use `1`/`0`; the master uses
+    /// `enabled`/`disabled`. When the master is off, every per-vector flag is
+    /// emitted as `0` so the node matches the all-off intent (master gate).
+    pub fn ghostd_flags(&self) -> Vec<String> {
+        let on = self.enabled;
+        let b = |x: bool| if on && x { "1" } else { "0" };
+        vec![
+            format!("-ghostreaper={}", if on { "enabled" } else { "disabled" }),
+            format!(
+                "-ghostreaper-rejectinscription={}",
+                b(self.reject_inscription)
+            ),
+            format!(
+                "-ghostreaper-rejectdropstuffing={}",
+                b(self.reject_dropstuffing)
+            ),
+            format!(
+                "-ghostreaper-rejectfakepubkey={}",
+                b(self.reject_fakepubkey)
+            ),
+            format!("-ghostreaper-rejectannex={}", b(self.reject_annex)),
+            format!("-ghostreaper-rejectopreturn={}", b(self.reject_opreturn)),
+            format!("-ghostreaper-rejectrunestone={}", b(self.reject_runestone)),
+            format!("-ghostreaper-maxopreturn={}", self.max_op_return_bytes),
+            format!("-ghostreaper-mindropsize={}", self.min_drop_size),
+        ]
     }
 }
 
@@ -1437,6 +1561,95 @@ mod tests {
         let config = NodeConfig::default();
         assert_eq!(config.network.sv2_port, SV2_STRATUM_PORT);
         assert_eq!(config.bitcoin.network, BitcoinNetwork::Signet);
+    }
+
+    #[test]
+    fn test_reaper_settings_backward_compat() {
+        // Legacy pool.toml with only the master switch must deserialise to
+        // all-detectors-on (today's behaviour) via the per-field serde defaults.
+        let legacy: ReaperSettings = toml::from_str("enabled = true").unwrap();
+        assert!(legacy.enabled);
+        assert!(legacy.reject_inscription);
+        assert!(legacy.reject_runestone);
+        assert!(legacy.reject_legacy_data_stuffing);
+        assert!(legacy.validate_pubkey_curve_point);
+        assert_eq!(legacy.max_op_return_bytes, 82);
+        assert_eq!(legacy.min_drop_size, 76);
+        assert_eq!(legacy.min_excess_witness_bytes, 500);
+        assert_eq!(legacy.legacy_max_push_bytes, 80);
+
+        // An entirely empty table is also all-on.
+        let empty: ReaperSettings = toml::from_str("").unwrap();
+        assert!(empty.enabled && empty.reject_annex && empty.reject_opreturn);
+
+        // enabled=false leaves the per-vector fields deserialising to their
+        // defaults; the master gate is what disables enforcement.
+        let off: ReaperSettings = toml::from_str("enabled = false").unwrap();
+        assert!(!off.enabled);
+        assert!(off.reject_inscription);
+    }
+
+    #[test]
+    fn test_reaper_settings_per_vector_roundtrip() {
+        // A partial per-vector config: only some detectors disabled.
+        let cfg: ReaperSettings = toml::from_str(
+            "enabled = true\nreject_runestone = false\nreject_annex = false\nmax_op_return_bytes = 40\n",
+        )
+        .unwrap();
+        assert!(cfg.enabled);
+        assert!(!cfg.reject_runestone);
+        assert!(!cfg.reject_annex);
+        assert!(cfg.reject_inscription); // untouched -> default true
+        assert_eq!(cfg.max_op_return_bytes, 40);
+
+        // Round-trips through serialisation unchanged.
+        let s = toml::to_string(&cfg).unwrap();
+        let back: ReaperSettings = toml::from_str(&s).unwrap();
+        assert!(!back.reject_runestone && !back.reject_annex && back.reject_inscription);
+        assert_eq!(back.max_op_return_bytes, 40);
+    }
+
+    #[test]
+    fn test_ghostd_flags_all_on() {
+        let flags = ReaperSettings::default().ghostd_flags();
+        assert!(flags.contains(&"-ghostreaper=enabled".to_string()));
+        assert!(flags.contains(&"-ghostreaper-rejectinscription=1".to_string()));
+        assert!(flags.contains(&"-ghostreaper-rejectannex=1".to_string()));
+        assert!(flags.contains(&"-ghostreaper-rejectopreturn=1".to_string()));
+        assert!(flags.contains(&"-ghostreaper-rejectrunestone=1".to_string()));
+        assert!(flags.contains(&"-ghostreaper-maxopreturn=82".to_string()));
+        assert!(flags.contains(&"-ghostreaper-mindropsize=76".to_string()));
+        // Pool-only vectors must NOT leak into ghostd flags.
+        assert!(!flags.iter().any(|f| f.contains("unreachable")));
+        assert!(!flags.iter().any(|f| f.contains("excess")));
+        assert!(!flags.iter().any(|f| f.contains("legacy")));
+    }
+
+    #[test]
+    fn test_ghostd_flags_master_off_zeroes_all() {
+        let s = ReaperSettings {
+            enabled: false,
+            ..Default::default()
+        };
+        let flags = s.ghostd_flags();
+        assert!(flags.contains(&"-ghostreaper=disabled".to_string()));
+        // every per-vector flag is 0 regardless of its individual setting
+        assert!(flags.iter().all(|f| !f.ends_with("=1")));
+        assert!(flags.contains(&"-ghostreaper-rejectannex=0".to_string()));
+    }
+
+    #[test]
+    fn test_ghostd_flags_mixed() {
+        let s = ReaperSettings {
+            enabled: true,
+            reject_runestone: false,
+            reject_opreturn: false,
+            ..Default::default()
+        };
+        let flags = s.ghostd_flags();
+        assert!(flags.contains(&"-ghostreaper-rejectrunestone=0".to_string()));
+        assert!(flags.contains(&"-ghostreaper-rejectopreturn=0".to_string()));
+        assert!(flags.contains(&"-ghostreaper-rejectinscription=1".to_string()));
     }
 
     #[test]

--- a/crates/ghost-common/src/setup.rs
+++ b/crates/ghost-common/src/setup.rs
@@ -217,31 +217,83 @@ pub fn apply_change_setup(
     })
 }
 
-/// Reaper — toggle reaper + configure custom policy filters
+/// Reaper — master switch plus per-vector detector selection.
+///
+/// Only the keys actually present in `fields` are applied, so partial updates
+/// (e.g. a single detector toggled from the dashboard) leave the rest intact.
+/// Field keys match the canonical `[reaper]` config keys; `"reaper"` is kept as
+/// the master-switch key for the existing setup contract.
 pub fn apply_reaper(
     fields: &HashMap<String, FieldValue>,
     config_path: &Path,
 ) -> Result<String, String> {
     load_and_modify(config_path, |config| {
+        let r = &mut config.reaper;
         if let Some(v) = fields.get("reaper") {
-            config.reaper.enabled = v.as_bool();
+            r.enabled = v.as_bool();
         }
-        if config.reaper.enabled {
-            let mut custom = config.policy.custom.clone().unwrap_or_default();
-            if let Some(v) = fields.get("filter_inscriptions") {
-                custom.allow_inscriptions = !v.as_bool();
+        // Per-vector detector toggles.
+        for (key, slot) in [
+            ("reject_inscription", &mut r.reject_inscription),
+            ("reject_dropstuffing", &mut r.reject_dropstuffing),
+            ("reject_fakepubkey", &mut r.reject_fakepubkey),
+            ("reject_annex", &mut r.reject_annex),
+            ("reject_opreturn", &mut r.reject_opreturn),
+            ("reject_runestone", &mut r.reject_runestone),
+            ("reject_unreachable_code", &mut r.reject_unreachable_code),
+            ("reject_excess_witness", &mut r.reject_excess_witness),
+            (
+                "reject_legacy_data_stuffing",
+                &mut r.reject_legacy_data_stuffing,
+            ),
+            (
+                "validate_pubkey_curve_point",
+                &mut r.validate_pubkey_curve_point,
+            ),
+        ] {
+            if let Some(v) = fields.get(key) {
+                *slot = v.as_bool();
             }
-            if let Some(v) = fields.get("filter_runes") {
-                custom.allow_runes = !v.as_bool();
-            }
-            if let Some(v) = fields.get("max_witness_size") {
+        }
+        // Thresholds.
+        for (key, slot) in [
+            ("max_op_return_bytes", &mut r.max_op_return_bytes),
+            ("min_drop_size", &mut r.min_drop_size),
+            ("min_excess_witness_bytes", &mut r.min_excess_witness_bytes),
+            ("legacy_max_push_bytes", &mut r.legacy_max_push_bytes),
+        ] {
+            if let Some(v) = fields.get(key) {
                 if let Ok(n) = v.as_text().parse::<usize>() {
-                    custom.max_witness_per_input = n;
+                    *slot = n;
                 }
             }
-            config.policy.custom = Some(custom);
         }
     })
+}
+
+/// Render a systemd drop-in for ghostd that applies the per-vector reaper
+/// settings to the node mempool reaper.
+///
+/// `exec_argv` is the daemon's resolved command line (e.g. the `argv[]` from
+/// `systemctl show ghostd -p ExecStart --value`). Any existing `-ghostreaper*`
+/// flags are stripped and the full set from `settings` is appended, wrapped in
+/// a drop-in that resets and replaces `ExecStart` (the systemd override idiom:
+/// an empty `ExecStart=` clears the inherited value before the new one is set).
+pub fn ghostd_reaper_dropin(exec_argv: &str, settings: &crate::config::ReaperSettings) -> String {
+    let base: Vec<&str> = exec_argv
+        .split_whitespace()
+        .filter(|tok| !tok.starts_with("-ghostreaper"))
+        .collect();
+    let flags = settings.ghostd_flags();
+    format!(
+        "# Managed by `ghost-setup apply-reaper` — per-vector Ghost Reaper flags.\n\
+         # Do not edit by hand; regenerate from pool.toml [reaper].\n\
+         [Service]\n\
+         ExecStart=\n\
+         ExecStart={} {}\n",
+        base.join(" "),
+        flags.join(" ")
+    )
 }
 
 /// Pool setup — configure mining pool settings
@@ -320,4 +372,31 @@ pub fn apply_mempool_policy(
             };
         }
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::ReaperSettings;
+
+    #[test]
+    fn test_ghostd_reaper_dropin_strips_and_appends() {
+        let exec = "/opt/ghost/bin/ghostd -signet -datadir=/var/lib/bitcoin -ghostreaper=enabled -port=38333";
+        let s = ReaperSettings {
+            reject_annex: false,
+            ..Default::default()
+        };
+        let dropin = ghostd_reaper_dropin(exec, &s);
+
+        // resets ExecStart then re-emits the base (minus any -ghostreaper*)
+        assert!(dropin.contains("[Service]\nExecStart=\nExecStart="));
+        assert!(dropin.contains("/opt/ghost/bin/ghostd"));
+        assert!(dropin.contains("-signet"));
+        assert!(dropin.contains("-port=38333"));
+        // the old hardcoded master flag is stripped, replaced by the managed set
+        assert_eq!(dropin.matches("-ghostreaper=").count(), 1);
+        assert!(dropin.contains("-ghostreaper=enabled"));
+        assert!(dropin.contains("-ghostreaper-rejectannex=0"));
+        assert!(dropin.contains("-ghostreaper-rejectinscription=1"));
+    }
 }

--- a/crates/ghost-verification/src/routes.rs
+++ b/crates/ghost-verification/src/routes.rs
@@ -4630,15 +4630,21 @@ async fn api_config_template_profile_handler(
     }))
 }
 
-/// API v1 Config reaper handler
+/// API v1 Config reaper handler — returns the per-vector reaper configuration
+/// from the full node config (pool.toml `[reaper]`).
 async fn api_config_reaper_handler(
     State(state): State<Arc<VerificationState>>,
 ) -> impl IntoResponse {
-    let config = state.dashboard_config.read();
+    let settings = state
+        .full_node_config
+        .as_ref()
+        .map(|c| c.read().reaper.clone())
+        .unwrap_or_default();
     Json(serde_json::json!({
-        "enabled": config.reaper,
-        "mode": if config.reaper { "strict" } else { "disabled" },
-        "message": "Reaper mode configuration"
+        "enabled": settings.enabled,
+        "mode": if settings.enabled { "strict" } else { "disabled" },
+        "settings": serde_json::to_value(&settings).unwrap_or_else(|_| serde_json::json!({})),
+        "message": "Reaper per-vector configuration",
     }))
 }
 
@@ -4776,17 +4782,47 @@ async fn api_config_public_mining_post_handler(
     }))
 }
 
-/// API v1 Config reaper POST handler
+/// API v1 Config reaper POST handler — accepts the full per-vector reaper
+/// settings, persists them to the node config (pool.toml `[reaper]`), and signals
+/// a ghost-pool restart so the pool template reaper picks them up. The node-level
+/// (ghostd) mempool reaper still needs `ghost-setup apply-reaper`, surfaced via
+/// `ghostd_restart_required`. A legacy `{ "enabled": bool }` body still works
+/// (the per-vector fields fall back to their serde defaults = all-on).
 async fn api_config_reaper_post_handler(
     State(state): State<Arc<VerificationState>>,
-    Json(payload): Json<ToggleRequest>,
+    Json(payload): Json<ghost_common::config::ReaperSettings>,
 ) -> impl IntoResponse {
-    let mut config = state.dashboard_config.write();
-    config.reaper = payload.enabled;
+    let mut persisted = false;
+    if let Some(ref full) = state.full_node_config {
+        let mut cfg = full.write();
+        cfg.reaper = payload.clone();
+        if let Some(ref path) = state.full_node_config_path {
+            match cfg.save_atomic(path) {
+                Ok(()) => persisted = true,
+                Err(e) => error!(error = %e, "Failed to persist reaper config"),
+            }
+        }
+    }
+    // Keep the dashboard master mirror in sync (capability / share displays).
+    {
+        let mut dc = state.dashboard_config.write();
+        dc.reaper = payload.enabled;
+    }
+    // The pool template reaper reads its config at startup; a restart applies it.
+    if persisted {
+        state.request_restart();
+    }
     Json(serde_json::json!({
         "success": true,
+        "persisted": persisted,
         "enabled": payload.enabled,
-        "message": "Reaper mode updated"
+        "settings": serde_json::to_value(&payload).unwrap_or_else(|_| serde_json::json!({})),
+        "ghostd_restart_required": true,
+        "message": if persisted {
+            "Pool reaper updated; ghost-pool will restart to apply. Run `ghost-setup apply-reaper` (or restart ghostd) to apply node-level mempool filtering."
+        } else {
+            "Reaper settings received but no node config path is configured — changes were not persisted."
+        },
     }))
 }
 

--- a/dashboard/src/app/(dashboard)/settings/wizards/ReaperWizard.tsx
+++ b/dashboard/src/app/(dashboard)/settings/wizards/ReaperWizard.tsx
@@ -6,97 +6,104 @@ import { Toggle } from '@/components/ui/Toggle';
 import { Input } from '@/components/ui/Input';
 import { Badge } from '@/components/ui/Badge';
 import { useToast } from '@/components/ui/Toast';
-import { useSetReaper, useConfig } from '@/hooks/queries';
-
-interface ReaperData {
-  reaper: boolean;
-  filter_inscriptions: boolean;
-  filter_brc20: boolean;
-  filter_runes: boolean;
-  max_witness_size: number;
-  dust_limit: number;
-}
+import { useSetReaper, useReaperConfig } from '@/hooks/queries';
+import { type ReaperSettings, REAPER_DEFAULTS } from '@/lib/api/config';
 
 interface ReaperWizardProps {
   isOpen: boolean;
   onClose: () => void;
 }
 
+// Per-detector metadata, grouped by which enforcement layer honours it.
+type Vector = { key: keyof ReaperSettings; label: string; desc: string };
+
+const SHARED: Vector[] = [
+  { key: 'reject_inscription', label: 'Inscription envelopes', desc: 'OP_FALSE OP_IF … OP_ENDIF ordinal/inscription wrappers' },
+  { key: 'reject_dropstuffing', label: 'Drop stuffing', desc: 'A large data push immediately followed by OP_DROP / OP_2DROP' },
+  { key: 'reject_fakepubkey', label: 'Fake pubkeys', desc: 'Bare multisig outputs with invalid pubkey prefixes' },
+  { key: 'reject_annex', label: 'P2TR annex', desc: 'Taproot inputs carrying a witness annex' },
+];
+const NODE_ONLY: Vector[] = [
+  { key: 'reject_opreturn', label: 'Oversized OP_RETURN', desc: 'OP_RETURN payloads larger than the max below' },
+  { key: 'reject_runestone', label: 'Runestones', desc: 'Runestone protocol outputs (OP_RETURN OP_13)' },
+];
+const POOL_ONLY: Vector[] = [
+  { key: 'reject_unreachable_code', label: 'Unreachable code', desc: 'Witness code after an OP_RETURN opcode' },
+  { key: 'reject_excess_witness', label: 'Excess witness', desc: 'Witness data beyond what execution requires' },
+  { key: 'reject_legacy_data_stuffing', label: 'Legacy scriptSig stuffing', desc: 'Non-sig/non-pubkey data pushes in legacy scriptSig' },
+  { key: 'validate_pubkey_curve_point', label: 'Pubkey curve check', desc: 'Also verify bare-multisig pubkeys are on the secp256k1 curve' },
+];
+
 export default function ReaperWizard({ isOpen, onClose }: ReaperWizardProps) {
-  const { data: config } = useConfig();
+  const { data: reaper } = useReaperConfig();
   const setReaper = useSetReaper();
   const toast = useToast();
 
-  const steps: WizardStep<ReaperData>[] = [
+  const steps: WizardStep<ReaperSettings>[] = [
+    { id: 'enable', title: 'Enable', description: 'Master switch for Ghost Reaper' },
+    { id: 'detectors', title: 'Detectors', description: 'Choose which vectors to reject' },
     {
-      id: 'enable',
-      title: 'Enable',
-      description: 'Enable or disable Ghost Reaper mode',
-    },
-    {
-      id: 'filters',
-      title: 'Filters',
-      description: 'Configure mempool filtering rules',
-      validate: (data) => {
-        if (data.reaper) {
-          if (data.max_witness_size < 100) {
-            return 'Maximum witness size must be at least 100 bytes';
-          }
-          if (data.max_witness_size > 1000000) {
-            return 'Maximum witness size cannot exceed 1,000,000 bytes';
-          }
-          if (data.dust_limit < 330) {
-            return 'Dust limit must be at least 330 satoshis';
-          }
-          if (data.dust_limit > 100000) {
-            return 'Dust limit cannot exceed 100,000 satoshis';
-          }
-        }
-        return null;
-      },
-    },
-    {
-      id: 'preview',
-      title: 'Preview',
-      description: 'Review your filtering configuration',
+      id: 'thresholds',
+      title: 'Thresholds',
+      description: 'Tune detector limits',
+      validate: (d) =>
+        d.max_op_return_bytes < 1 || d.min_drop_size < 1
+          ? 'Thresholds must be greater than zero'
+          : null,
     },
     {
       id: 'confirm',
       title: 'Confirm',
       description: 'Apply Ghost Reaper settings',
       onSubmit: async (data) => {
-        await setReaper.mutateAsync(data.reaper);
+        const res = await setReaper.mutateAsync(data);
         toast.success(
           'Ghost Reaper Updated',
-          data.reaper
-            ? 'Ghost Reaper enabled -- mempool filtering is now active'
-            : 'Ghost Reaper disabled -- filtering is now inactive'
+          res.ghostd_restart_required
+            ? 'Pool reaper applied. Run `ghost-setup apply-reaper` (or restart ghostd) to apply node-level mempool filtering.'
+            : 'Reaper settings saved.'
         );
         onClose();
       },
     },
   ];
 
-  const wizard = useWizard<ReaperData>({
+  const wizard = useWizard<ReaperSettings>({
     steps,
-    initialData: {
-      reaper: config?.reaper ?? false,
-      filter_inscriptions: true,
-      filter_brc20: true,
-      filter_runes: true,
-      max_witness_size: 400,
-      dust_limit: 546,
-    },
+    initialData: reaper?.settings ?? REAPER_DEFAULTS,
   });
 
+  const renderGroup = (
+    title: string,
+    note: string,
+    vectors: Vector[],
+    data: ReaperSettings,
+    setData: (patch: Partial<ReaperSettings>) => void
+  ) => (
+    <div className="p-4 rounded-lg bg-gray-800/50 space-y-4">
+      <div>
+        <h4 className="text-gray-100 font-medium">{title}</h4>
+        <p className="text-xs text-gray-500 mt-0.5">{note}</p>
+      </div>
+      {vectors.map((v) => (
+        <div key={v.key} className="flex items-center justify-between">
+          <div className="pr-4">
+            <span className="text-gray-100">{v.label}</span>
+            <p className="text-sm text-gray-400 mt-1">{v.desc}</p>
+          </div>
+          <Toggle
+            enabled={Boolean(data[v.key])}
+            onChange={(val) => setData({ [v.key]: val } as Partial<ReaperSettings>)}
+            label={v.label}
+            disabled={!data.enabled}
+          />
+        </div>
+      ))}
+    </div>
+  );
+
   return (
-    <WizardDialog
-      isOpen={isOpen}
-      onClose={onClose}
-      title="Ghost Reaper Setup"
-      wizard={wizard}
-      size="lg"
-    >
+    <WizardDialog isOpen={isOpen} onClose={onClose} title="Ghost Reaper Setup" wizard={wizard} size="lg">
       {(data, setData) => (
         <div className="space-y-6">
           {/* Step 1: Enable */}
@@ -104,193 +111,53 @@ export default function ReaperWizard({ isOpen, onClose }: ReaperWizardProps) {
             <div className="space-y-4">
               <div className="p-4 rounded-lg bg-gray-800/50">
                 <div className="flex items-center justify-between">
-                  <div>
+                  <div className="pr-4">
                     <span className="text-gray-100 font-medium">Reaper Mode</span>
                     <p className="text-sm text-gray-400 mt-1">
-                      Reject transactions with dead code in witness scripts. Filters inscriptions,
-                      drop stuffing, and other non-financial data from your mempool.
+                      Master switch. When off, every detector is disabled on both the pool template
+                      reaper and the node mempool reaper. When on, the per-detector choices below apply.
                     </p>
                   </div>
-                  <Toggle
-                    enabled={data.reaper}
-                    onChange={(enabled) => setData({ reaper: enabled })}
-                    label="Reaper"
-                  />
+                  <Toggle enabled={data.enabled} onChange={(e) => setData({ enabled: e })} label="Reaper" />
                 </div>
               </div>
-              {data.reaper && (
+              {data.enabled && (
                 <div className="p-4 rounded-lg bg-green-900/20 border border-green-800">
                   <div className="flex items-center gap-2">
                     <Badge variant="success">+2 Shares</Badge>
-                    <span className="text-sm text-green-300">
-                      Enables Reaper capability verification for node rewards
-                    </span>
+                    <span className="text-sm text-green-300">Enables Reaper capability verification for node rewards</span>
                   </div>
                 </div>
               )}
-              <div className="p-4 rounded-lg bg-gray-800/50">
-                <h4 className="text-gray-100 font-medium mb-2">What Ghost Reaper filters</h4>
-                <ul className="space-y-2 text-sm text-gray-400">
-                  <li className="flex items-center gap-2">
-                    <span className="text-orange-300">--</span>
-                    Ordinal inscriptions embedded in witness data
-                  </li>
-                  <li className="flex items-center gap-2">
-                    <span className="text-orange-300">--</span>
-                    BRC-20 token operations (JSON in witness)
-                  </li>
-                  <li className="flex items-center gap-2">
-                    <span className="text-orange-300">--</span>
-                    Runes protocol metadata
-                  </li>
-                  <li className="flex items-center gap-2">
-                    <span className="text-orange-300">--</span>
-                    Oversized witness data (drop stuffing)
-                  </li>
-                </ul>
-              </div>
             </div>
           )}
 
-          {/* Step 2: Filters */}
+          {/* Step 2: Detectors */}
           {wizard.currentStep === 1 && (
             <div className="space-y-4">
-              {!data.reaper && (
+              {!data.enabled && (
                 <div className="p-4 rounded-lg bg-orange-900/20 border border-orange-800">
-                  <p className="text-sm text-orange-300">
-                    Reaper is disabled. These filters will not be active until you enable it.
-                  </p>
+                  <p className="text-sm text-orange-300">Reaper is disabled — these choices take effect once you enable it.</p>
                 </div>
               )}
-              <div className="p-4 rounded-lg bg-gray-800/50 space-y-4">
-                <h4 className="text-gray-100 font-medium">Transaction Type Filters</h4>
-                <div className="flex items-center justify-between">
-                  <div>
-                    <span className="text-gray-100">Filter Inscriptions</span>
-                    <p className="text-sm text-gray-400 mt-1">
-                      Reject ordinal inscription transactions
-                    </p>
-                  </div>
-                  <Toggle
-                    enabled={data.filter_inscriptions}
-                    onChange={(v) => setData({ filter_inscriptions: v })}
-                    label="Filter Inscriptions"
-                    disabled={!data.reaper}
-                  />
-                </div>
-                <div className="flex items-center justify-between">
-                  <div>
-                    <span className="text-gray-100">Filter BRC-20</span>
-                    <p className="text-sm text-gray-400 mt-1">
-                      Reject BRC-20 token operations
-                    </p>
-                  </div>
-                  <Toggle
-                    enabled={data.filter_brc20}
-                    onChange={(v) => setData({ filter_brc20: v })}
-                    label="Filter BRC-20"
-                    disabled={!data.reaper}
-                  />
-                </div>
-                <div className="flex items-center justify-between">
-                  <div>
-                    <span className="text-gray-100">Filter Runes</span>
-                    <p className="text-sm text-gray-400 mt-1">
-                      Reject Runes protocol transactions
-                    </p>
-                  </div>
-                  <Toggle
-                    enabled={data.filter_runes}
-                    onChange={(v) => setData({ filter_runes: v })}
-                    label="Filter Runes"
-                    disabled={!data.reaper}
-                  />
-                </div>
-              </div>
-              <div className="p-4 rounded-lg bg-gray-800/50 space-y-4">
-                <h4 className="text-gray-100 font-medium">Size Limits</h4>
-                <div>
-                  <Input
-                    label="Max Witness Size (bytes)"
-                    type="number"
-                    value={data.max_witness_size}
-                    onChange={(e) => setData({ max_witness_size: Number(e.target.value) })}
-                    disabled={!data.reaper}
-                  />
-                  <p className="text-sm text-gray-400 mt-1">
-                    Transactions with witness data exceeding this size will be rejected.
-                    Default: 400 bytes.
-                  </p>
-                </div>
-                <div>
-                  <Input
-                    label="Dust Limit (satoshis)"
-                    type="number"
-                    value={data.dust_limit}
-                    onChange={(e) => setData({ dust_limit: Number(e.target.value) })}
-                    disabled={!data.reaper}
-                  />
-                  <p className="text-sm text-gray-400 mt-1">
-                    Outputs below this value are considered dust and may be filtered.
-                    Default: 546 sats.
-                  </p>
-                </div>
-              </div>
+              {renderGroup('Shared detectors', 'Apply to both the pool (block templates) and the node (mempool relay).', SHARED, data, setData)}
+              {renderGroup('Node-level only', 'Apply to the ghostd mempool reaper. Needs `ghost-setup apply-reaper` to take effect.', NODE_ONLY, data, setData)}
+              {renderGroup('Pool-level only', 'Apply to the pool template reaper (what this node mines).', POOL_ONLY, data, setData)}
             </div>
           )}
 
-          {/* Step 3: Preview */}
+          {/* Step 3: Thresholds */}
           {wizard.currentStep === 2 && (
-            <div className="space-y-4">
-              <div className="p-4 rounded-lg bg-gray-800/50">
-                <h4 className="text-gray-100 font-medium mb-3">Configuration Summary</h4>
-                <div className="space-y-3">
-                  <div className="flex items-center justify-between">
-                    <span className="text-gray-400">Reaper Mode</span>
-                    <Badge variant={data.reaper ? 'success' : 'default'}>
-                      {data.reaper ? 'Enabled' : 'Disabled'}
-                    </Badge>
-                  </div>
-                  <div className="border-t border-gray-700 pt-3 space-y-2">
-                    <div className="flex items-center justify-between">
-                      <span className="text-gray-400">Inscriptions</span>
-                      <Badge variant={data.filter_inscriptions && data.reaper ? 'error' : 'default'}>
-                        {data.filter_inscriptions && data.reaper ? 'Filtered' : 'Allowed'}
-                      </Badge>
-                    </div>
-                    <div className="flex items-center justify-between">
-                      <span className="text-gray-400">BRC-20</span>
-                      <Badge variant={data.filter_brc20 && data.reaper ? 'error' : 'default'}>
-                        {data.filter_brc20 && data.reaper ? 'Filtered' : 'Allowed'}
-                      </Badge>
-                    </div>
-                    <div className="flex items-center justify-between">
-                      <span className="text-gray-400">Runes</span>
-                      <Badge variant={data.filter_runes && data.reaper ? 'error' : 'default'}>
-                        {data.filter_runes && data.reaper ? 'Filtered' : 'Allowed'}
-                      </Badge>
-                    </div>
-                  </div>
-                  <div className="border-t border-gray-700 pt-3 space-y-2">
-                    <div className="flex items-center justify-between">
-                      <span className="text-gray-400">Max Witness Size</span>
-                      <span className="text-gray-100">{data.max_witness_size.toLocaleString()} bytes</span>
-                    </div>
-                    <div className="flex items-center justify-between">
-                      <span className="text-gray-400">Dust Limit</span>
-                      <span className="text-gray-100">{data.dust_limit.toLocaleString()} sats</span>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              {data.reaper && (
-                <div className="p-4 rounded-lg bg-green-900/20 border border-green-800">
-                  <p className="text-sm text-green-300">
-                    With these settings, your node will actively filter non-financial transactions
-                    from its mempool and earn +2 shares in the node reward pool.
-                  </p>
-                </div>
-              )}
+            <div className="p-4 rounded-lg bg-gray-800/50 space-y-4">
+              <h4 className="text-gray-100 font-medium">Thresholds</h4>
+              <Input label="Max OP_RETURN bytes (shared)" type="number" value={data.max_op_return_bytes}
+                onChange={(e) => setData({ max_op_return_bytes: Number(e.target.value) })} disabled={!data.enabled} />
+              <Input label="Min drop-stuffing push size (shared)" type="number" value={data.min_drop_size}
+                onChange={(e) => setData({ min_drop_size: Number(e.target.value) })} disabled={!data.enabled} />
+              <Input label="Min excess-witness bytes (pool)" type="number" value={data.min_excess_witness_bytes}
+                onChange={(e) => setData({ min_excess_witness_bytes: Number(e.target.value) })} disabled={!data.enabled} />
+              <Input label="Legacy max push bytes (pool)" type="number" value={data.legacy_max_push_bytes}
+                onChange={(e) => setData({ legacy_max_push_bytes: Number(e.target.value) })} disabled={!data.enabled} />
             </div>
           )}
 
@@ -298,24 +165,25 @@ export default function ReaperWizard({ isOpen, onClose }: ReaperWizardProps) {
           {wizard.currentStep === 3 && (
             <div className="space-y-4">
               <div className="p-4 rounded-lg bg-gray-800/50">
-                <h4 className="text-gray-100 font-medium mb-3">Ready to Apply</h4>
                 <div className="flex items-center justify-between">
-                  <span className="text-gray-400">Ghost Reaper</span>
-                  <div className="flex items-center gap-2">
-                    <Badge variant={config?.reaper ? 'success' : 'default'}>
-                      {config?.reaper ? 'Enabled' : 'Disabled'}
-                    </Badge>
-                    <span className="text-gray-500">-&gt;</span>
-                    <Badge variant={data.reaper ? 'success' : 'default'}>
-                      {data.reaper ? 'Enabled' : 'Disabled'}
-                    </Badge>
-                  </div>
+                  <span className="text-gray-400">Reaper Mode</span>
+                  <Badge variant={data.enabled ? 'success' : 'default'}>{data.enabled ? 'Enabled' : 'Disabled'}</Badge>
+                </div>
+                <div className="border-t border-gray-700 mt-3 pt-3 grid grid-cols-2 gap-2 text-sm">
+                  {[...SHARED, ...NODE_ONLY, ...POOL_ONLY].map((v) => (
+                    <div key={v.key} className="flex items-center justify-between">
+                      <span className="text-gray-400">{v.label}</span>
+                      <Badge variant={data.enabled && Boolean(data[v.key]) ? 'error' : 'default'}>
+                        {data.enabled && Boolean(data[v.key]) ? 'Reject' : 'Allow'}
+                      </Badge>
+                    </div>
+                  ))}
                 </div>
               </div>
               <div className="p-4 rounded-lg bg-orange-900/20 border border-orange-800">
                 <p className="text-sm text-orange-300">
-                  Click Finish to apply the Ghost Reaper configuration.
-                  Changes will take effect immediately on your node.
+                  Click Finish to save. The pool reaper applies on the next ghost-pool restart;
+                  node-level (mempool) changes require running <code>ghost-setup apply-reaper</code>.
                 </p>
               </div>
             </div>

--- a/dashboard/src/hooks/queries/useConfigQueries.ts
+++ b/dashboard/src/hooks/queries/useConfigQueries.ts
@@ -5,6 +5,8 @@ import {
   setGhostMode,
   setArchiveMode,
   setReaper,
+  getReaper,
+  type ReaperSettings,
   setMempoolProfile,
   setTemplateProfile,
   getMempoolProfiles,
@@ -77,11 +79,18 @@ export function useSetArchiveMode() {
   });
 }
 
+export function useReaperConfig() {
+  return useQuery({
+    queryKey: [...configKeys.all, 'reaper'] as const,
+    queryFn: getReaper,
+  });
+}
+
 export function useSetReaper() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (enabled: boolean) => setReaper(enabled),
+    mutationFn: (input: ReaperSettings | boolean) => setReaper(input),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: configKeys.all });
     },

--- a/dashboard/src/lib/api/config.ts
+++ b/dashboard/src/lib/api/config.ts
@@ -51,10 +51,75 @@ export async function setPublicMiningConfig(enabled: boolean): Promise<NodeConfi
   });
 }
 
-export async function setReaper(enabled: boolean): Promise<NodeConfig> {
-  return fetchApi<NodeConfig>('/api/v1/config/reaper', {
+// Per-vector Ghost Reaper configuration. Field names match pool.toml [reaper].
+export interface ReaperSettings {
+  enabled: boolean;
+  // Shared (pool template reaper + ghostd mempool reaper)
+  reject_inscription: boolean;
+  reject_dropstuffing: boolean;
+  reject_fakepubkey: boolean;
+  reject_annex: boolean;
+  // Node-only (ghostd mempool reaper)
+  reject_opreturn: boolean;
+  reject_runestone: boolean;
+  // Pool-only (template reaper)
+  reject_unreachable_code: boolean;
+  reject_excess_witness: boolean;
+  reject_legacy_data_stuffing: boolean;
+  validate_pubkey_curve_point: boolean;
+  // Thresholds
+  max_op_return_bytes: number;
+  min_drop_size: number;
+  min_excess_witness_bytes: number;
+  legacy_max_push_bytes: number;
+}
+
+export interface ReaperConfigResponse {
+  enabled: boolean;
+  mode: string;
+  settings: ReaperSettings;
+  message: string;
+}
+
+export interface ReaperUpdateResponse {
+  success: boolean;
+  persisted: boolean;
+  enabled: boolean;
+  ghostd_restart_required: boolean;
+  message: string;
+}
+
+export async function getReaper(): Promise<ReaperConfigResponse> {
+  return fetchApi<ReaperConfigResponse>('/api/v1/config/reaper');
+}
+
+// All-detectors-on defaults, matching pool.toml's [reaper] serde defaults.
+export const REAPER_DEFAULTS: ReaperSettings = {
+  enabled: true,
+  reject_inscription: true,
+  reject_dropstuffing: true,
+  reject_fakepubkey: true,
+  reject_annex: true,
+  reject_opreturn: true,
+  reject_runestone: true,
+  reject_unreachable_code: true,
+  reject_excess_witness: true,
+  reject_legacy_data_stuffing: true,
+  validate_pubkey_curve_point: true,
+  max_op_return_bytes: 82,
+  min_drop_size: 76,
+  min_excess_witness_bytes: 500,
+  legacy_max_push_bytes: 80,
+};
+
+// Accepts the full per-vector settings, or a bare boolean for a coarse
+// master on/off toggle (per-vector defaults to all-on).
+export async function setReaper(input: ReaperSettings | boolean): Promise<ReaperUpdateResponse> {
+  const settings: ReaperSettings =
+    typeof input === 'boolean' ? { ...REAPER_DEFAULTS, enabled: input } : input;
+  return fetchApi<ReaperUpdateResponse>('/api/v1/config/reaper', {
     method: 'POST',
-    body: JSON.stringify({ enabled }),
+    body: JSON.stringify(settings),
   });
 }
 


### PR DESCRIPTION
Lets operators choose, **per detector**, what the Ghost Reaper rejects — instead of today's single on/off toggle. Surfaced in the node dashboard and driving **both** enforcement layers.

## Why
Both reapers already implement per-vector detectors (the Rust `ghost_reaper::ReaperConfig` fields and ghostd's `-ghostreaper-reject*` flags), but every hop from UI → config → runtime collapsed to one `enabled` bool. The dashboard wizard even collected per-filter checkboxes that were **discarded on submit**.

## What changed
- **Config** (`crates/ghost-common`): `[reaper]` (`ReaperSettings`) gains per-vector toggles + thresholds, all `#[serde(default)]` so an existing `pool.toml` (only `enabled`, or no `[reaper]`) stays all-detectors-on. Adds `ReaperSettings::ghostd_flags()` (master-gated; emits only ghostd's detectors) and `NodeConfig::load()`.
- **Pool template reaper** (`bins/ghost-pool`): `reaper_config_from_settings()` maps the settings into `ReaperConfig` instead of hardcoding all-on/all-off. Applies on the next ghost-pool restart.
- **ghostd mempool reaper** (`bins/ghost-setup`, `crates/ghost-common`): new `ghost-setup apply-reaper` writes a systemd drop-in (`ghostd_reaper_dropin()`) that re-emits ghostd's `ExecStart` with the `-ghostreaper-reject*` flags and restarts it. Operator-run under sudo (the pool runs unprivileged and can't restart ghostd); the dashboard surfaces this via `ghostd_restart_required`. The base unit's master flag is stripped+replaced by the drop-in, so it stays a sensible default when no drop-in is present.
- **Dashboard** (`dashboard/`, `crates/ghost-verification`): the `ReaperWizard` is rebuilt with the real per-vector toggles grouped **shared / node-only / pool-only**, plus thresholds. The reaper `GET`/`POST` handlers read/write the full per-vector settings on the node config (`pool.toml`), signal a ghost-pool restart, and return `ghostd_restart_required`. `DashboardConfig.reaper` stays a master bool to avoid churning the ~12 capability/share read-sites. A bare `{ "enabled": bool }` body still works (coarse master toggle).

## Vector mapping
Shared (both layers): inscription, drop-stuffing, fake-pubkey, annex. Node-only (ghostd): OP_RETURN oversize, runestone. Pool-only (Rust): unreachable-code, excess-witness, legacy-stuffing, pubkey curve check. Shared thresholds: `max_op_return_bytes` (82), `min_drop_size` (76).

## Tests / verification
- Rust: config back-compat + round-trip, settings→`ReaperConfig` mapping (incl. master-off), ghostd flag generation (master-gated, pool-only vectors omitted), drop-in render. `cargo test` green (ghost-common 217, ghost-reaper 119, ghost-pool reaper mapping), clippy + fmt clean.
- Dashboard: `tsc --noEmit` 0 errors + `npm run build` ✓.

## Notes / follow-ups
- The ghostd apply path shells out to `sudo systemctl`/`tee` and depends on the deployment's systemd unit; **validate `ghost-setup apply-reaper` on a VM before relying on it** (it was not exercised against a live ghostd here).
- TUI parity is out of scope — the node TUI lives in the separate `bitcoin-ghost` repo.