### PR TITLE
fix(stats): correct mesh miner-count undercount + best-share difficulty

### DIFF
--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -3337,10 +3337,20 @@ async fn main() -> Result<()> {
     });
 
     // Mesh-wide deduplicated active miner count. Unions local active miner_id
-    // hashes with the most-recent set from each connected peer (60s freshness).
+    // hashes with the most-recent set from each connected peer.
+    //
+    // The freshness window must match the 300s miner-activity window the local
+    // and gossiped sets are computed over (`active_miner_id_hashes(300)`), NOT a
+    // tight 60s. At 60s a peer that simply missed a few ~10s health pings (jitter,
+    // GC, momentary load) was excluded entirely, dropping ALL of its active miners
+    // from the union — so a node would report e.g. 4 of 5 miners, and since the
+    // figure is gossip-derived the whole mesh could undercount at once. Dedup is by
+    // miner_id hash, so a wider window cannot double-count, and a disconnected miner
+    // still ages out at the source node's 300s `last_seen`, so the count stays
+    // honest while becoming robust to transient ping loss.
     let mesh_for_active = Arc::clone(&mesh);
     verification_state = verification_state
-        .with_mesh_active_miners(move || mesh_for_active.mesh_active_miner_count(60) as u32);
+        .with_mesh_active_miners(move || mesh_for_active.mesh_active_miner_count(300) as u32);
 
     // Mesh-wide pool hashrate (TH/s) — sum of every node's own realized
     // hashrate (60s peer freshness). One term per node, scoped by received_by

--- a/crates/ghost-storage/src/queries.rs
+++ b/crates/ghost-storage/src/queries.rs
@@ -2333,8 +2333,20 @@ impl Database {
                 .unwrap_or_default()
                 .as_secs() as i64)
                 - window_secs;
+            // Only LOCALLY-CONNECTED miners — those whose miner_id is a real SV1
+            // identity `payout_address.worker` (always contains '.'). The `miners`
+            // table also accumulates the converged cross-node share ledger, where
+            // a replicated share-proof records the miner under `hex(SHA256(id)[..8])`
+            // (16 bare hex chars, no '.'). Counting those would double-count every
+            // miner: once as its full id on its home node, once as the gossip hash
+            // on every node — so 5 real miners read as 10. Each miner connects to
+            // exactly one node, so the mesh union of per-node LOCAL sets is the
+            // true distinct count. (Mirrors the `received_by` scoping in
+            // `local_hashrate_th` that keeps the mesh hashrate from double-counting.)
             let mut stmt = conn
-                .prepare("SELECT miner_id FROM miners WHERE last_seen > ?1")
+                .prepare(
+                    "SELECT miner_id FROM miners WHERE last_seen > ?1 AND instr(miner_id, '.') > 0",
+                )
                 .map_err(|e| GhostError::Database(e.to_string()))?;
             let rows = stmt
                 .query_map(params![cutoff], |row| row.get::<_, String>(0))
@@ -2399,9 +2411,13 @@ impl Database {
                 .unwrap_or_default()
                 .as_secs() as i64)
                 - window_secs;
+            // Count only locally-connected miners (real `address.worker` ids).
+            // The `miners` table also holds the converged cross-node share ledger,
+            // where replicated proofs are keyed by `hex(SHA256(id)[..8])` (no '.');
+            // counting those double-counts each miner (see `active_miner_id_hashes`).
             let count: i64 = conn
                 .query_row(
-                    "SELECT COUNT(*) FROM miners WHERE last_seen > ?1",
+                    "SELECT COUNT(*) FROM miners WHERE last_seen > ?1 AND instr(miner_id, '.') > 0",
                     params![cutoff],
                     |row| row.get(0),
                 )
