### PR TITLE
fix(translator): timeout fallback so subscribe-defer can't deadlock serializing miners

### DIFF
--- a/bins/translator-sv2/src/lib/sv1/sv1_server/mod.rs
+++ b/bins/translator-sv2/src/lib/sv1/sv1_server/mod.rs
@@ -32,6 +32,15 @@ pub(super) fn is_mining_configure(msg: &Message) -> bool {
     }
 }
 
+/// Check if Sv1 message is mining.subscribe.
+pub(super) fn is_mining_subscribe(msg: &Message) -> bool {
+    if let json_rpc::Message::StandardRequest(r) = &msg {
+        r.method == "mining.subscribe"
+    } else {
+        false
+    }
+}
+
 /// Extracts the worker-identifier portion of an SV1 `mining.authorize` username for use as the
 /// per-downstream identity that flows into the Worker-Specific Hashrate Tracking TLV.
 ///

--- a/bins/translator-sv2/src/lib/sv1/sv1_server/sv1_server.rs
+++ b/bins/translator-sv2/src/lib/sv1/sv1_server/sv1_server.rs
@@ -7,7 +7,7 @@ use crate::{
         downstream::{downstream::Downstream, SubmitShareWithChannelId},
         sv1_server::{
             channel::Sv1ServerChannelState, is_mining_authorize, is_mining_configure,
-            KEEPALIVE_JOB_ID_DELIMITER,
+            is_mining_subscribe, KEEPALIVE_JOB_ID_DELIMITER,
         },
     },
     utils::AGGREGATED_CHANNEL_ID,
@@ -506,9 +506,71 @@ impl Sv1Server {
                     data.queued_sv1_handshake_messages
                         .push(downstream_message.clone())
                 });
+
+                // mining.subscribe timeout fallback (serializer safety).
+                //
+                // PIPELINING miners (AxeOS/bitaxe) fire subscribe + authorize back-to-back, so
+                // the channel opens within ~100ms and the queued subscribe is answered with the
+                // REAL extranonce by the channel-open path (no set_extranonce needed). But
+                // SERIALIZING miners (cgminer / Avalon) wait for the subscribe RESPONSE before
+                // sending authorize — and the channel only opens on authorize. Queuing subscribe
+                // with no fallback deadlocks them: no response → no authorize → no channel → no
+                // response. After ~1.5s with no channel, answer subscribe with the placeholder
+                // extranonce so the serializer proceeds; the channel then opens and the existing
+                // set_extranonce path corrects the extranonce (serializing miners support that
+                // extension). The channel-open path and this timer both claim the queued subscribe
+                // atomically under the data lock, so exactly one of them answers it.
+                if is_mining_subscribe(&downstream_message) {
+                    let server = self.clone();
+                    let did = downstream_id;
+                    tokio::spawn(async move {
+                        tokio::time::sleep(std::time::Duration::from_millis(1500)).await;
+                        let Some(downstream) =
+                            server.downstreams.get(&did).map(|r| r.value().clone())
+                        else {
+                            return;
+                        };
+                        // Claim the queued subscribe iff the channel still hasn't opened (i.e. the
+                        // open path hasn't already answered it — a pipelining miner).
+                        let subscribe_msg = downstream.downstream_data.super_safe_lock(|data| {
+                            if data.channel_id.is_some() {
+                                return None;
+                            }
+                            data.queued_sv1_handshake_messages
+                                .iter()
+                                .position(|m| is_mining_subscribe(m))
+                                .map(|pos| data.queued_sv1_handshake_messages.remove(pos))
+                        });
+                        if let Some(msg) = subscribe_msg {
+                            info!(
+                                "Down: subscribe-response timeout for downstream {} — serializing \
+                                 miner waiting on subscribe before authorize; answering with \
+                                 placeholder extranonce (set_extranonce corrects it on channel open)",
+                                did
+                            );
+                            match server.clone().handle_message(Some(did), msg) {
+                                Ok(Some(resp)) => {
+                                    if let Err(e) = downstream
+                                        .downstream_channel_state
+                                        .downstream_sv1_sender
+                                        .send(resp.into())
+                                        .await
+                                    {
+                                        warn!("Down: failed to send fallback subscribe response to downstream {}: {:?}", did, e);
+                                    }
+                                }
+                                Ok(None) => {}
+                                Err(e) => {
+                                    error!("Down: error building fallback subscribe response for downstream {}: {:?}", did, e);
+                                }
+                            }
+                        }
+                    });
+                }
+
                 return Ok(());
             }
