### PR TITLE
fix(consensus): GHOST-02 — validators recompute payout split (Option A)

### DIFF
--- a/bins/ghost-pool/src/convergence.rs
+++ b/bins/ghost-pool/src/convergence.rs
@@ -49,6 +49,7 @@ pub type ConvergenceSendFn = Arc<dyn Fn(Vec<u8>) -> GhostResult<()> + Send + Syn
 pub struct ConvergenceHandler {
     round_manager: Arc<RoundManager>,
     send: Option<ConvergenceSendFn>,
+    db: Option<Arc<ghost_storage::Database>>,
 }
 
 impl ConvergenceHandler {
@@ -56,12 +57,21 @@ impl ConvergenceHandler {
         Self {
             round_manager,
             send: None,
+            db: None,
         }
     }
 
     /// Attach the mesh broadcast used to reply to requests in production.
     pub fn with_send(mut self, send: ConvergenceSendFn) -> Self {
         self.send = Some(send);
+        self
+    }
+
+    /// Attach the database so backfilled proofs also adopt their signed payout
+    /// address (GHOST-02 / Option A), keeping addresses converged on the
+    /// convergence path as well as the gossip path.
+    pub fn with_db(mut self, db: Arc<ghost_storage::Database>) -> Self {
+        self.db = Some(db);
         self
     }
 
@@ -110,6 +120,12 @@ impl ConvergenceHandler {
             }
             if self.round_manager.handle_share_proof(proof.clone()).is_ok() {
                 applied += 1;
+                // GHOST-02 / Option A: adopt the backfilled proof's signed payout
+                // address (first-writer-wins) so addresses converge here too.
+                if let (Some(db), Some(addr)) = (&self.db, &proof.payout_address) {
+                    let miner_hex = hex::encode(&proof.miner_id[..8]);
+                    let _ = db.adopt_miner_address(&miner_hex, addr);
+                }
             }
         }
         applied

--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -1480,7 +1480,8 @@ async fn main() -> Result<()> {
     };
     let convergence_handler = Arc::new(
         ghost_pool::convergence::ConvergenceHandler::new(Arc::clone(&round_manager))
-            .with_send(conv_send),
+            .with_send(conv_send)
+            .with_db(Arc::clone(&db)),
     );
     mesh.register_handler(Arc::clone(&convergence_handler)
         as Arc<dyn ghost_consensus::mesh::MessageHandler + Send + Sync>);
@@ -3193,6 +3194,34 @@ async fn main() -> Result<()> {
         Arc::clone(&template_processor),
         Arc::clone(&qualification_provider_for_health), // Reuse provider from health_handler
     )?);
+
+    // GHOST-02: install the ledger-recompute validator on the vote handler now
+    // that the PayoutHandler exists. A peer's payout proposal is vote-approved
+    // only if its split matches what THIS node recomputes from its own converged
+    // share ledger (GHOST-03) and converged payout addresses (Option A).
+    {
+        let ph = Arc::clone(&payout_handler);
+        let rm = Arc::clone(&round_manager);
+        let db_for_validator = Arc::clone(&db);
+        let validator: ghost_consensus::vote_handler::ProposalValidateFn =
+            Arc::new(move |proposal: &ghost_common::types::PayoutProposal| {
+                let local_work = rm.get_miner_work_scaled(proposal.round_id);
+                let treasury_state = match db_for_validator.get_treasury_balance() {
+                    Ok(balance) => {
+                        let threshold_ts = db_for_validator
+                            .get_treasury_threshold_reached()
+                            .ok()
+                            .flatten()
+                            .and_then(|ts| chrono::DateTime::from_timestamp(ts, 0))
+                            .map(|dt| dt.with_timezone(&chrono::Utc));
+                        TreasuryState::from_stored(balance, threshold_ts)
+                    }
+                    Err(_) => TreasuryState::new(),
+                };
+                ph.validate_proposal_split(proposal, &local_work, &treasury_state)
+            });
+        vote_handler.set_proposal_validator(validator);
+    }
 
     // Start verification HTTP server
     let rpc_for_verification = Arc::clone(&rpc);

--- a/bins/ghost-pool/src/payout.rs
+++ b/bins/ghost-pool/src/payout.rs
@@ -753,6 +753,61 @@ impl PayoutProposalCreator {
         Ok(proposal)
     }
 
