### PR TITLE
fix(web): stop quadruple-counting pool hashrate across nodes

### DIFF
--- a/ghost-web/core.html
+++ b/ghost-web/core.html
@@ -644,7 +644,12 @@
     var hashrate = 0, maxActive = 0, mesh = null, height = 0, blocksFound = 0;
     all.forEach(function (r) {
       if (!r) return;
-      hashrate += r.total_hashrate || 0;
+      // Sum per-node `local_hashrate_th` (each node's own contribution), NOT
+      // `total_hashrate` — post-PR#27 every node reports the mesh-wide pool
+      // total there, so summing it across 4 nodes ~4x's the real figure.
+      hashrate += (typeof r.local_hashrate_th === 'number')
+        ? r.local_hashrate_th
+        : (r.total_hashrate || 0);
       var a = r.active_miners || 0;
       if (a > maxActive) maxActive = a;
       if (typeof r.mesh_active_miners === 'number' && (mesh === null || r.mesh_active_miners > mesh)) mesh = r.mesh_active_miners;

--- a/ghost-web/index.html
+++ b/ghost-web/index.html
@@ -569,7 +569,12 @@
         results.forEach(function (r) {
           if (!r) return;
           online++;
-          hash += r.total_hashrate || 0;
+          // Sum per-node `local_hashrate_th` (each node's own contribution),
+          // NOT `total_hashrate` — post-PR#27 every node reports the mesh-wide
+          // pool total there, so summing across 4 nodes ~4x's the real figure.
+          hash += (typeof r.local_hashrate_th === 'number')
+            ? r.local_hashrate_th
+            : (r.total_hashrate || 0);
           if (r.block_height && r.block_height > height) height = r.block_height;
           var a = r.active_miners || 0;
           if (a > maxActive) maxActive = a;

--- a/ghost-web/pool.html
+++ b/ghost-web/pool.html
@@ -632,7 +632,15 @@
       var hashrate = 0, blocks = 0, height = 0, mesh = null, maxActive = 0;
       results.forEach(function (r) {
         if (!r) return;
-        hashrate += r.total_hashrate || 0;
+        // Sum each node's OWN hashrate (`local_hashrate_th`), not
+        // `total_hashrate`. Post-PR#27 every node reports the mesh-wide pool
+        // total in `total_hashrate` (so all 4 agree), and summing those would
+        // multiply the real figure by ~4. `local_hashrate_th` is the per-node
+        // contribution and sums to the true total. Fall back to
+        // `total_hashrate` for any pre-PR#27 node (there it is still node-local).
+        hashrate += (typeof r.local_hashrate_th === 'number')
+          ? r.local_hashrate_th
+          : (r.total_hashrate || 0);
         blocks += r.blocks_found || 0;
         if (r.block_height && r.block_height > height) height = r.block_height;
         var a = r.active_miners || 0;


### PR DESCRIPTION
## Problem

The public pool page (`bitcoinghost.org/pool.html`) showed **~35 TH/s** against a true fleet of **~9 TH/s**. `pool.html`, `core.html` and `index.html` each poll all four VMs' `/api/v1/mining/status` and **summed `total_hashrate`**.

Since #27, every node reports the **mesh-wide pool total** in `total_hashrate` (so all four nodes agree on ~8.9). Summing those four therefore ~4×'s the real number. This was a regression introduced by the mesh-hashrate aggregation — before #27, `total_hashrate` was node-local, so summing it ≈ the true total.

## Fix

Sum each node's own **`local_hashrate_th`** (the per-node contribution added by #27, which sums to the true total), falling back to `total_hashrate` for any pre-#27 node where it is still node-local. This mirrors how the pages already **max** `mesh_active_miners` rather than summing it.

## Verified live (via the public proxy)

| node | total_hashrate | local_hashrate_th |
|------|----------------|-------------------|
| vm1 | 8.87 | 1.54 |
| vm2 | 8.87 | 0.00 |
| vm3 | 8.87 | 5.79 |
| vm4 | 8.90 | 1.57 |
| **sum** | **35.51** ❌ | **8.90** ✅ |

Already hot-deployed to all three pages on `bitcoinghost.org` (backups kept); this PR syncs the repo source.