### PR TITLE
feat(pool): converge best-hash records across the mesh

### DIFF
--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -106,6 +106,40 @@ pub const PAYOUT_ADDRESS_GROUPING_HEIGHT: u64 = 946_743;
 /// share variance while still tracking real changes within a few minutes.
 const MESH_HASHRATE_WINDOW_SECS: i64 = 600;
 
+/// Records windows gossiped in health pings: `(name, cutoff_secs)`. MUST match
+/// the windows the `/api/v1/pool/records` endpoint serves so the gossiped best
+/// merges 1:1 with the local DB best per window.
+const RECORD_WINDOWS: [(&str, i64); 4] = [
+    ("block", 600),
+    ("day", 86_400),
+    ("week", 604_800),
+    ("month", 2_592_000),
+];
+
+/// Build this node's best (rarest) valid share per records window from the
+/// local DB, shaped exactly like the `/api/v1/pool/records` response (redacted
+/// miner_id, achieved difficulty from the hash). Gossiped in health pings so
+/// the mesh converges on the pool-wide rarest record per window. Windows with
+/// no local share are omitted (a receiving node just won't get a term from us).
+fn build_local_best_records(
+    db: &ghost_storage::Database,
+) -> Vec<ghost_common::types::WindowBestRecord> {
+    let now_s = chrono::Utc::now().timestamp();
+    let mut out = Vec::with_capacity(RECORD_WINDOWS.len());
+    for (window, cutoff) in RECORD_WINDOWS {
+        if let Ok(Some(best)) = db.get_best_share_since(now_s - cutoff) {
+            out.push(ghost_common::types::WindowBestRecord {
+                window: window.to_string(),
+                difficulty: ghost_verification::share_difficulty_from_hash_hex(&best.share_hash),
+                miner_id_redacted: ghost_verification::redact_miner_id(&best.miner_id),
+                share_hash: best.share_hash,
+                timestamp: best.timestamp,
+            });
+        }
+    }
+    out
+}
+
 /// H-8 SECURITY: Static storage for ZMQ subscriber to prevent memory leak.
 /// Previously used std::mem::forget which intentionally leaked memory.
 /// Using OnceLock ensures the subscriber lives for the program lifetime
@@ -996,6 +1030,17 @@ async fn main() -> Result<()> {
         db_for_local_hr
             .local_hashrate_th(MESH_HASHRATE_WINDOW_SECS, &self_rx_for_provider)
             .unwrap_or(0.0)
+    }));
+
+    // Gossip THIS node's best (rarest) valid share per records window so every
+    // node converges on the pool-wide rarest record per window. Without this,
+    // the record lives on whichever node received it and the website's fan-out
+    // flickers when that node is momentarily unreachable. Each entry mirrors the
+    // shape the `/api/v1/pool/records` endpoint returns (redacted miner_id,
+    // achieved difficulty) so a receiving node can serve it verbatim.
+    let db_for_best_records = Arc::clone(&db);
+    mesh_inner.set_best_records_provider(Arc::new(move || {
+        build_local_best_records(&db_for_best_records)
     }));
 
     let mesh = Arc::new(mesh_inner);
@@ -3368,6 +3413,16 @@ async fn main() -> Result<()> {
             .local_hashrate_th(MESH_HASHRATE_WINDOW_SECS, &self_rx_for_route)
             .unwrap_or(0.0)
     });
+
+    // Mesh-wide best records per window — every connected peer's gossiped best,
+    // reduced to one winner per window. The records endpoint merges this with
+    // the local DB best so the pool-wide rarest record survives the
+    // record-holding node being momentarily unreachable. 300s peer freshness
+    // (matches the active-miner window) so a couple of missed ~10s pings don't
+    // drop a peer's record from the merge.
+    let mesh_for_best_records = Arc::clone(&mesh);
+    verification_state = verification_state
+        .with_mesh_best_records(move || mesh_for_best_records.mesh_best_records(300));
 
     // Advertise this node's hardware-derived capacity via /api/internal/pool-nodes
     // so the colocated translator's load balancer routes by utilisation %.

