### PR TITLE
fix(consensus): GHOST-09 — authenticate ShareProof received_by

### DIFF
--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -3482,7 +3482,7 @@ async fn main() -> Result<()> {
             share_hash_bytes[..len].copy_from_slice(&decoded[..len]);
         }
 
-        let proof = ghost_common::types::ShareProof {
+        let mut proof = ghost_common::types::ShareProof {
             round_id,
             miner_id: miner_hash,
             difficulty: share.work,
@@ -3492,7 +3492,11 @@ async fn main() -> Result<()> {
             received_by: identity_for_shares.node_id(),
             template_id: rm_for_shares.current_template_id(),
             payout_address: share.payout_address.clone(),
+            signature: None,
         };
+        // GHOST-09: sign as the receiving node so peers can authenticate the
+        // node-reward credit and reject relayed/forged `received_by`.
+        proof.sign(identity_for_shares.as_ref());
 
         if let Err(e) = share_broadcast_tx.try_send(proof) {
             tracing::warn!(error = %e, "Share broadcast channel full or closed");

--- a/bins/ghost-pool/src/round.rs
+++ b/bins/ghost-pool/src/round.rs
@@ -1573,6 +1573,7 @@ mod tests {
             received_by: node_id,
             template_id: Some(template_id),
             payout_address: None,
+            signature: None,
         };
 
         // First submission should succeed

--- a/bins/ghost-pool/src/share_handler.rs
+++ b/bins/ghost-pool/src/share_handler.rs
@@ -74,6 +74,19 @@ impl ShareProofHandler {
             return Ok(());
         }
 
+        // GHOST-09: authenticate the node-reward credit. A remote proof must
+        // carry a valid signature by `received_by` over its canonical bytes,
+        // otherwise it's a forged or relayed credit (e.g. a relay re-crediting
+        // itself) and is dropped before it can inflate any node's shares.
+        if !proof.has_valid_received_by_signature() {
+            warn!(
+                from_node = %hex::encode(&proof.received_by[..4]),
+                round_id = proof.round_id,
+                "GHOST-09: dropping share proof with missing/invalid received_by signature"
+            );
+            return Ok(());
+        }
+
         // Timestamp freshness check
         let now = Utc::now().timestamp();
         let ts = proof.timestamp as i64;
@@ -234,6 +247,7 @@ mod tests {
             received_by: our_node_id, // Our own node
             template_id: Some([4u8; 32]),
             payout_address: None,
+            signature: None, // skipped before the GHOST-09 gate (own share)
         };
         let msg = ShareProofMessage { proof };
         let payload = serde_json::to_vec(&msg).expect("test serialization");
@@ -246,7 +260,8 @@ mod tests {
     #[tokio::test]
     async fn test_rejects_stale_timestamp() {
         let our_node_id = [1u8; 32];
-        let other_node_id = [2u8; 32];
+        let other = ghost_common::identity::NodeIdentity::generate();
+        let other_node_id = other.node_id();
         let db = Arc::new(Database::in_memory().expect("in-memory db"));
         let rm = Arc::new(RoundManager::new(
             our_node_id,
@@ -265,7 +280,10 @@ mod tests {
             received_by: other_node_id,
             template_id: Some([5u8; 32]),
             payout_address: None,
+            signature: None,
         };
+        // GHOST-09: sign as `other` so the proof passes the receive-path gate.
+        let proof = proof.signed(&other);
         let msg = ShareProofMessage { proof };
         let payload = serde_json::to_vec(&msg).expect("test serialization");
         let envelope = make_envelope(MessageType::ShareProof, payload);
@@ -277,7 +295,8 @@ mod tests {
     #[tokio::test]
     async fn test_rejects_future_timestamp() {
         let our_node_id = [1u8; 32];
-        let other_node_id = [2u8; 32];
+        let other = ghost_common::identity::NodeIdentity::generate();
+        let other_node_id = other.node_id();
         let db = Arc::new(Database::in_memory().expect("in-memory db"));
         let rm = Arc::new(RoundManager::new(
             our_node_id,
@@ -297,7 +316,10 @@ mod tests {
             received_by: other_node_id,
             template_id: Some([5u8; 32]),
             payout_address: None,
+            signature: None,
         };
+        // GHOST-09: sign as `other` so the proof passes the receive-path gate.
+        let proof = proof.signed(&other);
         let msg = ShareProofMessage { proof };
         let payload = serde_json::to_vec(&msg).expect("test serialization");
         let envelope = make_envelope(MessageType::ShareProof, payload);
@@ -309,7 +331,8 @@ mod tests {
     #[tokio::test]
     async fn test_valid_share_accepted_and_recorded() {
         let our_node_id = [1u8; 32];
-        let other_node_id = [2u8; 32];
+        let other = ghost_common::identity::NodeIdentity::generate();
+        let other_node_id = other.node_id();
         let db = Arc::new(Database::in_memory().expect("in-memory db"));
         let rm = Arc::new(RoundManager::new(
             our_node_id,
@@ -328,7 +351,10 @@ mod tests {
             received_by: other_node_id,
             template_id: Some([5u8; 32]),
             payout_address: None,
+            signature: None,
         };
+        // GHOST-09: sign as `other` so the proof passes the receive-path gate.
+        let proof = proof.signed(&other);
         let msg = ShareProofMessage { proof };
         let payload = serde_json::to_vec(&msg).expect("test serialization");
         let envelope = make_envelope(MessageType::ShareProof, payload);
@@ -344,7 +370,8 @@ mod tests {
     #[tokio::test]
     async fn test_duplicate_share_silently_ignored() {
         let our_node_id = [1u8; 32];
-        let other_node_id = [2u8; 32];
+        let other = ghost_common::identity::NodeIdentity::generate();
+        let other_node_id = other.node_id();
         let db = Arc::new(Database::in_memory().expect("in-memory db"));
         let rm = Arc::new(RoundManager::new(
             our_node_id,
@@ -362,7 +389,10 @@ mod tests {
             received_by: other_node_id,
             template_id: Some([5u8; 32]),
             payout_address: None,
+            signature: None,
         };
+        // GHOST-09: sign as `other` so the proof passes the receive-path gate.
+        let proof = proof.signed(&other);
         let msg = ShareProofMessage { proof };
         let payload = serde_json::to_vec(&msg).expect("test serialization");
 
@@ -385,7 +415,8 @@ mod tests {
     #[tokio::test]
     async fn test_miner_stats_incremented_on_valid_share() {
         let our_node_id = [1u8; 32];
-        let other_node_id = [2u8; 32];
+        let other = ghost_common::identity::NodeIdentity::generate();
+        let other_node_id = other.node_id();
         let db = Arc::new(Database::in_memory().expect("in-memory db"));
         let rm = Arc::new(RoundManager::new(
             our_node_id,
@@ -406,7 +437,9 @@ mod tests {
             received_by: other_node_id,
             template_id: Some([8u8; 32]),
             payout_address: None,
+            signature: None,
         };
+        let proof = proof.signed(&other);
         let msg = ShareProofMessage { proof };
         let payload = serde_json::to_vec(&msg).expect("test serialization");
 

--- a/crates/ghost-common/src/types.rs
+++ b/crates/ghost-common/src/types.rs
@@ -260,6 +260,56 @@ pub struct ShareProof {
     /// Payout address for the miner (needed by remote nodes that haven't seen this miner)
     #[serde(default)]
     pub payout_address: Option<String>,
+    /// GHOST-09: ed25519 signature by `received_by` over [`ShareProof::signing_bytes`].
+    /// Authenticates the node-reward credit recipient so a relayed proof can't be
+    /// re-credited to a different node. `None` on pre-GHOST-09 proofs, which fail
+    /// verification (secure by default). Stored as bytes for serde simplicity.
+    #[serde(default)]
+    pub signature: Option<Vec<u8>>,
+}
+
+impl ShareProof {
+    /// GHOST-09: canonical bytes the `received_by` node signs. Binds every
+    /// credit-relevant field, so a relay that mutates `received_by` (or the
+    /// share being credited) invalidates the signature.
+    pub fn signing_bytes(&self) -> Vec<u8> {
+        let mut m = Vec::with_capacity(120);
+        m.extend_from_slice(&self.round_id.to_le_bytes());
+        m.extend_from_slice(&self.miner_id);
+        m.extend_from_slice(&self.work.to_le_bytes());
+        m.extend_from_slice(&self.share_hash);
+        m.extend_from_slice(&self.timestamp.to_le_bytes());
+        m.extend_from_slice(&self.received_by);
+        if let Some(ref t) = self.template_id {
+            m.extend_from_slice(t);
+        }
+        m
+    }
+
+    /// GHOST-09: sign this proof as the receiving node. `received_by` must equal
+    /// `identity.node_id()` for the signature to verify on the receive side.
+    pub fn sign(&mut self, identity: &crate::identity::NodeIdentity) {
+        self.signature = Some(identity.sign(&self.signing_bytes()).to_vec());
+    }
+
+    /// GHOST-09: consume-and-sign convenience (builder/test ergonomics).
+    pub fn signed(mut self, identity: &crate::identity::NodeIdentity) -> Self {
+        self.sign(identity);
+        self
+    }
+
+    /// GHOST-09: true iff the proof carries a valid signature by `received_by`.
+    /// Unsigned (`None`) or malformed signatures return false — secure by default.
+    pub fn has_valid_received_by_signature(&self) -> bool {
+        let Some(ref sig) = self.signature else {
+            return false;
+        };
+        let Ok(sig) = <[u8; 64]>::try_from(sig.as_slice()) else {
+            return false;
+        };
+        crate::identity::verify_signature(&self.received_by, &self.signing_bytes(), &sig)
+            .unwrap_or(false)
+    }
 }
 
 /// Payout proposal for consensus
@@ -890,5 +940,67 @@ mod tests {
         assert_eq!(back.local_hashrate_th, 0.0);
         assert_eq!(back.active_miner_id_hashes.len(), 2);
         assert_eq!(back.miner_count, 2);
+    }
+
+    // ---- GHOST-09: ShareProof received_by authentication ----
+
+    fn ghost09_base_proof(received_by: NodeId) -> ShareProof {
+        ShareProof {
+            round_id: 7,
+            miner_id: [9u8; 32],
+            difficulty: 1000.0,
+            work: 1000.0,
+            share_hash: [3u8; 32],
+            timestamp: 1_700_000_000,
+            received_by,
+            template_id: Some([4u8; 32]),
+            payout_address: None,
+            signature: None,
+        }
+    }
+
+    #[test]
+    fn ghost09_honest_signed_proof_verifies() {
+        let node = crate::identity::NodeIdentity::generate();
+        let proof = ghost09_base_proof(node.node_id()).signed(&node);
+        assert!(proof.has_valid_received_by_signature());
+    }
+
+    #[test]
+    fn ghost09_unsigned_proof_rejected() {
+        let node = crate::identity::NodeIdentity::generate();
+        let proof = ghost09_base_proof(node.node_id()); // signature: None
+        assert!(
+            !proof.has_valid_received_by_signature(),
+            "an unsigned proof must not authenticate (secure by default)"
+        );
+    }
+
+    #[test]
+    fn ghost09_forged_received_by_rejected() {
+        // Attacker signs with their OWN key but claims received_by = victim to
+        // steal the victim's node-reward credit.
+        let attacker = crate::identity::NodeIdentity::generate();
+        let victim = crate::identity::NodeIdentity::generate();
+        let mut proof = ghost09_base_proof(victim.node_id());
+        proof.sign(&attacker);
+        assert!(
+            !proof.has_valid_received_by_signature(),
+            "an attacker cannot sign as the victim received_by"
+        );
+    }
+
+    #[test]
+    fn ghost09_relay_mutating_received_by_invalidates_signature() {
+        // A relay re-credits a valid proof to itself in flight.
+        let origin = crate::identity::NodeIdentity::generate();
+        let relay = crate::identity::NodeIdentity::generate();
+        let mut proof = ghost09_base_proof(origin.node_id()).signed(&origin);
+        assert!(proof.has_valid_received_by_signature());
+        proof.received_by = relay.node_id();
+        assert!(
+            !proof.has_valid_received_by_signature(),
+            "mutating received_by must break the origin's signature"
+        );
     }
 }


### PR DESCRIPTION
GHOST-09 (audit PR #32) — the **foundation of the payout-integrity cluster**. `ShareProof` had no signature field and the gossip-receive path did no verification, so `received_by` (which drives node-reward credit) was forgeable — a node could credit itself, or a relay re-credit another node's proof to itself.

Adds an ed25519 signature by `received_by` over the proof's canonical credit-bearing bytes; the originating node signs on creation and the receive path verifies against `received_by`, dropping any proof with a missing/invalid signature before it touches the ledger. `NodeId` is the verifying key (no key distribution). Unsigned ⇒ rejected (secure by default).

Tests (all green): honest signed verifies; unsigned, attacker-forged (signs claiming a victim `received_by`), and relay-mutated `received_by` all rejected. share_handler receive tests updated to sign.

⚠️ **WIRE-FORMAT CHANGE — do not deploy in isolation.** This is the base layer of the GHOST-02/03/11 cluster; needs coordinated fleet rollout + the multi-node harness in `docs/SECURITY_AUDIT_2026-06.md`.