### PR TITLE
feat(pool): mesh-aggregated pool hashrate in mining/status

### DIFF
--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -101,6 +101,11 @@ const EXIT_CODE_RESTART: i32 = 100;
 /// See `tasks/plan_payout_address_grouping.md` for the full rollout.
 pub const PAYOUT_ADDRESS_GROUPING_HEIGHT: u64 = 946_743;
 
+/// Trailing window for the per-node realized hashrate gossiped in health pings
+/// and summed into the mesh-wide pool total. 10 minutes smooths small-miner
+/// share variance while still tracking real changes within a few minutes.
+const MESH_HASHRATE_WINDOW_SECS: i64 = 600;
+
 /// H-8 SECURITY: Static storage for ZMQ subscriber to prevent memory leak.
 /// Previously used std::mem::forget which intentionally leaked memory.
 /// Using OnceLock ensures the subscriber lives for the program lifetime
@@ -976,6 +981,21 @@ async fn main() -> Result<()> {
         db_for_active_hashes
             .active_miner_id_hashes(300)
             .unwrap_or_default()
+    }));
+
+    // Gossip THIS node's own realized hashrate (10-min trailing window) so
+    // peers can sum one term per node into a pool-wide total that's stable
+    // under load-balancer migration. Scoped by `received_by = hex(node_id[..8])`
+    // so only shares this node received directly count — replicated peer
+    // share-proofs are excluded, which is what keeps the mesh sum from
+    // double-counting (each share counted once, by its origin node).
+    let self_received_by = hex::encode(&identity.node_id()[..8]);
+    let db_for_local_hr = Arc::clone(&db);
+    let self_rx_for_provider = self_received_by.clone();
+    mesh_inner.set_local_hashrate_provider(Arc::new(move || {
+        db_for_local_hr
+            .local_hashrate_th(MESH_HASHRATE_WINDOW_SECS, &self_rx_for_provider)
+            .unwrap_or(0.0)
     }));
 
     let mesh = Arc::new(mesh_inner);
