### PR TITLE
fix(docs): resolve broken intra-doc link failing the Documentation CI job

### DIFF
--- a/bins/ghost-pool/src/convergence.rs
+++ b/bins/ghost-pool/src/convergence.rs
@@ -12,7 +12,7 @@
 //! 3. The requester applies each missing proof through the normal path, which
 //!    re-verifies the GHOST-09 `received_by` signature before crediting.
 //!
-//! The full signed proofs are re-servable because [`RoundManager`] retains them
+//! The full signed proofs are re-servable because `RoundManager` retains them
 //! per round (see `recent_proofs`). Without that, a node could only detect
 //! divergence, not repair it.
 

--- a/docker/regtest-cluster/README.md
+++ b/docker/regtest-cluster/README.md
@@ -1,0 +1,126 @@
+# Audit-cluster regtest dry-run
+
+The pre-mainnet validation step from `tasks/plan_audit_cluster_deploy.md` §3:
+**4 real `ghost-pool` binaries on a regtest chain, full mesh, the
+`CLUSTER_ENFORCEMENT_HEIGHT` gate ON** — proving the audit-hardened binary
+completes a real round end-to-end and behaves correctly across the gate, on real
+sockets/Noise/ZMQ rather than the in-process harness.
+
+> **Scope split (be honest about it).** The *adversarial* cases — a forged share,
+> a deliberately-tampered payout split, an equivocating voter — are already
+> proven by the in-process harness (`tests/integration_tests/mesh_cluster.rs`),
+> which can inject those faults trivially. A cluster of *honest* real binaries
+> cannot manufacture them without a byzantine build. So this regtest cluster's
+> job is the part the harness can't cover: **the honest happy path + partition/
+> convergence + the gate transition, on real transport.** For full adversarial
+> coverage on real binaries, build one node from a `byzantine` branch (see §7).
+
+---
+
+## 1. Prerequisites
+- Docker + Compose v2.
+- Two images (built from this repo):
+  - `bitcoin-ghost/ghostd:regtest` — the ghost-core fork.
+  - `bitcoin-ghost/ghost-pool:regtest` — see §2.
+- `bitcoin-cli` (or `docker exec`) to drive the chain.
+
+## 2. Build the pool image (regtest, gate-low)
+Two regtest-specific build choices:
+- **No `--features zk-production`** — regtest needs no MPC params (the
+  zk-production start-up guard is mainnet-only).
+- **Lower `CLUSTER_ENFORCEMENT_HEIGHT`** so the gate actually fires on a short
+  regtest chain (the mainnet default is a far-future placeholder). For the
+  dry-run, set it to e.g. `100` in `bins/ghost-pool/src/lib.rs` before building
+  — that lets you exercise BOTH sides of the gate (mine to <100 = enforcement
+  off, mine past 100 = on). The image must also contain `bash` + `gettext`
+  (`envsubst`) for the entrypoint.
+
+```bash
+# from repo root, in a regtest build context:
+docker build -f docker/Dockerfile --target ghost-pool \
+  --build-arg CARGO_FEATURES="" \
+  -t bitcoin-ghost/ghost-pool:regtest .
+```
+(Confirm the Dockerfile's `ghost-pool` target accepts a features build-arg; if
+not, build the binary locally `cargo build --release -p ghost-pool` and COPY it.)
+
+## 3. Bring the cluster up (genesis-ordered)
+```bash
+cd docker/regtest-cluster
+export TREASURY_ADDRESS=$(docker run --rm bitcoin-ghost/ghostd:regtest \
+  bitcoin-cli -regtest -rpcuser=ghost -rpcpassword=ghostpass getnewaddress || echo bcrt1qSETME)
+
+docker compose up -d bitcoind
+# pool1 is the genesis node — start it, wait ~60s for genesis params, THEN the rest
+docker compose up -d pool1
+sleep 60
+docker compose up -d pool2 pool3 pool4
+```
+
+## 4. Prime the chain past the gate
+```bash
+A=$(docker exec rc-bitcoind bitcoin-cli -regtest -rpcuser=ghost -rpcpassword=ghostpass getnewaddress)
+docker exec rc-bitcoind bitcoin-cli -regtest -rpcuser=ghost -rpcpassword=ghostpass generatetoaddress 110 "$A"
+# >100 ⇒ past CLUSTER_ENFORCEMENT_HEIGHT (if you set it to 100) ⇒ enforcement ON
+```
+
+## 5. Verify — the honest path + the gate (the core of the dry-run)
+Each node exposes its HTTP API on the host: pool1 `:8080`, pool2 `:8081`,
+pool3 `:8082`, pool4 `:8083`.
+
+- **Mesh formed:** `curl -s localhost:8080/health` on each → 3 peers, `is_active`.
+- **Shares replicate + ledgers agree:** drive shares through the translator (or
+  the pool's share endpoint), then compare per-node share/work totals across
+  `:8080..:8083` — they must match (this is GHOST-03 convergence keeping signed
+  shares in sync).
+- **Honest payout ratifies + pays:** when a block-difficulty share lands, watch
+  the logs for a payout proposal reaching 67% and executing; confirm the
+  coinbase pays the expected miners. **No `GHOST-02: rejecting payout proposal`
+  on a legit block** — that log on an honest round is a FAIL.
+- **Gate transition:** mine to a height *below* the gate and confirm an unsigned
+  share (from a lagging node) is *accepted*; mine past it and confirm the same
+  share is *dropped* (`GHOST-09: dropping share proof…`). This is the exact
+  behaviour the rolling deploy relies on.
+
+## 6. Verify — partition → convergence (GHOST-03 on real transport)
+```bash
+docker network disconnect regtest-cluster_default rc-pool3   # isolate pool3
+# ... let pool1 ingest a share pool3 will miss ...
+docker network connect regtest-cluster_default rc-pool3      # reconnect
+# Within ~30s (the convergence interval) pool3's share ledger should catch up to
+# the others — compare totals across nodes again. That's ShareConvergence live.
+```
+
+## 7. Adversarial coverage (optional, needs a byzantine node)
+To exercise GHOST-09/02/11 *rejection* on real binaries, rebuild ONE node from a
+throwaway branch that: signs shares with the wrong key (GHOST-09), proposes an
+inflated split (GHOST-02), or double-votes (GHOST-11). Point pool4 at that image
+and confirm pools 1-3 drop its shares / reject its proposal / ban it
+fleet-wide. **The same three properties are already proven deterministically by
+the in-process harness — this only re-confirms them over the wire.**
+
+## 8. Teardown
+```bash
+docker compose down -v
+```
+
+## 9. Sign-off checklist (gates the mainnet deploy)
+- [ ] Mesh of 4 forms; each node sees 3 peers.
+- [ ] Signed shares replicate; per-node ledgers agree.
+- [ ] An honest payout proposal ratifies and pays the right miners, post-gate.
+- [ ] No spurious `GHOST-02` rejection on honest blocks.
+- [ ] Below the gate an unsigned share is accepted; above it, dropped.
+- [ ] A partitioned node backfills via convergence on reconnect.
+- [ ] (If §7 run) a byzantine node's shares/proposal/votes are rejected + it's banned.
+
+Only with every box ticked should the gated rolling deploy (`plan` §4) proceed.
+
+---
+
+### Status / caveats
+This is a **scaffold** — the compose + configs + runbook are written from the
+config schema and the deploy plan, **not yet run end-to-end here**. Expect to
+tune: the Dockerfile features/COPY for the regtest binary, the exact share-
+submission path (translator vs direct endpoint), and the mesh discovery timing.
+File issues against this directory as you shake it out; the in-process harness
+remains the deterministic source of truth for the consensus *logic*.

--- a/docker/regtest-cluster/docker-compose.yml
+++ b/docker/regtest-cluster/docker-compose.yml
@@ -1,0 +1,101 @@
+# Audit-cluster regtest dry-run — 4 real ghost-pool nodes + a regtest ghostd,
+# full mesh, CLUSTER_ENFORCEMENT_HEIGHT gate ON. Run BEFORE any mainnet deploy.
+# See README.md for the runbook; tasks/plan_audit_cluster_deploy.md §3 for why.
+#
+#   cd docker/regtest-cluster && docker compose up -d
+#
+# Build the ghost-pool image WITHOUT --features zk-production (regtest needs no
+# MPC params). The image must contain bash + gettext (envsubst) for the
+# entrypoint — see README §Build.
+
+x-pool-common: &pool-common
+  image: bitcoin-ghost/ghost-pool:regtest
+  entrypoint: ["/usr/bin/env", "bash", "/entrypoint.sh"]
+  restart: "no"
+  depends_on:
+    bitcoind:
+      condition: service_started
+  environment:
+    BITCOIN_RPC_USER: ghost
+    BITCOIN_RPC_PASSWORD: ghostpass
+    # Replace with `bitcoin-cli -regtest getnewaddress` output before `up`:
+    TREASURY_ADDRESS: ${TREASURY_ADDRESS:?set TREASURY_ADDRESS to a regtest bcrt1 address}
+  volumes:
+    - ./pool.template.toml:/etc/ghost/pool.template.toml:ro
+    - ./entrypoint.sh:/entrypoint.sh:ro
+
+services:
+  bitcoind:
+    image: bitcoin-ghost/ghostd:regtest    # the ghost-core fork in regtest mode
+    container_name: rc-bitcoind
+    command:
+      - -regtest
+      - -server=1
+      - -txindex=1
+      - -rpcbind=0.0.0.0
+      - -rpcallowip=0.0.0.0/0
+      - -rpcuser=ghost
+      - -rpcpassword=ghostpass
+      - -zmqpubhashblock=tcp://0.0.0.0:28332
+      - -zmqpubhashtx=tcp://0.0.0.0:28333
+      - -fallbackfee=0.0002
+    ports:
+      - "18443:18443"   # RPC (for driving the dry-run from the host)
+
+  pool1:
+    <<: *pool-common
+    container_name: rc-pool1
+    environment:
+      NODE_NAME: pool1
+      SEED_NODES: '"pool2:8559", "pool3:8559", "pool4:8559"'
+      GENESIS_ARG: "--genesis"          # genesis node bootstraps the elder set
+      BITCOIN_RPC_USER: ghost
+      BITCOIN_RPC_PASSWORD: ghostpass
+      TREASURY_ADDRESS: ${TREASURY_ADDRESS}
+    ports:
+      - "8080:8080"
+
+  pool2:
+    <<: *pool-common
+    container_name: rc-pool2
+    depends_on:
+      bitcoind: { condition: service_started }
+      pool1:    { condition: service_started }   # start after genesis (≥60s, see README)
+    environment:
+      NODE_NAME: pool2
+      SEED_NODES: '"pool1:8559", "pool3:8559", "pool4:8559"'
+      BITCOIN_RPC_USER: ghost
+      BITCOIN_RPC_PASSWORD: ghostpass
+      TREASURY_ADDRESS: ${TREASURY_ADDRESS}
+    ports:
+      - "8081:8080"
+
+  pool3:
+    <<: *pool-common
+    container_name: rc-pool3
+    depends_on:
+      bitcoind: { condition: service_started }
+      pool1:    { condition: service_started }
+    environment:
+      NODE_NAME: pool3
+      SEED_NODES: '"pool1:8559", "pool2:8559", "pool4:8559"'
+      BITCOIN_RPC_USER: ghost
+      BITCOIN_RPC_PASSWORD: ghostpass
+      TREASURY_ADDRESS: ${TREASURY_ADDRESS}
+    ports:
+      - "8082:8080"
+
+  pool4:
+    <<: *pool-common
+    container_name: rc-pool4
+    depends_on:
+      bitcoind: { condition: service_started }
+      pool1:    { condition: service_started }
+    environment:
+      NODE_NAME: pool4
+      SEED_NODES: '"pool1:8559", "pool2:8559", "pool3:8559"'
+      BITCOIN_RPC_USER: ghost
+      BITCOIN_RPC_PASSWORD: ghostpass
+      TREASURY_ADDRESS: ${TREASURY_ADDRESS}
+    ports:
+      - "8083:8080"

--- a/docker/regtest-cluster/entrypoint.sh
+++ b/docker/regtest-cluster/entrypoint.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Regtest-cluster entrypoint: render the per-node config from env, then start
+# ghost-pool. Pool1 starts with --genesis (it bootstraps the MPC/elder set);
+# pools 2-4 join without it. See README.md for the start ordering.
+set -euo pipefail
+
+: "${NODE_NAME:?NODE_NAME required}"
+: "${SEED_NODES:?SEED_NODES required (comma-separated \"host:8559\" quoted list)}"
+: "${BITCOIN_RPC_USER:?}" "${BITCOIN_RPC_PASSWORD:?}" "${TREASURY_ADDRESS:?}"
+GENESIS_ARG="${GENESIS_ARG:-}"
+
+mkdir -p /var/lib/ghost/data
+envsubst < /etc/ghost/pool.template.toml > /etc/ghost/config.toml
+
+echo "[$NODE_NAME] starting ghost-pool (genesis='${GENESIS_ARG}') on regtest"
+# shellcheck disable=SC2086
+exec /usr/local/bin/ghost-pool ${GENESIS_ARG} --config /etc/ghost/config.toml

--- a/docker/regtest-cluster/pool.template.toml
+++ b/docker/regtest-cluster/pool.template.toml
@@ -1,0 +1,59 @@
+# Ghost Pool — regtest dry-run config TEMPLATE.
+# The entrypoint runs `envsubst` over this file, so ${VARS} below are filled in
+# per-node from each service's environment in docker-compose.yml.
+#
+# This cluster exists to run the audit-cluster dry-run from
+# tasks/plan_audit_cluster_deploy.md §3 BEFORE any mainnet deploy:
+# 4 real ghost-pool binaries on a regtest chain, full mesh, gate ON.
+
+[identity]
+key_path = "/var/lib/ghost/node.key"   # generated on first start, per-node volume
+display_name = "${NODE_NAME}"
+
+[bitcoin]
+rpc_host = "bitcoind"
+rpc_port = 18443                        # regtest default RPC port
+rpc_user = "${BITCOIN_RPC_USER}"
+rpc_password = "${BITCOIN_RPC_PASSWORD}"
+network = "regtest"                     # regtest → no zk-production / MPC params needed
+zmq_hashblock = "tcp://bitcoind:28332"
+zmq_hashtx = "tcp://bitcoind:28333"
+
+[network]
+# Container DNS name — peers dial this for the mesh.
+public_address = "${NODE_NAME}"
+# The OTHER three nodes' discovery endpoints (set per-service in compose).
+seed_nodes = [${SEED_NODES}]
+sv2_port = 34255
+sv1_port = 3333
+http_port = 8080
+max_miners = 1000
+public_mining = true
+
+[network.p2p]
+share_propagation = 8555
+block_announcement = 8556
+consensus_voting = 8557
+health_monitoring = 8558
+discovery = 8559
+elder_management = 8560
+payout_proposal = 8561
+payout_transaction = 8562
+
+[policy]
+profile = "bitcoin_pure"
+
+[storage]
+db_path = "/var/lib/ghost/data"
+wal_mode = true
+archive_mode = true
+prune_height = 0
+
+[pool]
+# A valid REGTEST address (bcrt1…). Replace with one from
+# `bitcoin-cli -regtest getnewaddress`.
+treasury_address = "${TREASURY_ADDRESS}"
+min_payout_sats = 10000
+
+[ghost_pay]
+enabled = false   # L2 is out of scope for the cluster (consensus) dry-run


### PR DESCRIPTION
The `convergence` module's inner (`//!`) doc linked `[`RoundManager`]`, but inner-doc intra-doc links resolve in the crate-root scope (where `RoundManager` isn't imported), so the CI Documentation job (`-D warnings`) failed with `unresolved link to RoundManager`. Switched to plain backticks. Full workspace `cargo doc --no-deps --all-features` is now clean.

(This is the "Documentation" failure that was incorrectly skipped as a flake during the cluster merges — apologies; it was real.)