### PR TITLE
fix(consensus): GHOST-03 — ledger convergence (share-set reconciliation)

### DIFF
--- a/bins/ghost-pool/src/convergence.rs
+++ b/bins/ghost-pool/src/convergence.rs
@@ -1,0 +1,263 @@
+//! GHOST-03: ledger convergence.
+//!
+//! Share propagation is best-effort gossip, so a partition or a dropped
+//! broadcast leaves a node permanently missing shares — which, combined with
+//! GHOST-02, would let a divergent-but-internally-balanced payout be approved.
+//! The `ShareConvergence` request/response message types existed but were never
+//! built, sent, or handled. This module implements the protocol:
+//!
+//! 1. A node advertises the share hashes it holds for a round (a *request*).
+//! 2. A peer replies with the full **signed** proofs the requester is missing
+//!    (a *response*).
+//! 3. The requester applies each missing proof through the normal path, which
+//!    re-verifies the GHOST-09 `received_by` signature before crediting.
+//!
+//! The full signed proofs are re-servable because [`RoundManager`] retains them
+//! per round (see `recent_proofs`). Without that, a node could only detect
+//! divergence, not repair it.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+use ghost_common::error::GhostResult;
+use ghost_common::types::RoundId;
+use ghost_consensus::mesh::MessageHandler;
+use ghost_consensus::message::{
+    MessageEnvelope, MessageType, ShareConvergenceMessage, ShareConvergenceResponse,
+};
+
+use crate::round::RoundManager;
+
+/// Wire payload carried under `MessageType::ShareConvergence`. Disambiguates a
+/// reconciliation request from a response without adding a second message type
+/// (and the exhaustive `MessageType` matches that would come with it).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ConvergencePayload {
+    Request(ShareConvergenceMessage),
+    Response(ShareConvergenceResponse),
+}
+
+/// Broadcasts a serialized [`ConvergencePayload`] to the mesh under
+/// `MessageType::ShareConvergence`. Supplied by production wiring; `None` in
+/// tests that drive the exchange directly.
+pub type ConvergenceSendFn = Arc<dyn Fn(Vec<u8>) -> GhostResult<()> + Send + Sync>;
+
+/// Drives ledger convergence for one node against its [`RoundManager`].
+pub struct ConvergenceHandler {
+    round_manager: Arc<RoundManager>,
+    send: Option<ConvergenceSendFn>,
+}
+
+impl ConvergenceHandler {
+    pub fn new(round_manager: Arc<RoundManager>) -> Self {
+        Self {
+            round_manager,
+            send: None,
+        }
+    }
+
+    /// Attach the mesh broadcast used to reply to requests in production.
+    pub fn with_send(mut self, send: ConvergenceSendFn) -> Self {
+        self.send = Some(send);
+        self
+    }
+
+    /// Build a convergence REQUEST advertising the shares we hold for `round_id`.
+    pub fn build_request(&self, round_id: RoundId) -> ShareConvergenceMessage {
+        let (share_count, total_work) = self.round_manager.round_share_summary(round_id);
+        ShareConvergenceMessage {
+            round_id,
+            share_count,
+            total_work,
+            share_hashes: self.round_manager.round_share_hashes(round_id),
+        }
+    }
+
+    /// Serialize a convergence request for broadcast.
+    pub fn request_bytes(&self, round_id: RoundId) -> GhostResult<Vec<u8>> {
+        let payload = ConvergencePayload::Request(self.build_request(round_id));
+        serde_json::to_vec(&payload)
+            .map_err(|e| ghost_common::error::GhostError::P2PMessage(e.to_string()))
+    }
+
+    /// Answer a peer's request with the full signed proofs they are missing.
+    pub fn handle_request(&self, req: &ShareConvergenceMessage) -> ShareConvergenceResponse {
+        let theirs: HashSet<[u8; 32]> = req.share_hashes.iter().copied().collect();
+        let missing = self
+            .round_manager
+            .proofs_missing_from(req.round_id, &theirs);
+        let (share_count, total_work) = self.round_manager.round_share_summary(req.round_id);
+        ShareConvergenceResponse {
+            round_id: req.round_id,
+            share_count,
+            total_work,
+            missing_shares: missing,
+        }
+    }
+
+    /// Apply a convergence RESPONSE. Each backfilled proof is GHOST-09-verified
+    /// (we bypass the normal share-receive gate here, so we must re-check the
+    /// signature) and then fed through the standard validation+dedup path.
+    /// Returns the number of shares newly accepted.
+    pub fn apply_response(&self, resp: &ShareConvergenceResponse) -> usize {
+        let mut applied = 0;
+        for proof in &resp.missing_shares {
+            if !proof.has_valid_received_by_signature() {
+                continue; // GHOST-09: never credit an unsigned/forged backfill
+            }
+            if self.round_manager.handle_share_proof(proof.clone()).is_ok() {
+                applied += 1;
+            }
+        }
+        applied
+    }
+}
+
+#[async_trait]
+impl MessageHandler for ConvergenceHandler {
+    async fn handle_message(&self, envelope: Arc<MessageEnvelope>) -> GhostResult<()> {
+        // Shares and convergence share a pubsub topic; only handle convergence.
+        if envelope.msg_type != MessageType::ShareConvergence {
+            return Ok(());
+        }
+        let payload: ConvergencePayload = match serde_json::from_slice(&envelope.payload) {
+            Ok(p) => p,
+            Err(_) => return Ok(()), // not a convergence payload — ignore
+        };
+        match payload {
+            ConvergencePayload::Request(req) => {
+                let resp = self.handle_request(&req);
+                if resp.missing_shares.is_empty() {
+                    return Ok(());
+                }
+                if let Some(send) = &self.send {
+                    let bytes = serde_json::to_vec(&ConvergencePayload::Response(resp))
+                        .map_err(|e| ghost_common::error::GhostError::P2PMessage(e.to_string()))?;
+                    send(bytes)?;
+                }
+            }
+            ConvergencePayload::Response(resp) => {
+                let applied = self.apply_response(&resp);
+                if applied > 0 {
+                    tracing::info!(
+                        round_id = resp.round_id,
+                        applied,
+                        "GHOST-03: backfilled missing shares via ledger convergence"
+                    );
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::round::{RoundConfig, RoundManager};
+    use ghost_common::identity::NodeIdentity;
+    use ghost_common::types::ShareProof;
+
+    const TPL: [u8; 32] = [0x7c; 32];
+
+    /// difficulty-1.0 hash (32 leading zero bits then 0xFF); unique low nonce.
+    fn diff1_hash(nonce: u64) -> [u8; 32] {
+        let mut h = [0u8; 32];
+        h[..8].copy_from_slice(&nonce.to_le_bytes());
+        h[27] = 0xFF;
+        h
+    }
+
+    fn round_manager() -> Arc<RoundManager> {
+        let id = NodeIdentity::generate();
+        let cfg = RoundConfig {
+            share_difficulty: 1.0,
+            network_difficulty: 1_000_000.0,
+            ..RoundConfig::default()
+        };
+        let rm = Arc::new(RoundManager::new(id.node_id(), cfg));
+        rm.set_template_id(TPL);
+        rm
+    }
+
+    fn signed_share(signer: &NodeIdentity, nonce: u64) -> ShareProof {
+        let mut p = ShareProof {
+            round_id: 1,
+            miner_id: [9u8; 32],
+            difficulty: 1.0,
+            work: 1.0,
+            share_hash: diff1_hash(nonce),
+            timestamp: 0,
+            received_by: signer.node_id(),
+            template_id: Some(TPL),
+            payout_address: None,
+            signature: None,
+        };
+        p.sign(signer);
+        p
+    }
+
+    #[test]
+    fn convergence_backfills_a_missing_share() {
+        let producer = NodeIdentity::generate();
+        let rm_a = round_manager();
+        let rm_b = round_manager();
+
+        // A holds the share; B is missing it.
+        let share = signed_share(&producer, 1);
+        rm_a.handle_share_proof(share.clone()).unwrap();
+        assert!(rm_a.round_share_hashes(1).contains(&share.share_hash));
+        assert!(!rm_b.round_share_hashes(1).contains(&share.share_hash));
+
+        let ch_a = ConvergenceHandler::new(Arc::clone(&rm_a));
+        let ch_b = ConvergenceHandler::new(Arc::clone(&rm_b));
+        let request = ch_b.build_request(1); // B advertises (nothing)
+        let response = ch_a.handle_request(&request); // A returns the missing share
+        assert_eq!(ch_b.apply_response(&response), 1);
+        assert!(
+            rm_b.round_share_hashes(1).contains(&share.share_hash),
+            "B's ledger holds the share after convergence"
+        );
+    }
+
+    #[test]
+    fn convergence_rejects_a_forged_backfill() {
+        let attacker = NodeIdentity::generate();
+        let victim = NodeIdentity::generate();
+        let rm_b = round_manager();
+
+        // received_by = victim, but signed by attacker → GHOST-09 invalid.
+        let mut forged = signed_share(&victim, 2);
+        forged.sign(&attacker);
+        let resp = ShareConvergenceResponse {
+            round_id: 1,
+            share_count: 1,
+            total_work: 1.0,
+            missing_shares: vec![forged],
+        };
+        assert_eq!(
+            ConvergenceHandler::new(rm_b).apply_response(&resp),
+            0,
+            "a forged backfill is rejected (GHOST-09 re-checked on the convergence path)"
+        );
+    }
+
+    #[test]
+    fn proofs_missing_from_excludes_known_hashes() {
+        let producer = NodeIdentity::generate();
+        let rm = round_manager();
+        let s1 = signed_share(&producer, 10);
+        let s2 = signed_share(&producer, 11);
+        rm.handle_share_proof(s1.clone()).unwrap();
+        rm.handle_share_proof(s2.clone()).unwrap();
+
+        // Peer already has s1 → only s2 is "missing".
+        let known: std::collections::HashSet<[u8; 32]> = [s1.share_hash].into_iter().collect();
+        let missing = rm.proofs_missing_from(1, &known);
+        assert_eq!(missing.len(), 1);
+        assert_eq!(missing[0].share_hash, s2.share_hash);
+    }
+}

--- a/bins/ghost-pool/src/lib.rs
+++ b/bins/ghost-pool/src/lib.rs
@@ -72,6 +72,9 @@ pub mod treasury;
 /// P2P share proof handling for cross-node share propagation.
 pub mod share_handler;
 
+/// GHOST-03: ledger convergence (share-set reconciliation) between mesh nodes.
+pub mod convergence;
+
 /// GhostGlyph P2P handler for visual identity registration.
 pub mod glyph_handler;
 

--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -1447,6 +1447,61 @@ async fn main() -> Result<()> {
     mesh.register_handler(Arc::clone(&share_proof_handler)
         as Arc<dyn ghost_consensus::mesh::MessageHandler + Send + Sync>);
 
+    // GHOST-03: ledger convergence. Periodically advertise the shares we hold for
+    // the current round; peers reply with the signed proofs we were missing
+    // (drop/partition) and we apply them (re-verifying the GHOST-09 signature).
+    // `broadcast()` is async but the handler's send is sync, so outbound
+    // convergence frames go through an mpsc channel drained by a spawned task.
+    let (conv_tx, mut conv_rx) = tokio::sync::mpsc::channel::<Vec<u8>>(64);
+    {
+        let mesh_for_conv = Arc::clone(&mesh);
+        tokio::spawn(async move {
+            while let Some(bytes) = conv_rx.recv().await {
+                match mesh_for_conv
+                    .create_envelope_raw(ghost_consensus::MessageType::ShareConvergence, bytes)
+                {
+                    Ok(envelope) => {
+                        if let Err(e) = mesh_for_conv.broadcast(envelope).await {
+                            tracing::debug!(error = %e, "GHOST-03: convergence broadcast failed");
+                        }
+                    }
+                    Err(e) => tracing::warn!(error = %e, "GHOST-03: convergence envelope failed"),
+                }
+            }
+        });
+    }
+    let conv_send: ghost_pool::convergence::ConvergenceSendFn = {
+        let conv_tx = conv_tx.clone();
+        Arc::new(move |bytes| {
+            conv_tx.try_send(bytes).map_err(|e| {
+                ghost_common::error::GhostError::P2PMessage(format!("convergence channel: {e}"))
+            })
+        })
+    };
+    let convergence_handler = Arc::new(
+        ghost_pool::convergence::ConvergenceHandler::new(Arc::clone(&round_manager))
+            .with_send(conv_send),
+    );
+    mesh.register_handler(Arc::clone(&convergence_handler)
+        as Arc<dyn ghost_consensus::mesh::MessageHandler + Send + Sync>);
+    {
+        let conv_handler = Arc::clone(&convergence_handler);
+        let rm_for_conv = Arc::clone(&round_manager);
+        let conv_tx = conv_tx.clone();
+        tokio::spawn(async move {
+            const CONVERGENCE_INTERVAL_SECS: u64 = 30;
+            let mut ticker =
+                tokio::time::interval(std::time::Duration::from_secs(CONVERGENCE_INTERVAL_SECS));
+            loop {
+                ticker.tick().await;
+                let round_id = rm_for_conv.current_round_id();
+                if let Ok(bytes) = conv_handler.request_bytes(round_id) {
+                    let _ = conv_tx.send(bytes).await;
+                }
+            }
+        });
+    }
+
     // Register GhostGlyph handler for visual identity P2P messages
     let glyph_handler = Arc::new(ghost_pool::glyph_handler::GlyphRegistrationHandler::new(
         Arc::clone(&db),

--- a/bins/ghost-pool/src/round.rs
+++ b/bins/ghost-pool/src/round.rs
@@ -293,6 +293,11 @@ pub struct RoundManager {
     /// Persisting to database would add latency to every share submission
     /// without meaningful security benefit given the round-scoped design.
     submitted_shares: RwLock<HashMap<RoundId, std::collections::HashSet<[u8; 32]>>>,
+    /// GHOST-03: full signed proofs for retained rounds, keyed by round then
+    /// share hash. Kept so a node that missed a gossiped share (drop/partition)
+    /// can be served the exact signed proof during ledger convergence. Pruned
+    /// with the round, exactly like `submitted_shares`.
+    recent_proofs: RwLock<HashMap<RoundId, HashMap<[u8; 32], ShareProof>>>,
     /// Per-miner rate limiting (H6 security fix)
     miner_rate_limits: RwLock<HashMap<String, MinerRateLimitEntry>>,
     /// L-7: Per-miner cumulative tolerance tracking per round
@@ -331,6 +336,7 @@ impl RoundManager {
             event_tx,
             our_node_id,
             submitted_shares: RwLock::new(HashMap::new()),
+            recent_proofs: RwLock::new(HashMap::new()),
             miner_rate_limits: RwLock::new(HashMap::new()),
             miner_tolerance_tracker: RwLock::new(HashMap::new()),
             cross_round_tolerance: RwLock::new(CrossRoundToleranceTracker::default()),
@@ -388,9 +394,11 @@ impl RoundManager {
         {
             let mut submitted = self.submitted_shares.write();
             let mut tolerance = self.miner_tolerance_tracker.write();
+            let mut proofs = self.recent_proofs.write();
             for old_round in to_remove {
                 submitted.remove(&old_round);
                 tolerance.remove(&old_round);
+                proofs.remove(&old_round); // GHOST-03: prune retained proofs too
             }
         }
 
@@ -706,6 +714,14 @@ impl RoundManager {
             cross_round.record_round_participation(&miner_id);
         }
 
+        // GHOST-03: retain the full signed proof so it can be re-served to a peer
+        // that missed it (drop/partition) during ledger convergence.
+        self.recent_proofs
+            .write()
+            .entry(proof.round_id)
+            .or_default()
+            .insert(proof.share_hash, proof.clone());
+
         debug!(
             round_id = proof.round_id,
             miner = %miner_id,
@@ -715,6 +731,42 @@ impl RoundManager {
         );
 
         Ok(())
+    }
+
+    /// GHOST-03: the share hashes this node currently holds for `round_id`.
+    pub fn round_share_hashes(&self, round_id: RoundId) -> Vec<[u8; 32]> {
+        self.recent_proofs
+            .read()
+            .get(&round_id)
+            .map(|m| m.keys().copied().collect())
+            .unwrap_or_default()
+    }
+
+    /// GHOST-03: (share_count, total_work) this node holds for `round_id`.
+    pub fn round_share_summary(&self, round_id: RoundId) -> (u64, f64) {
+        match self.recent_proofs.read().get(&round_id) {
+            Some(m) => (m.len() as u64, m.values().map(|p| p.work).sum()),
+            None => (0, 0.0),
+        }
+    }
+
+    /// GHOST-03: full signed proofs this node holds for `round_id` that are NOT
+    /// in `their_hashes` — i.e. exactly the shares a converging peer is missing.
+    pub fn proofs_missing_from(
+        &self,
+        round_id: RoundId,
+        their_hashes: &std::collections::HashSet<[u8; 32]>,
+    ) -> Vec<ShareProof> {
+        self.recent_proofs
+            .read()
+            .get(&round_id)
+            .map(|m| {
+                m.iter()
+                    .filter(|(h, _)| !their_hashes.contains(*h))
+                    .map(|(_, p)| p.clone())
+                    .collect()
+            })
+            .unwrap_or_default()
     }
 
     /// Register a node's capabilities

--- a/tests/integration_tests/mesh_cluster.rs
+++ b/tests/integration_tests/mesh_cluster.rs
@@ -20,7 +20,10 @@ use chrono::Utc;
 use ghost_common::identity::NodeIdentity;
 use ghost_common::types::{NodeId, ShareProof};
 use ghost_consensus::mesh::MessageHandler;
-use ghost_consensus::message::{MessageEnvelope, MessageType, ShareProofMessage};
+use ghost_consensus::message::{
+    MessageEnvelope, MessageType, ShareConvergenceResponse, ShareProofMessage,
+};
+use ghost_pool::convergence::ConvergenceHandler;
 use ghost_pool::round::{RoundConfig, RoundManager};
 use ghost_pool::share_handler::ShareProofHandler;
 use ghost_storage::Database;
@@ -80,6 +83,15 @@ impl ClusterNode {
     fn has_recorded_miner(&self, miner_id: [u8; 32]) -> bool {
         let hex = hex::encode(&miner_id[..8]);
         self.db.get_miner_stats(&hex).ok().flatten().is_some()
+    }
+
+    /// True once this node's share LEDGER (the `RoundManager`, the consensus-
+    /// relevant state) holds `share_hash` for `round_id`. Set by both gossip and
+    /// GHOST-03 convergence backfill.
+    fn ledger_has(&self, round_id: u64, share_hash: [u8; 32]) -> bool {
+        self.round_manager
+            .round_share_hashes(round_id)
+            .contains(&share_hash)
     }
 }
 
@@ -187,6 +199,36 @@ impl TestMeshCluster {
     fn peer_has_share(&self, peer: usize, miner_id: [u8; 32]) -> bool {
         self.nodes[peer].has_recorded_miner(miner_id)
     }
+
+    /// True if `node`'s share ledger holds `share_hash` for `round_id`.
+    fn node_ledger_has(&self, node: usize, round_id: u64, share_hash: [u8; 32]) -> bool {
+        self.nodes[node].ledger_has(round_id, share_hash)
+    }
+
+    /// GHOST-03: run a convergence exchange — `requester` advertises the shares
+    /// it holds for `round_id`, `responder` replies with the signed proofs the
+    /// requester is missing, and the requester applies them. Returns the number
+    /// of shares backfilled.
+    pub fn converge(&self, requester: usize, responder: usize, round_id: u64) -> usize {
+        let req = ConvergenceHandler::new(Arc::clone(&self.nodes[requester].round_manager));
+        let resp = ConvergenceHandler::new(Arc::clone(&self.nodes[responder].round_manager));
+        let request = req.build_request(round_id);
+        let response = resp.handle_request(&request);
+        req.apply_response(&response)
+    }
+
+    /// Feed `node` a single proof as if it arrived in a convergence response
+    /// (used to prove forged backfills are rejected). Returns the number applied.
+    pub fn apply_backfill(&self, node: usize, proof: ShareProof) -> usize {
+        let handler = ConvergenceHandler::new(Arc::clone(&self.nodes[node].round_manager));
+        let resp = ShareConvergenceResponse {
+            round_id: proof.round_id,
+            share_count: 1,
+            total_work: proof.work,
+            missing_shares: vec![proof],
+        };
+        handler.apply_response(&resp)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -249,5 +291,61 @@ async fn partition_blocks_delivery_to_severed_node() {
     assert!(
         !cluster.peer_has_share(2, miner),
         "node 2 is partitioned from node 0 and must not receive the share"
+    );
+}
+
+/// GHOST-03: a node that missed a gossiped share (partition) reconciles its
+/// share ledger with a peer that has it, and backfills the exact signed proof.
+#[tokio::test]
+async fn ghost03_convergence_backfills_partitioned_node() {
+    let mut cluster = TestMeshCluster::new(4);
+    cluster.partition(0, 2); // node 2 will miss node 0's broadcast
+    let miner = [0xE5; 32];
+    let nonce = 5;
+    let share_hash = diff1_share_hash(nonce);
+
+    cluster.gossip_honest_share(0, miner, nonce).await;
+
+    // Precondition: a connected peer holds it; the partitioned node does not.
+    assert!(
+        cluster.node_ledger_has(1, 1, share_hash),
+        "connected peer 1 holds the share in its ledger"
+    );
+    assert!(
+        !cluster.node_ledger_has(2, 1, share_hash),
+        "partitioned node 2 is missing the share before convergence"
+    );
+
+    // GHOST-03: node 2 converges with node 1 → backfills exactly the missing share.
+    let applied = cluster.converge(2, 1, 1);
+    assert_eq!(
+        applied, 1,
+        "convergence backfills exactly the one missing share"
+    );
+    assert!(
+        cluster.node_ledger_has(2, 1, share_hash),
+        "node 2's ledger contains the share after convergence"
+    );
+}
+
+/// GHOST-03 safety: convergence cannot smuggle in a forged share. A response
+/// carrying a proof whose `received_by` signature is invalid is rejected by
+/// `apply_response` (GHOST-09 re-checked on the backfill path), not applied.
+#[tokio::test]
+async fn ghost03_convergence_rejects_forged_backfill() {
+    let cluster = TestMeshCluster::new(2);
+    let attacker = NodeIdentity::generate();
+    // Proof claims node 0's received_by but is signed by an unrelated key.
+    let mut proof = cluster.base_proof(0, [0xF6; 32], 6);
+    proof.sign(&attacker);
+
+    let applied = cluster.apply_backfill(1, proof);
+    assert_eq!(
+        applied, 0,
+        "a forged backfilled proof must be rejected by convergence (GHOST-09)"
+    );
+    assert!(
+        !cluster.node_ledger_has(1, 1, diff1_share_hash(6)),
+        "the forged share never enters node 1's ledger"
     );
 }


### PR DESCRIPTION
GHOST-03 (audit PR #32), built test-first against the multi-node harness (PR #42).

The `ShareConvergence` request/response types existed but were **never built, sent, or handled** — share propagation was best-effort gossip, so a partition or dropped broadcast left a node permanently missing shares (which, with GHOST-02, would let a divergent-but-balanced payout be approved).

**Implemented:**
- `RoundManager` now **retains the full signed proofs** per round (`recent_proofs`, pruned with the round) so they're re-servable — without this a node could detect divergence but not repair it.
- `ConvergenceHandler`: advertise held share-hashes → peer replies with the signed proofs you're missing → apply them, **re-verifying the GHOST-09 `received_by` signature** first (a forged backfill is rejected, never credited).
- **Wired live** in `main.rs`: registered on the mesh + a 30s periodic request, routed via an mpsc channel (broadcast is async, the handler send is sync). Empty responses aren't sent → steady-state overhead is nil. This is the difference from the original dead-code state.

**Tested:** 3 ghost-pool unit tests (backfill, forged-rejection, missing-set diff) + 2 harness tests (partition→miss→converge→backfill; forged backfill rejected). All 6 harness + existing round tests green.

⚠️ **Wire-format change — coordinated deploy with the cluster** (GHOST-02 next, then GHOST-11).