--- a/crates/ghost-common/src/types.rs
+++ b/crates/ghost-common/src/types.rs
@@ -440,6 +440,41 @@ pub struct HealthPing {
     /// as unknown / excluded from utilisation routing).
     #[serde(default)]
     pub max_capacity: u32,
+    /// This node's best (rarest) valid share per public records window
+    /// (`block | day | week | month`). Gossiped so every node knows the
+    /// global best per window and the `/api/v1/pool/records` endpoint can
+    /// return the mesh-wide rarest record instead of only its local one —
+    /// without that, the pool-wide record lives on a single node and the
+    /// website (which fans out and takes the min) flickers whenever that
+    /// node is momentarily unreachable. `#[serde(default)]` for backward
+    /// compatibility — older nodes that don't send it deserialise to an
+    /// empty Vec, and newer nodes simply ignore peers that omit it.
+    #[serde(default)]
+    pub best_records: Vec<WindowBestRecord>,
+}
+
+/// One node's best (rarest) valid share in a public records window.
+///
+/// Carried in [`HealthPing::best_records`] so every node can converge on the
+/// mesh-wide rarest record per window. The `share_hash` is the canonical
+/// record (lower = rarer); all other fields are derived presentation data
+/// already shaped the way the records API returns them, so a receiving node
+/// can serve a peer's record verbatim without re-querying.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct WindowBestRecord {
+    /// Records window this record belongs to: `block | day | week | month`.
+    pub window: String,
+    /// 64-char zero-padded big-endian hex of the share hash. Fixed width, so
+    /// lexicographic string comparison matches numeric order (lower = rarer).
+    pub share_hash: String,
+    /// Achieved difficulty derived from `share_hash` (the score), matching the
+    /// `difficulty` the records API returns.
+    pub difficulty: f64,
+    /// Unix-seconds timestamp of the share.
+    pub timestamp: i64,
+    /// Redacted miner_id (e.g. `bc1q7z…y492.avalon1`), already shaped the same
+    /// way the records API redacts — never the raw miner_id.
+    pub miner_id_redacted: String,
 }
 
 /// Hex-encoded serialization for the active miner-id hash list.
@@ -967,6 +1002,13 @@ mod tests {
             active_miner_id_hashes: vec![[1u8; 16], [2u8; 16]],
             local_hashrate_th: 4.0,
             max_capacity: 0,
+            best_records: vec![WindowBestRecord {
+                window: "day".to_string(),
+                share_hash: "0".repeat(8) + &"f".repeat(56),
+                difficulty: 4096.0,
+                timestamp: 1,
+                miner_id_redacted: "bc1q7z…y492.avalon1".to_string(),
+            }],
         }
     }
 
@@ -995,6 +1037,29 @@ mod tests {
         assert_eq!(back.local_hashrate_th, 0.0);
         assert_eq!(back.active_miner_id_hashes.len(), 2);
         assert_eq!(back.miner_count, 2);
+    }
+
+    #[test]
+    fn health_ping_best_records_roundtrip() {
+        let ping = sample_health_ping();
+        let json = serde_json::to_string(&ping).unwrap();
+        let back: HealthPing = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.best_records, ping.best_records);
+    }
+
+    #[test]
+    fn health_ping_deserializes_without_best_records_field() {
+        // Emulate an OLDER node's ping that predates `best_records`: serialize,
+        // strip the field, and confirm it defaults to an empty Vec (and the
+        // rest of the ping is unaffected). Proves the wire change is additive
+        // so a mixed-version rolling deploy stays compatible.
+        let ping = sample_health_ping();
+        let mut v = serde_json::to_value(&ping).unwrap();
+        assert!(v.as_object_mut().unwrap().remove("best_records").is_some());
+        let back: HealthPing = serde_json::from_value(v).unwrap();
+        assert!(back.best_records.is_empty());
+        assert_eq!(back.miner_count, 2);
+        assert_eq!(back.active_miner_id_hashes.len(), 2);
     }
 
     // ---- GHOST-09: ShareProof received_by authentication ----

