### PR TITLE
fix(deploy): correct regtest scaffold against the real binary

### DIFF
--- a/docker/regtest-cluster/README.md
+++ b/docker/regtest-cluster/README.md
@@ -117,10 +117,27 @@ Only with every box ticked should the gated rolling deploy (`plan` §4) proceed.
 
 ---
 
-### Status / caveats
-This is a **scaffold** — the compose + configs + runbook are written from the
-config schema and the deploy plan, **not yet run end-to-end here**. Expect to
-tune: the Dockerfile features/COPY for the regtest binary, the exact share-
-submission path (translator vs direct endpoint), and the mesh discovery timing.
-File issues against this directory as you shake it out; the in-process harness
-remains the deterministic source of truth for the consensus *logic*.
+### Status / caveats — partially shaken out 2026-06-20
+The binary side was **validated against the real ghost-pool** in a local 4-process
+regtest run; the config schema here reflects what that surfaced (the docker
+template earlier was stale). Confirmed working: the node **boots, starts the P2P
+mesh, discovers all 3 peers, runs MPC genesis on `--genesis`, serves `/health`
+(healthy), and the gate is active once the chain passes height 100.**
+
+Three issues showed up running 4 nodes on **one host at `127.0.0.1`** — all of
+which this container-per-node layout avoids (each container = its own netns, DNS
+name and `$HOME`):
+1. **Shared identity** — `key_path` isn't honoured for *generation*; a node falls
+   back to `~/.ghost/node.key`, so 4 processes sharing one `$HOME` get the *same*
+   node id. Separate containers each generate their own. (Belt-and-braces: run
+   `--generate-identity` once per node volume before first start.)
+2. **Port 8443 collision** — the verification-HTTPS port is fixed (not in the
+   offsettable p2p set), so 4 same-host processes fight over it. One per container
+   is fine.
+3. **M-11 SSRF** — peer health-checks refuse `127.0.0.1`; with container DNS
+   names (`pool2`, …) or the VMs' public IPs this doesn't trigger.
+
+Still to shake out before sign-off: the Dockerfile regtest build (features/COPY),
+the share-submission path (translator vs direct endpoint), and driving a full
+round to a payout. The in-process harness remains the deterministic source of
+truth for the consensus *logic*; this cluster is for the transport + happy path.

--- a/docker/regtest-cluster/docker-compose.yml
+++ b/docker/regtest-cluster/docker-compose.yml
@@ -47,7 +47,7 @@ services:
     container_name: rc-pool1
     environment:
       NODE_NAME: pool1
-      SEED_NODES: '"pool2:8559", "pool3:8559", "pool4:8559"'
+      SEED_NODES: '"pool2:8555", "pool3:8555", "pool4:8555"'
       GENESIS_ARG: "--genesis"          # genesis node bootstraps the elder set
       BITCOIN_RPC_USER: ghost
       BITCOIN_RPC_PASSWORD: ghostpass
@@ -63,7 +63,7 @@ services:
       pool1:    { condition: service_started }   # start after genesis (≥60s, see README)
     environment:
       NODE_NAME: pool2
-      SEED_NODES: '"pool1:8559", "pool3:8559", "pool4:8559"'
+      SEED_NODES: '"pool1:8555", "pool3:8555", "pool4:8555"'
       BITCOIN_RPC_USER: ghost
       BITCOIN_RPC_PASSWORD: ghostpass
       TREASURY_ADDRESS: ${TREASURY_ADDRESS}
@@ -78,7 +78,7 @@ services:
       pool1:    { condition: service_started }
     environment:
       NODE_NAME: pool3
-      SEED_NODES: '"pool1:8559", "pool2:8559", "pool4:8559"'
+      SEED_NODES: '"pool1:8555", "pool2:8555", "pool4:8555"'
       BITCOIN_RPC_USER: ghost
       BITCOIN_RPC_PASSWORD: ghostpass
       TREASURY_ADDRESS: ${TREASURY_ADDRESS}
@@ -93,7 +93,7 @@ services:
       pool1:    { condition: service_started }
     environment:
       NODE_NAME: pool4
-      SEED_NODES: '"pool1:8559", "pool2:8559", "pool3:8559"'
+      SEED_NODES: '"pool1:8555", "pool2:8555", "pool3:8555"'
       BITCOIN_RPC_USER: ghost
       BITCOIN_RPC_PASSWORD: ghostpass
       TREASURY_ADDRESS: ${TREASURY_ADDRESS}

--- a/docker/regtest-cluster/entrypoint.sh
+++ b/docker/regtest-cluster/entrypoint.sh
@@ -10,6 +10,7 @@ set -euo pipefail
 GENESIS_ARG="${GENESIS_ARG:-}"
 
 mkdir -p /var/lib/ghost/data
+export SIGNING_KEY="${SIGNING_KEY:-$(head -c 32 /dev/urandom | xxd -p -c 32)}"
 envsubst < /etc/ghost/pool.template.toml > /etc/ghost/config.toml
 
 echo "[$NODE_NAME] starting ghost-pool (genesis='${GENESIS_ARG}') on regtest"

--- a/docker/regtest-cluster/pool.template.toml
+++ b/docker/regtest-cluster/pool.template.toml
@@ -20,6 +20,9 @@ zmq_hashblock = "tcp://bitcoind:28332"
 zmq_hashtx = "tcp://bitcoind:28333"
 
 [network]
+# 32-byte hex consensus signing key (required for mining_mode=PublicPool);
+# the entrypoint generates one per node.
+signing_key = "${SIGNING_KEY}"
 # Container DNS name — peers dial this for the mesh.
 public_address = "${NODE_NAME}"
 # The OTHER three nodes' discovery endpoints (set per-service in compose).
@@ -53,7 +56,9 @@ prune_height = 0
 # A valid REGTEST address (bcrt1…). Replace with one from
 # `bitcoin-cli -regtest getnewaddress`.
 treasury_address = "${TREASURY_ADDRESS}"
+treasury_fee_percent = 1.0
 min_payout_sats = 10000
+payout_interval_blocks = 100
 
 [ghost_pay]
 enabled = false   # L2 is out of scope for the cluster (consensus) dry-run


### PR DESCRIPTION
Shook out the dry-run scaffold against 4 real ghost-pool nodes on regtest. **Confirmed working:** boots, P2P mesh forms (all peers discovered), MPC genesis on `--genesis`, `/health` healthy, gate active past the configured height. Corrects the (stale) config schema — `signing_key`, `payout_interval_blocks`, `treasury_fee_percent`, `:8555` seed port — and documents the three single-host artifacts (shared identity, port-8443 collision, M-11 SSRF on 127.0.0.1) that the container-per-node layout avoids.