-            // For subscribe/authorize: fall through to the normal handle_message path below.
+            // For authorize/configure: fall through to the normal handle_message path below.
             // Authorize-triggered channel open happens in the post-response block.
         }
 

--- a/bins/translator-sv2/tests/sv1_handshake_smoke.py
+++ b/bins/translator-sv2/tests/sv1_handshake_smoke.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+# Synthetic SV1 handshake test — proves the translator does NOT deadlock a
+# SERIALIZING miner (subscribe -> WAIT -> authorize), and serves a PIPELINING one.
+import socket, json, sys, time
+
+HOST = sys.argv[1] if len(sys.argv) > 1 else "95.111.221.169"
+PORT = int(sys.argv[2] if len(sys.argv) > 2 else 3333)
+USER = sys.argv[3] if len(sys.argv) > 3 else "bc1q7zvdh3uza6u52uemd3c60g0h0eu9g9yvm2y492.synthtest"
+
+def recv_lines(sock, timeout, want_id=None, want_method=None):
+    sock.settimeout(timeout); buf=b""; out=[]
+    t0=time.time()
+    try:
+        while time.time()-t0 < timeout:
+            data=sock.recv(4096)
+            if not data: break
+            buf+=data
+            while b"\n" in buf:
+                line,buf=buf.split(b"\n",1)
+                if not line.strip(): continue
+                msg=json.loads(line)
+                out.append(msg)
+                if want_id is not None and msg.get("id")==want_id and "result" in msg: return out
+                if want_method and msg.get("method")==want_method: return out
+    except socket.timeout:
+        pass
+    return out
+
+def test_serializer():
+    print(f"[SERIALIZER] connect {HOST}:{PORT}, subscribe, WAIT (no authorize) — expect a subscribe response (no deadlock)")
+    s=socket.create_connection((HOST,PORT),timeout=10)
+    s.sendall(json.dumps({"id":1,"method":"mining.subscribe","params":["synthtest/1.0"]}).encode()+b"\n")
+    # Do NOT send authorize. A deadlocked translator never replies to subscribe.
+    t0=time.time()
+    msgs=recv_lines(s, 4.0, want_id=1)
+    dt=time.time()-t0
+    sub=[m for m in msgs if m.get("id")==1 and "result" in m]
+    if sub:
+        r=sub[0]["result"]
+        en1 = r[1] if isinstance(r,list) and len(r)>1 else "?"
+        print(f"  ✅ PASS — got subscribe response in {dt:.2f}s, extranonce1={en1} (NO deadlock)")
+        # now send authorize and confirm we get set_difficulty / notify (channel opens)
+        s.sendall(json.dumps({"id":2,"method":"mining.authorize","params":[USER,"x"]}).encode()+b"\n")
+        m2=recv_lines(s, 6.0, want_method="mining.notify")
+        got_notify=any(m.get("method")=="mining.notify" for m in m2)
+        got_setx=any(m.get("method")=="mining.set_extranonce" for m in m2)
+        print(f"  channel-open after authorize: notify={got_notify} set_extranonce={got_setx}")
+        s.close(); return True
+    else:
+        print(f"  ❌ FAIL — NO subscribe response after {dt:.2f}s (DEADLOCK)")
+        s.close(); return False
+
+def test_pipeliner():
+    print(f"[PIPELINER] connect, send subscribe+authorize together — expect real extranonce + jobs")
+    s=socket.create_connection((HOST,PORT),timeout=10)
+    s.sendall(json.dumps({"id":1,"method":"mining.subscribe","params":["synthtest/1.0"]}).encode()+b"\n")
+    s.sendall(json.dumps({"id":2,"method":"mining.authorize","params":[USER,"x"]}).encode()+b"\n")
+    msgs=recv_lines(s, 8.0, want_method="mining.notify")
+    sub=[m for m in msgs if m.get("id")==1 and "result" in m]
+    got_notify=any(m.get("method")=="mining.notify" for m in msgs)
+    if sub and got_notify:
+        en1=sub[0]["result"][1]
+        is_placeholder = (en1 == "0000000000000000")
+        print(f"  ✅ PASS — subscribe response extranonce1={en1} ({'PLACEHOLDER!' if is_placeholder else 'real'}), notify received")
+        s.close(); return True
+    print(f"  ❌ FAIL — sub={bool(sub)} notify={got_notify}")
+    s.close(); return False
+
+ok1=test_serializer()
+print()
+ok2=test_pipeliner()
+print()
+print("RESULT:", "ALL PASS ✅" if (ok1 and ok2) else "FAILED ❌")
+sys.exit(0 if (ok1 and ok2) else 1)