--- a/crates/ghost-consensus/src/health_handler.rs
+++ b/crates/ghost-consensus/src/health_handler.rs
@@ -867,6 +867,10 @@ impl HealthPingHandler {
         // Hardware-derived capacity used by the LB for utilisation routing.
         self.peers
             .update_max_capacity(&envelope.sender, ping.max_capacity);
+        // Best (rarest) share per records window — merged with the local DB
+        // best so `/api/v1/pool/records` returns the mesh-wide rarest record.
+        self.peers
+            .update_best_records(&envelope.sender, ping.best_records.clone());
 
         // Persist to database if available
         if let Some(ref db) = self.db {

--- a/crates/ghost-consensus/src/mesh.rs
+++ b/crates/ghost-consensus/src/mesh.rs
@@ -238,6 +238,11 @@ pub struct MeshNetwork {
     /// hashrate (TH/s) over a trailing window. Gossiped in health pings so
     /// peers can SUM one term per node into a pool-wide total.
     local_hashrate_fn: Option<Arc<dyn Fn() -> f64 + Send + Sync>>,
+    /// Application-provided callback returning this node's best (rarest) valid
+    /// share per records window. Gossiped in health pings so every node can
+    /// converge on the mesh-wide rarest record per window.
+    best_records_fn:
+        Option<Arc<dyn Fn() -> Vec<ghost_common::types::WindowBestRecord> + Send + Sync>>,
     /// Hardware-derived effective capacity advertised in health pings.
     /// `0` means we haven't computed it yet (mesh started before capacity
     /// init); peers treat it as unknown and skip utilisation routing for us.
@@ -1051,6 +1056,7 @@ impl MeshNetwork {
             miner_count_fn: None,
             active_miner_hashes_fn: None,
             local_hashrate_fn: None,
+            best_records_fn: None,
             max_capacity: AtomicU32::new(0),
         })
     }
@@ -1102,6 +1108,46 @@ impl MeshNetwork {
     /// trailing window, gossiped in health pings for mesh-wide summation.
     pub fn set_local_hashrate_provider(&mut self, f: Arc<dyn Fn() -> f64 + Send + Sync>) {
         self.local_hashrate_fn = Some(f);
+    }
+
+    /// Set a callback providing this node's best (rarest) valid share per
+    /// records window, gossiped in health pings so the mesh converges on the
+    /// global rarest record per window. Without this, health pings carry an
+    /// empty list.
+    pub fn set_best_records_provider(
+        &mut self,
+        f: Arc<dyn Fn() -> Vec<ghost_common::types::WindowBestRecord> + Send + Sync>,
+    ) {
+        self.best_records_fn = Some(f);
+    }
+
+    /// Collect the best (rarest) record per window across the mesh: every
+    /// connected peer's most-recent gossiped `best_records` whose `last_seen`
+    /// is within `freshness_secs`. Returns one winner per window — the share
+    /// with the lexicographically smallest `share_hash` (fixed-width zero-
+    /// padded hex, so string order == numeric order, lower = rarer).
+    ///
+    /// This is the PEER contribution only; the caller merges it with the local
+    /// DB best (the local node serves its own record straight from SQLite).
+    pub fn mesh_best_records(
+        &self,
+        freshness_secs: u64,
+    ) -> Vec<ghost_common::types::WindowBestRecord> {
+        use std::collections::HashMap;
+        let mut best: HashMap<String, ghost_common::types::WindowBestRecord> = HashMap::new();
+        for peer in self.peers.get_connected_peers(freshness_secs) {
+            for rec in peer.best_records {
+                match best.get(&rec.window) {
+                    // Smaller hash = rarer share. Ignore empty/garbage hashes.
+                    Some(existing) if existing.share_hash <= rec.share_hash => {}
+                    _ if rec.share_hash.is_empty() => {}
+                    _ => {
+                        best.insert(rec.window.clone(), rec);
+                    }
+                }
+            }
+        }
+        best.into_values().collect()
     }
 
     /// Compute the mesh-wide pool hashrate (TH/s): this node's own realized
@@ -2627,6 +2673,13 @@ impl MeshNetwork {
                 .map(|f| f())
                 .unwrap_or_default();
             let local_hashrate_th = self.local_hashrate_fn.as_ref().map(|f| f()).unwrap_or(0.0);
+            // This node's best (rarest) share per records window, gossiped so
+            // the mesh converges on the global rarest record per window.
+            let best_records = self
+                .best_records_fn
+                .as_ref()
+                .map(|f| f())
+                .unwrap_or_default();
             let ping = ghost_common::types::HealthPing {
                 node_id: self.identity.node_id(),
                 public_address: String::new(), // S-7: Don't broadcast IP in cleartext ZMQ
@@ -2643,6 +2696,7 @@ impl MeshNetwork {
                 active_miner_id_hashes,
                 local_hashrate_th,
                 max_capacity: self.max_capacity.load(Ordering::Relaxed),
+                best_records,
             };
 
             match self.create_envelope(

--- a/crates/ghost-consensus/src/peer.rs
+++ b/crates/ghost-consensus/src/peer.rs
@@ -26,7 +26,7 @@ use parking_lot::RwLock;
 use std::collections::HashMap;
 use tracing::{debug, info};
 
-use ghost_common::types::{NodeCapabilities, NodeId};
+use ghost_common::types::{NodeCapabilities, NodeId, WindowBestRecord};
 
 /// L-3 FIX: Extract host portion from an address, handling both IPv4 and IPv6 formats.
 ///
@@ -149,6 +149,9 @@ impl PeerManager {
             }
             if merged.max_capacity == 0 {
                 merged.max_capacity = existing.max_capacity;
+            }
+            if merged.best_records.is_empty() {
+                merged.best_records = existing.best_records.clone();
             }
             merged.first_seen = merged.first_seen.min(existing.first_seen);
             peers.insert(merged.node_id, merged);
@@ -309,6 +312,16 @@ impl PeerManager {
         }
     }
 
+    /// Replace the peer's best-records-per-window list with the most recent
+    /// from a health ping. Merged with the local DB best (and every other
+    /// peer's) to converge on the mesh-wide rarest record per window. Older
+    /// peers that don't report it pass an empty Vec.
+    pub fn update_best_records(&self, node_id: &NodeId, best_records: Vec<WindowBestRecord>) {
+        if let Some(peer) = self.peers.write().get_mut(node_id) {
+            peer.best_records = best_records;
+        }
+    }
+
     /// Mark peer as disconnected
     ///
     /// P2P4-L1: Logs peer disconnection for observability
@@ -412,6 +425,11 @@ pub struct Peer {
     /// (legacy or pre-update node) — treated as "unknown" and excluded
     /// from utilisation-based routing.
     pub max_capacity: u32,
+    /// This peer's best (rarest) valid share per records window, from its most
+    /// recent health ping. Merged with the local DB best (and every other
+    /// peer's) so the `/api/v1/pool/records` endpoint returns the mesh-wide
+    /// rarest record per window. Empty for older peers that don't report it.
+    pub best_records: Vec<WindowBestRecord>,
 }
 
 impl Peer {
@@ -435,6 +453,7 @@ impl Peer {
             active_miner_id_hashes: Vec::new(),
             local_hashrate_th: 0.0,
             max_capacity: 0,
+            best_records: Vec::new(),
         }
     }
 
@@ -684,6 +703,14 @@ mod tests {
         mgr.update_active_miner_hashes(&pid, hashes.clone(), 4.5);
         mgr.update_health_metrics(&pid, 3, NodeCapabilities::default());
         mgr.update_max_capacity(&pid, 64);
+        let records = vec![WindowBestRecord {
+            window: "day".to_string(),
+            share_hash: "0".repeat(10) + &"a".repeat(54),
+            difficulty: 1024.0,
+            timestamp: 1,
+            miner_id_redacted: "bc1q…abcd.w1".to_string(),
+        }];
+        mgr.update_best_records(&pid, records.clone());
 
         // Discovery re-announces the SAME peer with a freshly-built (empty) Peer.
         let mut reannounce = Peer::new(pid, "1.2.3.4:8555".to_string());
@@ -698,6 +725,10 @@ mod tests {
         assert_eq!(got.local_hashrate_th, 4.5, "hashrate preserved");
         assert_eq!(got.miner_count, 3, "miner_count preserved");
         assert_eq!(got.max_capacity, 64, "max_capacity preserved");
+        assert_eq!(
+            got.best_records, records,
+            "re-announce must NOT wipe the gossiped best records"
+        );
 
         // A genuine ping update with new values still applies (not stuck).
         mgr.update_active_miner_hashes(&pid, vec![[9u8; 16]], 1.0);

--- a/crates/ghost-verification/src/routes.rs
+++ b/crates/ghost-verification/src/routes.rs
@@ -2487,16 +2487,21 @@ async fn api_miner_history_handler(
     }))
 }
 
-/// Public pool records — best (lowest-value, most-leading-zeros) share
-/// submitted to THIS node within the requested time window.
+/// Public pool records — best (rarest, lowest-value) valid share for the
+/// requested window, converged across the MESH.
 ///
-/// The website fans out to every node and takes the min across them to get
-/// a pool-wide best. No mesh gossip required; each node serves its own view.
+/// Each node stores only its own miners' shares, so the pool-wide record can
+/// live on any node. Every node gossips its per-window best in its health ping
+/// (`HealthPing::best_records`), so this handler merges the local DB best with
+/// every connected peer's gossiped best and returns the rarest across all of
+/// them. That makes the record stable + correct on first load: it no longer
+/// flickers when the record-holding node is momentarily unreachable, and the
+/// website's fan-out + min still returns the same value (now from any node).
 ///
 /// `?window=` accepts `block | day | week | month`. Defaults to `day`.
 /// "Block" is approximated as the last 10 minutes (average block interval)
 /// rather than looking up the actual network tip time — keeps the handler
-/// synchronous and DB-only.
+/// synchronous and DB-only for the local term.
 ///
 /// The miner ID is returned in redacted form to preserve privacy while
 /// still giving enough of a handle to recognise one's own worker.
@@ -2539,52 +2544,93 @@ async fn api_pool_records_handler(
         }));
     };
 
