### PR TITLE
ci: ignore bitcoin-core IPC integration tests in coverage

### DIFF
--- a/tests/integration-sv2/tests/bitcoin_core_ipc_integration.rs
+++ b/tests/integration-sv2/tests/bitcoin_core_ipc_integration.rs
@@ -7,6 +7,11 @@ use jd_client_sv2::config::ConfigJDCMode;
 use stratum_apps::stratum_core::{common_messages_sv2::*, job_declaration_sv2::*};
 
 // Pool propagates block via IPC
+// Requires a real bitcoin-core/ghostd binary with IPC (`start_bitcoin_core`),
+// which isn't available in CI — the Test job runs only `--lib --bins` + selected
+// integration targets, but `cargo llvm-cov` (Coverage) runs `--tests` and would
+// otherwise fail here. Run locally with `--ignored` against a built node.
+#[ignore = "requires a bitcoin-core/ghostd IPC harness; run with --ignored"]
 #[tokio::test]
 async fn pool_propagates_block_with_bitcoin_core_ipc() {
     start_tracing();
@@ -46,6 +51,8 @@ async fn pool_propagates_block_with_bitcoin_core_ipc() {
 }
 
 // JDC propagates block via IPC (PushSolution blocked to ensure IPC path)
+// See note above: needs a real bitcoin-core/ghostd IPC harness, not in CI.
+#[ignore = "requires a bitcoin-core/ghostd IPC harness; run with --ignored"]
 #[tokio::test]
 async fn jdc_propagates_block_with_bitcoin_core_ipc() {
     start_tracing();
@@ -125,6 +132,8 @@ async fn jdc_propagates_block_with_bitcoin_core_ipc() {
 }
 
 // JDC solo mining mode with BitcoinCoreIpc (mode = SOLOMINING, no upstreams)
+// See note above: needs a real bitcoin-core/ghostd IPC harness, not in CI.
+#[ignore = "requires a bitcoin-core/ghostd IPC harness; run with --ignored"]
 #[tokio::test]
 async fn jdc_solo_mining_with_bitcoin_core_ipc() {
     start_tracing();


### PR DESCRIPTION
## Problem

The **Coverage** CI job has failed on **every push to `main`** (PR #14, #15, #16, #27 merges all red). The only failing tests are three in `tests/integration-sv2/tests/bitcoin_core_ipc_integration.rs`:

- `pool_propagates_block_with_bitcoin_core_ipc`
- `jdc_propagates_block_with_bitcoin_core_ipc`
- `jdc_solo_mining_with_bitcoin_core_ipc`

They each spawn a **real bitcoin-core/ghostd node** via `start_bitcoin_core(...)` and talk IPC — infrastructure that isn't available in CI. This is the *only* integration-sv2 file using a real node; everything else uses mocks / `TemplateProvider`.

The **Test** job already skips them: it runs `cargo test --lib --bins` plus *selected* integration targets (`--test integration`, wraith). But the **Coverage** job runs `cargo llvm-cov` = `cargo test --tests` (all targets), so it runs and fails them.

## Fix

Mark the three `#[ignore]` (with a reason), matching the existing precedent in `jds_block_propagation.rs`. Coverage now skips them, so the job goes green. They remain runnable locally with `--ignored` against a built node.

Verified locally: `cargo test -p integration_tests_sv2 --test bitcoin_core_ipc_integration` → `0 passed; 0 failed; 3 ignored`.

Note: Coverage only runs on push-to-`main` (it's "skipping" on PRs), so this PR's checks won't exercise it — the fix is validated by the local ignored-run above and will show green on the post-merge `main` run.