### PR TITLE
docs: freshness pass + document cross-node enforcement gate

### DIFF
--- a/ghost-web/docs/consensus.md
+++ b/ghost-web/docs/consensus.md
@@ -39,6 +39,13 @@ Ghost Network (Full Mesh)
 | 8558 | Health Monitoring | PUB/SUB |
 | 8559 | Discovery Service | REQ/REP |
 | 8560 | Elder Management | PUB/SUB |
+| 8561 | Payout Proposal | PUB/SUB |
+| 8562 | Payout Transaction | PUB/SUB |
+| 8563 | Encrypted P2P (Noise) | point-to-point |
+
+Ports 8555–8562 carry the plaintext ZMQ PUB/SUB and REQ/REP traffic; sensitive
+message types (MPC, Elder, Payout, ZK) are additionally tunnelled over an
+encrypted Noise channel on **8563**.
 
 ## ZMQ Protocol
 
@@ -54,17 +61,19 @@ Ghost uses ZeroMQ for low-latency peer-to-peer communication:
 ### Message Format
 
 ```bash
-GhostMessage {
-  version: u8,              // Protocol version
+MessageEnvelope {
   msg_type: MessageType,    // Share, Block, Vote, etc.
+  sender:    [u8; 32],      // Node ID (Ed25519 public key)
   timestamp: u64,           // Unix timestamp (ms)
-  sender_id: [u8; 32],      // Node ID
-  payload: Vec<u8>,         // Serialized message
-  signature: Vec<u8>,       // secp256k1 signature
+  sequence:  u64,           // Per-sender sequence number (dedup / replay guard)
+  signature: [u8; 64],      // Ed25519 signature over the payload
+  payload:   Vec<u8>,       // JSON-serialized message
 }
 ```
 
-All messages are signed with secp256k1 signatures to prevent forgery.
+All messages are signed with **Ed25519** (the node identity key) to prevent
+forgery. (Bitcoin transactions — coinbase payouts, treasury spends — are signed
+with secp256k1, as Bitcoin requires; the P2P/consensus layer uses Ed25519.)
 
 ## Share Consensus
 
@@ -129,11 +138,11 @@ All nodes calculate PayoutProposal
         ↓ (1-2 seconds)
 All nodes broadcast proposals (port 8561)
         ↓
+Each validator RECOMPUTES the split from its own ledger
+        ↓
 All nodes vote on proposals (port 8557)
         ↓ (5 second timeout)
