### PR TITLE
fix(consensus): GHOST-11 — propagate + persist equivocation bans (closes the audit)

### DIFF
--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -1229,6 +1229,39 @@ async fn main() -> Result<()> {
     let ban_manager = Arc::new(BanManager::new());
     info!("Shared BanManager created for cross-handler ban enforcement");
 
+    // GHOST-11: re-apply equivocation bans persisted before this restart, so a
+    // restart doesn't silently un-ban an equivocator that is still inside its
+    // ban window. (Bans are otherwise in-memory only.)
+    {
+        const EQUIVOCATION_BAN_WINDOW_SECS: i64 = 600;
+        let now = chrono::Utc::now().timestamp();
+        match db.get_recent_equivocators(now - EQUIVOCATION_BAN_WINDOW_SECS) {
+            Ok(equivocators) => {
+                let mut restored = 0usize;
+                for (node_id, detected_at) in equivocators {
+                    let remaining = (detected_at + EQUIVOCATION_BAN_WINDOW_SECS) - now;
+                    if remaining > 0 {
+                        ban_manager.ban_for_duration(
+                            node_id,
+                            ghost_consensus::ban_manager::BanReason::Equivocation,
+                            std::time::Duration::from_secs(remaining as u64),
+                        );
+                        restored += 1;
+                    }
+                }
+                if restored > 0 {
+                    info!(
+                        restored,
+                        "GHOST-11: re-applied persisted equivocation bans on startup"
+                    );
+                }
+            }
+            Err(e) => {
+                warn!(error = %e, "GHOST-11: failed to load persisted equivocation bans")
+            }
+        }
+    }
+
     // Create vote handler with callbacks and shared ban manager
     // 4.5 SECURITY: Rate limiter persistence is now enabled by default to prevent
     // attackers from bypassing rate limits by triggering node restarts.

--- a/crates/ghost-consensus/src/message.rs
+++ b/crates/ghost-consensus/src/message.rs
@@ -683,6 +683,11 @@ pub struct EquivocationProofMessage {
     pub equivocator: [u8; 32],
     /// Round in which equivocation occurred
     pub round_id: u64,
+    /// GHOST-11: proposal hash both conflicting votes were cast on. Lets a
+    /// receiver verify the equivocator's two signatures INDEPENDENTLY of the
+    /// reporter (so a malicious reporter can't frame an honest node).
+    #[serde(with = "ghost_common::serde_hex::bytes32", default)]
+    pub proposal_hash: [u8; 32],
     /// Type of vote (e.g., "payout_vote", "zk_vote")
     pub vote_type: String,
     /// First vote (serialized VoteMessage or similar)
@@ -701,9 +706,11 @@ pub struct EquivocationProofMessage {
 
 impl EquivocationProofMessage {
     /// Create a new equivocation proof message
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         equivocator: [u8; 32],
         round_id: u64,
+        proposal_hash: [u8; 32],
         vote_type: String,
         vote1_data: Vec<u8>,
         vote2_data: Vec<u8>,
@@ -712,6 +719,7 @@ impl EquivocationProofMessage {
         Self {
             equivocator,
             round_id,
+            proposal_hash,
             vote_type,
             vote1_data,
             vote2_data,
@@ -728,6 +736,7 @@ impl EquivocationProofMessage {
         hasher.update(b"EquivocationProof/v1");
         hasher.update(self.equivocator);
         hasher.update(self.round_id.to_le_bytes());
+        hasher.update(self.proposal_hash);
         hasher.update(self.vote_type.as_bytes());
         hasher.update(&self.vote1_data);
         hasher.update(&self.vote2_data);

--- a/crates/ghost-consensus/src/vote_handler.rs
+++ b/crates/ghost-consensus/src/vote_handler.rs
@@ -47,7 +47,10 @@ use crate::mesh::MessageHandler;
 use crate::message::{
     EquivocationProofMessage, MessageEnvelope, MessageType, PayoutProposalMessage, VoteMessage,
 };
-use crate::voting::{compute_vote_signing_message, Vote, VoteResult, VotingManager, VotingSession};
+use crate::voting::{
+    compute_vote_signing_message, Vote, VoteEquivocationProof, VoteResult, VotingManager,
+    VotingSession,
+};
 
 /// Rate limiter for P2P messages to prevent DoS attacks
 ///
@@ -853,6 +856,50 @@ impl VoteHandler {
             .invalidate_voter_in_all_sessions(&node_id);
     }
 
+    /// GHOST-11: process a peer's equivocation proof. The two conflicting votes
+    /// are verified INDEPENDENTLY (both signed by the named equivocator over the
+    /// same round+proposal, with opposite decisions) — so a malicious reporter
+    /// cannot frame an honest node. On success the equivocator is banned here
+    /// too, so a node banned on one mesh member becomes banned on all of them.
+    fn handle_equivocation_proof(&self, msg: EquivocationProofMessage) {
+        if msg.equivocator == self.identity.node_id() {
+            return; // ignore reports against ourselves
+        }
+        if self.is_banned(&msg.equivocator) {
+            return; // already banned — nothing to do
+        }
+        let (Ok(vote1), Ok(vote2)) = (
+            serde_json::from_slice::<Vote>(&msg.vote1_data),
+            serde_json::from_slice::<Vote>(&msg.vote2_data),
+        ) else {
+            return; // malformed vote payloads
+        };
+        if vote1.voter != msg.equivocator || vote2.voter != msg.equivocator {
+            return; // votes are not from the named equivocator
+        }
+        let proof = VoteEquivocationProof {
+            voter: msg.equivocator,
+            round_id: msg.round_id,
+            proposal_hash: msg.proposal_hash,
+            vote1,
+            vote2,
+            detected_at: msg.timestamp,
+        };
+        if !proof.verify() {
+            warn!(
+                equivocator = %hex::encode(&msg.equivocator[..8]),
+                "GHOST-11: rejecting unverifiable equivocation proof from peer"
+            );
+            return;
+        }
+        warn!(
+            equivocator = %hex::encode(&msg.equivocator[..8]),
+            round_id = msg.round_id,
+            "GHOST-11: banning node on a peer-propagated, independently-verified equivocation"
+        );
+        self.ban_node(msg.equivocator);
+    }
+
     /// Check if a node is currently banned
     ///
     /// Checks shared BanManager if available (C1 fix), otherwise local tracking.
@@ -1517,6 +1564,7 @@ impl VoteHandler {
                         let mut proof_msg = EquivocationProofMessage::new(
                             sender,
                             vote_msg.round_id,
+                            proof.proposal_hash,
                             "payout_vote".to_string(),
                             vote1_data,
                             vote2_data,
@@ -1749,6 +1797,14 @@ impl MessageHandler for VoteHandler {
                     .map_err(|e| ghost_common::error::GhostError::Serialization(e.to_string()))?;
 
                 self.handle_proposal(proposal_msg.proposal)?;
+            }
+
+            MessageType::EquivocationProof => {
+                // GHOST-11: a peer reports an equivocation. Verify it
+                // independently and, if valid, ban the equivocator here too.
+                let msg: EquivocationProofMessage = serde_json::from_slice(&envelope.payload)
+                    .map_err(|e| ghost_common::error::GhostError::Serialization(e.to_string()))?;
+                self.handle_equivocation_proof(msg);
             }
 
             _ => {
@@ -2303,6 +2359,81 @@ mod tests {
             restored.bucket_count(),
             3,
             "from_persisted should restore all persisted buckets"
+        );
+    }
+
+    /// GHOST-11: a peer's independently-verifiable equivocation proof bans the
+    /// equivocator here too — cross-node ban propagation.
+    #[test]
+    fn ghost11_verified_equivocation_proof_bans_node() {
+        let handler = VoteHandler::new(
+            Arc::new(NodeIdentity::generate()),
+            Arc::new(VotingManager::new(100)),
+        );
+        let equivocator = NodeIdentity::generate();
+        let round_id = 1u64;
+        let proposal_hash = [9u8; 32];
+        let sign_vote = |approve: bool| -> Vote {
+            let m = compute_vote_signing_message(
+                round_id,
+                &proposal_hash,
+                &equivocator.node_id(),
+                approve,
+            );
+            Vote::new(equivocator.node_id(), approve, equivocator.sign(&m))
+        };
+
+        let msg = EquivocationProofMessage::new(
+            equivocator.node_id(),
+            round_id,
+            proposal_hash,
+            "payout_vote".to_string(),
+            serde_json::to_vec(&sign_vote(true)).unwrap(),
+            serde_json::to_vec(&sign_vote(false)).unwrap(),
+            NodeIdentity::generate().node_id(),
+        );
+
+        assert!(!handler.is_banned(&equivocator.node_id()));
+        handler.handle_equivocation_proof(msg);
+        assert!(
+            handler.is_banned(&equivocator.node_id()),
+            "a verified equivocation propagated from a peer must ban the node"
+        );
+    }
+
+    /// GHOST-11 safety: a forged report (the conflicting votes are NOT signed by
+    /// the accused) cannot frame an honest node — verification fails, no ban.
+    #[test]
+    fn ghost11_forged_equivocation_proof_does_not_ban() {
+        let handler = VoteHandler::new(
+            Arc::new(NodeIdentity::generate()),
+            Arc::new(VotingManager::new(100)),
+        );
+        let victim = NodeIdentity::generate();
+        let attacker = NodeIdentity::generate();
+        let round_id = 1u64;
+        let proposal_hash = [9u8; 32];
+        // Votes claim to be the victim's, but are signed by the attacker.
+        let forge = |approve: bool| -> Vote {
+            let m =
+                compute_vote_signing_message(round_id, &proposal_hash, &victim.node_id(), approve);
+            Vote::new(victim.node_id(), approve, attacker.sign(&m))
+        };
+
+        let msg = EquivocationProofMessage::new(
+            victim.node_id(),
+            round_id,
+            proposal_hash,
+            "payout_vote".to_string(),
+            serde_json::to_vec(&forge(true)).unwrap(),
+            serde_json::to_vec(&forge(false)).unwrap(),
+            attacker.node_id(),
+        );
+
+        handler.handle_equivocation_proof(msg);
+        assert!(
+            !handler.is_banned(&victim.node_id()),
+            "a forged equivocation (votes not signed by the accused) must NOT ban the victim"
         );
     }
 

--- a/crates/ghost-storage/src/queries.rs
+++ b/crates/ghost-storage/src/queries.rs
@@ -5570,6 +5570,38 @@ impl Database {
         })
     }
 
+    /// GHOST-11: distinct equivocators with a proof detected at/after
+    /// `since_unix`, and their latest detection time. Used to re-apply
+    /// equivocation bans on startup — bans are otherwise in-memory and silently
+    /// lost on restart, letting an equivocator vote again within its ban window.
+    pub fn get_recent_equivocators(&self, since_unix: i64) -> GhostResult<Vec<([u8; 32], i64)>> {
+        self.with_connection(|conn| {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT node_id, MAX(detected_at) FROM equivocation_proofs
+                     WHERE detected_at >= ?1 GROUP BY node_id",
+                )
+                .map_err(|e| GhostError::Database(e.to_string()))?;
+            let rows = stmt
+                .query_map(params![since_unix], |row| {
+                    let blob: Vec<u8> = row.get(0)?;
+                    let detected: i64 = row.get(1)?;
+                    Ok((blob, detected))
+                })
+                .map_err(|e| GhostError::Database(e.to_string()))?;
+            let mut out = Vec::new();
+            for r in rows {
+                let (blob, detected) = r.map_err(|e| GhostError::Database(e.to_string()))?;
+                if blob.len() == 32 {
+                    let mut id = [0u8; 32];
+                    id.copy_from_slice(&blob);
+                    out.push((id, detected));
+                }
+            }
+            Ok(out)
+        })
+    }
+
     /// Get equivocation proofs for a node
     ///
     /// Returns all stored equivocation proofs for forensic analysis.


### PR DESCRIPTION
GHOST-11, the **final** audit finding (13/13). Bans were in-memory + local-only: a node banned on one mesh member stayed an eligible voter on every other node, and bans vanished on restart. Local enforcement already existed; this closes the two real gaps.

**Propagation:** equivocation proofs were already broadcast but **no peer consumed them**. Adds `handle_equivocation_proof`, which reconstructs the two conflicting votes and **verifies them independently** (both signed by the named equivocator over the same round+proposal, opposite decisions) before banning — so a malicious reporter can't frame an honest node. `EquivocationProofMessage` now carries `proposal_hash` (serde `default` for compat) so the receiver can verify without trusting the reporter.

**Persistence:** on startup, re-apply bans for equivocators still inside the ban window (`get_recent_equivocators` + `ban_for_duration` with the remaining time), so a restart no longer silently un-bans them.

**Tests:** a verified proof from a peer bans the node; a forged proof does not. 234 consensus + 113 storage + 194 pool green; fmt + clippy clean.

⚠️ Wire-format change — coordinated deploy with the rest of the cluster.