@@ -3173,6 +3193,23 @@ async fn main() -> Result<()> {
     let mesh_for_active = Arc::clone(&mesh);
     verification_state = verification_state
         .with_mesh_active_miners(move || mesh_for_active.mesh_active_miner_count(60) as u32);
+
+    // Mesh-wide pool hashrate (TH/s) — sum of every node's own realized
+    // hashrate (60s peer freshness). One term per node, scoped by received_by
+    // at source, so it can't double-count and is identical on every node.
+    let mesh_for_hashrate = Arc::clone(&mesh);
+    verification_state = verification_state
+        .with_mesh_total_hashrate(move || mesh_for_hashrate.mesh_total_hashrate(60));
+
+    // This node's own contribution to that total, surfaced as `local_hashrate_th`
+    // so the per-node and mesh figures reconcile (same windowed value it gossips).
+    let db_for_local_hr_route = Arc::clone(&db);
+    let self_rx_for_route = self_received_by.clone();
+    verification_state = verification_state.with_local_hashrate(move || {
+        db_for_local_hr_route
+            .local_hashrate_th(MESH_HASHRATE_WINDOW_SECS, &self_rx_for_route)
+            .unwrap_or(0.0)
+    });
 
     // Advertise this node's hardware-derived capacity via /api/internal/pool-nodes
     // so the colocated translator's load balancer routes by utilisation %.

--- a/crates/ghost-common/src/types.rs
+++ b/crates/ghost-common/src/types.rs
@@ -352,6 +352,16 @@ pub struct HealthPing {
     /// that don't include it deserialize to an empty Vec.
     #[serde(default, with = "ghost_common_active_hashes")]
     pub active_miner_id_hashes: Vec<[u8; 16]>,
+    /// This node's own realized hashrate (TH/s) over a trailing window,
+    /// computed from shares THIS node received directly (scoped by
+    /// `received_by`, so replicated peer share-proofs aren't counted). Peers
+    /// SUM these across the mesh for a pool-wide total: shares are partitioned
+    /// by node, so the sum can't double-count and is identical on every node,
+    /// and a miner migrating between nodes shifts work from one term to another
+    /// without changing the total. `#[serde(default)]` for backward
+    /// compatibility — older nodes that don't send it contribute 0.
+    #[serde(default)]
+    pub local_hashrate_th: f64,
     /// Hardware-derived effective miner capacity. Translator's load balancer
     /// uses `miner_count / max_capacity` to compute utilisation and route
     /// new arrivals to the under-utilised peer. 0 = pre-update node (treated
@@ -837,5 +847,48 @@ mod tests {
         let json = serde_json::to_string(&addr).unwrap();
         let parsed: TreasuryAddress = serde_json::from_str(&json).unwrap();
         assert_eq!(addr, parsed);
+    }
+
+    fn sample_health_ping() -> HealthPing {
+        HealthPing {
+            node_id: [7u8; 32],
+            public_address: String::new(),
+            block_height: 0,
+            round_id: 0,
+            capabilities: NodeCapabilities::new(),
+            miner_count: 2,
+            timestamp: 1,
+            pow_proof: None,
+            active_miner_id_hashes: vec![[1u8; 16], [2u8; 16]],
+            local_hashrate_th: 4.0,
+            max_capacity: 0,
+        }
+    }
+
+    #[test]
+    fn health_ping_hashrate_roundtrip() {
+        let ping = sample_health_ping();
+        let json = serde_json::to_string(&ping).unwrap();
+        let back: HealthPing = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.local_hashrate_th, 4.0);
+        assert_eq!(back.active_miner_id_hashes.len(), 2);
+    }
+
+    #[test]
+    fn health_ping_deserializes_without_hashrate_field() {
+        // Emulate an OLDER node's ping that predates `local_hashrate_th`:
+        // serialize, strip the field, and confirm it defaults to 0.0 (and the
+        // rest of the ping is unaffected). Proves the wire change is additive.
+        let ping = sample_health_ping();
+        let mut v = serde_json::to_value(&ping).unwrap();
+        assert!(v
+            .as_object_mut()
+            .unwrap()
+            .remove("local_hashrate_th")
+            .is_some());
+        let back: HealthPing = serde_json::from_value(v).unwrap();
+        assert_eq!(back.local_hashrate_th, 0.0);
+        assert_eq!(back.active_miner_id_hashes.len(), 2);
+        assert_eq!(back.miner_count, 2);
     }
 }

--- a/crates/ghost-consensus/src/health_handler.rs
+++ b/crates/ghost-consensus/src/health_handler.rs
@@ -857,9 +857,13 @@ impl HealthPingHandler {
         // even when the peer address hasn't changed — these are live metrics.
         self.peers
             .update_health_metrics(&envelope.sender, ping.miner_count, ping.capabilities);
-        // Active miner_id hashes used for mesh-wide deduplicated counting.
-        self.peers
-            .update_active_miner_hashes(&envelope.sender, ping.active_miner_id_hashes.clone());
+        // Active miner_id hashes (mesh-wide dedup count) + this node's own
+        // realized hashrate (summed across the mesh for the pool total).
+        self.peers.update_active_miner_hashes(
+            &envelope.sender,
+            ping.active_miner_id_hashes.clone(),
+            ping.local_hashrate_th,
+        );
         // Hardware-derived capacity used by the LB for utilisation routing.
         self.peers
             .update_max_capacity(&envelope.sender, ping.max_capacity);

--- a/crates/ghost-consensus/src/mesh.rs
+++ b/crates/ghost-consensus/src/mesh.rs
@@ -234,6 +234,10 @@ pub struct MeshNetwork {
     /// to gossip the local active set so peers can compute a deduplicated
     /// mesh-wide active miner count.
     active_miner_hashes_fn: Option<Arc<dyn Fn() -> Vec<[u8; 16]> + Send + Sync>>,
+    /// Application-provided callback returning this node's own realized
+    /// hashrate (TH/s) over a trailing window. Gossiped in health pings so
+    /// peers can SUM one term per node into a pool-wide total.
+    local_hashrate_fn: Option<Arc<dyn Fn() -> f64 + Send + Sync>>,
     /// Hardware-derived effective capacity advertised in health pings.
     /// `0` means we haven't computed it yet (mesh started before capacity
     /// init); peers treat it as unknown and skip utilisation routing for us.
@@ -1046,6 +1050,7 @@ impl MeshNetwork {
             noise_pool,
             miner_count_fn: None,
             active_miner_hashes_fn: None,
+            local_hashrate_fn: None,
             max_capacity: AtomicU32::new(0),
         })
     }