+    /// GHOST-02: recompute the miner split from THIS node's own converged ledger
+    /// (and converged payout addresses — Option A) and confirm the proposal
+    /// matches. A proposer that inflates its own miners, shorts others, or
+    /// fabricates work produces a split honest validators (sharing the converged
+    /// ledger + addresses) will not reproduce, so it is rejected before voting.
+    ///
+    /// Reuses the exact production computation (`calculate_miner_payouts`), so
+    /// there is no reimplementation that could drift and false-reject an honest
+    /// proposal — the only inputs that vary are this node's own ledger and the
+    /// proposal's economic figures.
+    pub fn validate_proposal_split(
+        &self,
+        proposal: &PayoutProposal,
+        local_miner_work: &[(String, u128)],
+        treasury_state: &TreasuryState,
+    ) -> Result<(), String> {
+        // The treasury decay is year-granular; the proposal timestamp is within
+        // seconds of the block, so it yields the same decay_year (hence the same
+        // fee split) the proposer used.
+        let block_time =
+            chrono::DateTime::<chrono::Utc>::from_timestamp(proposal.timestamp as i64, 0)
+                .unwrap_or_else(chrono::Utc::now);
+        let fee_dist = FeeDistribution::calculate(
+            proposal.subsidy,
+            proposal.tx_fees,
+            treasury_state,
+            block_time,
+        );
+        let (expected, _dust) = self
+            .calculate_miner_payouts(local_miner_work, fee_dist.miner_pool)
+            .map_err(|e| format!("GHOST-02: recompute failed: {e}"))?;
+
+        let expected_map = Self::address_amount_map(&expected);
+        let proposal_map = Self::address_amount_map(&proposal.miner_payouts);
+        if expected_map != proposal_map {
+            return Err(format!(
+                "GHOST-02: miner split does not match local recompute \
+                 ({} expected payout addresses vs {} in proposal)",
+                expected_map.len(),
+                proposal_map.len()
+            ));
+        }
+        Ok(())
+    }
+
+    /// Address-grouped (address -> total amount) view of a payout set, for the
+    /// GHOST-02 comparison. Ordered so the comparison is independent of entry order.
+    fn address_amount_map(entries: &[PayoutEntry]) -> std::collections::BTreeMap<Vec<u8>, u64> {
+        let mut m = std::collections::BTreeMap::new();
+        for e in entries {
+            *m.entry(e.address.clone()).or_insert(0u64) += e.amount;
+        }
+        m
+    }
+
     /// Calculate miner payouts proportional to work
     /// Returns (payouts, dust_amount) where dust is redirected to node reward pool
     ///