--- a/bins/translator-sv2/tests/sv1_handshake_smoke.py
+++ b/bins/translator-sv2/tests/sv1_handshake_smoke.py
@@ -1,74 +1,140 @@
 #!/usr/bin/env python3
-# Synthetic SV1 handshake test — proves the translator does NOT deadlock a
-# SERIALIZING miner (subscribe -> WAIT -> authorize), and serves a PIPELINING one.
+"""Synthetic SV1 handshake smoke test for the Ghost translator.
+
+Reproduces the real-world miner quirks that have bitten us, as a run-before-deploy
+guard so a handshake regression can't reach the fleet silently again.
+
+Cases:
+  serializer      cgminer/Avalon: subscribe -> WAIT -> authorize. Must NOT deadlock
+                  (the avalon-night bug). The translator must answer subscribe within
+                  the ~1.5s timeout fallback even though authorize hasn't been sent.
+  pipeliner       AxeOS/Bitaxe: subscribe+authorize together. Must get the REAL
+                  extranonce in the subscribe response (the extranonce-subscribe-OFF
+                  fix), not the 8-byte placeholder.
+  bare-username   authorize without a `.worker` -> must be rejected (per-miner payout
+                  policy), not silently accepted.
+  version-rolling mining.configure (BIP310/AsicBoost, Antminer S19) -> must negotiate
+                  a version-rolling mask.
+
+Usage:  python3 sv1_handshake_smoke.py [HOST] [PORT] [USER]
+Exit 0 iff all cases pass.
+"""
 import socket, json, sys, time
 
-HOST = sys.argv[1] if len(sys.argv) > 1 else "95.111.221.169"
+HOST = sys.argv[1] if len(sys.argv) > 1 else "127.0.0.1"
 PORT = int(sys.argv[2] if len(sys.argv) > 2 else 3333)
 USER = sys.argv[3] if len(sys.argv) > 3 else "bc1q7zvdh3uza6u52uemd3c60g0h0eu9g9yvm2y492.synthtest"
+PLACEHOLDER = "0000000000000000"
 
-def recv_lines(sock, timeout, want_id=None, want_method=None):
-    sock.settimeout(timeout); buf=b""; out=[]
-    t0=time.time()
+
+def recv_until(sock, timeout, pred):
+    sock.settimeout(timeout)
+    buf = b""
+    out = []
+    t0 = time.time()
     try:
-        while time.time()-t0 < timeout:
-            data=sock.recv(4096)
-            if not data: break
-            buf+=data
+        while time.time() - t0 < timeout:
+            data = sock.recv(4096)
+            if not data:
+                break
+            buf += data
             while b"\n" in buf:
-                line,buf=buf.split(b"\n",1)
-                if not line.strip(): continue
-                msg=json.loads(line)
+                line, buf = buf.split(b"\n", 1)
+                if not line.strip():
+                    continue
+                try:
+                    msg = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
                 out.append(msg)
-                if want_id is not None and msg.get("id")==want_id and "result" in msg: return out
-                if want_method and msg.get("method")==want_method: return out
+                if pred(msg):
+                    return out
     except socket.timeout:
         pass
     return out
 
+
+def send(sock, obj):
+    sock.sendall(json.dumps(obj).encode() + b"\n")
+
+
 def test_serializer():
