### PR TITLE
docs: GHOST-09 fixed — audit register + cluster-plan update

### DIFF
--- a/docs/SECURITY_AUDIT_2026-06.md
+++ b/docs/SECURITY_AUDIT_2026-06.md
@@ -29,7 +29,7 @@ forgeable) · **MEDIUM** (correctness/robustness) · **LOW** (hygiene/docs).
 | GHOST-06 | MEDIUM | ghost-mpc | `verify_contribution` not called on consensus-approval path; no min-contribution / full hash-pin | PARTIAL (PR #36) — load now fails closed without a pinned BLOCK hash. Remaining: `verify_contribution` on the apply path (needs ceremony harness; future-join only) |
 | GHOST-07 | MEDIUM | ghost-pool / verification | `/api/internal/*` binds `0.0.0.0`; secret set on mainnet but bind is over-broad | RESOLVED — no change needed (already fail-closed on mainnet; secret set; bind required for mesh load-balancer polling) |
 | GHOST-08 | HIGH | ghost-zkp | `test_accept_all()` (returns `Ok(true)`) compiled into production verifiers | FIXED (PR #33, merged) — bypass branch compiled out under `zk-production` |
-| GHOST-09 | MEDIUM | ghost-consensus | `received_by` (node-reward credit) is unauthenticated → credit theft | OPEN — ShareProof has NO signature field; fix is a wire-format change (sign + verify gossiped proof). Payout-integrity cluster |
+| GHOST-09 | MEDIUM | ghost-consensus | `received_by` (node-reward credit) is unauthenticated → credit theft | FIXED (PR #40) — `ShareProof` now carries an ed25519 signature by `received_by`; receive path drops missing/invalid sigs (unsigned ⇒ rejected). Wire-format change; coordinated deploy. **This is the cluster's foundation.** |
 | GHOST-10 | MEDIUM | ghost-verification | Uptime gatekeeper only ever records `was_online=true` (no offline samples) | FIXED (PR #34, merged) — time-based liveness denominator |
 | GHOST-11 | MEDIUM | ghost-consensus | Equivocation bans are in-memory only; equivocating elder stays an eligible voter | OPEN — persistence is local but propagation is wire-format. Payout-integrity cluster |
 | GHOST-12 | MEDIUM | ghost-reconciliation | `MIN_BATCH_SIZE = 1` (comment: "MAINNET: raise back to 10") destroys batch anonymity | FIXED (PR #33, merged) — `MIN_BATCH_SIZE = 10` |
@@ -181,35 +181,41 @@ payout or a farmed reward pool.
 
 ## Remediation status (2026-06-19)
 
-9 of 13 findings are resolved or have a landed fix-PR; the remaining 4 are one coupled cluster.
+10 of 13 findings are resolved or have a landed fix-PR; the remaining 3 (GHOST-02, GHOST-03,
+GHOST-11) are one coupled cluster, now built on the GHOST-09 foundation.
 
-- **Merged to `main`:** GHOST-08, GHOST-10, GHOST-12 (PRs #33, #34) + this audit doc (#32).
-- **Fix PRs open:** GHOST-01 partial (#35), GHOST-06 partial (#36), GHOST-05 (#37), GHOST-04 (#38).
+- **Merged to `main`:** GHOST-08, GHOST-10, GHOST-12 (#33, #34), GHOST-01/06/05/04 (#35–#38),
+  audit doc + register (#32, #39).
+- **Fix PR open:** GHOST-09 signed shares (#40) — the cluster foundation.
 - **Resolved without code change:** GHOST-07, GHOST-13.
 
-### The payout-integrity cluster — GHOST-02, GHOST-03, GHOST-09, GHOST-11
+### The payout-integrity cluster — GHOST-02, GHOST-03, GHOST-11 (foundation GHOST-09 ✅)
 
 These four are **not independent patches**; they are one design that must ship and be validated
 together, because each is a change to the **gossiped consensus wire format** and they interlock:
 
-1. **GHOST-09 (signed shares)** is the foundation: `ShareProof` currently has *no* signature field,
-   so `received_by` (and `miner_id`, `work`) are forgeable. Add a node signature over the proof and
-   verify it on the gossip-receive path before crediting. *Wire-format change.*
+1. **GHOST-09 (signed shares)** — ✅ **DONE (PR #40)**, the foundation. `ShareProof` now carries an
+   ed25519 signature by `received_by`; the gossip-receive path drops missing/invalid signatures
+   before crediting (unsigned ⇒ rejected). Forged/relay-mutated `received_by` is unit-test-proven to
+   fail. *Wire-format change — coordinated deploy; the rest of the cluster builds on this.*
 2. **GHOST-03 (ledger convergence)** builds on signed shares: nodes exchange signed share-set
    digests and backfill gaps so their share ledgers actually agree before a payout vote. *Wire-format.*
 3. **GHOST-02 (proposal recompute)** depends on GHOST-03: validators recompute the payout split
    from their *own* converged ledger and reject a proposal that doesn't match, plus check the
    proposer is the real block-finder. Without GHOST-03 this would reject honest proposals.
-4. **GHOST-11 (ban propagation)** gates voter eligibility on a gossiped, persisted equivocation
-   record so a banned elder can't keep voting on one node's view. *Wire-format (propagation).*
-5. **GHOST-04 (#38)** already lets the quorum *form* at 4 elders — but quorum without 1–3 means
+4. **GHOST-11 (ban persistence + propagation).** NOTE: local enforcement already exists — a banned
+   equivocator's votes are rejected at receipt, before submission, and re-checked before a decision,
+   and its votes are invalidated in active sessions. The remaining gap is (a) **persistence** so a
+   restart doesn't forget the ban (`BanEntry` uses monotonic `Instant`; needs a wall-clock refactor +
+   DB) and (b) **propagation** so a node banned on one mesh member is banned on all. *(b) is wire-format.*
+5. **GHOST-04 (#38)** already lets the quorum *form* at 4 elders — but quorum without 2–3 means
    votes still ratify on internal checks only, so #38 must NOT deploy ahead of this cluster.
 
-**Why these aren't shipped here:** per this repo's "no half-fixes / validate before done" rule,
-blind-deploying wire-format consensus changes to the live mainnet mesh — with no multi-node test
-harness to prove honest nodes still converge and don't stall payouts — would be reckless. The
-required first step is a **regtest multi-node harness** (≥4 ghost-pool nodes, real mesh, fault
-injection) that can demonstrate: signed shares converge, an honest proposal is ratified, a forged
-`received_by` / dishonest split / divergent ledger is rejected, and a banned equivocator loses its
-vote. The cluster is then implemented against that harness and canaried (VM4 → VM3 → VM2 → VM1)
-exactly like every other consensus deploy.
+**Status:** the foundation (GHOST-09) is landed. The rest — GHOST-03 convergence, GHOST-02 recompute,
+GHOST-11 persistence+propagation — are cross-node behaviours that **cannot be meaningfully validated
+in a single process.** Per this repo's "no half-fixes / validate before done" rule, blind-deploying
+them to the live mainnet mesh would be reckless. The required next step is a **regtest multi-node
+harness** (≥4 ghost-pool nodes, real mesh, fault injection) that demonstrates: signed shares converge,
+an honest proposal is ratified, a forged `received_by` / dishonest split / divergent ledger is
+rejected, and a banned equivocator loses its vote across restarts and on peer nodes. The cluster is
+then implemented against that harness and canaried (VM4 → VM3 → VM2 → VM1) like every consensus deploy.


### PR DESCRIPTION
Marks GHOST-09 FIXED (PR #40, the cluster foundation); 10/13 resolved/PR'd. Records that GHOST-11's local ban enforcement already exists (banned nodes' votes are rejected at receipt, before submission, and re-checked before a decision), so only persistence + propagation remain. Remaining cluster = GHOST-02/03/11, gated on the multi-node regtest harness.