### PR TITLE
fix(stats): exclude gossiped share-ledger rows from the quasar feed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6434,9 +6434,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",

--- a/crates/ghost-storage/src/queries.rs
+++ b/crates/ghost-storage/src/queries.rs
@@ -915,11 +915,20 @@ impl Database {
         limit: u32,
     ) -> GhostResult<Vec<(String, String, i64, f64)>> {
         self.with_connection(|conn| {
+            // Only real `address.worker` miners (instr(miner_id,'.')>0). The
+            // shares table also holds replicated cross-node proofs keyed by the
+            // bare hex(SHA256(id)) gossip-ledger id, whose share_hash is stored in
+            // INTERNAL little-endian order (leading zeros at the high-index end,
+            // for cross-node C4) — so the quasar, which counts leading hex zeros
+            // from the FRONT, reads them as 0 bits and renders dead-center dots
+            // that never emanate. They are also duplicates of each miner's own
+            // local (display-order) shares, which the home node already serves.
+            // Excluding them leaves one correctly-oriented particle per real share.
             let mut stmt = conn
                 .prepare(
                     "SELECT miner_id, share_hash, timestamp, work
                      FROM shares
-                     WHERE timestamp > ?1 AND valid = 1
+                     WHERE timestamp > ?1 AND valid = 1 AND instr(miner_id, '.') > 0
                      ORDER BY timestamp ASC
                      LIMIT ?2",
                 )
@@ -9898,6 +9907,15 @@ mod tests {
             .expect("single")
             .unwrap();
         assert_eq!(single.miner_id, "bc1qexampleaddr.bitaxe3");
+
+        // The quasar feed must likewise exclude the gossip twin — its share_hash
+        // is stored internal-order (no leading zeros) and would render as a
+        // dead-center 0-bit dot, and it's a duplicate of the real share anyway.
+        let recent = db
+            .get_recent_valid_shares(now_s - 3600, 100)
+            .expect("recent");
+        assert_eq!(recent.len(), 1, "quasar feed must exclude the gossip twin");
+        assert_eq!(recent[0].0, "bc1qexampleaddr.bitaxe3");
     }
 
     #[test]


### PR DESCRIPTION
The quasar (`/api/v1/pool/recent_shares`) started showing mostly dead-center dots that never emanate.

## Cause
`get_recent_valid_shares` returned the replicated cross-node proof rows (bare `hex(SHA256(id))` miner_ids). Since **fb2e6a31** those proofs store `share_hash` in **internal little-endian order** (leading zeros at the high-index end, needed for cross-node C4 verification). The quasar counts leading hex zeros from the **front**, so each gossiped copy reads **0 bits → a dead-center dot**. The site polls all 4 nodes, so every real (home-node) share is accompanied by ~3 gossip dots, swamping the emanating particles. They're also duplicates of each miner's own local display-order shares.

## Fix
Same `instr(miner_id,'.') > 0` real-miner filter already applied to the leaderboard / records / active-miner count. Each node emits only its local real-miner shares (correct big-endian orientation, real `leading_zero_bits`); the site merges all 4 nodes, so every miner's shares appear once and emanate. The gossip dots disappear.

The C4 byte-order fix itself is correct and unchanged — the gossiped duplicates simply shouldn't be in the display feed.

## Test
`test_leaderboard_excludes_gossiped_ledger_rows` now also asserts `get_recent_valid_shares` returns only the real `address.worker` miner.