@@ -9770,6 +9786,48 @@ mod tests {
             db.get_total_reserved_for_lock("lock1", current_time)
                 .expect("LOW-STOR-8: Failed to get reserved for lock1 after delete"),
             0
+        );
+    }
+
+    #[test]
+    fn test_active_miner_count_excludes_gossiped_ledger_rows() {
+        // Regression: 5 miners read as 10. Each miner is stored under its full SV1
+        // id `address.worker` on its home node AND under `hex(SHA256(id)[..8])` in
+        // the converged cross-node share ledger on every node. Counting both
+        // double-counts every miner. Active-miner counting must include only the
+        // locally-connected `address.worker` rows (which contain '.').
+        let db = Database::in_memory().expect("create in-memory db");
+        let now_s = chrono::Utc::now().timestamp();
+
+        let mk = |miner_id: &str| MinerRecord {
+            miner_id: miner_id.to_string(),
+            payout_address: String::new(),
+            first_seen: now_s - 100,
+            last_seen: now_s - 10, // well within a 300s window
+            connected_node: None,
+            total_shares: 1,
+            total_work: 1000.0,
+            blocks_won: 0,
+            total_payouts_sats: 0,
+            avg_hashrate_ths: 0.0,
+        };
+
+        // One real locally-connected miner...
+        db.upsert_miner(&mk("bc1qexampleaddr.bitaxe1"))
+            .expect("insert local miner");
+        // ...and its gossip-ledger twin (hex(SHA256(full_id)[..8]), no '.').
+        db.upsert_miner(&mk("67eb564b74d01ed4"))
+            .expect("insert gossiped row");
+
+        assert_eq!(
+            db.count_active_miners(300).expect("count"),
+            1,
+            "only the locally-connected miner counts; the gossip-ledger row must not double it"
+        );
+        assert_eq!(
+            db.active_miner_id_hashes(300).expect("hashes").len(),
+            1,
+            "the mesh-union hash set must contain only the locally-connected miner"
         );
     }
 

--- a/crates/ghost-verification/src/routes.rs
+++ b/crates/ghost-verification/src/routes.rs
@@ -860,7 +860,9 @@ async fn shares_handler(State(state): State<Arc<VerificationState>>) -> impl Int
                     serde_json::json!({
                         "round_id": s.round_id,
                         "miner_id": s.miner_id,
-                        "difficulty": s.difficulty,
+                        // Achieved difficulty from the hash (the score). `work` is
+                        // the stored vardiff target used for payout/hashrate.
+                        "difficulty": share_difficulty_from_hash_hex(&s.share_hash),
                         "work": s.work,
                         "share_hash": s.share_hash,
                         "timestamp": s.timestamp,
@@ -2565,7 +2567,11 @@ async fn api_pool_records_handler(
                     "leading_hex_zeros": leading_hex_zeros,
                     "miner_id_redacted": redacted,
                     "timestamp": best.timestamp,
-                    "difficulty": best.difficulty,
+                    // Achieved difficulty from the hash (the score), NOT the stored
+                    // vardiff target. `assigned_difficulty` keeps the old value for
+                    // any consumer that wants the share's pool-credit work.
+                    "difficulty": share_difficulty_from_hash_hex(&best.share_hash),
+                    "assigned_difficulty": best.difficulty,
                 }
             }))
         }
@@ -2680,6 +2686,9 @@ async fn api_pool_leaderboard_handler(
                 "share_hash": hash,
                 "leading_zero_bits": leading_hex_zeros * 4,
                 "timestamp": ts,
+                // Achieved difficulty from the hash (the score). `claimed_difficulty`
+                // is the stored vardiff target, kept for back-compat.
+                "difficulty": share_difficulty_from_hash_hex(&hash),
                 "claimed_difficulty": difficulty,
             })
         })
