### PR TITLE
fix(consensus): GHOST-04 — adapt BFT voter floor (payout quorum can form)

### DIFF
--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -1232,10 +1232,20 @@ async fn main() -> Result<()> {
     // Create vote handler with callbacks and shared ban manager
     // 4.5 SECURITY: Rate limiter persistence is now enabled by default to prevent
     // attackers from bypassing rate limits by triggering node restarts.
-    // BFT voter threshold: mainnet requires 7 (f=2), non-mainnet allows 3 (f=1)
+    // GHOST-04: adapt the BFT voter floor to the registered elder set, clamped
+    // to [4, 7]. At the bootstrap 4-elder set this is 4 (f=1, 3-of-4 quorum) so
+    // payout consensus can actually FORM — a hard floor of 7 made mainnet payout
+    // voting impossible below 7 elders. It rises to 7 (f=2) as the set grows,
+    // capped at the long-term target; requiring the full registered set (up to
+    // 7) keeps a small-N quorum from being unsafe. NOTE: computed once at start;
+    // restart after the elder set changes materially.
     let rate_limiter_path = data_dir.join("rate_limiter.json");
     let vote_config = VoteHandlerConfig {
-        min_voters_for_bft: if is_mainnet_round { 7 } else { 3 },
+        min_voters_for_bft: if is_mainnet_round {
+            (db.get_mpc_elder_count().unwrap_or(0) as usize).clamp(4, 7)
+        } else {
+            3
+        },
         ..VoteHandlerConfig::default()
     };
     // Create proposal store callback so remote nodes store proposal data

--- a/crates/ghost-consensus/src/voting.rs
+++ b/crates/ghost-consensus/src/voting.rs
@@ -184,6 +184,12 @@ pub struct VotingSession {
     pub timeout_ms: u64,
     /// Eligible voters (node IDs)
     pub eligible_voters: HashSet<NodeId>,
+    /// GHOST-04: minimum voters this session requires for BFT — the floor used
+    /// at formation, and the threshold the mid-session invalidation check uses
+    /// to decide whether the session is still decidable. Stored (rather than
+    /// using the const) so a smaller bootstrap floor than MIN_VOTERS_FOR_BFT
+    /// doesn't get instantly suspended by the const-based check.
+    min_voters: usize,
     /// Votes received (stores full vote including signature for equivocation detection)
     pub votes: HashMap<NodeId, Vote>,
     /// Result (if decided)
@@ -276,6 +282,7 @@ impl VotingSession {
             started: Instant::now(),
             timeout_ms, // MED-CONS-1: Use the validated timeout directly (no clamping)
             eligible_voters,
+            min_voters,
             votes: HashMap::new(),
             result: None,
             equivocations: Vec::new(),
@@ -553,11 +560,14 @@ impl VotingSession {
         // Remove their vote if present
         let had_vote = self.votes.remove(node_id).is_some();
 
-        // H-13: Check if remaining voters dropped below minimum for BFT
-        if self.eligible_voters.len() < Self::MIN_VOTERS_FOR_BFT {
+        // H-13: Check if remaining voters dropped below minimum for BFT.
+        // GHOST-04: use this session's own min_voters, not the const, so a
+        // session formed with a smaller bootstrap floor isn't instantly
+        // suspended.
+        if self.eligible_voters.len() < self.min_voters {
             tracing::warn!(
                 remaining = self.eligible_voters.len(),
-                min_required = Self::MIN_VOTERS_FOR_BFT,
+                min_required = self.min_voters,
                 round_id = self.round_id,
                 voter = hex::encode(&node_id[..8]),
                 "H-13: Voter count dropped below minimum after invalidation — suspending session"
@@ -1031,6 +1041,27 @@ mod tests {
             VotingSession::MIN_VOTERS_FOR_BFT,
         )
         .expect("Test session should have enough voters")
+    }
+
+    /// GHOST-04: a 4-elder bootstrap set forms a session at a floor of 4 (so
+    /// mainnet payout consensus can actually run before the elder set reaches
+    /// 7), with a 3-of-4 (67%) quorum; a 3-voter set is rejected against that
+    /// floor (fails closed). Previously the hard floor of 7 made this impossible.
+    #[test]
+    fn test_ghost04_bootstrap_floor_of_four() {
+        let four: HashSet<NodeId> = (0..4u8).map(|i| [i; 32]).collect();
+        let session = VotingSession::new(1, [0u8; 32], VoteType::PayoutApproval, four, 5000, 4)
+            .expect("session forms at the 4-elder bootstrap floor");
+        assert_eq!(session.threshold(), 3, "67% of 4 = 3 (f=1)");
+
+        let three: HashSet<NodeId> = (0..3u8).map(|i| [i; 32]).collect();
+        assert!(
+            matches!(
+                VotingSession::new(2, [0u8; 32], VoteType::PayoutApproval, three, 5000, 4),
+                Err(GhostError::InsufficientVoters { .. })
+            ),
+            "a 3-voter set must be rejected against a floor of 4"
+        );
     }
 
     #[test]


### PR DESCRIPTION
GHOST-04 (audit PR #32). Mainnet hardcoded `min_voters_for_bft = 7`, but the elder set is 4 — so the payout BFT could never quorum and the BFT-voted payout path was inert. Now the floor adapts to the registered elder set, clamped to **[4, 7]**: 4 elders → floor 4 (f=1, 3-of-4 quorum); rising to 7 (f=2) as the set grows. Also stores `min_voters` on the session so the mid-session invalidation check (H-13) uses the session floor, not the const (which would instantly suspend a 4-voter session). Test added; 18 voting tests pass.

⚠️ **DO NOT DEPLOY IN ISOLATION.** Part of the coupled payout-integrity cluster (GHOST-02/03/09/11). Enabling quorum without GHOST-02 (validators recompute the proposal) and GHOST-03 (ledger convergence) means votes still approve on internal checks only. The cluster must be validated together on a multi-node regtest harness before any mainnet canary.