-    print(f"[SERIALIZER] connect {HOST}:{PORT}, subscribe, WAIT (no authorize) — expect a subscribe response (no deadlock)")
-    s=socket.create_connection((HOST,PORT),timeout=10)
-    s.sendall(json.dumps({"id":1,"method":"mining.subscribe","params":["synthtest/1.0"]}).encode()+b"\n")
-    # Do NOT send authorize. A deadlocked translator never replies to subscribe.
-    t0=time.time()
-    msgs=recv_lines(s, 4.0, want_id=1)
-    dt=time.time()-t0
-    sub=[m for m in msgs if m.get("id")==1 and "result" in m]
-    if sub:
-        r=sub[0]["result"]
-        en1 = r[1] if isinstance(r,list) and len(r)>1 else "?"
-        print(f"  ✅ PASS — got subscribe response in {dt:.2f}s, extranonce1={en1} (NO deadlock)")
-        # now send authorize and confirm we get set_difficulty / notify (channel opens)
-        s.sendall(json.dumps({"id":2,"method":"mining.authorize","params":[USER,"x"]}).encode()+b"\n")
-        m2=recv_lines(s, 6.0, want_method="mining.notify")
-        got_notify=any(m.get("method")=="mining.notify" for m in m2)
-        got_setx=any(m.get("method")=="mining.set_extranonce" for m in m2)
-        print(f"  channel-open after authorize: notify={got_notify} set_extranonce={got_setx}")
-        s.close(); return True
-    else:
-        print(f"  ❌ FAIL — NO subscribe response after {dt:.2f}s (DEADLOCK)")
-        s.close(); return False
+    s = socket.create_connection((HOST, PORT), timeout=10)
+    send(s, {"id": 1, "method": "mining.subscribe", "params": ["synthtest/1.0"]})
+    # Deliberately do NOT send authorize — a deadlocked translator never replies.
+    t0 = time.time()
+    msgs = recv_until(s, 4.0, lambda m: m.get("id") == 1 and "result" in m)
+    dt = time.time() - t0
+    got = any(m.get("id") == 1 and "result" in m for m in msgs)
+    s.close()
+    print(f"  [serializer]      {'PASS' if got else 'FAIL'} — subscribe answered in {dt:.2f}s "
+          f"({'no deadlock' if got else 'DEADLOCK — no response'})")
+    return got
+
 
 def test_pipeliner():
-    print(f"[PIPELINER] connect, send subscribe+authorize together — expect real extranonce + jobs")
-    s=socket.create_connection((HOST,PORT),timeout=10)
-    s.sendall(json.dumps({"id":1,"method":"mining.subscribe","params":["synthtest/1.0"]}).encode()+b"\n")
-    s.sendall(json.dumps({"id":2,"method":"mining.authorize","params":[USER,"x"]}).encode()+b"\n")
-    msgs=recv_lines(s, 8.0, want_method="mining.notify")
-    sub=[m for m in msgs if m.get("id")==1 and "result" in m]
-    got_notify=any(m.get("method")=="mining.notify" for m in msgs)
-    if sub and got_notify:
-        en1=sub[0]["result"][1]
-        is_placeholder = (en1 == "0000000000000000")
-        print(f"  ✅ PASS — subscribe response extranonce1={en1} ({'PLACEHOLDER!' if is_placeholder else 'real'}), notify received")
-        s.close(); return True
-    print(f"  ❌ FAIL — sub={bool(sub)} notify={got_notify}")
-    s.close(); return False
+    s = socket.create_connection((HOST, PORT), timeout=10)
+    send(s, {"id": 1, "method": "mining.subscribe", "params": ["synthtest/1.0"]})
+    send(s, {"id": 2, "method": "mining.authorize", "params": [USER, "x"]})
+    msgs = recv_until(s, 6.0, lambda m: m.get("id") == 1 and "result" in m)
+    sub = [m for m in msgs if m.get("id") == 1 and "result" in m]
+    en1 = sub[0]["result"][1] if sub and isinstance(sub[0]["result"], list) else None
+    # bonus: did a job arrive (NOT required — job cadence varies)
+    notify = any(m.get("method") == "mining.notify"
+                 for m in recv_until(s, 4.0, lambda m: m.get("method") == "mining.notify"))
+    s.close()
+    real = en1 is not None and en1 != PLACEHOLDER
+    print(f"  [pipeliner]       {'PASS' if real else 'FAIL'} — subscribe extranonce1={en1} "
+          f"({'real' if real else 'PLACEHOLDER — extranonce-OFF miners would reject'}); notify={notify}")
+    return real
 
