### PR TITLE
ci: scope coverage to --lib --bins (skip infra integration tests)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,12 @@ jobs:
       - uses: taiki-e/install-action@cargo-llvm-cov
       - run: sudo apt-get update && sudo apt-get install -y $LINUX_DEPS
       - name: Generate coverage
-        run: cargo llvm-cov $WORKSPACE_EXCLUDES --lcov --output-path lcov.info
+        # Match the Test job's selection (`--lib --bins`). The default `--tests`
+        # also runs the `[[test]]` integration targets, several of which need
+        # external infrastructure (a real bitcoin-core/ghostd node, a running
+        # stratum server, a live cluster) that isn't available in CI — those
+        # are exercised separately, not in the coverage gate.
+        run: cargo llvm-cov $WORKSPACE_EXCLUDES --lib --bins --lcov --output-path lcov.info
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:


### PR DESCRIPTION
## Problem

The **Coverage** job fails on every push to `main`. Root cause is structural, not a single bad test: `cargo llvm-cov` defaults to `--tests`, which runs **every `[[test]]` integration target** in the workspace. Several need external infrastructure absent in CI:

- `bitcoin_core_ipc_integration` — spawns a real bitcoin-core/ghostd node (addressed by #28, now `#[ignore]`)
- `sv1_minerd`-based targets — need a running stratum server (`Connection refused 127.0.0.1:…`)
- cluster-chaos tests — need a live multi-node cluster

The **Test** job is green because it runs only `cargo test --lib --bins` (plus a couple of explicitly-selected targets), never the broad `--tests` set.

## Fix

Scope the coverage run to `--lib --bins`, matching the Test job's green selection. The integration targets aren't part of the coverage gate in practice and are exercised separately.

```diff
- cargo llvm-cov $WORKSPACE_EXCLUDES --lcov --output-path lcov.info
+ cargo llvm-cov $WORKSPACE_EXCLUDES --lib --bins --lcov --output-path lcov.info
```

This is guaranteed green: the Test job already runs `cargo test --lib --bins $WORKSPACE_EXCLUDES` successfully every run; llvm-cov instruments the same set. Coverage only runs on push-to-`main`, so this PR's checks won't exercise it — validated on the post-merge run.

Builds on #28 (keeps the `#[ignore]` on the IPC tests as correct/harmless).