-67% consensus reached → PayoutTransaction created
-        ↓
-OR no 67% → median calculation used
+67% approve → PayoutTransaction created
 ```
 
 ### 67% Supermajority
@@ -144,15 +153,16 @@ Payout proposals require 67% agreement. If achieved:
 - Finding node creates payout transaction
 - All nodes verify and relay to Bitcoin network
 
-### Median Fallback
+### Deterministic split — validators recompute, not median
 
-If no proposal gets 67%, nodes calculate the median:
-
-- For each miner, take median of all proposed amounts
-- For each node, take median of all proposed rewards
-- Use median values as the consensus payout
-
-This ensures payouts always happen, even without perfect agreement.
+There is no "median of proposals" fallback. Instead, every validator
+**recomputes the payout split from its own converged share ledger** and rejects
+a proposal that doesn't match before voting (GHOST-02). Because all honest nodes
+converge on the same share set (GHOST-03 ledger convergence) and the split is a
+deterministic function of that set + the registered payout addresses, honest
+nodes independently arrive at the **same** answer — so an honest proposal gets
+67% by construction, and a manipulated one is rejected outright rather than
+averaged in.
 
 ## Byzantine Fault Tolerance
 
@@ -165,11 +175,11 @@ Ghost consensus is designed to resist Byzantine (malicious) nodes:
 | Share Consensus | All honest nodes agree on valid shares if 67% are honest |
 | Payout Consensus | Correct payouts enforced by honest majority |
 | Elder Consensus | Elder list immutable, revocation requires 67% witness |
-| Liveness | System never deadlocks (median fallback) |
+| Liveness | System never deadlocks; honest nodes converge on the same ledger + split |
 
 ### Cryptographic Security
 
-- **secp256k1 signatures** — All messages authenticated
+- **Ed25519 signatures** — All P2P/consensus messages authenticated (node identity key)
 - **Merkle proofs** — Share inclusion verifiable
 - **Hash chains** — State history tamper-proof
 
@@ -185,7 +195,7 @@ Ghost consensus is designed to resist Byzantine (malicious) nodes:
 
 **Attack:** Malicious nodes propose inflated payouts for themselves.
 
-**Defense:** 67% honest majority overrules bad proposals. Median fallback prevents deadlock.
+**Defense:** every validator recomputes the payout split from its own converged ledger and rejects a proposal that doesn't match (GHOST-02), so an inflated proposal never reaches 67% — it's rejected, not averaged in.
 
 ### Elder Sybil Attack
 
@@ -202,3 +212,36 @@ Ghost consensus is designed to resist Byzantine (malicious) nodes:
 :::warning 33% Limit
 If more than 33% of nodes are malicious, consensus guarantees break down. This is a fundamental limit of BFT systems. Ghost relies on economic incentives (node rewards) to keep the majority honest.
 :::
+
+## Hardened cross-node enforcement
+
+The consensus above describes *how* nodes agree. A second layer **enforces** that
+agreement so a single dishonest node can't credit itself for work it didn't
+receive or push through a payout split nobody else computed. Four enforcement
+properties run on the mesh:
+
+| ID | Enforces |
+| --- | --- |
+| **GHOST-09** | Every `ShareProof` carries an Ed25519 signature by the node that received it (`received_by`). Unsigned or wrongly-signed share proofs are **dropped** — you cannot claim node-reward credit for a share you didn't actually receive. |
+| **GHOST-02** | Payout-proposal validators recompute the split from their **own** converged ledger and **reject** a proposal whose split doesn't match — proposers can't inflate their own cut. |
+| **GHOST-03** | **Ledger convergence**: nodes reconcile their signed-share sets (a ~30s request loop + backfill that re-verifies GHOST-09), so every honest node holds the same share set before a payout is computed. |
+| **GHOST-11** | Equivocation (a node signing two conflicting things) is detected, **banned**, and the ban is propagated and persisted across the fleet. |
+
+### Why it activates at a block height (not a flag)
+
+Turning these on is a **wire-format** change — an old node and a new node must
+not disagree about whether an unsigned share is valid mid-rollout. So activation
+is gated on a **block height**, `CLUSTER_ENFORCEMENT_HEIGHT`, exactly like the
+earlier `PAYOUT_ADDRESS_GROUPING_HEIGHT`:
+
+- **Before the height** the binary still signs shares, converges ledgers and
+  propagates equivocation bans (all additive and mixed-version-safe), but it does
+  **not** yet drop unsigned shares or reject a mismatched split. This lets the
+  fleet roll the new binary out canary-style with no mixed-version enforcement
+  window.
+- **At the height** both enforcements (GHOST-09 drop + GHOST-02 reject) switch on
+  **everywhere at once**, deterministically, because every node runs the same
+  constant.
+
+This is the same pattern Bitcoin uses for soft-fork activation: deploy first in a
+dormant state, flip at an agreed height.

--- a/ghost-web/docs/deployment.md
+++ b/ghost-web/docs/deployment.md
@@ -347,7 +347,7 @@ INFO  Coinbase tag:   - G H O S T - PublicPool
 INFO  Loaded ZK params:  note_spend_vk (sha256: …)
 INFO  Loaded ZK params:  payout_vk (sha256: …)
 INFO  Loaded ZK params:  unshield_vk (sha256: …)
-INFO  Connected to bitcoind  network=mainnet  block_height=946700
+INFO  Connected to ghostd  network=mainnet  block_height=946700
 INFO  Mesh listening on tcp://0.0.0.0:8563  (Noise)
 INFO  Stratum V1 listening on 0.0.0.0:3333
 INFO  Stratum V2 listening on 0.0.0.0:34255

--- a/ghost-web/docs/load-balancer.md
+++ b/ghost-web/docs/load-balancer.md
@@ -43,7 +43,7 @@ Net effect: each translator has a real-time map of every pool node's miner count
 
 ## The proxy decision
 
-When a new SV1 miner connects to a pool node's translator on port 3333, the translator runs `should_proxy()` from `crates/translator/src/lib/load_balancer.rs`:
+When a new SV1 miner connects to a pool node's translator on port 3333, the translator runs `should_proxy()` from `bins/translator-sv2/src/lib/load_balancer.rs`:
 
 ```rust
 async fn should_proxy(
@@ -186,4 +186,4 @@ The mesh-driven approach has tradeoffs (no global health probing, no geo-aware r
 | `crates/ghost-verification/src/routes.rs` | `/api/internal/pool-nodes` endpoint that exposes the peer list |
 | `crates/ghost-consensus/src/peer.rs` | Mesh peer manager that tracks `last_seen` |
 
-The SV2 translator with TLV + load-balancer support is a downstream fork of the Stratum Reference Implementation, deployed to the pool VMs but not vendored in this repo. Its source (the `should_proxy` decision, `spawn_proxy` TCP forwarder, and SV1 connection handler shown above) lives at [github.com/bitcoin-ghost/translator-sv2](https://github.com/bitcoin-ghost/translator-sv2). Only the consensus / mesh side of the load balancer (the peer-list endpoint and mesh peer manager) is in the main `ghost` repo.
+The SV2 translator with TLV + load-balancer support began as a downstream fork of the Stratum Reference Implementation. It is now **amalgamated in-tree** in the main `ghost` repo at `bins/translator-sv2/` (the `should_proxy` decision, `spawn_proxy` TCP forwarder, and SV1 connection handler shown above all live under `bins/translator-sv2/src/lib/`), alongside the consensus / mesh side of the load balancer (the peer-list endpoint and mesh peer manager). The only external dependency is the SV2 protocol library (`stratum-core`), pinned by git rev.

--- a/ghost-web/docs/recovery.md
+++ b/ghost-web/docs/recovery.md
@@ -274,7 +274,7 @@ sqlite3 /home/ghost/.ghost/ghost-pay/ghost-pay.db \
 2. Check if it's still unspent on chain:
 
    ```bash
-   bitcoin-cli gettxout <TXID> <VOUT>
+   ghost-cli gettxout <TXID> <VOUT>
    ```
 
 3. If unspent, the session coordinator constructs a recovery transaction spending the funding UTXO back to participants using the known session keys. The ghost-pay binary exposes a `wraith recover --session-id <ID>` subcommand that builds and broadcasts the refund transaction; run it on the coordinator node (or any elder with read access to the same `ghost-pay.db`).

--- a/ghost-web/docs/wallet-light-cli.md
+++ b/ghost-web/docs/wallet-light-cli.md
@@ -1,10 +1,19 @@
-# ghost-light-wallet
+# Light wallet CLI
 
 *A lightweight command-line wallet that connects to Ghost nodes via the GSP protocol. No blockchain download required.*
 
+:::warning Superseded by the Wraith wallet
+The standalone `ghost-light-wallet` binary described below has been **retired**. The light/CLI wallet is now part of the **Wraith wallet** (`apps/wraith-wallet/`), which ships a CLI, a background daemon and a desktop GUI from one core:
+
+- **Crate:** `wraith-wallet-cli` &nbsp;→&nbsp; **binary:** `wraith`
+- **Build:** `cargo build --release -p wraith-wallet-cli`
+
+The command examples further down reflect the older `ghost-light-wallet` interface and may not match the `wraith` CLI one-for-one. Treat this page as conceptual (GSP connection, Ghost Keys, no full node) until it's rewritten against the `wraith` command set.
+:::
+
 ## Overview
 
-The `ghost-light-wallet` binary (built from the `ghost-light-wallet-cli` crate) is a self-custody Bitcoin wallet designed for users who don't want to run a full node. It connects to Ghost Service Provider (GSP) servers via WebSocket to query balances, submit transactions, and interact with Ghost Pay.
+The light wallet is a self-custody Bitcoin wallet designed for users who don't want to run a full node. It connects to Ghost Service Provider (GSP) servers via WebSocket to query balances, submit transactions, and interact with Ghost Pay.
 
 :::info Key Features
 - No blockchain download - connects via GSP WebSocket
@@ -31,8 +40,8 @@ curl -sSL https://get.bitcoinghost.org/wallet.sh | bash
 git clone https://github.com/bitcoin-ghost/ghost
 cd ghost
 
-# Build the light wallet CLI (crate is `ghost-light-wallet-cli`, binary is `ghost-light-wallet`)
-cargo build --release -p ghost-light-wallet-cli
+# Build the Wraith wallet CLI (crate is `wraith-wallet-cli`, binary is `wraith`)
+cargo build --release -p wraith-wallet-cli
 
 # Binary is at:
 ./target/release/ghost-light-wallet


### PR DESCRIPTION
Audited the website docs (`ghost-web/docs/`) against current code and fixed the **confirmed** staleness (each verified against a code file:line), plus documented the new audit-cluster enforcement.

## consensus.md (most stale)
- **Signatures**: mesh/share messages are **Ed25519** (node identity), not secp256k1 (`types.rs` ShareProof; GHOST-09). Bitcoin tx signing stays secp256k1 — clarified.
- **Envelope struct**: replaced the fictional `GhostMessage` sketch with the real `MessageEnvelope` (`crates/ghost-consensus/src/message.rs`).
- **Ports**: added 8561 (payout proposal), 8562 (payout transaction), 8563 (Noise encrypted P2P).
- **Median fallback removed**: no `median` exists in payout code anymore; replaced with the actual mechanism — validators recompute the split from their own converged ledger (GHOST-02/03).
- **NEW**: "Hardened cross-node enforcement" section — GHOST-09/02/03/11 + why activation is gated on `CLUSTER_ENFORCEMENT_HEIGHT` (soft-fork-style dark→enforcing).

## Other docs
- **load-balancer.md**: path `crates/translator` → `bins/translator-sv2`; the translator is **amalgamated in-tree**, not an external fork.
- **deployment.md / recovery.md**: `bitcoind`/`bitcoin-cli` → `ghostd`/`ghost-cli`.
- **wallet-light-cli.md**: `ghost-light-wallet-cli` is retired → "superseded by the Wraith wallet" banner (crate `wraith-wallet-cli`, binary `wraith`) + corrected build command.

## Not changed (flagged for you)
- **ghost-pay.md** "flat 0.1% fee" couldn't be confirmed in code (fee logic is sat/vB settlement + optional Wraith service fee) — left as-is, worth a team check.

Docs verified clean by the audit: ghost-pool, economics-deep-dive, elder-system, mpc, zk, reaper, node-dashboard, ghost-core, keys, key-management, buds, glyphs, and the rest.