### PR TITLE
fix(consensus): publish ZMQ broadcasts unconditionally (self-isolation deadlock)

### DIFF
--- a/bins/ghost-pool/src/convergence.rs
+++ b/bins/ghost-pool/src/convergence.rs
@@ -262,6 +262,120 @@ mod tests {
     }
 
     #[test]
+    fn remote_share_with_senders_template_is_accepted_local_stays_validated() {
+        // M-MINE-1 validates the template against THIS node's templates. A gossiped
+        // share (received_by = another node) was mined against the SENDER's coinbase
+        // template — which this node cannot know — so M-MINE-1 must NOT reject it:
+        // its trust anchors are the GHOST-09 signature (the signer vouches), C4 PoW,
+        // and C5 dedup, and the signer already validated its own template. Without
+        // this, every cross-node share is dropped as StaleTemplate and GHOST-02
+        // rejects every payout once enforcement activates.
+        let unknown_template = [0x33u8; 32]; // NOT the node's TPL
+
+        // Remote share: received_by = a different node, signed by it, sender's template.
+        let remote_signer = NodeIdentity::generate();
+        let mut remote = ShareProof {
+            round_id: 1,
+            miner_id: [9u8; 32],
+            difficulty: 1.0,
+            work: 1.0,
+            share_hash: diff1_hash(101),
+            timestamp: 0,
+            received_by: remote_signer.node_id(),
+            template_id: Some(unknown_template),
+            payout_address: None,
+            signature: None,
+        };
+        remote.sign(&remote_signer);
+        let rm = round_manager(); // template = TPL, our_node_id = (internal)
+        assert!(
+            rm.handle_share_proof(remote.clone()).is_ok(),
+            "a gossiped share carrying the sender's (locally-unknown) template must be accepted"
+        );
+        assert!(rm.round_share_hashes(1).contains(&remote.share_hash));
+
+        // Local share: received_by = self, unknown template → STILL stale-rejected.
+        let local_id = NodeIdentity::generate();
+        let cfg = RoundConfig {
+            share_difficulty: 1.0,
+            network_difficulty: 1_000_000.0,
+            ..RoundConfig::default()
+        };
+        let rm_local = Arc::new(RoundManager::new(local_id.node_id(), cfg));
+        rm_local.set_template_id(TPL);
+        let mut local = ShareProof {
+            round_id: 1,
+            miner_id: [9u8; 32],
+            difficulty: 1.0,
+            work: 1.0,
+            share_hash: diff1_hash(102),
+            timestamp: 0,
+            received_by: local_id.node_id(),
+            template_id: Some(unknown_template),
+            payout_address: None,
+            signature: None,
+        };
+        local.sign(&local_id);
+        assert!(
+            matches!(
+                rm_local.handle_share_proof(local),
+                Err(crate::round::ShareError::StaleTemplate)
+            ),
+            "a LOCAL share (received_by == self) with an unknown template is still stale-rejected"
+        );
+    }
+
+    #[test]
+    fn remote_share_work_consistency_uses_absolute_model_not_pool_min() {
+        // M-9 work-consistency must validate proof.work against proof.difficulty
+        // (the ABSOLUTE model: work == difficulty, exactly as the SRI/local path
+        // `record_share` credits it), NOT proof.difficulty / share_difficulty. The
+        // relative model assumes a pool minimum of 1; with the PRODUCTION DEFAULT
+        // share_difficulty=1000 it computed calculated_work = work/1000 and rejected
+        // every gossiped share, making the elders hold 0 shares and GHOST-02 reject
+        // every payout once enforcement activates. C4 already proves the hash meets
+        // proof.difficulty, so work==difficulty is fully PoW-bounded.
+        let producer = NodeIdentity::generate();
+        let cfg = RoundConfig {
+            share_difficulty: 1000.0, // PRODUCTION DEFAULT (round_manager() uses 1.0 and hides the bug)
+            network_difficulty: 1_000_000.0,
+            ..RoundConfig::default()
+        };
+        let rm = Arc::new(RoundManager::new(NodeIdentity::generate().node_id(), cfg));
+        rm.set_template_id(TPL);
+
+        let mut p = ShareProof {
+            round_id: 1,
+            miner_id: [9u8; 32],
+            difficulty: 1.0,
+            work: 1.0, // absolute: work == difficulty (what the SRI sets)
+            share_hash: diff1_hash(50),
+            timestamp: 0,
+            received_by: producer.node_id(),
+            template_id: Some(TPL),
+            payout_address: None,
+            signature: None,
+        };
+        p.sign(&producer);
+        assert!(
+            rm.handle_share_proof(p.clone()).is_ok(),
+            "a gossiped share with work==difficulty must pass M-9 regardless of the local share_difficulty"
+        );
+
+        // A share that claims more work than its difficulty justifies is still rejected.
+        let mut inflated = p.clone();
+        inflated.work = 10.0; // 10x the claimed difficulty
+        inflated.sign(&producer);
+        assert!(
+            matches!(
+                rm.handle_share_proof(inflated),
+                Err(crate::round::ShareError::WorkValueTooHigh { .. })
+            ),
+            "claiming work that exceeds the difficulty is still rejected (no inflation)"
+        );
+    }
+
+    #[test]
     fn proofs_missing_from_excludes_known_hashes() {
         let producer = NodeIdentity::generate();
         let rm = round_manager();

--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -3611,10 +3611,23 @@ async fn main() -> Result<()> {
         hasher.update(share.miner_id.as_bytes());
         let miner_hash: [u8; 32] = hasher.finalize().into();
 
+        // The SV2/SRI layer reports share_hash in big-endian DISPLAY order (PoW
+        // leading zeros at the front). The pool's difficulty machinery
+        // (DifficultyCalculator::difficulty_from_hash / C4) and the in-process
+        // harness both read the hash in INTERNAL (little-endian) order, with the
+        // leading zeros at the HIGH-index end. Store it internal so cross-node C4
+        // validation on the elders reads the real difficulty instead of a
+        // near-zero one (which made them reject every gossiped share).
         let mut share_hash_bytes = [0u8; 32];
         if let Ok(decoded) = hex::decode(&share.share_hash) {
-            let len = decoded.len().min(32);
-            share_hash_bytes[..len].copy_from_slice(&decoded[..len]);
+            if decoded.len() == 32 {
+                for (i, b) in decoded.iter().rev().enumerate() {
+                    share_hash_bytes[i] = *b; // display (big-endian) -> internal (little-endian)
+                }
+            } else {
+                let len = decoded.len().min(32);
+                share_hash_bytes[..len].copy_from_slice(&decoded[..len]);
+            }
         }
 
         let mut proof = ghost_common::types::ShareProof {

--- a/bins/ghost-pool/src/round.rs
+++ b/bins/ghost-pool/src/round.rs
@@ -561,9 +561,16 @@ impl RoundManager {
             }
         };
 
-        // M-MINE-1: Validate template is current or recent
-        // This prevents accepting shares for old/stale templates
-        if !self.is_valid_template(&template_id) {
+        // M-MINE-1: Validate template is current or recent — but ONLY for shares
+        // THIS node received/signed (received_by == our_node_id). A gossiped share
+        // (received_by = another node) was mined against the SENDER's coinbase
+        // template, which this node cannot know or validate; its trust anchors are
+        // the GHOST-09 signature (the signer vouches for the credit), C4 PoW, and
+        // C5 dedup, and the signer already validated its own template before
+        // signing. Enforcing the local-template check on remote shares would drop
+        // every cross-node share as stale and make GHOST-02 reject every payout
+        // once enforcement activates.
+        if proof.received_by == self.our_node_id && !self.is_valid_template(&template_id) {
             warn!(
                 template_id = %hex::encode(&template_id[..8]),
                 round_id = proof.round_id,
@@ -579,39 +586,41 @@ impl RoundManager {
             return Err(ShareError::InvalidShareHash);
         }
 
-        // C4: Verify work consistency - calculated work should match claimed work
-        // M-9 SECURITY FIX: Reduced tolerance from 0.1% to 0.01%
+        // C4: Verify work consistency - claimed work must match the claimed difficulty.
+        // M-9 SECURITY FIX: tight 0.01% tolerance limits any gaming to ≤0.1% pool
+        // inflation per round; combined with L-7 cumulative tracking (1% cap/miner)
+        // this prevents meaningful inflation.
         //
-        // Previous 0.1% per-share tolerance allowed systematic gaming:
-        // - 1000 shares/round * 0.1% = 1% total pool inflation possible
-        // - Attackers could claim 1.001x their actual work on every share
-        //
-        // New 0.01% tolerance limits total gaming potential to:
-        // - 1000 shares/round * 0.01% = 0.1% maximum pool inflation
-        // - This is acceptable for floating-point rounding tolerance
-        //
-        // Combined with L-7 cumulative tolerance tracking (1% cap per miner),
-        // this prevents any meaningful payout inflation.
-        let calculated_work = diff_calc.calculate_work(proof.difficulty);
+        // The work model is ABSOLUTE: a share's work == its difficulty, exactly as
+        // the SRI/local path `record_share` credits it (and as main.rs builds the
+        // proof: `difficulty = work = share.work`). C4 above already proved the hash
+        // meets `proof.difficulty`, so binding `proof.work` to `proof.difficulty`
+        // bounds the credited work by real PoW. The previous relative model
+        // (`difficulty / share_difficulty`) assumed a pool minimum of 1; with the
+        // production default share_difficulty it computed `work/1000` and rejected
+        // EVERY gossiped share, leaving elders with 0 shares so GHOST-02 rejected
+        // every payout once enforcement activated. Validate against difficulty
+        // directly so the cross-node ledger matches the local ledger.
+        let expected_work = proof.difficulty;
         // M3: Guard against NaN/Inf from degenerate difficulty values
-        if !calculated_work.is_finite() || calculated_work <= 0.0 {
+        if !expected_work.is_finite() || expected_work <= 0.0 {
             return Err(ShareError::WorkValueTooHigh {
                 got: proof.work,
-                max: calculated_work,
+                max: expected_work,
             });
         }
-        let per_share_tolerance = calculated_work * 0.0001; // M-9: 0.01% tolerance (was 0.1%)
-        let work_difference = proof.work - calculated_work;
+        let per_share_tolerance = expected_work * 0.0001; // M-9: 0.01% tolerance
+        let work_difference = proof.work - expected_work;
         if work_difference.abs() > per_share_tolerance {
             tracing::warn!(
                 claimed_work = proof.work,
-                calculated_work = calculated_work,
+                expected_work = expected_work,
                 tolerance = per_share_tolerance,
-                "M-9: Share proof work mismatch exceeds 0.01% tolerance"
+                "M-9: Share proof work does not match claimed difficulty (>0.01% tolerance)"
             );
             return Err(ShareError::WorkValueTooHigh {
                 got: proof.work,
-                max: calculated_work,
+                max: expected_work,
             });
         }
 
@@ -655,7 +664,7 @@ impl RoundManager {
             let tracker = tolerance_trackers.entry(proof.round_id).or_default();
 
             if let Err(exploitation_percent) =
-                tracker.record_tolerance(&miner_id, calculated_work, work_difference)
+                tracker.record_tolerance(&miner_id, expected_work, work_difference)
             {
                 // M-29: Record this tolerance limit hit in cross-round tracker
                 {
@@ -701,9 +710,14 @@ impl RoundManager {
             .entry(proof.round_id)
             .or_insert_with(|| RoundShares::new(proof.round_id, 0));
 
-        // Add miner work using the CALCULATED work, not claimed work
+        // Credit the miner with proof.work (absolute model: work == difficulty,
+        // validated above and PoW-bounded by C4). This MUST match what the local
+        // SRI path `record_share` credits (raw `share.work`); recording the
+        // relative `calculate_work` value here instead diverged the cross-node
+        // ledger by a factor of `share_difficulty`, so GHOST-02's recompute never
+        // matched the proposer once enforcement activated.
         let miner_id = hex::encode(&proof.miner_id[..8]);
-        round.add_miner_work(&miner_id, calculated_work);
+        round.add_miner_work(&miner_id, proof.work);
 
         // Credit the node that received it
         round.increment_node_shares(&proof.received_by);
@@ -725,7 +739,7 @@ impl RoundManager {
         debug!(
             round_id = proof.round_id,
             miner = %miner_id,
-            work = calculated_work,
+            work = proof.work,
             from_node = ?hex::encode(&proof.received_by[..4]),
             "Processed share proof (verified)"
         );

--- a/crates/ghost-accounting/src/shares.rs
+++ b/crates/ghost-accounting/src/shares.rs
@@ -407,36 +407,32 @@ impl DifficultyCalculator {
     ///
     /// Lower hash values = higher difficulty
     pub fn difficulty_from_hash(hash: &[u8; 32]) -> f64 {
-        // Bitcoin uses little-endian, but hashes are typically displayed big-endian
-        // The hash is treated as a 256-bit number
-
-        // Find the first non-zero byte (counting leading zeros)
-        let mut leading_zeros = 0;
-        for byte in hash.iter().rev() {
-            if *byte == 0 {
-                leading_zeros += 8;
-            } else {
-                leading_zeros += byte.leading_zeros() as usize;
-                break;
-            }
+        // The hash is a 256-bit number with its most-significant byte at index 31
+        // (the PoW leading zeros sit at the high-index end). The share's difficulty
+        // is the standard pool difficulty `diff1_target / hash_value`, where the
+        // difficulty-1 target (pdiff) is 0xFFFF * 2^208.
+        //
+        // This uses the FULL hash value, not just the leading-zero count. The old
+        // leading-zeros approximation (2^(leading_zeros-32)) ignored everything
+        // after the first non-zero byte and so under-counted by up to ~2x — which
+        // made C4 verify_share_difficulty reject valid gossiped shares whose `work`
+        // (the standard difficulty reported by the SV2/SRI layer) exceeded the
+        // approximation. f64 has ~52 bits of mantissa, ample for the difficulty
+        // comparison (which carries a 0.1% tolerance); the low bits of the hash do
+        // not affect the result.
+        let mut hash_value = 0.0_f64;
+        for &byte in hash.iter().rev() {
+            hash_value = hash_value * 256.0 + byte as f64;
         }
 
-        // If all zeros (shouldn't happen), return max difficulty
-        if leading_zeros >= 256 {
+        // All-zero hash (shouldn't occur in practice) — treat as maximal difficulty.
+        if hash_value == 0.0 {
             return f64::MAX;
         }
 
-        // Calculate approximate difficulty
-        // Each leading zero bit doubles the difficulty
-        // Base difficulty 1 corresponds to target with 32 leading zero bits (4 zero bytes)
-        // H-20: Use saturating subtraction to prevent overflow on edge cases
-        let diff_bits = (leading_zeros as i32).saturating_sub(32);
-
-        if diff_bits >= 0 {
-            2.0_f64.powi(diff_bits)
-        } else {
-            1.0 / 2.0_f64.powi(-diff_bits)
-        }
+        // diff1_target (pdiff) = 0xFFFF * 2^208. Both factors are exact in f64.
+        let diff1_target = 65535.0_f64 * 2.0_f64.powi(208);
+        diff1_target / hash_value
     }
 
     /// Verify that a share hash meets the claimed difficulty
@@ -520,6 +516,48 @@ mod tests {
         assert!(!calc.meets_share_difficulty(500.0));
         assert!(!calc.is_valid_block(500_000.0));
         assert!(calc.is_valid_block(1_500_000.0));
+    }
+
+    #[test]
+    fn test_difficulty_from_hash_is_precise_not_leading_zero_underestimate() {
+        // Regression: difficulty_from_hash was a leading-zeros approximation
+        // (2^(leading_zeros-32)) that under-counts by up to ~2x because it ignores
+        // everything after the first non-zero byte. The SV2/SRI layer reports the
+        // STANDARD difficulty as `work`, so C4 verify_share_difficulty rejected
+        // valid gossiped shares whose leading-zero count understated them — every
+        // share dropped on the elders, every payout rejected by GHOST-02.
+        //
+        // The difficulty-1 target (pdiff) is 0xFFFF * 2^208; a hash equal to it has
+        // difficulty exactly 1.0.
+        let mut diff1 = [0u8; 32];
+        diff1[26] = 0xFF;
+        diff1[27] = 0xFF;
+        let d1 = DifficultyCalculator::difficulty_from_hash(&diff1);
+        assert!((d1 - 1.0).abs() < 1e-6, "diff-1 target → 1.0, got {d1}");
+
+        // A hash AT the difficulty-1.5 target: 0xAAAA * 2^208 (0xFFFF / 1.5 = 0xAAAA).
+        // Precise difficulty = 1.5. The old leading-zeros formula gave only 1.0
+        // (32 leading zero bits, then 0xAA), so verify_share_difficulty(_, 1.5)
+        // wrongly REJECTED it.
+        let mut h = [0u8; 32];
+        h[26] = 0xAA;
+        h[27] = 0xAA;
+        let d = DifficultyCalculator::difficulty_from_hash(&h);
+        assert!((d - 1.5).abs() < 0.01, "diff-1.5 target → ~1.5, got {d}");
+
+        let calc = DifficultyCalculator::new(1.0, 1_000_000.0);
+        assert!(
+            calc.verify_share_difficulty(&h, 1.5),
+            "a hash meeting the claimed standard difficulty must pass C4 \
+             (regression: leading-zeros under-count rejected it)"
+        );
+        // And a hash that genuinely does NOT meet the claimed difficulty is rejected.
+        let mut easy = [0u8; 32];
+        easy[27] = 0xFF; // difficulty ~1.0
+        assert!(
+            !calc.verify_share_difficulty(&easy, 4.0),
+            "a hash below the claimed difficulty must still be rejected"
+        );
     }
 
     /// SEC-SHARE-TEST-1: Verify that negative work values are rejected

--- a/crates/ghost-common/src/types.rs
+++ b/crates/ghost-common/src/types.rs
@@ -268,6 +268,20 @@ pub struct ShareProof {
     pub signature: Option<Vec<u8>>,
 }
 
+/// Map an `f64` to the value it deserializes to after a serde_json round-trip.
+///
+/// serde_json's f64 (de)serialization is not guaranteed bit-exact, so a value
+/// signed before serialization can deserialize ~1 ULP off on a peer. This
+/// round-trip is idempotent, so applying it on both the signer and the verifier
+/// yields the identical value that actually crossed the wire — used by
+/// `ShareProof::signing_bytes` so GHOST-09 signatures survive gossip.
+fn canonical_json_f64(x: f64) -> f64 {
+    serde_json::to_string(&x)
+        .ok()
+        .and_then(|s| serde_json::from_str::<f64>(&s).ok())
+        .unwrap_or(x)
+}
+
 impl ShareProof {
     /// GHOST-09: canonical bytes the `received_by` node signs. Binds every
     /// credit-relevant field, so a relay that mutates `received_by` (or the
@@ -276,7 +290,15 @@ impl ShareProof {
         let mut m = Vec::with_capacity(120);
         m.extend_from_slice(&self.round_id.to_le_bytes());
         m.extend_from_slice(&self.miner_id);
-        m.extend_from_slice(&self.work.to_le_bytes());
+        // GHOST-09: `work` is an f64 and the proof is gossiped as JSON, but
+        // serde_json's f64 (de)serialization is NOT guaranteed bit-exact (it can
+        // differ by ~1 ULP). Committing to the raw bits would make a verifier's
+        // recomputed signing_bytes differ from the signer's and reject every
+        // share — and then GHOST-02 rejects every payout for lack of shares.
+        // Commit to the JSON-canonical value instead: the round-trip is
+        // idempotent, so signer and verifier agree on the value that crossed the
+        // wire regardless of the original f64's exact bits.
+        m.extend_from_slice(&canonical_json_f64(self.work).to_le_bytes());
         m.extend_from_slice(&self.share_hash);
         m.extend_from_slice(&self.timestamp.to_le_bytes());
         m.extend_from_slice(&self.received_by);
@@ -714,6 +736,41 @@ impl From<&str> for TreasuryAddress {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_share_proof_signature_survives_json_roundtrip() {
+        // GHOST-09 over real transport: a ShareProof signed by `received_by` must
+        // still verify after a serde_json round-trip (gossip serializes the proof
+        // inside ShareProofMessage). If any signed field doesn't round-trip
+        // bit-exactly, peers drop the share as "invalid received_by signature".
+        let id = crate::identity::NodeIdentity::generate();
+        let mut proof = ShareProof {
+            round_id: 7,
+            miner_id: [3u8; 32],
+            difficulty: 2.3305991803113107e-07,
+            work: 2.3305991803113107e-07,
+            share_hash: [5u8; 32],
+            timestamp: 1_781_964_482,
+            received_by: id.node_id(),
+            template_id: Some([9u8; 32]),
+            payout_address: Some("bcrt1qexample".to_string()),
+            signature: None,
+        };
+        proof.sign(&id);
+        assert!(
+            proof.has_valid_received_by_signature(),
+            "signature must be valid immediately after signing"
+        );
+
+        let json = serde_json::to_vec(&proof).expect("serialize");
+        let proof2: ShareProof = serde_json::from_slice(&json).expect("deserialize");
+        assert!(
+            proof2.has_valid_received_by_signature(),
+            "signature must still verify after a serde_json round-trip (gossip path)"
+        );
+    }
+
+
 
     #[test]
     fn test_node_capabilities_shares() {

--- a/crates/ghost-common/src/types.rs
+++ b/crates/ghost-common/src/types.rs
@@ -770,8 +770,6 @@ mod tests {
         );
     }
 
-
-
     #[test]
     fn test_node_capabilities_shares() {
         let mut caps = NodeCapabilities::new();

--- a/crates/ghost-consensus/src/mesh.rs
+++ b/crates/ghost-consensus/src/mesh.rs
@@ -1509,6 +1509,22 @@ impl MeshNetwork {
 
     /// Broadcast a message to all peers
     pub async fn broadcast(&self, envelope: MessageEnvelope) -> GhostResult<usize> {
+        // ZMQ PUB/SUB broadcast messages (HealthPing, Discovery — and every
+        // message type when Noise is disabled) are published on the PUB socket
+        // exactly once, independent of the known-peer set: the publisher fans
+        // them out to every topic-subscribed peer, so one enqueue reaches all.
+        //
+        // Iterating get_connected_peers() here was a self-isolation deadlock:
+        // with zero peers it published ZERO times, and since a peer's liveness
+        // is only refreshed by *received* HealthPings, a node that aged out all
+        // peers stopped emitting HealthPings and could never be re-discovered or
+        // refresh its own set. Publishing unconditionally lets it recover.
+        if !self.should_use_noise(envelope.msg_type) {
+            self.publish_zmq_broadcast(&envelope)?;
+            return Ok(1);
+        }
+
+        // Sensitive messages use point-to-point Noise to each known peer.
         let peers = self.peers.get_connected_peers(60);
         let mut sent = 0;
 
@@ -1830,6 +1846,35 @@ impl MeshNetwork {
     ///
     /// Automatically routes messages through Noise encryption for sensitive message types
     /// (MPC, Elder, Payout, ZK, etc.) or ZMQ for broadcast messages (Discovery, HealthPing).
+    /// Publish a ZMQ broadcast envelope on the PUB socket exactly once.
+    ///
+    /// The publisher task ignores the per-message endpoint and routes purely by
+    /// the topic prefix, so a single enqueue reaches every connected subscriber.
+    /// This is deliberately independent of `get_connected_peers()` so HealthPing
+    /// and Discovery keep flowing even when this node has momentarily lost all
+    /// peers — which is exactly how it recovers and re-populates its peer set.
+    fn publish_zmq_broadcast(&self, envelope: &MessageEnvelope) -> GhostResult<()> {
+        if !self.running.load(Ordering::SeqCst) {
+            return Err(GhostError::NotRunning("Mesh network not running".into()));
+        }
+        let data = envelope
+            .serialize()
+            .map_err(|e| GhostError::Serialization(e.to_string()))?;
+        // Endpoint is ignored by the publisher; it routes by topic prefix.
+        match self.outbound_tx.try_send((String::new(), data)) {
+            Ok(_) => {
+                self.messages_sent.fetch_add(1, Ordering::Relaxed);
+                Ok(())
+            }
+            Err(mpsc::error::TrySendError::Full(_)) => Err(GhostError::P2PMessage(
+                "M-8: Outbound channel full - apply backpressure".to_string(),
+            )),
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                Err(GhostError::NotRunning("Outbound channel closed".into()))
+            }
+        }
+    }
+
     pub async fn send_to_peer(&self, peer: &Peer, envelope: &MessageEnvelope) -> GhostResult<()> {
         if !self.running.load(Ordering::SeqCst) {
             return Err(GhostError::NotRunning("Mesh network not running".into()));
@@ -3565,6 +3610,55 @@ mod tests {
 
         let result = MeshNetwork::try_new(identity, config);
         assert!(result.is_ok(), "M-2: Disabled Noise should always succeed");
+    }
+
+    #[tokio::test]
+    async fn test_zmq_broadcast_publishes_with_zero_peers() {
+        // Regression (self-isolation deadlock): ZMQ PUB/SUB broadcast messages
+        // (HealthPing, Discovery) must be published on the PUB socket even when
+        // this node currently knows zero connected peers — the publisher fans
+        // them out to every topic-subscribed peer, so a single publish suffices.
+        //
+        // The previous broadcast() iterated get_connected_peers() and called
+        // send_to_peer once per peer, so with zero peers it published ZERO
+        // times. A node that aged out all its peers (HealthPings are only
+        // refreshed by *received* HealthPings) therefore stopped emitting
+        // HealthPings entirely and could never be re-discovered or refresh its
+        // own peer set — a permanent, unrecoverable isolation.
+        let identity = Arc::new(NodeIdentity::generate());
+        let mut config = MeshConfig::default();
+        config.noise_enabled = false; // exercise the ZMQ (plaintext) broadcast path
+        config.noise_required = false;
+        let mesh = MeshNetwork::try_new(identity, config).expect("mesh construct");
+        mesh.running.store(true, Ordering::SeqCst);
+
+        // Precondition: genuinely zero connected peers.
+        assert_eq!(
+            mesh.peers.get_connected_peers(60).len(),
+            0,
+            "precondition: no connected peers"
+        );
+
+        let envelope = mesh
+            .create_envelope_raw(MessageType::HealthPing, vec![0u8; 4])
+            .expect("create envelope");
+        let published = mesh.broadcast(envelope).await.expect("broadcast ok");
+
+        assert_eq!(
+            published, 1,
+            "HealthPing must publish exactly once with zero peers (regression: was 0 → deadlock)"
+        );
+
+        // The publish actually reached the outbound channel feeding the PUB socket.
+        let mut rx = mesh
+            .outbound_rx
+            .write()
+            .take()
+            .expect("outbound rx present");
+        assert!(
+            rx.try_recv().is_ok(),
+            "a PUB-socket message must be enqueued even with zero peers"
+        );
     }
 
     #[test]

--- a/crates/ghost-consensus/src/mesh.rs
+++ b/crates/ghost-consensus/src/mesh.rs
@@ -2745,14 +2745,10 @@ impl MeshNetwork {
         info!(address = %address, "Connecting to peer");
 
         // Generate a temporary node ID from the address hash
-        // (actual node ID will be learned from first health ping received)
-        use std::hash::{Hash, Hasher};
-        let mut hasher = std::collections::hash_map::DefaultHasher::new();
-        address.hash(&mut hasher);
-        let hash = hasher.finish();
-        let mut temp_node_id = [0u8; 32];
-        temp_node_id[..8].copy_from_slice(&hash.to_le_bytes());
-        temp_node_id[8..16].copy_from_slice(&hash.to_be_bytes());
+        // (actual node ID will be learned from first health ping received).
+        // Shared derivation so upsert_peer's same-host reconcile recognises this
+        // exact stub and retires it when the real identity arrives.
+        let temp_node_id = crate::peer::placeholder_node_id(address);
 
         // Create a new peer entry - mark as Connected initially
         // (stale detection will mark disconnected if we don't hear from them)

--- a/crates/ghost-consensus/src/peer.rs
+++ b/crates/ghost-consensus/src/peer.rs
@@ -59,6 +59,25 @@ fn extract_host_from_address(address: &str) -> String {
     address.to_string()
 }
 
+/// Compute the deterministic bootstrap-placeholder node_id for a seed address.
+///
+/// `MeshNetwork::connect_peer` registers a not-yet-identified seed peer under a
+/// temporary node_id derived purely from its address, until the real identity is
+/// learned from the first health ping. This is the single source of that
+/// derivation: `connect_peer` calls it to mint the stub, and `upsert_peer`'s
+/// same-host reconcile calls it to recognise such a stub by exact identity — so a
+/// real peer sharing a host is never mistaken for (and evicted as) a placeholder.
+pub(crate) fn placeholder_node_id(address: &str) -> NodeId {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    address.hash(&mut hasher);
+    let hash = hasher.finish();
+    let mut node_id = [0u8; 32];
+    node_id[..8].copy_from_slice(&hash.to_le_bytes());
+    node_id[8..16].copy_from_slice(&hash.to_be_bytes());
+    node_id
+}
+
 /// Extract the /24 subnet prefix from an address string.
 /// Returns `Some("a.b.c")` for IPv4 addresses, `None` for IPv6 or unparseable.
 fn extract_ipv4_subnet(address: &str) -> Option<String> {
@@ -112,19 +131,25 @@ impl PeerManager {
             return;
         }
 
-        // Reconcile by host: one physical host belongs to one identity. If a
-        // DIFFERENT node_id already holds this exact host, it is a superseded
-        // bootstrap placeholder — the seed-connect path ("Connecting to peer")
-        // registers peers with a temp node_id = hash(address) until the real
-        // identity is learned via discovery (on a different port). Remove the
-        // stale entry so the real identity can take the slot. Without this,
-        // co-located nodes (all on one /24 — a docker bridge or any test
-        // cluster) exhaust MAX_PEERS_PER_SUBNET with placeholders and the real
-        // identities are rejected below, leaving peers that HealthPings (keyed
-        // by the real node_id) can never refresh — so they age out of
-        // get_connected_peers and encrypted broadcasts reach zero peers.
-        // Matching the EXACT host (not the /24) keeps Sybil protection intact:
-        // genuinely distinct hosts still count toward the subnet limit.
+        // Reconcile a superseded bootstrap placeholder for this host. The
+        // seed-connect path ("Connecting to peer") registers peers with a temp
+        // node_id = placeholder_node_id(address) until the real identity is
+        // learned via discovery (on a different port). Keyed purely by node_id,
+        // the placeholder and the later real identity for the same host become
+        // two entries — and on a shared /24 (a docker bridge or any co-located
+        // cluster) three such placeholders exhaust MAX_PEERS_PER_SUBNET, so the
+        // real identities are rejected below and never land. HealthPings, keyed
+        // by the real node_id, can never refresh the placeholders, which age out
+        // of get_connected_peers, leaving encrypted broadcasts with zero peers.
+        //
+        // Remove ONLY a same-host entry that is itself a placeholder — i.e. whose
+        // node_id matches the address-derived stub. A same-host entry with any
+        // other node_id is a real peer and is left untouched: PeerManager indexes
+        // by node_id and deliberately allows duplicate addresses, with address-
+        // hijack protection living one layer up in DiscoveryHandler. Evicting a
+        // real peer here would itself be a hijack vector (a later claimant
+        // displacing the rightful owner of an address), so the reconcile is
+        // strictly scoped to the bootstrap stub it was written to retire.
         let new_host = extract_host_from_address(&peer.public_address);
         if !new_host.is_empty() {
             let superseded: Vec<NodeId> = peers
@@ -132,6 +157,7 @@ impl PeerManager {
                 .filter(|(nid, p)| {
                     **nid != peer.node_id
                         && extract_host_from_address(&p.public_address) == new_host
+                        && **nid == placeholder_node_id(&p.public_address)
                 })
                 .map(|(nid, _)| *nid)
                 .collect();
@@ -533,8 +559,12 @@ mod tests {
         // encrypted broadcast reached zero peers. upsert_peer must reconcile by
         // host: a real identity supersedes the same-host placeholder.
         let mgr = PeerManager::new([0u8; 32], 100);
-        for i in 10u8..13 {
-            let mut p = Peer::new([i; 32], format!("172.30.0.{}:8555", i));
+        // Genuine bootstrap stubs: node_id is the address-derived placeholder,
+        // exactly as connect_peer mints them — three fill the /24 quota.
+        let placeholder_addrs: Vec<String> =
+            (10u8..13).map(|i| format!("172.30.0.{}:8555", i)).collect();
+        for addr in &placeholder_addrs {
+            let mut p = Peer::new(placeholder_node_id(addr), addr.clone());
             p.state = PeerState::Connected;
             mgr.upsert_peer(p);
         }
@@ -557,7 +587,8 @@ mod tests {
             "real identity must supersede the same-host placeholder despite the subnet limit"
         );
         assert!(
-            !all.iter().any(|p| p.node_id == [10u8; 32]),
+            !all.iter()
+                .any(|p| p.node_id == placeholder_node_id("172.30.0.10:8555")),
             "the superseded same-host placeholder must be removed"
         );
         // A genuinely new host in the same /24 is still capped (Sybil protection intact).
@@ -567,6 +598,45 @@ mod tests {
         assert!(
             !mgr.get_all_peers().iter().any(|p| p.node_id == [200u8; 32]),
             "a new distinct host in a full /24 must still be rejected (Sybil cap holds)"
+        );
+    }
+
+    #[test]
+    fn test_upsert_does_not_evict_real_same_host_peer() {
+        // Hijack-safety: the same-host reconcile must retire ONLY address-derived
+        // placeholders, never a real peer. Two distinct real identities sharing an
+        // address both survive — PeerManager indexes by node_id and allows
+        // duplicate addresses; address-hijack protection is one layer up in
+        // DiscoveryHandler. This mirrors integration test 941 at the unit level so
+        // a future reconcile change can't silently reintroduce the eviction vector.
+        let mgr = PeerManager::new([0xFFu8; 32], 100);
+
+        let real_a = [10u8; 32];
+        let real_b = [20u8; 32];
+        // Neither node_id is the address-derived placeholder for this host.
+        assert_ne!(real_a, placeholder_node_id("1.2.3.4:8555"));
+        assert_ne!(real_b, placeholder_node_id("1.2.3.4:8555"));
+
+        let mut pa = Peer::new(real_a, "1.2.3.4:8555".to_string());
+        pa.state = PeerState::Connected;
+        mgr.upsert_peer(pa);
+        let mut pb = Peer::new(real_b, "1.2.3.4:8555".to_string());
+        pb.state = PeerState::Connected;
+        mgr.upsert_peer(pb);
+
+        let all = mgr.get_all_peers();
+        assert!(
+            all.iter().any(|p| p.node_id == real_a),
+            "first real peer at the shared host must NOT be evicted by the second"
+        );
+        assert!(
+            all.iter().any(|p| p.node_id == real_b),
+            "second real peer at the shared host must be admitted"
+        );
+        assert_eq!(
+            mgr.peer_count(),
+            2,
+            "two real peers may share an address; the reconcile only retires placeholders"
         );
     }
 

--- a/crates/ghost-consensus/src/peer.rs
+++ b/crates/ghost-consensus/src/peer.rs
@@ -538,7 +538,11 @@ mod tests {
             p.state = PeerState::Connected;
             mgr.upsert_peer(p);
         }
-        assert_eq!(mgr.get_all_peers().len(), 3, "three placeholders fill the /24 quota");
+        assert_eq!(
+            mgr.get_all_peers().len(),
+            3,
+            "three placeholders fill the /24 quota"
+        );
 
         // Real identity for the same host as the first placeholder (172.30.0.10),
         // discovered on the discovery port (:8559) with a different node_id.

--- a/crates/ghost-consensus/src/peer.rs
+++ b/crates/ghost-consensus/src/peer.rs
@@ -112,6 +112,34 @@ impl PeerManager {
             return;
         }
 
+        // Reconcile by host: one physical host belongs to one identity. If a
+        // DIFFERENT node_id already holds this exact host, it is a superseded
+        // bootstrap placeholder — the seed-connect path ("Connecting to peer")
+        // registers peers with a temp node_id = hash(address) until the real
+        // identity is learned via discovery (on a different port). Remove the
+        // stale entry so the real identity can take the slot. Without this,
+        // co-located nodes (all on one /24 — a docker bridge or any test
+        // cluster) exhaust MAX_PEERS_PER_SUBNET with placeholders and the real
+        // identities are rejected below, leaving peers that HealthPings (keyed
+        // by the real node_id) can never refresh — so they age out of
+        // get_connected_peers and encrypted broadcasts reach zero peers.
+        // Matching the EXACT host (not the /24) keeps Sybil protection intact:
+        // genuinely distinct hosts still count toward the subnet limit.
+        let new_host = extract_host_from_address(&peer.public_address);
+        if !new_host.is_empty() {
+            let superseded: Vec<NodeId> = peers
+                .iter()
+                .filter(|(nid, p)| {
+                    **nid != peer.node_id
+                        && extract_host_from_address(&p.public_address) == new_host
+                })
+                .map(|(nid, _)| *nid)
+                .collect();
+            for nid in superseded {
+                peers.remove(&nid);
+            }
+        }
+
         if peers.len() >= self.max_peers {
             return;
         }
@@ -490,6 +518,52 @@ mod tests {
         manager.upsert_peer(peer);
 
         assert_eq!(manager.peer_count(), 1);
+    }
+
+    #[test]
+    fn test_upsert_reconciles_same_host_placeholder() {
+        // Regression: the seed-connect path creates bootstrap *placeholder* peers
+        // with a temp node_id = hash(address) (mesh.rs "Connecting to peer"). When
+        // many nodes share one /24 (e.g. a docker bridge, or any co-located test
+        // cluster), three such placeholders fill MAX_PEERS_PER_SUBNET (=3). The
+        // real identity for the same host, learned later via discovery on a
+        // different port, was then REJECTED by the subnet limit and never landed —
+        // and HealthPings (keyed by the real node_id) could never refresh the
+        // surviving placeholder, which aged out of get_connected_peers, so the
+        // encrypted broadcast reached zero peers. upsert_peer must reconcile by
+        // host: a real identity supersedes the same-host placeholder.
+        let mgr = PeerManager::new([0u8; 32], 100);
+        for i in 10u8..13 {
+            let mut p = Peer::new([i; 32], format!("172.30.0.{}:8555", i));
+            p.state = PeerState::Connected;
+            mgr.upsert_peer(p);
+        }
+        assert_eq!(mgr.get_all_peers().len(), 3, "three placeholders fill the /24 quota");
+
+        // Real identity for the same host as the first placeholder (172.30.0.10),
+        // discovered on the discovery port (:8559) with a different node_id.
+        let real_id = [99u8; 32];
+        let mut real = Peer::new(real_id, "172.30.0.10:8559".to_string());
+        real.state = PeerState::Connected;
+        mgr.upsert_peer(real);
+
+        let all = mgr.get_all_peers();
+        assert!(
+            all.iter().any(|p| p.node_id == real_id),
+            "real identity must supersede the same-host placeholder despite the subnet limit"
+        );
+        assert!(
+            !all.iter().any(|p| p.node_id == [10u8; 32]),
+            "the superseded same-host placeholder must be removed"
+        );
+        // A genuinely new host in the same /24 is still capped (Sybil protection intact).
+        let mut sybil = Peer::new([200u8; 32], "172.30.0.99:8555".to_string());
+        sybil.state = PeerState::Connected;
+        mgr.upsert_peer(sybil);
+        assert!(
+            !mgr.get_all_peers().iter().any(|p| p.node_id == [200u8; 32]),
+            "a new distinct host in a full /24 must still be rejected (Sybil cap holds)"
+        );
     }
 
     #[test]

--- a/tests/integration_tests/mesh_cluster.rs
+++ b/tests/integration_tests/mesh_cluster.rs
@@ -31,9 +31,10 @@ use ghost_storage::Database;
 /// Shared test template every node accepts (so share-proof validation passes).
 const TEST_TEMPLATE_ID: [u8; 32] = [0x7c; 32];
 
-/// A difficulty-1.0 share hash: exactly 32 leading zero bits (`bytes[28..32] = 0`)
-/// then a non-zero byte, which `DifficultyCalculator::difficulty_from_hash` maps
-/// to `2^(32-32) = 1.0`. The low 8 bytes carry a unique nonce (never examined by
+/// A valid share hash for pool difficulty 1.0: `bytes[28..32] = 0` and
+/// `bytes[27] = 0xFF`, which `DifficultyCalculator::difficulty_from_hash` maps to
+/// ~1.004 (0xFFFF*2^208 / (0xFF*2^216)) — comfortably above the pool minimum of
+/// 1.0, so it is accepted PoW. The low 8 bytes carry a unique nonce (never examined by
 /// the leading-zero count) so each share is distinct and not deduplicated.
 fn diff1_share_hash(nonce: u64) -> [u8; 32] {
     let mut h = [0u8; 32];


### PR DESCRIPTION
`mesh.broadcast()` drove HealthPing/Discovery by iterating `get_connected_peers()` + `send_to_peer()` once per peer. But the publisher binds **one PUB socket and fans out by topic prefix** (it ignores the per-peer endpoint), so one publish reaches all subscribers — N peers just meant N redundant publishes, and **zero peers meant zero publishes**.

Since peer liveness is only refreshed by *received* HealthPings, a node that ever aged out all its peers (restart / blip / stall) stopped emitting HealthPings and could **never recover** — permanent self-isolation. Masked on public-IP fleets (always-fresh mesh) but a real latent fragility.

**Fix:** ZMQ broadcast types (`!should_use_noise`) publish exactly once via `publish_zmq_broadcast()`, independent of the peer set; Noise messages keep the per-peer path. Steady-state it's also strictly less work.

**Test-first:** `test_zmq_broadcast_publishes_with_zero_peers` fails on old code (0 publishes), passes after (1). All 236 ghost-consensus lib tests green.