### PR TITLE
chore: bump workspace version to 1.10.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-ghost-tests"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "bitcoin",
  "chrono",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin_core_sv2"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "async-channel 1.9.0",
  "bitcoin-capnp-types",
@@ -3083,7 +3083,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-accounting"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "bitcoin",
  "ghost-common",
@@ -3097,7 +3097,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-buds"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "bitcoin",
  "ghost-common",
@@ -3111,7 +3111,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-cli"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3129,7 +3129,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-common"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -3162,7 +3162,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-consensus"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3193,7 +3193,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-glyph"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "hex",
  "serde",
@@ -3204,7 +3204,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-gsp"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3266,7 +3266,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-gsp-proto"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "bitcoin",
  "chrono",
@@ -3283,7 +3283,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-keys"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "bech32",
  "bitcoin",
@@ -3305,7 +3305,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-locks"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "bitcoin",
  "getrandom 0.2.17",
@@ -3348,7 +3348,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-pay"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3395,7 +3395,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-policy"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "bitcoin",
  "ghost-buds",
@@ -3408,7 +3408,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-pool"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "anyhow",
  "async-channel 2.5.0",
@@ -3460,7 +3460,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-reaper"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "bitcoin",
  "hex",
@@ -3472,7 +3472,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-reconciliation"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "async-trait",
  "bitcoin",
@@ -3498,7 +3498,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-registry"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -3533,7 +3533,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-setup"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "clap",
  "dirs 5.0.1",
@@ -3544,7 +3544,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-storage"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "base64 0.22.1",
  "chacha20poly1305",
@@ -3565,7 +3565,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-tap-core"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3607,7 +3607,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-tap-desktop"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "dirs 6.0.0",
  "getrandom 0.2.17",
@@ -3633,7 +3633,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-tap-integration"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "ghost-gsp-proto",
  "ghost-tap-core",
@@ -3647,7 +3647,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-template"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "bitcoin",
  "ghost-buds",
@@ -3663,7 +3663,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-verification"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "axum 0.7.9",
  "bitcoin",
@@ -4635,7 +4635,7 @@ dependencies = [
 
 [[package]]
 name = "jd_client_sv2"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "async-channel 1.9.0",
  "bitcoin_core_sv2",
@@ -4651,7 +4651,7 @@ dependencies = [
 
 [[package]]
 name = "jd_server_sv2"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -6152,7 +6152,7 @@ dependencies = [
 
 [[package]]
 name = "pool_sv2"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "async-channel 1.9.0",
  "bitcoin_core_sv2",
@@ -7876,7 +7876,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stratum-apps"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "async-channel 1.9.0",
  "axum 0.8.9",
@@ -9089,7 +9089,7 @@ dependencies = [
 
 [[package]]
 name = "translator_sv2"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "async-channel 1.9.0",
  "clap",
@@ -10417,7 +10417,7 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "wraith-coordinator"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -10448,7 +10448,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-protocol"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "bitcoin",
  "getrandom 0.2.17",
@@ -10469,7 +10469,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-cli"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "clap",
  "clap_complete",
@@ -10482,7 +10482,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-core"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -10519,7 +10519,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-daemon"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "axum 0.7.9",
  "base64 0.22.1",
@@ -10542,7 +10542,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-gui"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -10556,7 +10556,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-ipc"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "libc",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ exclude = []
 # Use scripts/build-all-wallets.sh to build all wallet types.
 
 [workspace.package]
-version = "1.10.2"
+version = "1.10.3"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Bitcoin Ghost Team"]


### PR DESCRIPTION
Patch bump `1.10.2 → 1.10.3` for the translator new-miner fixes (PRs #75 + #78), now deployed + verified live on the fleet (translator sha `397670ff`):

- **Real extranonce in the `mining.subscribe` response** — stock SV1 miners with extranonce-subscribe OFF (AxeOS default) were 100% rejected.
- **Timeout fallback** so the subscribe-defer can't deadlock serializing miners (cgminer/Avalon: subscribe → wait → authorize).
- **Vardiff floor** at `min_individual_miner_hashrate` (was the 1.0 H/s lib default).
- Synthetic SV1 handshake smoke test (4 quirk cases) as a run-before-deploy guard.

Both miner classes verified live (avalon + friend's bitaxe). No API/wire change; SV2 crates inherit the workspace version so the translator reports 1.10.3.