@@ -1091,6 +1096,37 @@ impl MeshNetwork {
             }
         }
         set.len()
+    }
+
+    /// Set a callback providing this node's own realized hashrate (TH/s) over a
+    /// trailing window, gossiped in health pings for mesh-wide summation.
+    pub fn set_local_hashrate_provider(&mut self, f: Arc<dyn Fn() -> f64 + Send + Sync>) {
+        self.local_hashrate_fn = Some(f);
+    }
+
+    /// Compute the mesh-wide pool hashrate (TH/s): this node's own realized
+    /// hashrate plus the most recent value reported by every peer whose
+    /// `last_seen` is within `freshness_secs`.
+    ///
+    /// This is a plain sum of one term per node — NOT a per-miner dedup —
+    /// because every share is recorded on exactly one node (scoped by
+    /// `received_by` at the source), so the per-node values are disjoint and
+    /// cannot double-count. The result is therefore identical on every node,
+    /// and a miner migrating between nodes shifts work from one term to another
+    /// without changing the total. (The earlier per-miner `local`-always-wins
+    /// approach produced inconsistent, inflated totals under migration.)
+    pub fn mesh_total_hashrate(&self, freshness_secs: u64) -> f64 {
+        let local = self.local_hashrate_fn.as_ref().map(|f| f()).unwrap_or(0.0);
+        let peers = self.peers.get_connected_peers(freshness_secs);
+        Self::compute_mesh_total_hashrate(local, peers.iter().map(|p| p.local_hashrate_th))
+    }
+
+    /// Pure sum behind [`Self::mesh_total_hashrate`], split out for unit
+    /// testing without a live `MeshNetwork`. Negative inputs are clamped to 0
+    /// so a stray `-0.0`/garbage term can't drag the total below zero.
+    pub(crate) fn compute_mesh_total_hashrate(local: f64, peers: impl Iterator<Item = f64>) -> f64 {
+        let total = local.max(0.0) + peers.map(|hr| hr.max(0.0)).sum::<f64>();
+        total.max(0.0)
     }
 
     /// Create a new mesh network (infallible, panics on failure)
