### PR TITLE
feat(consensus): set CLUSTER_ENFORCEMENT_HEIGHT activation to 955200

### DIFF
--- a/bins/ghost-pool/src/lib.rs
+++ b/bins/ghost-pool/src/lib.rs
@@ -87,11 +87,14 @@ pub mod convergence;
 /// (GHOST-02) — making it behaviour-identical to the pre-audit binary in a mixed
 /// mesh. After it, both enforcements are live everywhere at once.
 ///
-/// PLACEHOLDER — the operator MUST set this to roughly `(current tip + ~150)`
-/// (~24h of blocks past expected full-roll completion) in the activation build.
-/// The default is far enough in the future that an accidental deploy stays in
-/// the safe, non-enforcing dark mode.
-pub const CLUSTER_ENFORCEMENT_HEIGHT: u64 = 999_999_999;
+/// ACTIVATION HEIGHT — set for the audit-cluster rollout. Chosen at `954_736`
+/// (the chain tip when this was cut) + ~464 blocks ≈ 77h of headroom, leaving
+/// well over 24h between the completion of the canary roll (VM4→VM1, a few hours)
+/// and the gate firing, so the whole fleet is on the audit binary in dark mode
+/// before enforcement turns on everywhere at once. If the deploy slips far enough
+/// that the tip approaches this height before the roll completes, bump this value
+/// and rebuild — the binary must reach every VM while still below the gate.
+pub const CLUSTER_ENFORCEMENT_HEIGHT: u64 = 955_200;
 
 /// GhostGlyph P2P handler for visual identity registration.
 pub mod glyph_handler;


### PR DESCRIPTION
## What

Sets the audit-cluster enforcement gate `CLUSTER_ENFORCEMENT_HEIGHT` from the far-future placeholder (`999_999_999`) to a concrete activation height: **955200**.

## Why this height

| | |
|---|---|
| Chain tip at cut time | 954736 |
| Headroom | +464 blocks (~77h) |
| Activation | block 955200 |

The margin leaves well over 24h between the completion of the canary roll (VM4→VM3→VM2→VM1, a few hours) and the gate firing, so the entire fleet runs the audit binary in **non-enforcing dark mode** before `GHOST-09` (drop unsigned shares) and `GHOST-02` (reject mismatched payout split) activate everywhere at the same chain position.

## Rollout safety

Mirrors the proven `PAYOUT_ADDRESS_GROUPING_HEIGHT` pattern — a deterministic block-height gate means **no mixed-version enforcement window** during the rolling deploy. Pre-gate the binary still signs shares, converges ledgers and propagates equivocation bans (all additive, mixed-version-safe); only the two enforcement actions are height-gated.

If the deploy slips far enough that the tip approaches 955200 before the roll completes, the value must be bumped and the binary rebuilt — the binary must reach every VM while still below the gate.