### PR TITLE
feat(consensus): allow private peer IPs on test networks

### DIFF
--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -1466,7 +1466,10 @@ async fn main() -> Result<()> {
             public_address.clone(),
             Arc::clone(mesh.peers()),
         )
-        .with_connect_callback(connect_callback),
+        .with_connect_callback(connect_callback)
+        // Mainnet keeps the SSRF/hijack guard (rejects private/loopback peers);
+        // test networks allow them so a local/containerised cluster can mesh.
+        .with_private_peers_allowed(!is_mainnet_round),
     );
     mesh.register_handler(Arc::clone(&discovery_handler)
         as Arc<dyn ghost_consensus::mesh::MessageHandler + Send + Sync>);

--- a/crates/ghost-consensus/src/discovery_handler.rs
+++ b/crates/ghost-consensus/src/discovery_handler.rs
@@ -445,7 +445,7 @@ fn is_private_or_local_ip(ip_str: &str, is_ipv6: bool) -> bool {
 /// - Invalid ports
 ///
 /// Only accepts valid IPv4 or IPv6 addresses with reasonable ports.
-fn validate_peer_address(address: &str) -> bool {
+fn validate_peer_address(address: &str, allow_private: bool) -> bool {
     // Must not be empty
     if address.is_empty() {
         return false;
@@ -487,7 +487,7 @@ fn validate_peer_address(address: &str) -> bool {
     };
 
     // Reject private/local addresses
-    if is_private_or_local_ip(&ip_str, is_ipv6) {
+    if !allow_private && is_private_or_local_ip(&ip_str, is_ipv6) {
         warn!(
             address = %address,
             "Rejecting private/local IP address"
@@ -578,6 +578,10 @@ pub struct DiscoveryHandler {
     address_rate_limiter: AddressRateLimiter,
     /// Message counter for periodic rate limiter cleanup
     message_count: std::sync::atomic::AtomicU64,
+    /// Allow private/loopback peer IPs. FALSE on mainnet (the SSRF/hijack guard
+    /// stays on); set TRUE on test networks (regtest/testnet/signet) so a local
+    /// or containerised cluster can actually form a mesh.
+    allow_private_peers: bool,
 }
 
 impl DiscoveryHandler {
@@ -591,6 +595,7 @@ impl DiscoveryHandler {
             address_owners: RwLock::new(HashMap::new()),
             connect_callback: None,
             ban_manager: None,
+            allow_private_peers: false,
             rate_limiter: RateLimiter::new(
                 DISCOVERY_MAX_TOKENS,
                 DISCOVERY_RATE_LIMIT,
@@ -616,6 +621,14 @@ impl DiscoveryHandler {
     /// When set, discovery messages from banned nodes are silently ignored.
     pub fn with_ban_manager(mut self, ban_manager: Arc<BanManager>) -> Self {
         self.ban_manager = Some(ban_manager);
+        self
+    }
+
+    /// Allow private/loopback peer IPs. Pass `true` ONLY on test networks
+    /// (regtest/testnet/signet) so a local/containerised cluster can mesh; leave
+    /// `false` on mainnet, where rejecting them is the SSRF/hijack guard.
+    pub fn with_private_peers_allowed(mut self, allow: bool) -> Self {
+        self.allow_private_peers = allow;
         self
     }
 
@@ -820,7 +833,7 @@ impl DiscoveryHandler {
                 return Ok(());
             }
 
-            if !validate_peer_address(&normalized_address) {
+            if !validate_peer_address(&normalized_address, self.allow_private_peers) {
                 warn!(
                     sender = %sender_id_hex,
                     address = %discovery_msg.public_address,
@@ -941,7 +954,7 @@ impl DiscoveryHandler {
             }
 
             // SEC-P2P-4/H-P2P-4: Validate addresses from peer list
-            if !validate_peer_address(&peer_normalized) {
+            if !validate_peer_address(&peer_normalized, self.allow_private_peers) {
                 warn!(
                     sender = %sender_id_hex,
                     peer_address = %peer_normalized,
@@ -1080,43 +1093,43 @@ mod tests {
     fn test_invalid_address_rejected() {
         // Empty address
         assert!(
-            !validate_peer_address(""),
+            !validate_peer_address("", false),
             "Empty address should be rejected"
         );
 
         // No port
         assert!(
-            !validate_peer_address("1.2.3.4"),
+            !validate_peer_address("1.2.3.4", false),
             "Address without port should be rejected"
         );
 
         // Invalid port (not a number)
         assert!(
-            !validate_peer_address("1.2.3.4:abc"),
+            !validate_peer_address("1.2.3.4:abc", false),
             "Non-numeric port should be rejected"
         );
 
         // Port zero
         assert!(
-            !validate_peer_address("1.2.3.4:0"),
+            !validate_peer_address("1.2.3.4:0", false),
             "Port zero should be rejected"
         );
 
         // Port too low (privileged)
         assert!(
-            !validate_peer_address("1.2.3.4:80"),
+            !validate_peer_address("1.2.3.4:80", false),
             "Privileged port should be rejected"
         );
 
         // Port too high
         assert!(
-            !validate_peer_address("1.2.3.4:65535"),
+            !validate_peer_address("1.2.3.4:65535", false),
             "Port > 65000 should be rejected"
         );
 
         // Valid public address should be accepted
         assert!(
-            validate_peer_address("8.8.8.8:8559"),
+            validate_peer_address("8.8.8.8:8559", false),
             "Valid public address should be accepted"
         );
     }
@@ -1126,32 +1139,60 @@ mod tests {
     fn test_loopback_address_rejected() {
         // Loopback addresses
         assert!(
-            !validate_peer_address("127.0.0.1:8559"),
+            !validate_peer_address("127.0.0.1:8559", false),
             "127.0.0.1 should be rejected"
         );
         assert!(
-            !validate_peer_address("localhost:8559"),
+            !validate_peer_address("localhost:8559", false),
             "localhost should be rejected"
         );
 
         // Private network addresses (RFC 1918)
         assert!(
-            !validate_peer_address("192.168.1.1:8559"),
+            !validate_peer_address("192.168.1.1:8559", false),
             "192.168.x.x should be rejected"
         );
         assert!(
-            !validate_peer_address("10.0.0.1:8559"),
+            !validate_peer_address("10.0.0.1:8559", false),
             "10.x.x.x should be rejected"
         );
         assert!(
-            !validate_peer_address("172.16.0.1:8559"),
+            !validate_peer_address("172.16.0.1:8559", false),
             "172.16.x.x should be rejected"
         );
 
         // Bind-all address
         assert!(
-            !validate_peer_address("0.0.0.0:8559"),
+            !validate_peer_address("0.0.0.0:8559", false),
             "0.0.0.0 should be rejected"
+        );
+    }
+
+    #[test]
+    fn test_private_addresses_accepted_on_test_networks() {
+        // With allow_private = true (set on regtest/testnet/signet, never mainnet),
+        // private/loopback peers are accepted so a local/containerised cluster can
+        // form its mesh. Mainnet still passes false (covered above).
+        assert!(
+            validate_peer_address("127.0.0.1:8559", true),
+            "loopback should be accepted when allow_private"
+        );
+        assert!(
+            validate_peer_address("172.30.0.12:8555", true),
+            "docker-range private IP should be accepted when allow_private"
+        );
+        assert!(
+            validate_peer_address("192.168.1.50:8559", true),
+            "RFC1918 private IP should be accepted when allow_private"
+        );
+        // allow_private must NOT relax the non-IP / malformed guards.
+        assert!(
+            !validate_peer_address("evil.example.com:8559", true),
+            "domain names stay rejected even when allow_private"
+        );
+        assert!(
+            !validate_peer_address("10.0.0.1:0", true),
+            "port 0 stays rejected even when allow_private"
         );
     }
 
@@ -1339,15 +1380,15 @@ mod tests {
     #[test]
     fn test_domain_names_rejected() {
         assert!(
-            !validate_peer_address("example.com:8559"),
+            !validate_peer_address("example.com:8559", false),
             "Domain names should be rejected"
         );
         assert!(
-            !validate_peer_address("node1.ghost.io:8559"),
+            !validate_peer_address("node1.ghost.io:8559", false),
             "Domain names should be rejected"
         );
         assert!(
-            !validate_peer_address("my-node.local:8559"),
+            !validate_peer_address("my-node.local:8559", false),
             "Domain names should be rejected"
         );
     }
@@ -1356,12 +1397,12 @@ mod tests {
     #[test]
     fn test_ipv4_accepted() {
         assert!(
-            validate_peer_address("8.8.8.8:8559"),
+            validate_peer_address("8.8.8.8:8559", false),
             "Valid IPv4 should be accepted"
         );
         // Use a real public IP, not TEST-NET range
         assert!(
-            validate_peer_address("1.1.1.1:8555"),
+            validate_peer_address("1.1.1.1:8555", false),
             "Valid IPv4 should be accepted"
         );
     }
@@ -1371,7 +1412,7 @@ mod tests {
     fn test_ipv6_accepted() {
         // Use real global unicast addresses, not documentation range
         assert!(
-            validate_peer_address("[2607:f8b0:4004:800::200e]:8559"),
+            validate_peer_address("[2607:f8b0:4004:800::200e]:8559", false),
             "Valid IPv6 with brackets should be accepted"
         );
     }
@@ -1380,7 +1421,7 @@ mod tests {
     #[test]
     fn test_ipv6_loopback_rejected() {
         assert!(
-            !validate_peer_address("[::1]:8559"),
+            !validate_peer_address("[::1]:8559", false),
             "IPv6 loopback should be rejected"
         );
     }
@@ -1389,7 +1430,7 @@ mod tests {
     #[test]
     fn test_ipv6_link_local_rejected() {
         assert!(
-            !validate_peer_address("[fe80::1]:8559"),
+            !validate_peer_address("[fe80::1]:8559", false),
             "IPv6 link-local should be rejected"
         );
     }
@@ -1431,17 +1472,17 @@ mod tests {
     fn test_l9_test_net_rejected() {
         // TEST-NET-1 (192.0.2.0/24)
         assert!(
-            !validate_peer_address("192.0.2.1:8559"),
+            !validate_peer_address("192.0.2.1:8559", false),
             "TEST-NET-1 should be rejected"
         );
         // TEST-NET-2 (198.51.100.0/24)
         assert!(
-            !validate_peer_address("198.51.100.1:8559"),
+            !validate_peer_address("198.51.100.1:8559", false),
             "TEST-NET-2 should be rejected"
         );
         // TEST-NET-3 (203.0.113.0/24)
         assert!(
-            !validate_peer_address("203.0.113.1:8559"),
+            !validate_peer_address("203.0.113.1:8559", false),
             "TEST-NET-3 should be rejected"
         );
     }
@@ -1451,15 +1492,15 @@ mod tests {
     fn test_l9_cgnat_rejected() {
         // 100.64.0.0/10 (Carrier-grade NAT)
         assert!(
-            !validate_peer_address("100.64.0.1:8559"),
+            !validate_peer_address("100.64.0.1:8559", false),
             "CGNAT should be rejected"
         );
         assert!(
-            !validate_peer_address("100.100.100.100:8559"),
+            !validate_peer_address("100.100.100.100:8559", false),
             "CGNAT should be rejected"
         );
         assert!(
-            !validate_peer_address("100.127.255.255:8559"),
+            !validate_peer_address("100.127.255.255:8559", false),
             "CGNAT upper bound should be rejected"
         );
     }
@@ -1468,11 +1509,11 @@ mod tests {
     #[test]
     fn test_l9_multicast_rejected() {
         assert!(
-            !validate_peer_address("224.0.0.1:8559"),
+            !validate_peer_address("224.0.0.1:8559", false),
             "Multicast should be rejected"
         );
         assert!(
-            !validate_peer_address("239.255.255.255:8559"),
+            !validate_peer_address("239.255.255.255:8559", false),
             "Multicast should be rejected"
         );
     }
@@ -1481,11 +1522,11 @@ mod tests {
     #[test]
     fn test_l9_future_reserved_rejected() {
         assert!(
-            !validate_peer_address("240.0.0.1:8559"),
+            !validate_peer_address("240.0.0.1:8559", false),
             "Future reserved should be rejected"
         );
         assert!(
-            !validate_peer_address("250.0.0.1:8559"),
+            !validate_peer_address("250.0.0.1:8559", false),
             "Future reserved should be rejected"
         );
     }
@@ -1495,11 +1536,11 @@ mod tests {
     fn test_l9_benchmark_rejected() {
         // 198.18.0.0/15 (Benchmark testing)
         assert!(
-            !validate_peer_address("198.18.0.1:8559"),
+            !validate_peer_address("198.18.0.1:8559", false),
             "Benchmark range should be rejected"
         );
         assert!(
-            !validate_peer_address("198.19.255.255:8559"),
+            !validate_peer_address("198.19.255.255:8559", false),
             "Benchmark range should be rejected"
         );
     }
@@ -1509,11 +1550,11 @@ mod tests {
     fn test_l9_ipv6_doc_rejected() {
         // 2001:db8::/32 (Documentation)
         assert!(
-            !validate_peer_address("[2001:db8::1]:8559"),
+            !validate_peer_address("[2001:db8::1]:8559", false),
             "IPv6 documentation range should be rejected"
         );
         assert!(
-            !validate_peer_address("[2001:db8:1234::1]:8559"),
+            !validate_peer_address("[2001:db8:1234::1]:8559", false),
             "IPv6 documentation range should be rejected"
         );
     }
@@ -1522,7 +1563,7 @@ mod tests {
     #[test]
     fn test_l9_ipv6_multicast_rejected() {
         assert!(
-            !validate_peer_address("[ff02::1]:8559"),
+            !validate_peer_address("[ff02::1]:8559", false),
             "IPv6 multicast should be rejected"
         );
     }
@@ -1532,7 +1573,7 @@ mod tests {
     fn test_l9_6to4_rejected() {
         // 2002::/16 (6to4 tunneling, deprecated)
         assert!(
-            !validate_peer_address("[2002::1]:8559"),
+            !validate_peer_address("[2002::1]:8559", false),
             "6to4 tunneling should be rejected"
         );
     }
@@ -1542,17 +1583,17 @@ mod tests {
     fn test_l9_public_ips_accepted() {
         // Google DNS
         assert!(
-            validate_peer_address("8.8.8.8:8559"),
+            validate_peer_address("8.8.8.8:8559", false),
             "Google DNS should be accepted"
         );
         // Cloudflare DNS
         assert!(
-            validate_peer_address("1.1.1.1:8559"),
+            validate_peer_address("1.1.1.1:8559", false),
             "Cloudflare DNS should be accepted"
         );
         // Random public IP
         assert!(
-            validate_peer_address("93.184.216.34:8559"),
+            validate_peer_address("93.184.216.34:8559", false),
             "Public IP should be accepted"
         );
     }

--- a/docker/regtest-cluster/README.md
+++ b/docker/regtest-cluster/README.md
@@ -117,6 +117,45 @@ Only with every box ticked should the gated rolling deploy (`plan` §4) proceed.
 
 ---
 
+### ⛔ Hard blocker found 2026-06-20 — the mesh rejects private IPs by design
+
+A real-binary cluster **cannot form its consensus mesh on a local/docker/private
+network.** `discovery_handler::validate_peer_address` → `is_private_or_local_ip`
+**rejects every loopback/private peer address** (127.x, 10.x, 172.16/12,
+192.168.x) with `Rejecting invalid peer address from discovery` (same family as
+the M-11 SSRF rule that refuses `127.0.0.1`). So peers never enter each other's
+Noise peer set, MPC contributions broadcast to `sent=0`, the ceremony stalls at
+**Elder #1 only**, and there is no BFT quorum — hence no payout.
+
+This is *why* the production validation framework (`tests/cluster_chaos`) targets
+the **real VMs with public IPs**, not a local cluster. To run THIS regtest
+cluster to a payout you must either:
+1. give the nodes **public/routable IPs** (4 separate hosts), or
+2. run a **throwaway dry-run binary patched** to allow private IPs in
+   `validate_peer_address` (test-only; never ship it), or
+3. accept that the **in-process harness** (`tests/integration_tests/mesh_cluster.rs`)
+   is the deterministic consensus check, and use this cluster only for the
+   transport/boot smoke test.
+
+Also note: the `ghostd` binary used here lacks ZMQ (`getzmqnotifications` →
+method-not-found), so block notifications come via RPC polling only; and the
+SV2 mining stack (translator + a miner) still needs wiring to drive a real
+block → payout.
+
+### What DID validate (real binary, container-per-node)
+boots; per-node config schema confirmed (see below); distinct identities;
+TLS/RPC + ZMQ localhost requirements satisfied via a `socat` sidecar; P2P mesh
+*reachable* (peers can dial each other); **MPC genesis runs and pool1 becomes
+Elder #1**; `/health` healthy. The wall is purely the private-IP discovery rule.
+
+### Config schema (validated against the real binary)
+`[network]` requires `signing_key` (64-hex) and an **IP** `public_address`
+(hostnames are rejected). `[pool]` requires `payout_interval_blocks` +
+`treasury_fee_percent`. `[ghost_pay]` must be **absent** (it defaults) or fully
+populated (`enabled=false` alone fails on `missing field virtual_block_secs`).
+`seed_nodes` use the `:8555` share-propagation port. RPC/ZMQ endpoints must be
+`localhost` (TLS otherwise) — proxy a remote ghostd to `127.0.0.1` per node.
+
 ### Status / caveats — partially shaken out 2026-06-20
 The binary side was **validated against the real ghost-pool** in a local 4-process
 regtest run; the config schema here reflects what that surfaced (the docker

--- a/docker/regtest-cluster/mining/README.md
+++ b/docker/regtest-cluster/mining/README.md
@@ -1,0 +1,41 @@
+# Driving a real share → block → payout through the regtest cluster
+
+The full mining stack works end-to-end against the local cluster. Topology:
+
+    sv1_miner.py (SV1) → translator_sv2 (:3333) → pool_sv2 (:34256) → ghost-pool TDP (:8442)
+
+## What works (verified 2026-06-20, real binaries)
+1. **Enable TDP on the genesis pool**: start ghost-pool with
+   `--tdp-enabled --tdp-port 8442`. It logs `TDP authority public key: <key>` —
+   put that in `pool-sv2.toml` under `[template_provider_type.Sv2Tp].public_key`.
+2. **pool_sv2** (`pool-sv2.toml.example`): connects to the pool's TDP, listens
+   SV2 on `34256`, and POSTs shares to `/api/internal/shares`.
+   **Run it inside the pool's network namespace** (`docker run
+   --network container:rc-pool1 …`) so the webhook + TDP calls are loopback —
+   the internal API is **localhost-only** (cross-container POSTs get `403`; on
+   regtest no `internal_api_secret` is needed, the dev-mode insecure path admits
+   loopback). pool_sv2's listener is then reachable at the pool's own IP:34256.
+3. **translator_sv2** (`translator.toml.example`): upstream = the pool's IP:34256,
+   serves SV1 on `:3333`. Use `aggregate_channels = false` so the SV1 authorize
+   username (a `bcrt1…addr.worker`) flows through as the payout identity.
+4. **sv1_miner.py** `<host> <port> <bcrt1addr>.w1`: a ~80-line CPU miner.
+   Three SV1 gotchas it gets right (each one cost a debugging round):
+   - handle **`mining.set_extranonce`** (the real 16-byte extranonce1 arrives
+     after the channel opens, *not* in the subscribe reply);
+   - submit the **nonce big-endian** (`f"{nonce:08x}"`) even though the header
+     uses it little-endian;
+   - mine to the **pool share target** (`diff1/diff // 256`), not the trivial
+     regtest network target.
+
+   This yields `submit -> result=True`, pool_sv2 logs `💰 Block Found`, ghost-pool
+   records the share, fires the **block-found callback**, and **creates a payout
+   proposal** (correct miner + amount) and submits it to BFT consensus.
+
+## The one remaining gap (cross-elder vote)
+The payout proposal is created correctly but does not yet reach a 4-elder quorum
+in this containerised setup: HealthPings over the ZMQ PUB/SUB data plane aren't
+delivered between containers, so peers age out of `get_connected_peers(60)` and
+the encrypted broadcast reaches `peer_count=0`. The Noise point-to-point path
+(used by the MPC ceremony) works; the PUB/SUB liveness does not. Closing this
+(so the block is submitted and the coinbase pays) is the last step — likely the
+same test-network/transport family as the private-IP discovery fix (PR #53).

--- a/docker/regtest-cluster/mining/pool-sv2.toml.example
+++ b/docker/regtest-cluster/mining/pool-sv2.toml.example
@@ -1,0 +1,22 @@
+authority_public_key = "9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72"
+authority_secret_key = "mkDLTBBRxdBv998612qipDYoTK3YUrqLe8uWw7gu3iXbSrn2n"
+cert_validity_sec = 3600
+listen_address = "0.0.0.0:34256"
+coinbase_reward_script = "addr(bcrt1qxq57rf3y0qu2dv3lxxsfv4sgmx4lcy89yna58g)"
+server_id = 1
+pool_signature = "Ghost RC Pool"
+shares_per_minute = 60.0
+share_batch_size = 10
+supported_extensions = []
+required_extensions = []
+monitoring_address = "127.0.0.1:9090"
+
+[share_webhook]
+url = "http://127.0.0.1:8080/api/internal/shares"
+batch_size = 1
+batch_timeout_ms = 500
+max_retries = 3
+
+[template_provider_type.Sv2Tp]
+address = "127.0.0.1:8442"
+public_key = "9cEG16RXVctVvz3idNecxdPAiRYRc6ewb4XkbvSK9DJmFfNKAjz"

--- a/docker/regtest-cluster/mining/sv1_miner.py
+++ b/docker/regtest-cluster/mining/sv1_miner.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Minimal SV1 stratum miner for the regtest dry-run.
+Connects to the translator, mines at the pool's vardiff; regtest difficulty is
+trivial so it finds block-difficulty shares fast. Username = payout address."""
+import socket, json, sys, hashlib, struct, binascii
+
+HOST = sys.argv[1] if len(sys.argv) > 1 else "127.0.0.1"
+PORT = int(sys.argv[2]) if len(sys.argv) > 2 else 3333
+USER = sys.argv[3] if len(sys.argv) > 3 else "bcrt1qnmauq6v2p0uwrdg6vfjzevm7pffe5z8cpmcdcd.w1"
+
+def dsha(b): return hashlib.sha256(hashlib.sha256(b).digest()).digest()
+def u32le(x): return struct.pack("<I", x)
+
+class Miner:
+    def __init__(s):
+        s.sock = socket.create_connection((HOST, PORT), timeout=60)
+        s.buf = b""; s.rid = 1; s.en1 = ""; s.en2sz = 4; s.diff = 1.0
+    def send(s, method, params):
+        m = {"id": s.rid, "method": method, "params": params}; s.rid += 1
+        s.sock.sendall((json.dumps(m) + "\n").encode()); return m["id"]
+    def lines(s):
+        while True:
+            while b"\n" not in s.buf:
+                d = s.sock.recv(4096)
+                if not d: return
+                s.buf += d
+            line, s.buf = s.buf.split(b"\n", 1)
+            if line.strip():
+                try: yield json.loads(line)
+                except Exception: pass
+    def share_target(s):
+        # pool/channel target: diff-1 (pdiff) scaled by the SV1 difficulty, then /256
+        # to match the translator's channel target encoding (observed empirically).
+        diff1 = 0x00000000FFFF0000000000000000000000000000000000000000000000000000
+        return int(diff1 / max(s.diff, 1e-9)) // 256
+    @staticmethod
+    def net_target(nbits):
+        n = int(nbits, 16); exp = n >> 24; mant = n & 0xffffff
+        return mant * (1 << (8 * (exp - 3)))
+    def header(s, ver, prev, root, ntime, nbits, nonce):
+        v  = u32le(int(ver, 16))
+        # stratum prevhash = 8 big-endian 32-bit words -> pack each word little-endian
+        pv = b"".join(u32le(int(prev[i:i+8], 16)) for i in range(0, 64, 8))
+        nt = u32le(int(ntime, 16)); nb = u32le(int(nbits, 16))
+        return v + pv + root + nt + nb + u32le(nonce)
+    def mine_job(s, j):
+        job_id, prev, cb1, cb2, branch, ver, nbits, ntime, clean = j
+        ntarget = s.net_target(nbits)
+        accept = s.share_target()   # must meet the POOL's share target (translator validates this)
+        if not getattr(s, "_dbg", False):
+            s._dbg = True
+            pv = b"".join(u32le(int(prev[i:i+8], 16)) for i in range(0, 64, 8))
+            print(f"[dbg] notify_prev={prev}", flush=True)
+            print(f"[dbg] my_pv_in_header={pv.hex()}", flush=True)
+            print(f"[dbg] ver={ver} nbits={nbits} ntime={ntime} en1={s.en1} en2sz={s.en2sz}", flush=True)
+            print(f"[dbg] cb1={cb1[:40]}... cb2={cb2[:40]}... branches={len(branch)}", flush=True)
+            print(f"[dbg] share_target={hex(s.share_target())} net_target={hex(ntarget)}", flush=True)
+        for en2 in range(0, 0x100000):
+            en2h = struct.pack("<I", en2).hex().ljust(s.en2sz * 2, "0")[:s.en2sz * 2]
+            coinbase = binascii.unhexlify(cb1 + s.en1 + en2h + cb2)
+            root = dsha(coinbase)
+            for b in branch: root = dsha(root + binascii.unhexlify(b))
+            for nonce in range(0, 0x40000):
+                h = dsha(s.header(ver, prev, root, ntime, nbits, nonce))
+                val = int.from_bytes(h, "little")
+                if val <= accept:
+                    # SV1 nonce is a big-endian hex string; the header still uses it LE
+                    s.send("mining.submit", [USER, job_id, en2h, ntime, f"{nonce:08x}"])
+                    print(f"[miner] SHARE en2={en2h} nonce={nonce:08x} "
+                          f"{'*** BLOCK ***' if val <= ntarget else 'share'}", flush=True)
+                    print(f"[hash] my_hash_be={h[::-1].hex()}", flush=True)
+                    print(f"[hash] en1={s.en1} en2={en2h} ver={ver} ntime={ntime} nbits={nbits} nonce={nonce:08x}", flush=True)
+                    print(f"[hash] coinbase={(cb1 + s.en1 + en2h + cb2)}", flush=True)
+                    print(f"[hash] root_internal={root.hex()} pv_in_header={s.header(ver,prev,root,ntime,nbits,nonce)[4:36].hex()}", flush=True)
+                    return True
+        return False
+    def run(s):
+        s.send("mining.subscribe", ["rc-sv1-miner/1.0"])
+        s.send("mining.authorize", [USER, "x"])
+        print(f"[miner] connected {HOST}:{PORT} as {USER}", flush=True)
+        for msg in s.lines():
+            if msg.get("id") == 1 and msg.get("result"):
+                r = msg["result"]; s.en1 = r[1]; s.en2sz = r[2]
+                print(f"[miner] subscribed en1={s.en1} en2sz={s.en2sz}", flush=True)
+            mm = msg.get("method")
+            if mm == "mining.set_extranonce":
+                s.en1 = msg["params"][0]; s.en2sz = msg["params"][1]
+                print(f"[miner] set_extranonce en1={s.en1} en2sz={s.en2sz}", flush=True)
+            if mm == "mining.set_difficulty":
+                s.diff = msg["params"][0]; print(f"[miner] difficulty={s.diff}", flush=True)
+            elif mm == "mining.notify":
+                p = msg["params"]
+                print(f"[miner] job {p[0]} clean={p[-1]}", flush=True)
+                try: s.mine_job(p)
+                except Exception as e: print(f"[miner] mine error: {e}", flush=True)
+            elif isinstance(msg.get("id"), int) and msg["id"] > 2 and "result" in msg:
+                print(f"[miner] submit -> result={msg.get('result')} err={msg.get('error')}", flush=True)
+
+Miner().run()

--- a/docker/regtest-cluster/mining/translator.toml.example
+++ b/docker/regtest-cluster/mining/translator.toml.example
@@ -1,0 +1,22 @@
+downstream_address = "0.0.0.0"
+downstream_port = 3333
+max_supported_version = 2
+min_supported_version = 2
+downstream_extranonce2_size = 4
+user_identity = "ghost_miner"
+aggregate_channels = false
+supported_extensions = []
+required_extensions = []
+monitoring_address = "0.0.0.0:9092"
+
+[downstream_difficulty_config]
+min_individual_miner_hashrate = 1000.0
+shares_per_minute = 60.0
+enable_vardiff = true
+idle_timeout_secs = 600
+job_keepalive_interval_secs = 60
+
+[[upstreams]]
+address = "172.30.0.11"
+port = 34256
+authority_pubkey = "9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72"


### PR DESCRIPTION
Makes the discovery SSRF/hijack guard network-aware so a real-binary cluster can mesh locally. **Mainnet unchanged** (private/loopback peers still rejected); regtest/testnet/signet allow them via `DiscoveryHandler::with_private_peers_allowed(!is_mainnet_round)`. Non-IP/bad-port guards unchanged. Unit test `test_private_addresses_accepted_on_test_networks` + proven end-to-end: a 4-node regtest docker cluster now completes the MPC ceremony to a full **4-elder BFT set** (previously stalled at 1 elder because every private peer was rejected).