### PR TITLE
feat(consensus): CLUSTER_ENFORCEMENT_HEIGHT gate — safe audit-cluster rollout

### DIFF
--- a/bins/ghost-pool/src/lib.rs
+++ b/bins/ghost-pool/src/lib.rs
@@ -75,6 +75,24 @@ pub mod share_handler;
 /// GHOST-03: ledger convergence (share-set reconciliation) between mesh nodes.
 pub mod convergence;
 
+/// Chain height at which the security-audit cluster's ENFORCEMENT activates
+/// fleet-wide. Mirrors `PAYOUT_ADDRESS_GROUPING_HEIGHT`: baking the activation as
+/// a deterministic block-height gate (not a flag) means every node — running the
+/// same binary — flips at the exact same chain position, so the fleet can roll
+/// the binary out canary-style with NO mixed-version enforcement window.
+///
+/// Before this height the binary still SIGNS shares, converges ledgers and
+/// propagates equivocation bans (all additive, mixed-version-safe), but it does
+/// NOT yet drop unsigned shares (GHOST-09) or reject a mismatched payout split
+/// (GHOST-02) — making it behaviour-identical to the pre-audit binary in a mixed
+/// mesh. After it, both enforcements are live everywhere at once.
+///
+/// PLACEHOLDER — the operator MUST set this to roughly `(current tip + ~150)`
+/// (~24h of blocks past expected full-roll completion) in the activation build.
+/// The default is far enough in the future that an accidental deploy stays in
+/// the safe, non-enforcing dark mode.
+pub const CLUSTER_ENFORCEMENT_HEIGHT: u64 = 999_999_999;
+
 /// GhostGlyph P2P handler for visual identity registration.
 pub mod glyph_handler;
 