@@ -2537,6 +2573,15 @@ impl MeshNetwork {
             // Create and broadcast health ping with actual node capabilities
             // Include PoW proof for Sybil resistance
             let pow_proof = self.identity.pow_proof().map(|p| (p.nonce, p.difficulty));
+            // Active miner id-hashes feed the deduped mesh-wide active count;
+            // `local_hashrate_th` is this node's own realized hashrate, summed
+            // (one term per node) into the pool-wide total.
+            let active_miner_id_hashes = self
+                .active_miner_hashes_fn
+                .as_ref()
+                .map(|f| f())
+                .unwrap_or_default();
+            let local_hashrate_th = self.local_hashrate_fn.as_ref().map(|f| f()).unwrap_or(0.0);
             let ping = ghost_common::types::HealthPing {
                 node_id: self.identity.node_id(),
                 public_address: String::new(), // S-7: Don't broadcast IP in cleartext ZMQ
@@ -2550,11 +2595,8 @@ impl MeshNetwork {
                     .unwrap_or(self.peers.peer_count() as u32),
                 timestamp: chrono::Utc::now().timestamp_millis() as u64,
                 pow_proof,
-                active_miner_id_hashes: self
-                    .active_miner_hashes_fn
-                    .as_ref()
-                    .map(|f| f())
-                    .unwrap_or_default(),
+                active_miner_id_hashes,
+                local_hashrate_th,
                 max_capacity: self.max_capacity.load(Ordering::Relaxed),
             };
 
@@ -3691,5 +3733,47 @@ mod tests {
             message_type_requires_noise(MessageType::MpcParametersResponse),
             "MpcParametersResponse must use Noise"
         );
+    }
+
+    #[test]
+    fn mesh_hashrate_sums_one_term_per_node() {
+        // Local node 1.0 + two peers 2.0, 3.0 => 6.0. One term per node.
+        let total = MeshNetwork::compute_mesh_total_hashrate(1.0, [2.0, 3.0].into_iter());
+        assert!((total - 6.0).abs() < 1e-9, "expected 6.0, got {total}");
+    }
+
+    #[test]
+    fn mesh_hashrate_total_invariant_under_migration() {
+        // The whole point of the redesign: a miner migrating between two nodes
+        // shifts work from one node's term to another's; the fleet total is
+        // unchanged and identical regardless of where the miner sits. We model
+        // a 4-node fleet whose true total is 10.0 and move 2.0 of hashrate from
+        // node B to node C — the sum must stay 10.0 in both arrangements.
+        let before = MeshNetwork::compute_mesh_total_hashrate(1.0, [5.0, 1.0, 3.0].into_iter());
+        let after = MeshNetwork::compute_mesh_total_hashrate(1.0, [3.0, 3.0, 3.0].into_iter());
+        assert!((before - 10.0).abs() < 1e-9, "before={before}");
+        assert!((after - 10.0).abs() < 1e-9, "after={after}");
+        assert!(
+            (before - after).abs() < 1e-9,
+            "migration must not change the total: {before} vs {after}"
+        );
+    }
+
+    #[test]
+    fn mesh_hashrate_old_peer_contributes_zero() {
+        // Backward compat: an older peer that doesn't report hashrate sends the
+        // serde-default 0.0, so it simply adds nothing.
+        let total = MeshNetwork::compute_mesh_total_hashrate(4.0, [0.0, 0.0].into_iter());
+        assert!(
+            (total - 4.0).abs() < 1e-9,
+            "expected only local 4.0, got {total}"
+        );
+    }
+
+    #[test]
+    fn mesh_hashrate_clamps_negative_terms() {
+        // A stray -0.0 / garbage term can't drag the total below the real sum.
+        let total = MeshNetwork::compute_mesh_total_hashrate(-0.0, [5.0, -2.0].into_iter());
+        assert!((total - 5.0).abs() < 1e-9, "expected 5.0, got {total}");
     }
 }

--- a/crates/ghost-consensus/src/peer.rs
+++ b/crates/ghost-consensus/src/peer.rs
@@ -214,11 +214,20 @@ impl PeerManager {
         }
     }
 
-    /// Replace the active miner_id hash list for a peer with the most recent
-    /// from a health ping. Used for mesh-wide deduplicated active counting.
-    pub fn update_active_miner_hashes(&self, node_id: &NodeId, hashes: Vec<[u8; 16]>) {
+    /// Replace the active miner_id hash list and the peer's own realized
+    /// hashrate with the most recent from a health ping. The hashes feed the
+    /// mesh-wide deduplicated active count; `local_hashrate_th` is summed
+    /// (one term per node) for the pool-wide hashrate. Older peers that don't
+    /// report hashrate pass `0.0`.
+    pub fn update_active_miner_hashes(
+        &self,
+        node_id: &NodeId,
+        hashes: Vec<[u8; 16]>,
+        local_hashrate_th: f64,
+    ) {
         if let Some(peer) = self.peers.write().get_mut(node_id) {
             peer.active_miner_id_hashes = hashes;
+            peer.local_hashrate_th = local_hashrate_th;
         }
     }
 
@@ -314,6 +323,10 @@ pub struct Peer {
     /// last ~5 min, from the most recent health ping. Used for mesh-wide
     /// deduplicated active-miner counting.
     pub active_miner_id_hashes: Vec<[u8; 16]>,
+    /// This peer's own realized hashrate (TH/s) over a trailing window, from
+    /// its most recent health ping. Summed across the mesh (one term per node)
+    /// for the pool-wide hashrate. 0 for older peers that don't report it.
+    pub local_hashrate_th: f64,
     /// Peer's hardware-derived effective miner capacity, advertised in its
     /// health pings. The translator's load balancer divides `miner_count`
     /// by this value to compute utilisation and pick the under-utilised
@@ -342,6 +355,7 @@ impl Peer {
             messages_sent: 0,
             miner_count: 0,
             active_miner_id_hashes: Vec::new(),
+            local_hashrate_th: 0.0,
             max_capacity: 0,
         }
     }

--- a/crates/ghost-storage/src/queries.rs
+++ b/crates/ghost-storage/src/queries.rs
@@ -2351,6 +2351,40 @@ impl Database {
         })
     }
 
