### PR TITLE
fix(translator): handle SV2 Reconnect / ChannelEndpointChanged instead of panicking

### DIFF
--- a/bins/translator-sv2/src/lib/error.rs
+++ b/bins/translator-sv2/src/lib/error.rs
@@ -201,6 +201,9 @@ pub enum TproxyErrorKind {
     InvalidKey,
     /// Downstream not found with given downstream_id
     DownstreamNotPresent(DownstreamId),
+    /// Upstream sent a `Reconnect` control message — drop and reconnect to the
+    /// configured upstream (the server-supplied redirect target is ignored).
+    UpstreamRequestedReconnect,
 }
 
 impl std::error::Error for TproxyErrorKind {}
@@ -278,6 +281,7 @@ impl fmt::Display for TproxyErrorKind {
                 f,
                 "downstream not found with downstream_id: {downstream_id}"
             ),
+            UpstreamRequestedReconnect => write!(f, "upstream requested reconnect"),
         }
     }
 }

--- a/bins/translator-sv2/src/lib/sv2/upstream/common_message_handler.rs
+++ b/bins/translator-sv2/src/lib/sv2/upstream/common_message_handler.rs
@@ -9,7 +9,7 @@ use stratum_apps::stratum_core::{
     handlers_sv2::HandleCommonMessagesFromServerAsync,
     parsers_sv2::Tlv,
 };
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 #[cfg_attr(not(test), hotpath::measure_all)]
 impl HandleCommonMessagesFromServerAsync for Upstream {
@@ -48,8 +48,15 @@ impl HandleCommonMessagesFromServerAsync for Upstream {
         msg: ChannelEndpointChanged,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        info!("Received: {}", msg);
-        todo!()
+        // Informational for a non-Job-Declaration proxy: the upstream pushes jobs
+        // (SetNewPrevHash / NewExtendedMiningJob) for every channel regardless, so
+        // there is nothing to reconcile here. Log and continue — this must NOT be
+        // treated as an error or trigger a fallback/disconnect.
+        warn!(
+            "Received {} — no-op (translator does not use Job Declaration)",
+            msg
+        );
+        Ok(())
     }
 
     async fn handle_reconnect(
@@ -58,7 +65,57 @@ impl HandleCommonMessagesFromServerAsync for Upstream {
         msg: Reconnect<'_>,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        info!("Received: {}", msg);
-        todo!()
+        // SECURITY: do NOT follow the server-supplied new_host/new_port. Honouring
+        // an arbitrary redirect would let a compromised/malicious upstream point the
+        // translator — and all of its miners — at an attacker's pool. Instead, drop
+        // and reconnect to our OWN configured upstream(s): returning a Fallback error
+        // tears down this connection and lets the FallbackCoordinator re-establish it
+        // (the same path `handle_setup_connection_error` uses). The requested target
+        // is logged for diagnostics only.
+        warn!(
+            "Received {} — reconnecting to configured upstream (ignoring server redirect target)",
+            msg
+        );
+        Err(TproxyError::fallback(
+            TproxyErrorKind::UpstreamRequestedReconnect,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use stratum_apps::stratum_core::binary_sv2::Str0255;
+
+    // Regression: these two handlers used to be `todo!()` and would PANIC the
+    // translator if the upstream ever sent the message. They must now return
+    // gracefully.
+
+    #[tokio::test]
+    async fn channel_endpoint_changed_is_noop_not_error() {
+        let mut up = Upstream::for_test();
+        let res = up
+            .handle_channel_endpoint_changed(None, ChannelEndpointChanged { channel_id: 7 }, None)
+            .await;
+        assert!(
+            res.is_ok(),
+            "ChannelEndpointChanged must be a no-op (translator has no Job Declaration), not an error/disconnect"
+        );
+    }
+
+    #[tokio::test]
+    async fn reconnect_returns_fallback_error_not_panic() {
+        let mut up = Upstream::for_test();
+        let msg = Reconnect {
+            new_host: Str0255::try_from(String::new()).unwrap(),
+            new_port: 0,
+        };
+        let res = up.handle_reconnect(None, msg, None).await;
+        // Returning an Err triggers the FallbackCoordinator to reconnect to our
+        // configured upstream — it must not panic and must not silently succeed.
+        assert!(
+            res.is_err(),
+            "Reconnect must return a (fallback) error so the upstream is re-established"
+        );
     }
 }

--- a/bins/translator-sv2/src/lib/sv2/upstream/upstream.rs
+++ b/bins/translator-sv2/src/lib/sv2/upstream/upstream.rs
@@ -49,6 +49,23 @@ pub struct Upstream {
     address: SocketAddr,
 }
 
+#[cfg(test)]
+impl Upstream {
+    /// Minimal instance for unit-testing message handlers that only read the
+    /// incoming message. The channels are unbounded and never driven, and the
+    /// address is a stub — handlers that touch the live connection must not use
+    /// this.
+    pub(crate) fn for_test() -> Self {
+        let (us_tx, us_rx) = unbounded();
+        let (cm_tx, cm_rx) = unbounded();
+        Self {
+            upstream_channel_state: UpstreamChannelState::new(us_rx, us_tx, cm_tx, cm_rx),
+            required_extensions: vec![],
+            address: "127.0.0.1:0".parse().unwrap(),
+        }
+    }
+}
+
 #[cfg_attr(not(test), hotpath::measure_all)]
 impl Upstream {
     /// Creates a new upstream connection by attempting to connect to configured servers.


### PR DESCRIPTION
Fixes the two `todo!()` in the translator's upstream common-message handler — the only clear correctness bugs in the SV2 stack. Both would **panic the translator** on receipt of an SV2 control message; latent today (the local `pool_sv2` never sends them) but a crash-on-receipt for any varied/standards-compliant upstream.

- **`handle_channel_endpoint_changed`** → no-op + log. Informational for a non-Job-Declaration proxy (the upstream pushes jobs regardless); must not error/disconnect.
- **`handle_reconnect`** → log + return a `Fallback` error so the existing `FallbackCoordinator` reconnects to the **configured** upstream. **Security:** the server-supplied `new_host`/`new_port` redirect is deliberately **ignored** — honouring it would let a compromised upstream redirect the translator and all its miners to an attacker's pool.

Adds `TproxyErrorKind::UpstreamRequestedReconnect` + a `#[cfg(test)]` `Upstream::for_test()` constructor. **Test-first**: two regression tests assert the handlers return gracefully (Ok / fallback-Err) instead of panicking. 27 translator lib tests green, clippy + fmt clean.

No coinbase / template / Job-Declaration changes — Ghost keeps full coinbase control by design.