### PR TITLE
ci: free runner disk before heavy Linux builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,18 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
 
+      # Free up runner disk before the heavy `--all-targets` build. The default
+      # GitHub Linux runner has ~14 GB free, which the full workspace build can
+      # exhaust ("No space left on device", intermittent). Dropping preinstalled
+      # toolchains we don't use reclaims ~20+ GB.
+      - name: Free disk space (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+                      /opt/hostedtoolcache/CodeQL /usr/local/share/boost
+          sudo docker image prune --all --force >/dev/null 2>&1 || true
+          df -h /
+
       # Install system dependencies (Linux)
       - name: Install dependencies (Linux)
         if: runner.os == 'Linux'
@@ -143,6 +155,13 @@ jobs:
           components: llvm-tools-preview
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@cargo-llvm-cov
+      # Free up runner disk before the instrumented build (see Test job note).
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+                      /opt/hostedtoolcache/CodeQL /usr/local/share/boost
+          sudo docker image prune --all --force >/dev/null 2>&1 || true
+          df -h /
       - run: sudo apt-get update && sudo apt-get install -y $LINUX_DEPS
       - name: Generate coverage
         # Match the Test job's selection (`--lib --bins`). The default `--tests`


### PR DESCRIPTION
Adds a disk-cleanup step to the Test (Linux) and Coverage jobs to fix intermittent `No space left on device` failures during the full `--all-targets` build (seen on PR #30's ubuntu run). Removes unused preinstalled toolchains (~20+ GB reclaimed). CI-only; no code change.