### PR TITLE
chore: put SV2 crates on the workspace version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin_core_sv2"
-version = "0.1.1"
+version = "1.10.1"
 dependencies = [
  "async-channel 1.9.0",
  "bitcoin-capnp-types",
@@ -4635,7 +4635,7 @@ dependencies = [
 
 [[package]]
 name = "jd_client_sv2"
-version = "0.1.4"
+version = "1.10.1"
 dependencies = [
  "async-channel 1.9.0",
  "bitcoin_core_sv2",
@@ -4651,7 +4651,7 @@ dependencies = [
 
 [[package]]
 name = "jd_server_sv2"
-version = "0.1.2"
+version = "1.10.1"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -6152,7 +6152,7 @@ dependencies = [
 
 [[package]]
 name = "pool_sv2"
-version = "0.2.2"
+version = "1.10.1"
 dependencies = [
  "async-channel 1.9.0",
  "bitcoin_core_sv2",
@@ -7876,7 +7876,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stratum-apps"
-version = "0.3.1"
+version = "1.10.1"
 dependencies = [
  "async-channel 1.9.0",
  "axum 0.8.9",
@@ -9089,7 +9089,7 @@ dependencies = [
 
 [[package]]
 name = "translator_sv2"
-version = "0.2.4"
+version = "1.10.1"
 dependencies = [
  "async-channel 1.9.0",
  "clap",

--- a/bins/jd-client-sv2/Cargo.toml
+++ b/bins/jd-client-sv2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jd_client_sv2"
-version = "0.1.4"
+version.workspace = true
 authors = ["The Stratum V2 Developers"]
 edition = "2021"
 description = "Job Declarator Client (JDC) role"
@@ -16,14 +16,14 @@ name = "jd_client_sv2"
 path = "src/lib/mod.rs"
 
 [dependencies]
-stratum-apps = { version = "0.3.0", path = "../../crates/stratum-apps", features = ["jd_client"] }
+stratum-apps = { path = "../../crates/stratum-apps", features = ["jd_client"] }
 async-channel = "1.5.1"
 serde = { version = "1.0.89", default-features = false, features = ["derive", "alloc"] }
 tokio = { version = "1.44.1", features = ["full"] }
 ext-config = { version = "0.14.0", features = ["toml"], package = "config" }
 tracing = { version = "0.1" }
 clap = { version = "4.5.39", features = ["derive"] }
-bitcoin_core_sv2 = { version = "0.1.0", path = "../../crates/bitcoin-core-sv2" }
+bitcoin_core_sv2 = { path = "../../crates/bitcoin-core-sv2" }
 hex = "0.4.3"
 hotpath = "0.14.0"
 

--- a/bins/jd-server-sv2/Cargo.toml
+++ b/bins/jd-server-sv2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jd_server_sv2"
-version = "0.1.2"
+version.workspace = true
 authors = ["The Stratum V2 Developers"]
 edition = "2021"
 description = "Sv2 Job Declaration Server"
@@ -16,10 +16,10 @@ name = "jd_server_sv2"
 path = "src/lib/mod.rs"
 
 [dependencies]
-stratum-apps = { version = "0.3.0", path = "../../crates/stratum-apps", features = ["jd_server"] }
+stratum-apps = { path = "../../crates/stratum-apps", features = ["jd_server"] }
 async-channel = "1.5.1"
 
-bitcoin_core_sv2 = { version = "0.1.0", path = "../../crates/bitcoin-core-sv2" }
+bitcoin_core_sv2 = { path = "../../crates/bitcoin-core-sv2" }
 serde = { version = "1.0.89", features = ["derive", "alloc"], default-features = false }
 tracing = { version = "0.1" }
 tokio = { version = "1.44.1", features = ["full"] }

--- a/bins/pool-sv2/Cargo.toml
+++ b/bins/pool-sv2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pool_sv2"
-version = "0.2.2"
+version.workspace = true
 authors = ["The Stratum V2 Developers"]
 edition = "2021"
 description = "SV2 pool role"
@@ -17,7 +17,7 @@ name = "pool_sv2"
 path = "src/lib/mod.rs"
 
 [dependencies]
-stratum-apps = { version = "0.3.0", path = "../../crates/stratum-apps", features = ["pool"] }
+stratum-apps = { path = "../../crates/stratum-apps", features = ["pool"] }
 async-channel = "1.5.1"
 serde = { version = "1.0.89", features = ["derive", "alloc"], default-features = false }
 reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
@@ -26,8 +26,8 @@ tokio = { version = "1.44.1", features = ["full"] }
 ext-config = { version = "0.14.0", features = ["toml"], package = "config" }
 tracing = { version = "0.1" }
 clap = { version = "4.5.39", features = ["derive"] }
-bitcoin_core_sv2 = { version = "0.1.0", path = "../../crates/bitcoin-core-sv2" }
-jd_server_sv2 = { version = "0.1.0", path = "../jd-server-sv2" }
+bitcoin_core_sv2 = { path = "../../crates/bitcoin-core-sv2" }
+jd_server_sv2 = { path = "../jd-server-sv2" }
 hex = "0.4.3"
 hotpath = "0.14.0"
 

--- a/bins/translator-sv2/Cargo.toml
+++ b/bins/translator-sv2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "translator_sv2"
-version = "0.2.4"
+version.workspace = true
 authors = ["The Stratum V2 Developers"]
 edition = "2021"
 description = "SV1 to SV2 translation proxy"
@@ -20,7 +20,7 @@ name = "translator_sv2"
 path = "src/main.rs"
 
 [dependencies]
-stratum-apps = { version = "0.3.0", path = "../../crates/stratum-apps", features = ["translator"] }
+stratum-apps = { path = "../../crates/stratum-apps", features = ["translator"] }
 async-channel = "1.5.1"
 serde = { version = "1.0.89", default-features = false, features = ["derive", "alloc"] }
 serde_json = { version = "1.0.64", default-features = false, features = ["alloc"] }

--- a/crates/bitcoin-core-sv2/Cargo.toml
+++ b/crates/bitcoin-core-sv2/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bitcoin_core_sv2"
 description = "A library to get Stratum V2 Template Distribution Protocol from Bitcoin Core over IPC"
-version = "0.1.1"
+version.workspace = true
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["The Stratum V2 Developers"]

--- a/crates/stratum-apps/Cargo.toml
+++ b/crates/stratum-apps/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stratum-apps"
-version = "0.3.1"
+version.workspace = true
 authors = ["The Stratum V2 Developers"]
 edition = "2021"
 readme = "README.md"

--- a/tests/integration-sv2/Cargo.toml
+++ b/tests/integration-sv2/Cargo.toml
@@ -14,10 +14,10 @@ keywords = ["stratum", "mining", "bitcoin", "protocol"]
 exclude = ["resources/high_diff_chain.tar.gz"]
 
 [dependencies]
-stratum-apps = { version = "0.3.0", path = "../../crates/stratum-apps", features = ["network", "config"] }
-jd_client_sv2 = { version = "0.1.3", path = "../../bins/jd-client-sv2" }
-pool_sv2 = { version = "0.2.1", path = "../../bins/pool-sv2" }
-translator_sv2 = { version = "0.2.1", path = "../../bins/translator-sv2" }
+stratum-apps = { path = "../../crates/stratum-apps", features = ["network", "config"] }
+jd_client_sv2 = { path = "../../bins/jd-client-sv2" }
+pool_sv2 = { path = "../../bins/pool-sv2" }
+translator_sv2 = { path = "../../bins/translator-sv2" }
 async-channel = { version = "1.5.1", default-features = false }
 corepc-node = { version = "0.7.0", default-features = false, features = ["28_0"] }
 ureq = "2.12"


### PR DESCRIPTION
The amalgamated SV2 crates kept their SRI-derived versions, so those binaries reported a different version than the workspace — e.g. the `v1.10.1` release's `translator_sv2` reported `0.2.4`.

| Crate | Was | Now |
|---|---|---|
| translator_sv2 | 0.2.4 | workspace (1.10.1) |
| pool_sv2 | 0.2.2 | workspace |
| jd_server_sv2 | 0.1.2 | workspace |
| jd_client_sv2 | 0.1.4 | workspace |
| stratum-apps | 0.3.1 | workspace |
| bitcoin_core_sv2 | 0.1.1 | workspace |

Set all six to `version.workspace = true` and dropped the redundant `version = "X"` pins on their internal path deps (path-only is valid for workspace-internal crates and avoids per-release pin maintenance). They now track the workspace version automatically. No code changes; `cargo check` on translator_sv2 / pool_sv2 / ghost-pool + lockfile regen verified — all 6 resolve to 1.10.1.