@@ -1317,6 +1372,19 @@ impl PayoutHandler {
 
     /// Handle a block found event by creating and submitting a payout proposal
     ///
+    /// GHOST-02: validate a peer's payout proposal by recomputing the miner
+    /// split from this node's own converged ledger. Delegates to the proposal
+    /// creator (which owns the payout maths). Returns `Err(reason)` to reject.
+    pub fn validate_proposal_split(
+        &self,
+        proposal: &PayoutProposal,
+        local_miner_work: &[(String, u128)],
+        treasury_state: &TreasuryState,
+    ) -> Result<(), String> {
+        self.creator
+            .validate_proposal_split(proposal, local_miner_work, treasury_state)
+    }
+
     /// H-MINE-1 SECURITY: The QualifiedCapabilityProvider is REQUIRED in the constructor.
     /// Node rewards will only be distributed to nodes with VERIFIED capabilities,
     /// never to nodes with merely CLAIMED capabilities.
@@ -1479,6 +1547,75 @@ mod tests {
 
     fn test_identity() -> Arc<NodeIdentity> {
         Arc::new(NodeIdentity::generate())
+    }
+
+    // ---- GHOST-02: proposal split recompute ----
+
+    fn ghost02_creator() -> PayoutProposalCreator {
+        let config = PayoutConfig {
+            treasury_address: Some(vec![1u8; 20]),
+            network: ghost_common::config::BitcoinNetwork::Regtest,
+            ..Default::default()
+        };
+        let db = Arc::new(ghost_storage::Database::in_memory().expect("in-memory db"));
+        PayoutProposalCreator::new(test_identity(), config, db).expect("creator")
+    }
+
+    fn ghost02_proposal(subsidy: u64, miner_payouts: Vec<PayoutEntry>) -> PayoutProposal {
+        PayoutProposal {
+            proposal_hash: [0u8; 32],
+            round_id: 1,
+            block_hash: [0u8; 32],
+            block_height: 100,
+            proposer: [0u8; 32],
+            miner_payouts,
+            node_payouts: vec![],
+            treasury_amount: 0,
+            treasury_address: vec![1u8; 20],
+            tx_fees: 0,
+            subsidy,
+            timestamp: 1_700_000_000,
+            tx_fees_unallocated: 0,
+        }
+    }
+
+    #[test]
+    fn ghost02_rejects_payout_unsupported_by_local_ledger() {
+        let creator = ghost02_creator();
+        let ts = TreasuryState::new();
+        // This node's ledger is empty → no miner is owed anything for the round.
+        let local_work: Vec<(String, u128)> = vec![];
+        // The proposal nonetheless claims a 1 BTC miner payout.
+        let proposal = ghost02_proposal(
+            5_000_000_000,
+            vec![PayoutEntry {
+                address: vec![2u8; 22],
+                amount: 100_000_000,
+                recipient_id: [3u8; 32],
+                payout_type: PayoutType::Mining,
+            }],
+        );
+        assert!(
+            creator
+                .validate_proposal_split(&proposal, &local_work, &ts)
+                .is_err(),
+            "GHOST-02: a payout the local ledger does not support must be rejected"
+        );
+    }
+
+    #[test]
+    fn ghost02_accepts_split_matching_local_recompute() {
+        let creator = ghost02_creator();
+        let ts = TreasuryState::new();
+        // Empty ledger → the only honest split is the empty one.
+        let local_work: Vec<(String, u128)> = vec![];
+        let proposal = ghost02_proposal(5_000_000_000, vec![]);
+        assert!(
+            creator
+                .validate_proposal_split(&proposal, &local_work, &ts)
+                .is_ok(),
+            "GHOST-02: an empty split matches an empty-ledger recompute"
+        );
     }
 
     #[test]

--- a/bins/ghost-pool/src/share_handler.rs
+++ b/bins/ghost-pool/src/share_handler.rs
@@ -111,7 +111,7 @@ impl ShareProofHandler {
 
         let miner_hex = hex::encode(&proof.miner_id[..8]);
         let from_node = hex::encode(&proof.received_by[..4]);
-        let _payout_address = proof.payout_address.clone(); // M-06: Not used for remote proofs
+        let payout_address = proof.payout_address.clone(); // GHOST-02/Option A: adopted below
         let round_id = proof.round_id;
         let share_hash = hex::encode(proof.share_hash);
         let work = proof.work;
@@ -157,10 +157,19 @@ impl ShareProofHandler {
                     }
                 }
 
-                // M-06: Do NOT update miner payout address from remote P2P share proofs.
-                // A malicious node could broadcast share proofs with a legitimate miner's ID
-                // but substitute their own payout address, redirecting that miner's payouts.
-                // Payout addresses are only trusted from local stratum connections (main.rs).
+                // GHOST-02 / Option A: adopt the miner's payout address from this
+                // GHOST-09-SIGNED proof, first-writer-wins. This is what lets
+                // payout addresses converge across nodes so validators can
+                // reproduce the proposer's address-grouped split (GHOST-02).
+                // The original M-06 concern (a node substituting its own address
+                // for a legitimate miner) is contained: the proof is signature-
+                // verified above, and `adopt_miner_address` never overwrites an
+                // already-established address.
+                if let Some(addr) = &payout_address {
+                    if let Err(e) = self.db.adopt_miner_address(&miner_hex, addr) {
+                        warn!(miner = %miner_hex, error = %e, "GHOST-02: failed to adopt signed payout address");
+                    }
+                }
 
                 debug!(
                     miner = %miner_hex,

--- a/crates/ghost-consensus/src/vote_handler.rs
+++ b/crates/ghost-consensus/src/vote_handler.rs
@@ -535,6 +535,11 @@ pub type ProposalStoreFn = Arc<dyn Fn(PayoutProposal) + Send + Sync>;
 /// Arguments: (revoked_node_id_hex, elder_position, reason)
 pub type RevocationFn = Arc<dyn Fn(&str, u32, &str) -> GhostResult<()> + Send + Sync>;
 
+/// GHOST-02: ledger-recompute validator. Lets the pool layer (which owns the
+/// share ledger + payout maths) gate vote-approval by recomputing the proposal's
+/// split from this node's own converged ledger. Returns `Err(reason)` to reject.
+pub type ProposalValidateFn = Arc<dyn Fn(&PayoutProposal) -> Result<(), String> + Send + Sync>;
+
 /// Rate limit configuration for P2P messages
 ///
 /// Default: 100 messages burst, 20/second sustained per node
@@ -627,6 +632,11 @@ pub struct VoteHandler {
     proposal_store_fn: Option<ProposalStoreFn>,
     /// Callback for executing elder revocation when BFT consensus reaches 67%+
     revocation_fn: Option<RevocationFn>,
+    /// GHOST-02: optional ledger-recompute validator; when set, a proposal must
+    /// also match this node's own recomputed split to be vote-approved. Behind a
+    /// lock so it can be installed after construction (the pool's PayoutHandler
+    /// is built later than the VoteHandler).
+    ledger_validator_fn: RwLock<Option<ProposalValidateFn>>,
     /// Tracked revocation proposals: proposal_hash -> (node_id_hex, reason)
     revocation_proposals: RwLock<HashMap<[u8; 32], (String, String)>>,
 }
@@ -664,6 +674,7 @@ impl VoteHandler {
             known_best_height: RwLock::new(None),
             proposal_store_fn: None,
             revocation_fn: None,
+            ledger_validator_fn: RwLock::new(None),
             revocation_proposals: RwLock::new(HashMap::new()),
         }
     }
@@ -951,6 +962,14 @@ impl VoteHandler {
         self
     }
 
+    /// GHOST-02: install a ledger-recompute validator (after construction, since
+    /// the pool's PayoutHandler is built later). When set, a proposal must pass
+    /// it — the node's own recomputed split — in addition to the internal
+    /// structural checks before this node will vote to approve.
+    pub fn set_proposal_validator(&self, f: ProposalValidateFn) {
+        *self.ledger_validator_fn.write() = Some(f);
+    }
+
     /// Propose revocation of an offline elder.
     /// Creates a deterministic VotingSession, casts our approve vote, and
     /// returns a serialized VoteMessage for broadcast. Returns None if
@@ -1193,6 +1212,19 @@ impl VoteHandler {
                 "Rejecting payout proposal"
             );
             return false;
+        }
+        // GHOST-02: recompute the split against this node's own converged ledger.
+        // An honest proposer's split is reproduced exactly; an inflated/shorted/
+        // fabricated one is not, and is rejected before voting.
+        if let Some(validate) = self.ledger_validator_fn.read().as_ref() {
+            if let Err(reason) = validate(proposal) {
+                warn!(
+                    round_id = proposal.round_id,
+                    reason = %reason,
+                    "GHOST-02: rejecting payout proposal — split does not match local ledger"
+                );
+                return false;
+            }
         }
         true
     }