@@ -2719,6 +2728,41 @@ async fn api_pool_leaderboard_handler(
 /// historical shares table still holds signet/testnet translator
 /// entries. They outrank real miners on lifetime work just because
 /// they've been up longer, which isn't useful to show.
+/// Achieved difficulty of a share, derived from its hash — the standard pool
+/// "best share" / score metric (`diff1_target / hash_value`).
+///
+/// The `shares.difficulty`/`shares.work` DB columns store the SV2/SRI-assigned
+/// *vardiff target* (used for payout and hashrate accounting), NOT how good the
+/// share's hash actually was — so a lucky 60-leading-zero-bit share is stored as
+/// e.g. ~1.5K, six orders of magnitude below its true ~600M difficulty. Any stat
+/// that means "how good was this share" must therefore be computed from the hash.
+///
+/// `share_hash` is stored/served big-endian (leading hex zeros at the front =
+/// higher difficulty), so this mirrors the web client's `hashToDifficulty`
+/// (`BigInt('0x'+hash)`) exactly — most-significant byte first — giving backend
+/// and frontend identical numbers and reading historical rows correctly with no
+/// migration. (Note: `DifficultyCalculator::difficulty_from_hash` uses the
+/// opposite, internal little-endian byte order, so it is deliberately NOT reused
+/// here.) The difficulty-1 target (pdiff) is `0xFFFF * 2^208`.
+///
+/// Returns 0.0 for a hash that isn't 32 bytes of hex (treated as "unknown").
+fn share_difficulty_from_hash_hex(share_hash_hex: &str) -> f64 {
+    let bytes = match hex::decode(share_hash_hex) {
+        Ok(b) if b.len() == 32 => b,
+        _ => return 0.0,
+    };
+    // Big-endian: byte[0] is most-significant.
+    let mut hash_value = 0.0_f64;
+    for &byte in bytes.iter() {
+        hash_value = hash_value * 256.0 + byte as f64;
+    }
+    if hash_value == 0.0 {
+        return f64::MAX;
+    }
+    let diff1_target = 65535.0_f64 * 2.0_f64.powi(208);
+    diff1_target / hash_value
+}
+
 fn is_system_miner(miner_id: &str) -> bool {
     let worker = miner_id.rsplit_once('.').map(|(_, w)| w).unwrap_or("");
     let lower = worker.to_ascii_lowercase();
@@ -7043,6 +7087,31 @@ async fn api_system_mempool_handler(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_share_difficulty_from_hash_hex() {
+        // The difficulty-1 target (pdiff) is 0xFFFF * 2^208 → difficulty 1.0.
+        // In the big-endian hash string that is 0xFFFF after 8 leading hex zeros.
+        let diff1 = "00000000ffff0000000000000000000000000000000000000000000000000000";
+        let d1 = share_difficulty_from_hash_hex(diff1);
+        assert!((d1 - 1.0).abs() < 1e-6, "diff-1 target hex → 1.0, got {d1}");
+
+        // A real best-share hash with many leading zeros must read as a LARGE
+        // achieved difficulty — the regression returned the ~1.5K vardiff target
+        // instead. This exact hash mapped to ≈596.69M live (and via the web
+        // client's hashToDifficulty), pinning byte order + formula together.
+        let big = "000000000000000732a94aee7325d02fd49adbe4f89f9cfcb11ebf0bd33bc26b";
+        let d = share_difficulty_from_hash_hex(big);
+        assert!(
+            (d - 596_688_523.7).abs() / 596_688_523.7 < 1e-6,
+            "best-share hash must match the web client's 596.69M, got {d}"
+        );
+
+        // Malformed / wrong-length input is treated as unknown (0.0), never a panic.
+        assert_eq!(share_difficulty_from_hash_hex(""), 0.0);
+        assert_eq!(share_difficulty_from_hash_hex("not-hex"), 0.0);
+        assert_eq!(share_difficulty_from_hash_hex("00ff"), 0.0);
+    }
 
     #[test]
     fn test_archive_query() {


### PR DESCRIPTION
Fixes two pool-stats bugs visible on bitcoinghost.org/pool.

## 1. Miner count intermittently low (e.g. 4 of 5)

`mesh_active_miner_count` (the deduplicated pool-wide active-miner count) unioned each peer's gossiped active-miner set **only for peers seen within 60s** (`main.rs`), while the sets themselves are computed over a **300s** activity window (`active_miner_id_hashes(300)`). A peer that merely missed a few ~10s health pings (jitter / GC / momentary load) was excluded entirely, dropping **all** of its active miners from the union — and because the figure is gossip-derived, the whole mesh could undercount at the same time.

Observed live: `mesh_active_miners` = VM1:10, VM2:10, **VM3:9**, VM4:10.

**Fix:** widen the freshness window 60s → 300s to match the activity window. Dedup is by `miner_id` hash so a wider window can't double-count, and a disconnected miner still ages out at the source node's 300s `last_seen`.

## 2. Best-share difficulty wrong by orders of magnitude

`shares.difficulty`/`shares.work` store the SV2/SRI-assigned **vardiff target** (used for payout + hashrate accounting), not the **achieved** difficulty of the share's hash. So the records / leaderboard / `/shares` APIs returned e.g. `1,495` for a 60-leading-zero-bit share whose true difficulty is `596,688,523`:

| node | share leading-zero bits | API returned (was) | true achieved (now) |
|---|---|---|---|
| VM3 | 60 | 1,495 | 596.69M |
| VM2 | 56 | 1,995 | 212.70M |

**Fix:** compute the score from `share_hash` (big-endian `diff1_target / hash_value`, byte-for-byte matching the web client's `hashToDifficulty`) at the API boundary — so backend and frontend agree, and historical rows read correctly with **no migration**. The assigned value is preserved as `assigned_difficulty` / `claimed_difficulty` / `work`.

> The public `pool.html` already recomputed from the hash client-side, so the page itself was correct; this fixes the API so any other consumer (per-operator dashboard, external) is correct too.

## Tests
`test_share_difficulty_from_hash_hex` pins the formula **and byte order** to the web client's exact value (596.69M), and covers malformed input → 0.0. Builds + ghost-verification lib tests green; clippy clean under CI flags.