+    /// This node's own realized hashrate (TH/s) over a trailing `window_secs`,
+    /// as a windowed rate: `SUM(work) * 2^32 / window_secs / 1e12`.
+    ///
+    /// Scoped to shares THIS node received directly via `received_by` — local
+    /// shares store `received_by = hex(node_id[..8])` (16 hex chars), whereas
+    /// replicated peer share-proofs store the 8-char `hex(origin[..4])`, so the
+    /// filter excludes replicated rows. This is essential: each node sums only
+    /// its own work, and the mesh total (sum of these across nodes) therefore
+    /// counts every share exactly once. A fixed `window_secs` denominator (not
+    /// `now - first_seen`) keeps the value stable and additive across nodes —
+    /// a miner present for only part of the window contributes proportionally,
+    /// which is correct for a fleet rate and avoids the per-miner elapsed-clamp
+    /// that over-reported bursty/transient miners under load-balancer churn.
+    pub fn local_hashrate_th(&self, window_secs: i64, received_by: &str) -> GhostResult<f64> {
+        self.with_connection(|conn| {
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs() as i64;
+            let cutoff = now - window_secs;
+            let total_work: f64 = conn
+                .query_row(
+                    "SELECT COALESCE(SUM(work), 0.0)
+                     FROM shares
+                     WHERE timestamp >= ?1 AND valid = 1 AND received_by = ?2",
+                    params![cutoff, received_by],
+                    |row| row.get::<_, f64>(0),
+                )
+                .map_err(|e| GhostError::Database(e.to_string()))?;
+            let window = window_secs.max(1) as f64;
+            Ok(total_work * 4294967296.0 / window / 1e12)
+        })
+    }
+
     /// Count miners whose `last_seen` is within the given window (seconds).
     ///
     /// Used for stable "active miners" reporting that's independent of round
@@ -8730,6 +8764,54 @@ mod tests {
             .expect("LOW-STOR-8: Failed to get shares by round");
         assert_eq!(shares.len(), 1);
         assert_eq!(shares[0].miner_id, "abc123");
+    }
+
+    #[test]
+    fn test_local_hashrate_th_excludes_replicated_peer_shares() {
+        // The mesh-wide pool hashrate sums each node's local_hashrate_th. For
+        // that sum to count every share exactly once, each node must count ONLY
+        // shares it received directly — NOT replicated peer share-proofs (which
+        // the origin node already counts). Local shares store the 16-hex
+        // received_by; replicated ones store the 8-hex origin id. This guards
+        // the double-count bug the earlier per-miner design missed.
+        let db = Database::in_memory().expect("create in-memory db");
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+        const SELF_ID: &str = "fb71fee87bb05169"; // hex(node_id[..8]) — local
+        let mk = |hash: &str, work: f64, rx: &str| ShareRecord {
+            id: None,
+            round_id: 1,
+            miner_id: "m".to_string(),
+            difficulty: work,
+            work,
+            share_hash: hash.to_string(),
+            timestamp: now - 60,
+            received_by: rx.to_string(),
+            valid: true,
+        };
+        db.insert_share(&mk("a", 1000.0, SELF_ID)).unwrap();
+        db.insert_share(&mk("b", 1000.0, SELF_ID)).unwrap();
+        db.insert_share(&mk("c", 5000.0, "849bcece")).unwrap(); // replicated peer
+
+        let window = 600i64;
+        let hr = db.local_hashrate_th(window, SELF_ID).unwrap();
+        let expected = 2000.0 * 4294967296.0 / window as f64 / 1e12; // local work only
+        assert!(
+            (hr - expected).abs() < 1e-12,
+            "local-only hashrate wrong: {hr} vs {expected}"
+        );
+        let with_peer = 7000.0 * 4294967296.0 / window as f64 / 1e12;
+        assert!(
+            (hr - with_peer).abs() > 1e-12,
+            "must NOT include replicated peer shares"
+        );
+        // Unknown received_by (no local shares) reports 0.
+        assert_eq!(
+            db.local_hashrate_th(window, "deadbeefdeadbeef").unwrap(),
+            0.0
+        );
     }
 
     #[test]