--- a/crates/ghost-storage/src/queries.rs
+++ b/crates/ghost-storage/src/queries.rs
@@ -2503,6 +2503,36 @@ impl Database {
         })
     }
 
+    /// GHOST-02 / Option A: adopt a miner's payout address from a GHOST-09-signed
+    /// share proof, FIRST-WRITER-WINS. The address is set only if the miner has
+    /// none yet; an established address is never overwritten by a later (possibly
+    /// conflicting) signed proof. This is what lets payout addresses converge
+    /// across nodes — so validators can reproduce the proposer's address-grouped
+    /// split (GHOST-02) — without reintroducing the M-06 address-hijack vector.
+    pub fn adopt_miner_address(&self, miner_id: &str, payout_address: &str) -> GhostResult<()> {
+        if payout_address.is_empty() {
+            return Ok(());
+        }
+        let now = chrono::Utc::now().timestamp();
+        let encrypted_address = self.encrypt_address(payout_address)?;
+        self.with_connection(|conn| {
+            conn.execute(
+                "INSERT INTO miners (miner_id, payout_address, first_seen, last_seen)
+                 VALUES (?1, ?2, ?3, ?3)
+                 ON CONFLICT(miner_id) DO UPDATE SET
+                     payout_address = CASE
+                         WHEN miners.payout_address IS NULL OR miners.payout_address = ''
+                         THEN excluded.payout_address
+                         ELSE miners.payout_address
+                     END,
+                     last_seen = excluded.last_seen",
+                params![miner_id, encrypted_address, now],
+            )
+            .map_err(|e| GhostError::Database(e.to_string()))?;
+            Ok(())
+        })
+    }
+
     /// Increment miner share count and work
     ///
     /// MED-STOR-1: Uses saturating arithmetic to prevent overflow. If values would overflow,


### PR DESCRIPTION
GHOST-02 (audit PR #32), built on GHOST-09 + GHOST-03 + the harness. Implements the user-chosen **Option A** (adopt GHOST-09-signed payout addresses so the ledger *and* addresses converge → an exact recompute).

**Part 1 — address convergence**
- `adopt_miner_address` (storage): **first-writer-wins** — adopts a payout address from a GHOST-09-signed proof but **never overwrites an established one**, so M-06's address-hijack concern stays closed (the proof is signature-verified; an existing address is immutable).
- `share_handler` + convergence `apply_response` adopt the signed address on accept, so `get_miner_address` converges across nodes.

**Part 2 — the recompute**
- `validate_proposal_split` recomputes the miner split from THIS node's own converged ledger by **reusing `calculate_miner_payouts`** (exact production maths — no reimplementation that could drift and false-reject an honest proposal → stall payouts) and compares the address-grouped (address → amount) map.
- **Wired live (not dead code):** `VoteHandler` gains an optional ledger-validator hook (`set_proposal_validator`); `main.rs` installs a callback recomputing from the node's `RoundManager` ledger + treasury state. A proposal this node can't reproduce is rejected **before voting**.

**Tests:** rejects a payout the local ledger doesn't support; accepts a matching split. 194 ghost-pool + 36 vote + 113 storage tests green; harness unaffected.

⚠️ Wire-format/behaviour change — coordinated deploy + canary with the cluster. (Proposer↔block-finder binding is a follow-up refinement; the split recompute is the primary GHOST-02 vector.)