--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -3203,8 +3203,8 @@ async fn main() -> Result<()> {
         let ph = Arc::clone(&payout_handler);
         let rm = Arc::clone(&round_manager);
         let db_for_validator = Arc::clone(&db);
-        let validator: ghost_consensus::vote_handler::ProposalValidateFn =
-            Arc::new(move |proposal: &ghost_common::types::PayoutProposal| {
+        let validator: ghost_consensus::vote_handler::ProposalValidateFn = Arc::new(
+            move |proposal: &ghost_common::types::PayoutProposal| {
                 let local_work = rm.get_miner_work_scaled(proposal.round_id);
                 let treasury_state = match db_for_validator.get_treasury_balance() {
                     Ok(balance) => {
@@ -3218,8 +3218,26 @@ async fn main() -> Result<()> {
                     }
                     Err(_) => TreasuryState::new(),
                 };
-                ph.validate_proposal_split(proposal, &local_work, &treasury_state)
-            });
+                let result = ph.validate_proposal_split(proposal, &local_work, &treasury_state);
+                // GATED on CLUSTER_ENFORCEMENT_HEIGHT: pre-activation the fleet's
+                // ledgers/addresses haven't fully converged (old nodes don't sign
+                // or converge), so a recompute mismatch is expected and must NOT
+                // block consensus. We still recompute and log it for visibility,
+                // and only enforce (reject) once the gate fires fleet-wide.
+                if proposal.block_height >= ghost_pool::CLUSTER_ENFORCEMENT_HEIGHT {
+                    result
+                } else {
+                    if let Err(reason) = &result {
+                        tracing::warn!(
+                            reason = %reason,
+                            height = proposal.block_height,
+                            "GHOST-02 (pre-gate): split mismatch — would reject after CLUSTER_ENFORCEMENT_HEIGHT"
+                        );
+                    }
+                    Ok(())
+                }
+            },
+        );
         vote_handler.set_proposal_validator(validator);
     }
 

--- a/bins/ghost-pool/src/share_handler.rs
+++ b/bins/ghost-pool/src/share_handler.rs
@@ -78,7 +78,16 @@ impl ShareProofHandler {
         // carry a valid signature by `received_by` over its canonical bytes,
         // otherwise it's a forged or relayed credit (e.g. a relay re-crediting
         // itself) and is dropped before it can inflate any node's shares.
-        if !proof.has_valid_received_by_signature() {
+        //
+        // GATED on CLUSTER_ENFORCEMENT_HEIGHT: pre-activation the fleet is still
+        // partly running the pre-audit binary that emits UNSIGNED proofs, so
+        // enforcing here would silently drop those nodes' shares and diverge the
+        // ledger. Until the gate height we therefore accept them; nodes already
+        // sign their own shares (always-on) so the converged state is primed for
+        // the moment the gate fires fleet-wide.
+        if self.round_manager.current_height() >= crate::CLUSTER_ENFORCEMENT_HEIGHT
+            && !proof.has_valid_received_by_signature()
+        {
             warn!(
                 from_node = %hex::encode(&proof.received_by[..4]),
                 round_id = proof.round_id,

--- a/tests/integration_tests/mesh_cluster.rs
+++ b/tests/integration_tests/mesh_cluster.rs
@@ -53,7 +53,7 @@ struct ClusterNode {
 }
 
 impl ClusterNode {
-    fn new() -> Self {
+    fn new(height: u64) -> Self {
         let identity = Arc::new(NodeIdentity::generate());
         let node_id = identity.node_id();
         let db = Arc::new(Database::in_memory().expect("in-memory db"));
@@ -65,6 +65,10 @@ impl ClusterNode {
         };
         let round_manager = Arc::new(RoundManager::new(node_id, cfg));
         round_manager.set_template_id(TEST_TEMPLATE_ID);
+        // start_round(1) sets the node's current chain height, which drives the
+        // CLUSTER_ENFORCEMENT_HEIGHT gate for GHOST-09 (and creates round 1, the
+        // round all harness shares target).
+        round_manager.start_round(height);
         let share_handler = Arc::new(ShareProofHandler::new(
             Arc::clone(&round_manager),
             Arc::clone(&db),
@@ -103,8 +107,15 @@ pub struct TestMeshCluster {
 }
 
 impl TestMeshCluster {
+    /// Cluster at/above CLUSTER_ENFORCEMENT_HEIGHT — GHOST-09 enforcement ON.
     pub fn new(n: usize) -> Self {
-        let nodes = (0..n).map(|_| ClusterNode::new()).collect();
+        Self::new_at_height(n, ghost_pool::CLUSTER_ENFORCEMENT_HEIGHT)
+    }
+
+    /// Cluster pinned to a specific chain height — to exercise the enforcement
+    /// gate (below the gate height, GHOST-09 enforcement is OFF for rollout safety).
+    pub fn new_at_height(n: usize, height: u64) -> Self {
+        let nodes = (0..n).map(|_| ClusterNode::new(height)).collect();
         Self {
             nodes,
             connected: vec![vec![true; n]; n],
@@ -347,5 +358,22 @@ async fn ghost03_convergence_rejects_forged_backfill() {
     assert!(
         !cluster.node_ledger_has(1, 1, diff1_share_hash(6)),
         "the forged share never enters node 1's ledger"
+    );
+}
+
+/// Cluster enforcement gate: BELOW `CLUSTER_ENFORCEMENT_HEIGHT`, GHOST-09
+/// enforcement is OFF (rollout safety) — an unsigned share from a not-yet-
+/// upgraded node is still accepted, so a mixed-version mesh keeps converging.
+/// At/above the gate (the default cluster) that same unsigned share is dropped —
+/// see `ghost09_unsigned_share_is_dropped_clusterwide`.
+#[tokio::test]
+async fn cluster_gate_pre_activation_accepts_unsigned_shares() {
+    let cluster = TestMeshCluster::new_at_height(4, ghost_pool::CLUSTER_ENFORCEMENT_HEIGHT - 1);
+    let miner = [0xE7; 32];
+    cluster.gossip_unsigned_share(0, miner, 7).await;
+    assert_eq!(
+        cluster.peers_with_share(0, miner),
+        3,
+        "pre-activation an unsigned share is accepted, so a mixed-version mesh keeps converging"
     );
 }


### PR DESCRIPTION
Prerequisite for the coordinated fleet deploy (see `tasks/plan_audit_cluster_deploy.md`). Gates the cluster's two enforcement points on a deterministic block height (mirroring `PAYOUT_ADDRESS_GROUPING_HEIGHT`):

- **GHOST-09** (drop unsigned shares) — gated on `round_manager.current_height()`
- **GHOST-02** (reject mismatched split) — gated on `proposal.block_height` in the vote-handler callback (recompute + log always, reject only post-gate)

**Before the gate:** nodes still sign shares, converge ledgers, and propagate bans (all additive, mixed-version-safe) but don't drop/reject — behaviour-identical to the pre-audit binary. So the binary rolls out **canary-style with zero mixed-version-enforcement window**. **At the gate:** both enforcements flip on everywhere at once (same binary, same chain position), with the converged state already primed.

`CLUSTER_ENFORCEMENT_HEIGHT` is a far-future **placeholder** the operator sets to `(tip + ~150)` in the activation build. Harness updated (nodes pin a height; default = the gate); new test proves pre-gate unsigned shares are accepted. 7 harness + 194 pool tests green; fmt + clippy clean.