--- a/crates/ghost-verification/src/routes.rs
+++ b/crates/ghost-verification/src/routes.rs
@@ -1581,6 +1581,14 @@ async fn api_mining_status_handler(
         .and_then(|db| db.count_active_miners(300).ok())
         .unwrap_or(0);
     let mesh_active_miners = state.mesh_active_miners().unwrap_or(active_miners);
+    // Pool-wide hashrate (sum of every node's own realized hashrate) is the
+    // figure operators expect: it stays put when the load balancer migrates a
+    // miner between nodes. Falls back to the node-local sum on older deploys
+    // without the mesh provider. `local_hashrate_th` shows this node's own
+    // contribution (the same windowed value it gossips), so the per-node and
+    // mesh figures reconcile.
+    let mesh_hashrate_th = state.mesh_total_hashrate().unwrap_or(total_hashrate_th);
+    let local_hashrate_th = state.local_hashrate().unwrap_or(total_hashrate_th);
 
     Json(serde_json::json!({
         // Backend fields
@@ -1589,7 +1597,7 @@ async fn api_mining_status_handler(
         "block_height": health.block_height,
         "round_id": health.round_id,
         "miner_count": health.miner_count,
-        "total_hashrate": total_hashrate_th,
+        "total_hashrate": mesh_hashrate_th,
         "shares_this_round": health.capabilities.total_shares,
         "difficulty": 1.0,
         "best_hash": null,
@@ -1598,8 +1606,10 @@ async fn api_mining_status_handler(
         "enabled": true,
         "private_mining": config.private_mining.unwrap_or(false),
         "public_mining": health.capabilities.public_mining,
-        "hashrate_th": total_hashrate_th,
-        "connected_miners": health.miner_count,
+        "hashrate_th": mesh_hashrate_th,
+        "local_hashrate_th": local_hashrate_th,
+        "connected_miners": mesh_active_miners,
+        "local_connected_miners": health.miner_count,
         "active_miners": active_miners,
         "mesh_active_miners": mesh_active_miners,
         "shares_submitted": shares_submitted,

--- a/crates/ghost-verification/src/server.rs
+++ b/crates/ghost-verification/src/server.rs
@@ -940,6 +940,16 @@ pub struct VerificationState {
     /// count that's stable across the round rotations and load-balancer
     /// hopping that make per-VM counts misleading when summed.
     get_mesh_active_miners: Option<Box<dyn Fn() -> u32 + Send + Sync>>,
+    /// Mesh-wide pool hashrate (TH/s): sum of every node's own realized
+    /// hashrate (one term per node, scoped by `received_by` at source so it
+    /// can't double-count), so load-balancer migrations don't crater or inflate
+    /// the figure. None on older deploys without the mesh provider wired up —
+    /// callers fall back to the node-local value.
+    get_mesh_total_hashrate: Option<Box<dyn Fn() -> f64 + Send + Sync>>,
+    /// This node's own realized hashrate (TH/s) over the trailing window — the
+    /// exact term it contributes to `get_mesh_total_hashrate`. Surfaced as
+    /// `local_hashrate_th` so the per-node and mesh figures reconcile.
+    get_local_hashrate: Option<Box<dyn Fn() -> f64 + Send + Sync>>,
     /// Signal to trigger graceful restart (set by config update API)
     /// When true, main.rs will initiate shutdown and exit with code 100
     pub restart_signal: Arc<AtomicBool>,
@@ -1109,6 +1119,8 @@ impl VerificationState {
             get_pool_peers: None,
             get_reaper_stats: None,
             get_mesh_active_miners: None,
+            get_mesh_total_hashrate: None,
+            get_local_hashrate: None,
             // VF-C2: Default to requiring internal auth for security
             require_internal_auth: true,
             restart_signal: Arc::new(AtomicBool::new(false)),
@@ -1589,6 +1601,30 @@ impl VerificationState {
     /// callback has been wired up (older deploys without the mesh provider).
     pub fn mesh_active_miners(&self) -> Option<u32> {
         self.get_mesh_active_miners.as_ref().map(|f| f())
+    }
+
+    /// Set the mesh-wide pool hashrate (TH/s) callback.
+    pub fn with_mesh_total_hashrate(mut self, f: impl Fn() -> f64 + Send + Sync + 'static) -> Self {
+        self.get_mesh_total_hashrate = Some(Box::new(f));
+        self
+    }
+
+    /// Returns the mesh-wide pool hashrate (TH/s), or None if no callback has
+    /// been wired up (older deploys without the mesh provider).
+    pub fn mesh_total_hashrate(&self) -> Option<f64> {
+        self.get_mesh_total_hashrate.as_ref().map(|f| f())
+    }
+
+    /// Set this node's own realized-hashrate (TH/s) callback.
+    pub fn with_local_hashrate(mut self, f: impl Fn() -> f64 + Send + Sync + 'static) -> Self {
+        self.get_local_hashrate = Some(Box::new(f));
+        self
+    }
+
+    /// Returns this node's own realized hashrate (TH/s) — its contribution to
+    /// the mesh total — or None if no callback has been wired up.
+    pub fn local_hashrate(&self) -> Option<f64> {
+        self.get_local_hashrate.as_ref().map(|f| f())
     }
 
     /// Set archive handler


### PR DESCRIPTION
## Problem

The node dashboard's headline hashrate and connected-miner count are computed from the **local node only** (`get_all_miners_stats()` / `health.miner_count` in `mining/status`). The mesh TCP load balancer routinely migrates miners between nodes, so when a miner moves off the node you're viewing, the figures crater even though the miner is healthy and hashing normally. This reads as "my miners are running a lot slower than normal" when nothing is actually wrong.

`mesh_active_miners` already solves this for the *count* (deduplicated across the mesh via health-ping gossip). This change extends the same proven path to **hashrate**.

## Approach

- `HealthPing` carries `active_miner_hashrates: Vec<f64>`, aligned 1:1 with the existing `active_miner_id_hashes`. Additive and `#[serde(default)]`, so the wire change is **backward-compatible** — older nodes deserialise it to empty and ignore the field, and no coordinated restart is required.
- `mesh_total_hashrate()` sums per-miner hashrate across the local node and every fresh peer, **deduplicated by id-hash with the freshest ping winning** — a miner that briefly appears on two nodes mid-migration is counted once, not doubled. The dedup logic is split into a pure `compute_mesh_total_hashrate` and unit-tested.
- `mining/status` emits the mesh figure for `total_hashrate`/`hashrate_th` and the deduplicated mesh count for `connected_miners`. Node-local values are retained as `local_hashrate_th` / `local_connected_miners` for per-node debugging.
- Per-miner hashrate uses the **same formula** already in `mining/status` (`SUM(work) * 2^32 / elapsed / 1e12`, elapsed clamped `[300, 1800]`).

## Scope

Headline numbers only. The per-worker `miners/full` table remains node-local (a unified fleet view is a larger, separate change with a privacy trade-off).

## Tests

6 new (2 `HealthPing` serde backward-compat, 4 `mesh_total_hashrate` dedup incl. the migrating-miner-counts-once case) plus all existing tests in the touched crates green. `cargo clippy` clean; release build green.