-    match db.get_best_share_since(since_ts) {
-        Ok(None) => Json(serde_json::json!({
-            "window": window_name,
-            "since_ts": since_ts,
-            "found": false,
-        })),
-        Ok(Some(best)) => {
-            // Count leading '0' hex chars (each = 4 binary leading zeros).
-            // This is a coarse signal; the hash itself is the definitive
-            // record, but "47 zeros" reads better than a hex blob in tiles.
-            let leading_hex_zeros = best.share_hash.chars().take_while(|c| *c == '0').count();
-            let leading_zero_bits = leading_hex_zeros * 4;
-            // Redact miner_id: `bc1q...tip.worker` keeps enough for the
-            // miner themself to recognise while shedding most of the
-            // address. Format: first 6 chars, ellipsis, last 4 chars of
-            // the address portion, then `.worker` intact.
-            let redacted = redact_miner_id(&best.miner_id);
-
-            Json(serde_json::json!({
-                "window": window_name,
-                "since_ts": since_ts,
-                "found": true,
-                "best": {
-                    "share_hash": best.share_hash,
-                    "leading_zero_bits": leading_zero_bits,
-                    "leading_hex_zeros": leading_hex_zeros,
-                    "miner_id_redacted": redacted,
-                    "timestamp": best.timestamp,
-                    // Achieved difficulty from the hash (the score), NOT the stored
-                    // vardiff target. `assigned_difficulty` keeps the old value for
-                    // any consumer that wants the share's pool-credit work.
-                    "difficulty": share_difficulty_from_hash_hex(&best.share_hash),
-                    "assigned_difficulty": best.difficulty,
-                }
-            }))
-        }
+    // Local term: this node's own best for the window, from SQLite. We keep the
+    // stored vardiff target separately so the response can still expose
+    // `assigned_difficulty` when the local share wins (peers only gossip the
+    // achieved difficulty, so that field is null when a peer's record wins).
+    let local_best = match db.get_best_share_since(since_ts) {
+        Ok(best) => best,
         Err(e) => {
             error!(error = %e, "Failed to query best share");
-            Json(serde_json::json!({
+            return Json(serde_json::json!({
                 "window": window_name,
                 "since_ts": since_ts,
                 "found": false,
                 "error": "Database error",
-            }))
+            }));
+        }
+    };
+
+    // Candidate winner so far: the rarest `share_hash` seen. `assigned_diff`
+    // is Some only for the local share. Hashes are fixed-width zero-padded hex,
+    // so string `<` matches numeric order (smaller = rarer).
+    let mut winning_hash: Option<String> = None;
+    let mut winning_redacted = String::new();
+    let mut winning_timestamp: i64 = 0;
+    let mut winning_assigned_diff: Option<f64> = None;
+
+    if let Some(best) = local_best {
+        winning_hash = Some(best.share_hash.clone());
+        winning_redacted = redact_miner_id(&best.miner_id);
+        winning_timestamp = best.timestamp;
+        winning_assigned_diff = Some(best.difficulty);
+    }
+
+    // Mesh term: every connected peer's gossiped best for THIS window. The
+    // miner_id is already redacted at the source. A peer record beats the
+    // current winner only when its hash is strictly smaller (rarer).
+    if let Some(peer_records) = state.mesh_best_records() {
+        for rec in peer_records {
+            if rec.window != window_name || rec.share_hash.is_empty() {
+                continue;
+            }
+            let beats = winning_hash
+                .as_ref()
+                .map(|w| rec.share_hash < *w)
+                .unwrap_or(true);
+            if beats {
+                winning_hash = Some(rec.share_hash);
+                winning_redacted = rec.miner_id_redacted;
+                winning_timestamp = rec.timestamp;
+                // A peer's record carries no stored vardiff target.
+                winning_assigned_diff = None;
+            }
         }
     }
+
+    let Some(share_hash) = winning_hash else {
+        return Json(serde_json::json!({
+            "window": window_name,
+            "since_ts": since_ts,
+            "found": false,
+        }));
+    };
+
+    // Recompute the leading-zero presentation from the WINNING hash (the local
+    // and peer hashes use the same big-endian zero-padded hex encoding).
+    // Each leading '0' hex char = 4 binary leading zeros — a coarse signal;
+    // the hash itself is the definitive record but reads worse in tiles.
+    let leading_hex_zeros = share_hash.chars().take_while(|c| *c == '0').count();
+    let leading_zero_bits = leading_hex_zeros * 4;
+
+    Json(serde_json::json!({
+        "window": window_name,
+        "since_ts": since_ts,
+        "found": true,
+        "best": {
+            "share_hash": share_hash,
+            "leading_zero_bits": leading_zero_bits,
+            "leading_hex_zeros": leading_hex_zeros,
+            "miner_id_redacted": winning_redacted,
+            "timestamp": winning_timestamp,
+            // Achieved difficulty from the hash (the score), NOT the stored
+            // vardiff target. `assigned_difficulty` keeps the stored value for
+            // any consumer that wants the share's pool-credit work — null when
+            // a peer's record wins (peers don't gossip their vardiff target).
+            "difficulty": share_difficulty_from_hash_hex(&share_hash),
+            "assigned_difficulty": winning_assigned_diff,
+        }
+    }))
 }
 
 /// Public leaderboard for the pool page. Returns both the best-hash