-ok1=test_serializer()
-print()
-ok2=test_pipeliner()
-print()
-print("RESULT:", "ALL PASS ✅" if (ok1 and ok2) else "FAILED ❌")
-sys.exit(0 if (ok1 and ok2) else 1)
+
+def test_bare_username():
+    s = socket.create_connection((HOST, PORT), timeout=10)
+    send(s, {"id": 1, "method": "mining.subscribe", "params": ["synthtest/1.0"]})
+    send(s, {"id": 2, "method": "mining.authorize",
+             "params": ["bc1qbareaddressnoworkerxxxxxxxxxxxxxxxxxxxxx", "x"]})
+    msgs = recv_until(s, 5.0, lambda m: m.get("id") == 2)
+    auth = [m for m in msgs if m.get("id") == 2]
+    rejected = bool(auth) and (auth[0].get("result") in (False, None) or auth[0].get("error"))
+    s.close()
+    print(f"  [bare-username]   {'PASS' if rejected else 'FAIL'} — bare-worker authorize "
+          f"{'rejected' if rejected else 'ACCEPTED (policy hole)'}")
+    return rejected
+
+
+def test_version_rolling():
+    s = socket.create_connection((HOST, PORT), timeout=10)
+    send(s, {"id": 1, "method": "mining.configure",
+             "params": [["version-rolling"],
+                        {"version-rolling.mask": "1fffe000", "version-rolling.min-bit-count": 2}]})
+    msgs = recv_until(s, 5.0, lambda m: m.get("id") == 1 and "result" in m)
+    res = [m for m in msgs if m.get("id") == 1 and "result" in m]
+    r = res[0]["result"] if res else {}
+    ok = isinstance(r, dict) and r.get("version-rolling") is True and r.get("version-rolling.mask")
+    s.close()
+    print(f"  [version-rolling] {'PASS' if ok else 'FAIL'} — "
+          f"version-rolling={r.get('version-rolling') if isinstance(r, dict) else None} "
+          f"mask={r.get('version-rolling.mask') if isinstance(r, dict) else None}")
+    return bool(ok)
+
+
+def main():
+    print(f"SV1 handshake smoke test vs {HOST}:{PORT}")
+    results = {
+        "serializer": test_serializer(),
+        "pipeliner": test_pipeliner(),
+        "bare-username": test_bare_username(),
+        "version-rolling": test_version_rolling(),
+    }
+    print()
+    bad = [k for k, v in results.items() if not v]
+    if bad:
+        print("RESULT: FAILED ❌ —", ", ".join(bad))
+        return 1
+    print("RESULT: ALL PASS ✅")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Re-does the extranonce fix correctly. The defer (deliver real extranonce in the subscribe response) is right for pipelining miners but **deadlocked serializing miners** (cgminer/Avalon: subscribe → *wait for response* → authorize; the channel only opens on authorize). That took the Avalon offline fleet-wide tonight.

**Fix:** a ~1.5s **timeout fallback**. Queue subscribe as before; if the channel hasn't opened by 1.5s (serializer waiting on us), answer with the placeholder so it proceeds, then `set_extranonce` corrects it on channel-open. Pipeliners open the channel in ~100ms → answered with the **real** extranonce first; the timer no-ops. Both paths claim the queued subscribe atomically.

**Validated on a VM4 canary with a synthetic SV1 client** (committed as `tests/sv1_handshake_smoke.py` — the regression guard that was missing):
- serializer → response at 1.83s (fallback), no deadlock, channel opens ✅
- pipeliner → real extranonce `0001000f…` in the subscribe response ✅

Not rolling fleet-wide until the **real Avalon** (serializer) and **friend's bitaxe** (pipeliner-OFF) both confirm on the canary.