### PR TITLE
Revert extranonce-defer (deadlocks cgminer/avalon); keep vardiff floor

### DIFF
--- a/bins/translator-sv2/src/lib/sv1/sv1_server/mod.rs
+++ b/bins/translator-sv2/src/lib/sv1/sv1_server/mod.rs
@@ -20,6 +20,15 @@ pub(super) fn is_mining_authorize(msg: &Message) -> bool {
     }
 }
 
+/// Check if Sv1 message is mining.subscribe
+pub(super) fn is_mining_subscribe(msg: &Message) -> bool {
+    if let json_rpc::Message::StandardRequest(r) = &msg {
+        r.method == "mining.subscribe"
+    } else {
+        false
+    }
+}
+
 /// Check if Sv1 message is mining.configure (BIP310 version-rolling negotiation).
 /// Stateless handshake message that needs an immediate response — must NOT be
 /// queued behind channel-open or the miner deadlocks waiting for the configure

--- a/bins/translator-sv2/src/lib/sv1/sv1_server/sv1_server.rs
+++ b/bins/translator-sv2/src/lib/sv1/sv1_server/sv1_server.rs
@@ -7,7 +7,7 @@ use crate::{
         downstream::{downstream::Downstream, SubmitShareWithChannelId},
         sv1_server::{
             channel::Sv1ServerChannelState, is_mining_authorize, is_mining_configure,
-            KEEPALIVE_JOB_ID_DELIMITER,
+            is_mining_subscribe, KEEPALIVE_JOB_ID_DELIMITER,
         },
     },
     utils::AGGREGATED_CHANNEL_ID,
@@ -467,35 +467,29 @@ impl Sv1Server {
             // BEFORE authorize — too early to know the user_identity.
             //
             // New flow:
-            //   - `mining.subscribe`: QUEUE it until the channel opens, then process it so its
-            //     response carries the REAL channel-allocated extranonce. The subscribe response
-            //     (`[subscriptions, extranonce1, extranonce2_size]`) is built from
-            //     `data.extranonce1` — which is the real value by the time the queue is drained
-            //     (set on `OpenExtendedMiningChannelSuccess` before queued-message processing).
-            //     This is the correctness fix for stock SV1 miners: `mining.set_extranonce` is an
-            //     OPTIONAL extension (a miner must send `mining.extranonce.subscribe` to opt in),
-            //     so the previous "respond with an 8-byte placeholder, then post-hoc
-            //     set_extranonce" path silently broke every miner with extranonce-subscribe OFF —
-            //     their shares were built against the placeholder and 100% rejected. Delivering
-            //     the real extranonce in the subscribe response itself works for ALL miners,
-            //     opted-in or not, with no mid-stream re-key. The channel opens within ~100ms of
-            //     subscribe (the miner pipelines subscribe+authorize), so deferring the response
-            //     does not risk a subscribe timeout.
+            //   - `mining.subscribe`: process immediately. The subscribe response carries the
+            //     extranonce1 from `data.extranonce1`, which is pre-initialised to a per-
+            //     downstream placeholder by `DownstreamData::new`. The miner gets a fast
+            //     response and won't time out. We update extranonce1 to the real value once
+            //     the upstream channel opens, and notify the miner via SV1
+            //     `mining.set_extranonce`.
             //   - `mining.authorize`: process immediately so `data.user_identity` /
             //     `data.authorized_worker_name` are populated, then trigger
-            //     `handle_open_channel_request`. (Authorize, not subscribe, opens the channel —
-            //     so queuing subscribe does NOT block the open: the miner pipelines them.)
+            //     `handle_open_channel_request`.
             //   - `mining.configure`: process immediately. BIP310 version-rolling negotiation
             //     is stateless — the miner sends configure first to learn the version mask,
             //     then sends subscribe/authorize. If we queue configure waiting for the
             //     channel to open, some Bitaxe firmware (BM1370 v2.12.0 observed) waits for
-            //     the configure response before sending subscribe at all, which deadlocks.
+            //     the configure response before sending subscribe at all, which deadlocks:
+            //     no channel can open until authorize, no authorize until subscribe, no
+            //     subscribe until configure responds.
             //   - Anything else: queue until the channel is open (existing behaviour).
             //
             // Aggregated mode is unaffected — every downstream still piggybacks on the single
             // shared upstream channel that the channel_manager already opened, so this branch
             // simply falls through for `mining.submit` etc. once the channel exists.
-            let process_immediately = is_mining_authorize(&downstream_message)
+            let process_immediately = is_mining_subscribe(&downstream_message)
+                || is_mining_authorize(&downstream_message)
                 || is_mining_configure(&downstream_message);
             if !process_immediately {
                 debug!(


### PR DESCRIPTION
Reverts the extranonce change from #75. It deadlocked **cgminer-based miners** (the avalon) that **serialize** the SV1 handshake — they wait for the `mining.subscribe` response before sending `authorize`, and deferring the subscribe response means the channel never opens → connect/deadlock/reconnect loop → miner offline. Bitaxes (AxeOS) pipeline so they were fine, masking it until the avalon dropped.

Production is already rolled back to the floor-only binary (`a596d7ad`); this makes `main` match production again. **The vardiff floor (#75's other fix) is kept.**

The correct extranonce fix needs a **timeout fallback**: defer the subscribe response for pipelining miners (real extranonce up front, no set_extranonce), but fall back to the placeholder + `set_extranonce` after ~1.5s for serializing miners (which support the extension). That's a follow-up, to be built + tested against both a serializer (avalon) and a non-subscriber (the friend's bitaxe) before redeploy.