### PR TITLE
sri-translator: readiness gate to avoid upstream-not-ready restart churn

### DIFF
--- a/config/sri/sri-translator.service
+++ b/config/sri/sri-translator.service
@@ -7,6 +7,14 @@ Wants=sri-pool.service
 Type=simple
 User=ghost
 Group=ghost
+# Readiness gate: After=/Wants= only orders *start*, not readiness. pool_sv2
+# listens before it has fetched its first template from ghost-pool, and the
+# translator gives up after 3 upstream retries (CouldNotInitiateSystem) if it
+# connects too early — relying on Restart=always to recover, which churns.
+# Wait (up to ~60s) for pool_sv2's monitoring API to answer, then a short
+# settle for the first template, before connecting. Always exits 0 so it can
+# never block startup indefinitely.
+ExecStartPre=/bin/sh -c 'i=0; while [ $i -lt 30 ]; do /usr/bin/curl -sf -m2 http://127.0.0.1:9090/api/v1/clients >/dev/null 2>&1 && { sleep 10; exit 0; }; sleep 2; i=$((i+1)); done; exit 0'
 ExecStart=/opt/ghost/bin/translator_sv2 --config /etc/ghost/translator-config.toml
 Restart=always
 RestartSec=5


### PR DESCRIPTION
## Problem
When the pool stack is restarted (e.g. during a ghost-pool deploy), `pool_sv2` comes back and spends a moment fetching its first template from ghost-pool (*"Waiting for initial template and prevhash from Template Provider"*). If `sri-translator` connects during that window it burns its 3 upstream retries, logs `All upstreams failed → CouldNotInitiateSystem`, and shuts down — recovering only via `Restart=always`. That churn is what left the SV2 stack briefly unable to accept miners after this session's coordinated ghost-pool restarts.

`After=`/`Wants=` only order *start*, not *readiness*, so they don't cover this.

## Fix
Add an `ExecStartPre` to `config/sri/sri-translator.service` that polls `pool_sv2`'s monitoring API (`:9090`, reachable by the unprivileged `ghost` user) until it answers, then settles briefly for the first template, before `ExecStart`. It always `exit 0`, so it can never block startup indefinitely — `Restart=always` remains the backstop.

## Validation
Applied as a systemd drop-in on all 4 production VMs and restarted the translators: **0 `CouldNotInitiateSystem`**, clean single start (`NRestarts=0`), upstream established, `:3333` listening. Before the gate the same restart produced the failed-upstream loop.

The translator binary's "give up after 3 retries" is the root behaviour; making it retry persistently would be the deeper fix, but the readiness gate removes the practical churn without a binary change.