@@ -2746,7 +2792,10 @@ async fn api_pool_leaderboard_handler(
 /// here.) The difficulty-1 target (pdiff) is `0xFFFF * 2^208`.
 ///
 /// Returns 0.0 for a hash that isn't 32 bytes of hex (treated as "unknown").
-fn share_difficulty_from_hash_hex(share_hash_hex: &str) -> f64 {
+/// Achieved difficulty for a 64-char big-endian hex share hash (`diff1_target
+/// / hash_value`). Returns 0.0 for malformed input. `pub` so the ping builder
+/// in ghost-pool derives the same score it would here.
+pub fn share_difficulty_from_hash_hex(share_hash_hex: &str) -> f64 {
     let bytes = match hex::decode(share_hash_hex) {
         Ok(b) if b.len() == 32 => b,
         _ => return 0.0,
@@ -2769,7 +2818,10 @@ fn is_system_miner(miner_id: &str) -> bool {
     lower.contains("translator") || lower == "proxy"
 }
 
-fn redact_miner_id(id: &str) -> String {
+/// Redact a `address.worker` miner_id for public display: first 6 + ellipsis +
+/// last 4 of the address portion, worker kept intact. `pub` so the ping builder
+/// in ghost-pool redacts gossiped records identically to this endpoint.
+pub fn redact_miner_id(id: &str) -> String {
     let (addr, worker) = match id.find('.') {
         Some(i) => (&id[..i], &id[i..]), // worker has leading '.'
         None => (id, ""),

--- a/crates/ghost-verification/src/server.rs
+++ b/crates/ghost-verification/src/server.rs
@@ -31,7 +31,7 @@ use ghost_common::error::{GhostError, GhostResult};
 use ghost_common::identity::NodeIdentity;
 use ghost_common::metrics::Metrics;
 use ghost_common::rpc::BitcoinRpc;
-use ghost_common::types::NodeCapabilities;
+use ghost_common::types::{NodeCapabilities, WindowBestRecord};
 use ghost_policy::{PolicyEngine, PolicyProfile};
 use ghost_storage::Database;
 use std::path::PathBuf;
@@ -950,6 +950,13 @@ pub struct VerificationState {
     /// exact term it contributes to `get_mesh_total_hashrate`. Surfaced as
     /// `local_hashrate_th` so the per-node and mesh figures reconcile.
     get_local_hashrate: Option<Box<dyn Fn() -> f64 + Send + Sync>>,
+    /// Mesh-wide best (rarest) records per window: the connected peers'
+    /// gossiped `best_records`, already reduced to one winner per window.
+    /// The records endpoint merges this with the local DB best so it returns
+    /// the pool-wide rarest record even when the record-holding node is
+    /// momentarily unreachable. None on older deploys without the provider —
+    /// callers fall back to the node-local DB record only.
+    get_mesh_best_records: Option<Box<dyn Fn() -> Vec<WindowBestRecord> + Send + Sync>>,
     /// Signal to trigger graceful restart (set by config update API)
     /// When true, main.rs will initiate shutdown and exit with code 100
     pub restart_signal: Arc<AtomicBool>,
@@ -1121,6 +1128,7 @@ impl VerificationState {
             get_mesh_active_miners: None,
             get_mesh_total_hashrate: None,
             get_local_hashrate: None,
+            get_mesh_best_records: None,
             // VF-C2: Default to requiring internal auth for security
             require_internal_auth: true,
             restart_signal: Arc::new(AtomicBool::new(false)),
@@ -1625,6 +1633,21 @@ impl VerificationState {
     /// the mesh total — or None if no callback has been wired up.
     pub fn local_hashrate(&self) -> Option<f64> {
         self.get_local_hashrate.as_ref().map(|f| f())
+    }
+
+    /// Set the mesh-wide best-records-per-window callback.
+    pub fn with_mesh_best_records(
+        mut self,
+        f: impl Fn() -> Vec<WindowBestRecord> + Send + Sync + 'static,
+    ) -> Self {
+        self.get_mesh_best_records = Some(Box::new(f));
+        self
+    }
+
+    /// Returns the connected peers' best records per window (already reduced to
+    /// one winner per window), or None if no callback has been wired up.
+    pub fn mesh_best_records(&self) -> Option<Vec<WindowBestRecord>> {
+        self.get_mesh_best_records.as_ref().map(|f| f())
     }
 
     /// Set archive handler


### PR DESCRIPTION
**Fixes the records flicker** the records cards showed (last-month dropping from 1.63G to ~596M and back).

**Root cause:** `/api/v1/pool/records` is per-node — each node only stores its own miners' shares, so the pool-wide rarest record lives on one node. The website merges all 4 nodes' bests, so when the record-holding node is momentarily rate-limited the record vanishes from that cycle.

**Fix:** gossip each node's per-window best in the health ping, exactly mirroring `active_miner_id_hashes`/`local_hashrate_th`. Every node then knows the global best and the endpoint returns the merged rarest record — stable and correct from any node, even on first load.

- `WindowBestRecord` in `ghost-common`; `#[serde(default)]` field on `HealthPing` + `Peer`
- local population (block/day/week/month) → ping; receipt → peer; `upsert_peer` preserves on re-announce (PR #59 pattern)
- `mesh_best_records` reducer; records handler merges local + peers, rarest `share_hash` wins
- response shape byte-identical; frontend latch stays as a second layer

**Wire compat:** strictly additive via `#[serde(default)]` — old↔new pings interop, **no gate**, plain rolling deploy is safe (back-compat covered by tests).

**Tests:** build + clippy clean; ghost-consensus 239 / ghost-verification 119 pass; + `health_ping_best_records_roundtrip`, `health_ping_deserializes_without_best_records_field`, `test_upsert_preserves_gossiped_metrics_on_reannounce`.

**Deploy:** NOT yet deployed. Consensus/gossip layer = highest blast radius, so the canary VM4→fleet roll should be a fresh, focused pass with mixed-version soak — not bundled at the end of a long session.