### PR TITLE
feat(pool): gated-off coordinator-election service (Wraith increment 4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3456,6 +3456,7 @@ dependencies = [
  "toml 0.8.2",
  "tracing",
  "tracing-subscriber",
+ "wraith-protocol",
 ]
 
 [[package]]

--- a/bins/ghost-pool/Cargo.toml
+++ b/bins/ghost-pool/Cargo.toml
@@ -51,6 +51,7 @@ ghost-consensus = { workspace = true }
 ghost-accounting = { workspace = true }
 ghost-reconciliation = { workspace = true }
 ghost-verification = { workspace = true }
+wraith-protocol = { workspace = true }
 ghost-template = { workspace = true }
 ghost-glyph = { workspace = true }
 

--- a/bins/ghost-pool/src/coordinator_election.rs
+++ b/bins/ghost-pool/src/coordinator_election.rs
@@ -1,0 +1,424 @@
+//! Decentralised Wraith coordinator election — live wiring (read-only).
+//!
+//! Increment 4 of `tasks/plan_decentralised_coordinators.md`: feed the PURE
+//! election library (`wraith_protocol::{sortition, epoch, service}`) with live
+//! node state (the elder roster, the chain height, and a per-epoch beacon
+//! anchor) and expose the resulting [`CoordinatorView`] read-only.
+//!
+//! ## What this increment deliberately does NOT do
+//!
+//! It computes and *publishes* the election only. It NEVER:
+//! - activates a coordinator role (no node starts coordinating anything here),
+//! - touches `coordinator_redundancy` or any Wraith mixing,
+//! - emits or changes any consensus message.
+//!
+//! It is gated behind `[coordinator] wraith_election_enabled` (default false).
+//! When the flag is off the [`CoordinatorElection`] is never constructed and
+//! every accessor returns the inert "disabled" answer, so worst case this is
+//! dead code behind a default-false flag with zero effect on the node.
+//!
+//! ## Determinism
+//!
+//! All three election inputs are derived from state the network already agrees
+//! on (the elder set, the chain height, and a chain anchor hash), then passed
+//! through the deterministic library so a node and a wallet independently
+//! compute the byte-identical schedule. The roster is canonicalised
+//! (`epoch::canonical_roster`) before election so the result is independent of
+//! the order peers were collected in.
+
+use std::sync::Arc;
+
+use parking_lot::RwLock;
+use sha2::{Digest, Sha256};
+
+use ghost_common::identity::NodeIdentity;
+use ghost_common::rpc::BitcoinRpc;
+use ghost_consensus::mesh::MeshNetwork;
+use ghost_common::types::NodeCapabilities;
+
+use wraith_protocol::epoch::canonical_roster;
+use wraith_protocol::service::{CoordinatorView, EndpointMap};
+use wraith_protocol::sortition::CoordinatorNodeId;
+
+/// Blocks per coordinator epoch — `epoch = height / COORDINATOR_EPOCH_BLOCKS`.
+/// ~1 day at 10-minute blocks. The draw is reshuffled every epoch, so
+/// coordination rotates across the qualified set over time.
+///
+/// Kept local (rather than reusing `wraith_protocol::epoch::EPOCH_BLOCKS`, also
+/// 144) so the live cadence is owned and tuneable at the wiring layer without
+/// changing the pure library's test fixtures.
+pub const COORDINATOR_EPOCH_BLOCKS: u64 = 144;
+
+/// Target number of concurrent coordinator seats per epoch. Sessions are
+/// sharded across these seats so no single coordinator owns every round.
+pub const COORDINATOR_SEATS: usize = 5;
+
+/// Domain separator for the beacon hash so it can never collide with any other
+/// hash in the system. Versioned for forward changes.
+const BEACON_DOMAIN: &[u8] = b"ghost/wraith/coordinator-beacon/v1";
+
+/// The coordinator epoch a chain height falls in.
+pub const fn epoch_for_height(height: u64) -> u64 {
+    height / COORDINATOR_EPOCH_BLOCKS
+}
+
+/// The chain height whose anchor freezes epoch `E` — the first block of epoch
+/// `E` (`E * K`). Using the epoch-start block (rather than a far-future one)
+/// keeps the anchor reachable the moment the epoch begins; its grinding
+/// resistance is addressed by the security note on [`derive_beacon`].
+pub const fn anchor_height_for_epoch(epoch: u64) -> u64 {
+    epoch.saturating_mul(COORDINATOR_EPOCH_BLOCKS)
+}
+
+/// Derive the 32-byte per-epoch beacon from an anchor hash the whole network
+/// agrees on: `SHA256(domain ‖ epoch_le ‖ anchor_hash)`.
+///
+/// SECURITY: the anchor used here is the block hash at the epoch-start height
+/// (see [`CoordinatorElection::beacon_for_epoch`]). A miner who finds that block
+/// can choose among the candidate hashes it could publish, so this interim
+/// anchor's grinding-resistance is BOUNDED — adequate for a read-only,
+/// role-inactive view, but NOT the endgame. The unbiasable beacon is the
+/// threshold-VRF / DKG construction (plan increment 5, gated on an EXTERNAL
+/// crypto audit). Because `epoch.rs`/`service.rs` are beacon-agnostic (they take
+/// the 32-byte beacon as a value), swapping this for the audited beacon changes
+/// nothing else in the wiring.
+pub fn derive_beacon(epoch: u64, anchor_hash: &[u8; 32]) -> [u8; 32] {
+    let mut h = Sha256::new();
+    h.update(BEACON_DOMAIN);
+    h.update(epoch.to_le_bytes());
+    h.update(anchor_hash);
+    h.finalize().into()
+}
+
+/// Decode a Bitcoin block-hash hex string into the 32-byte anchor used by the
+/// beacon. Returns `None` for malformed input (the caller then skips the
+/// recompute and keeps the last good view).
+fn anchor_from_block_hash_hex(hex_str: &str) -> Option<[u8; 32]> {
+    let bytes = hex::decode(hex_str.trim()).ok()?;
+    if bytes.len() != 32 {
+        return None;
+    }
+    let mut anchor = [0u8; 32];
+    anchor.copy_from_slice(&bytes);
+    Some(anchor)
+}
+
+/// The serialised, cached state for the current epoch — what the read-only
+/// endpoint reports. `None` until the first successful recompute.
+#[derive(Debug, Clone)]
+struct Cached {
+    epoch: u64,
+    view: CoordinatorView,
+}
+
+/// Live coordinator-election service for ghost-pool.
+///
+/// Constructed only when `wraith_election_enabled` is true. Holds the inputs it
+/// needs to (re)compute a [`CoordinatorView`] each time the epoch changes, and
+/// caches the latest view for the read-only accessors and the HTTP endpoint.
+pub struct CoordinatorElection {
+    /// This node's own id, and whether it is itself an elder (so it can be in
+    /// the roster). `[u8; 32]`, matches `wraith_protocol`'s `CoordinatorNodeId`.
+    self_id: CoordinatorNodeId,
+    self_is_elder: bool,
+    /// Mesh handle — source of the elder roster (`peers().get_elder_peers()`).
+    mesh: Arc<MeshNetwork>,
+    /// Ghost Core RPC — source of the beacon anchor (block hash at a height).
+    rpc: Arc<BitcoinRpc>,
+    /// Cached current-epoch view.
+    cached: RwLock<Option<Cached>>,
+}
+
+impl CoordinatorElection {
+    /// Build the service from live handles. Call only when the config flag is
+    /// on; see [`maybe_new`].
+    pub fn new(
+        identity: &NodeIdentity,
+        capabilities: &NodeCapabilities,
+        mesh: Arc<MeshNetwork>,
+        rpc: Arc<BitcoinRpc>,
+    ) -> Self {
+        Self {
+            self_id: identity.node_id(),
+            self_is_elder: capabilities.elder_status,
+            mesh,
+            rpc,
+            cached: RwLock::new(None),
+        }
+    }
+
+    /// Construct the service iff `enabled`, else `None` (gated-off path). When
+    /// `None`, nothing else in this module runs — zero effect on the node.
+    pub fn maybe_new(
+        enabled: bool,
+        identity: &NodeIdentity,
+        capabilities: &NodeCapabilities,
+        mesh: Arc<MeshNetwork>,
+        rpc: Arc<BitcoinRpc>,
+    ) -> Option<Arc<Self>> {
+        if !enabled {
+            return None;
+        }
+        Some(Arc::new(Self::new(identity, capabilities, mesh, rpc)))
+    }
+
+    /// The qualified roster for this epoch: the current elder node ids, plus
+    /// self when self is an elder. Canonicalised (dedup + sort) so every node
+    /// derives the byte-identical roster from the same membership.
+    fn roster(&self) -> Vec<CoordinatorNodeId> {
+        let mut ids: Vec<CoordinatorNodeId> = self
+            .mesh
+            .peers()
+            .get_elder_peers()
+            .into_iter()
+            .map(|p| p.node_id)
+            .collect();
+        if self.self_is_elder {
+            ids.push(self.self_id);
+        }
+        canonical_roster(&ids)
+    }
+
+    /// Fetch the beacon for `epoch` by anchoring on the epoch-start block hash
+    /// from Ghost Core. Returns `None` if the anchor height isn't available yet
+    /// (chain not that tall) or the RPC/decode fails — the caller keeps the
+    /// previous cached view in that case.
+    async fn beacon_for_epoch(&self, epoch: u64) -> Option<[u8; 32]> {
+        let anchor_height = anchor_height_for_epoch(epoch);
+        let hex_hash = self.rpc.get_block_hash(anchor_height).await.ok()?;
+        let anchor = anchor_from_block_hash_hex(&hex_hash)?;
+        Some(derive_beacon(epoch, &anchor))
+    }
+
+    /// Recompute and cache the [`CoordinatorView`] for the epoch `current_height`
+    /// falls in — but only when the epoch has actually changed since the last
+    /// cached view (cheap no-op otherwise). Safe to call on every new block /
+    /// round advance. Returns the (possibly unchanged) current epoch.
+    ///
+    /// On any input failure (no anchor block yet, RPC error) it leaves the
+    /// existing cache untouched and returns the current epoch unchanged — never
+    /// poisons the cache with a partial view.
+    pub async fn refresh_for_height(&self, current_height: u64) -> u64 {
+        let epoch = epoch_for_height(current_height);
+
+        // Fast path: same epoch as the cached view → nothing to do.
+        if let Some(c) = self.cached.read().as_ref() {
+            if c.epoch == epoch {
+                return epoch;
+            }
+        }
+
+        let Some(beacon) = self.beacon_for_epoch(epoch).await else {
+            // Anchor not reachable yet — keep the last good view.
+            return epoch;
+        };
+        let roster = self.roster();
+        // Endpoint map stays empty for this read-only increment: node→endpoint
+        // discovery (so a wallet can dial the owning coordinator) is a later
+        // layer. The election itself (who is seated) is unaffected by it.
+        let view = CoordinatorView::build(
+            epoch,
+            &beacon,
+            &roster,
+            EndpointMap::new(),
+            COORDINATOR_SEATS,
+        );
+        *self.cached.write() = Some(Cached { epoch, view });
+        epoch
+    }
+
+    /// Whether THIS node is an elected coordinator in the currently-cached
+    /// epoch. `false` before the first successful recompute. Read-only — this
+    /// does NOT activate any coordinator behaviour, it only reports the draw.
+    pub fn am_i_coordinator(&self) -> bool {
+        self.cached
+            .read()
+            .as_ref()
+            .map(|c| c.view.am_i_coordinator(&self.self_id))
+            .unwrap_or(false)
+    }
+
+    /// A JSON snapshot of the cached election for the read-only HTTP endpoint:
+    /// `{enabled, epoch, seats, my_seat, elected: [hex node ids]}`. Pre-
+    /// serialised so `ghost-verification` needn't depend on `wraith-protocol`.
+    pub fn status_json(&self) -> serde_json::Value {
+        let guard = self.cached.read();
+        let Some(c) = guard.as_ref() else {
+            // Service is on but hasn't computed a view yet (e.g. anchor block
+            // not reachable). Report enabled-but-pending rather than failing.
+            return serde_json::json!({
+                "enabled": true,
+                "epoch": serde_json::Value::Null,
+                "seats": 0,
+                "my_seat": serde_json::Value::Null,
+                "elected": [],
+            });
+        };
+
+        let elected = self.elected_hex(&c.view);
+        serde_json::json!({
+            "enabled": true,
+            "epoch": c.view.epoch(),
+            "seats": c.view.seats(),
+            "my_seat": c.view.my_seat(&self.self_id),
+            "elected": elected,
+        })
+    }
+
+    /// The elected coordinators' node ids, hex-encoded in seat order. Derived by
+    /// re-querying the view per seat via the session-sharding map is not exposed,
+    /// so reconstruct the seated set from the public seat predicate over the
+    /// roster (the same roster the view was built from).
+    fn elected_hex(&self, view: &CoordinatorView) -> Vec<String> {
+        // The view exposes seats() and per-id predicates, not the raw set, so
+        // walk the roster and keep the seated ids ordered by seat index.
+        let roster = self.roster();
+        let mut seated: Vec<(u32, CoordinatorNodeId)> = roster
+            .into_iter()
+            .filter_map(|id| view.my_seat(&id).map(|seat| (seat, id)))
+            .collect();
+        seated.sort_unstable_by_key(|(seat, _)| *seat);
+        seated
+            .into_iter()
+            .map(|(_, id)| hex::encode(id))
+            .collect()
+    }
+}
+
+/// The JSON returned for the read-only endpoint when the feature is OFF (the
+/// service was never constructed). Centralised so the route and tests agree.
+pub fn disabled_status_json() -> serde_json::Value {
+    serde_json::json!({ "enabled": false })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn node(i: u8) -> CoordinatorNodeId {
+        let mut id = [0u8; 32];
+        id[0] = i;
+        id[1] = i.wrapping_mul(7);
+        id
+    }
+
+    // The pure-library glue is exercised directly via CoordinatorView::build so
+    // the unit tests don't need a live mesh/RPC. The wiring-specific logic under
+    // test here is: epoch maths, beacon derivation, the disabled path, and the
+    // hex/seat reporting shape.
+
+    #[test]
+    fn epoch_and_anchor_height_maths() {
+        assert_eq!(epoch_for_height(0), 0);
+        assert_eq!(epoch_for_height(COORDINATOR_EPOCH_BLOCKS - 1), 0);
+        assert_eq!(epoch_for_height(COORDINATOR_EPOCH_BLOCKS), 1);
+        assert_eq!(epoch_for_height(COORDINATOR_EPOCH_BLOCKS * 9 + 7), 9);
+
+        assert_eq!(anchor_height_for_epoch(0), 0);
+        assert_eq!(anchor_height_for_epoch(1), COORDINATOR_EPOCH_BLOCKS);
+        assert_eq!(anchor_height_for_epoch(5), 5 * COORDINATOR_EPOCH_BLOCKS);
+    }
+
+    #[test]
+    fn beacon_is_deterministic_and_epoch_bound() {
+        let anchor = [42u8; 32];
+        // Same inputs → same beacon (determinism).
+        assert_eq!(derive_beacon(7, &anchor), derive_beacon(7, &anchor));
+        // A different epoch → a different beacon (rotation).
+        assert_ne!(derive_beacon(7, &anchor), derive_beacon(8, &anchor));
+        // A different anchor → a different beacon (anchored).
+        assert_ne!(derive_beacon(7, &anchor), derive_beacon(7, &[43u8; 32]));
+    }
+
+    #[test]
+    fn anchor_decode_rejects_bad_lengths() {
+        assert!(anchor_from_block_hash_hex(&"ab".repeat(32)).is_some());
+        assert!(anchor_from_block_hash_hex("not-hex").is_none());
+        assert!(anchor_from_block_hash_hex(&"ab".repeat(16)).is_none()); // 16 bytes
+        assert!(anchor_from_block_hash_hex(&"ab".repeat(33)).is_none()); // 33 bytes
+    }
+
+    #[test]
+    fn disabled_status_is_inert() {
+        let j = disabled_status_json();
+        assert_eq!(j["enabled"], serde_json::json!(false));
+        // Nothing else is leaked when off.
+        assert_eq!(j.as_object().unwrap().len(), 1);
+    }
+
+    // ── election-through-the-view tests (the library + our reporting shape) ──
+
+    #[test]
+    fn election_is_deterministic_for_fixed_inputs() {
+        let roster: Vec<_> = (0u8..12).map(node).collect();
+        let beacon = derive_beacon(3, &[1u8; 32]);
+        let a = CoordinatorView::build(3, &beacon, &roster, EndpointMap::new(), COORDINATOR_SEATS);
+        let b = CoordinatorView::build(3, &beacon, &roster, EndpointMap::new(), COORDINATOR_SEATS);
+        // Same inputs → identical seating.
+        assert_eq!(a.seats(), b.seats());
+        assert_eq!(a.seats(), COORDINATOR_SEATS);
+        for id in &roster {
+            assert_eq!(a.my_seat(id), b.my_seat(id));
+            assert_eq!(a.am_i_coordinator(id), b.am_i_coordinator(id));
+        }
+    }
+
+    #[test]
+    fn epoch_advancement_changes_the_view() {
+        let roster: Vec<_> = (0u8..20).map(node).collect();
+        let anchor = [9u8; 32];
+        let v_e3 = CoordinatorView::build(
+            3,
+            &derive_beacon(3, &anchor),
+            &roster,
+            EndpointMap::new(),
+            COORDINATOR_SEATS,
+        );
+        let v_e4 = CoordinatorView::build(
+            4,
+            &derive_beacon(4, &anchor),
+            &roster,
+            EndpointMap::new(),
+            COORDINATOR_SEATS,
+        );
+        let seated = |v: &CoordinatorView| -> Vec<CoordinatorNodeId> {
+            roster
+                .iter()
+                .copied()
+                .filter(|id| v.am_i_coordinator(id))
+                .collect()
+        };
+        assert_ne!(
+            seated(&v_e3),
+            seated(&v_e4),
+            "a new epoch must reshuffle the coordinator set"
+        );
+    }
+
+    #[test]
+    fn self_as_coordinator_detection_matches_the_view() {
+        let roster: Vec<_> = (0u8..30).map(node).collect();
+        let beacon = derive_beacon(2, &[5u8; 32]);
+        let view = CoordinatorView::build(2, &beacon, &roster, EndpointMap::new(), COORDINATOR_SEATS);
+        // For every roster member, am_i_coordinator agrees with my_seat.is_some.
+        let mut seated_count = 0;
+        for id in &roster {
+            let is_coord = view.am_i_coordinator(id);
+            assert_eq!(is_coord, view.my_seat(id).is_some());
+            if is_coord {
+                seated_count += 1;
+            }
+        }
+        assert_eq!(seated_count, COORDINATOR_SEATS);
+        // A node not in the roster is never seated.
+        assert!(!view.am_i_coordinator(&node(200)));
+    }
+
+    #[test]
+    fn empty_roster_seats_nobody() {
+        let beacon = derive_beacon(1, &[0u8; 32]);
+        let view = CoordinatorView::build(1, &beacon, &[], EndpointMap::new(), COORDINATOR_SEATS);
+        assert_eq!(view.seats(), 0);
+        assert!(!view.am_i_coordinator(&node(0)));
+    }
+}

--- a/bins/ghost-pool/src/coordinator_election.rs
+++ b/bins/ghost-pool/src/coordinator_election.rs
@@ -3,7 +3,7 @@
 //! Increment 4 of `tasks/plan_decentralised_coordinators.md`: feed the PURE
 //! election library (`wraith_protocol::{sortition, epoch, service}`) with live
 //! node state (the elder roster, the chain height, and a per-epoch beacon
-//! anchor) and expose the resulting [`CoordinatorView`] read-only.
+//! anchor) and expose the resulting `CoordinatorView` read-only.
 //!
 //! ## What this increment deliberately does NOT do
 //!
@@ -13,7 +13,7 @@
 //! - emits or changes any consensus message.
 //!
 //! It is gated behind `[coordinator] wraith_election_enabled` (default false).
-//! When the flag is off the [`CoordinatorElection`] is never constructed and
+//! When the flag is off the `CoordinatorElection` is never constructed and
 //! every accessor returns the inert "disabled" answer, so worst case this is
 //! dead code behind a default-false flag with zero effect on the node.
 //!
@@ -33,8 +33,8 @@ use sha2::{Digest, Sha256};
 
 use ghost_common::identity::NodeIdentity;
 use ghost_common::rpc::BitcoinRpc;
-use ghost_consensus::mesh::MeshNetwork;
 use ghost_common::types::NodeCapabilities;
+use ghost_consensus::mesh::MeshNetwork;
 
 use wraith_protocol::epoch::canonical_roster;
 use wraith_protocol::service::{CoordinatorView, EndpointMap};
@@ -65,7 +65,7 @@ pub const fn epoch_for_height(height: u64) -> u64 {
 /// The chain height whose anchor freezes epoch `E` — the first block of epoch
 /// `E` (`E * K`). Using the epoch-start block (rather than a far-future one)
 /// keeps the anchor reachable the moment the epoch begins; its grinding
-/// resistance is addressed by the security note on [`derive_beacon`].
+/// resistance is addressed by the security note on `derive_beacon`.
 pub const fn anchor_height_for_epoch(epoch: u64) -> u64 {
     epoch.saturating_mul(COORDINATOR_EPOCH_BLOCKS)
 }
@@ -74,7 +74,7 @@ pub const fn anchor_height_for_epoch(epoch: u64) -> u64 {
 /// agrees on: `SHA256(domain ‖ epoch_le ‖ anchor_hash)`.
 ///
 /// SECURITY: the anchor used here is the block hash at the epoch-start height
-/// (see [`CoordinatorElection::beacon_for_epoch`]). A miner who finds that block
+/// (see `CoordinatorElection::beacon_for_epoch`). A miner who finds that block
 /// can choose among the candidate hashes it could publish, so this interim
 /// anchor's grinding-resistance is BOUNDED — adequate for a read-only,
 /// role-inactive view, but NOT the endgame. The unbiasable beacon is the
@@ -114,7 +114,7 @@ struct Cached {
 /// Live coordinator-election service for ghost-pool.
 ///
 /// Constructed only when `wraith_election_enabled` is true. Holds the inputs it
-/// needs to (re)compute a [`CoordinatorView`] each time the epoch changes, and
+/// needs to (re)compute a `CoordinatorView` each time the epoch changes, and
 /// caches the latest view for the read-only accessors and the HTTP endpoint.
 pub struct CoordinatorElection {
     /// This node's own id, and whether it is itself an elder (so it can be in
@@ -131,7 +131,7 @@ pub struct CoordinatorElection {
 
 impl CoordinatorElection {
     /// Build the service from live handles. Call only when the config flag is
-    /// on; see [`maybe_new`].
+    /// on; see `maybe_new`.
     pub fn new(
         identity: &NodeIdentity,
         capabilities: &NodeCapabilities,
@@ -190,7 +190,7 @@ impl CoordinatorElection {
         Some(derive_beacon(epoch, &anchor))
     }
 
-    /// Recompute and cache the [`CoordinatorView`] for the epoch `current_height`
+    /// Recompute and cache the `CoordinatorView` for the epoch `current_height`
     /// falls in — but only when the epoch has actually changed since the last
     /// cached view (cheap no-op otherwise). Safe to call on every new block /
     /// round advance. Returns the (possibly unchanged) current epoch.
@@ -278,10 +278,7 @@ impl CoordinatorElection {
             .filter_map(|id| view.my_seat(&id).map(|seat| (seat, id)))
             .collect();
         seated.sort_unstable_by_key(|(seat, _)| *seat);
-        seated
-            .into_iter()
-            .map(|(_, id)| hex::encode(id))
-            .collect()
+        seated.into_iter().map(|(_, id)| hex::encode(id)).collect()
     }
 }
 
@@ -399,7 +396,8 @@ mod tests {
     fn self_as_coordinator_detection_matches_the_view() {
         let roster: Vec<_> = (0u8..30).map(node).collect();
         let beacon = derive_beacon(2, &[5u8; 32]);
-        let view = CoordinatorView::build(2, &beacon, &roster, EndpointMap::new(), COORDINATOR_SEATS);
+        let view =
+            CoordinatorView::build(2, &beacon, &roster, EndpointMap::new(), COORDINATOR_SEATS);
         // For every roster member, am_i_coordinator agrees with my_seat.is_some.
         let mut seated_count = 0;
         for id in &roster {

--- a/bins/ghost-pool/src/lib.rs
+++ b/bins/ghost-pool/src/lib.rs
@@ -114,4 +114,9 @@ pub mod capacity;
 /// total, plus per-DeadCodeType counters. Read by `/api/v1/reaper/status`.
 pub mod reaper_stats;
 
+/// Decentralised Wraith coordinator election — live wiring (read-only, gated
+/// off by default). Computes and publishes the per-epoch coordinator draw via
+/// `wraith-protocol`; activates no role and changes no consensus message.
+pub mod coordinator_election;
+
 // L2 uses NullifierRouteHandler from ghost-consensus (sender-side proofs).

--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -3436,6 +3436,28 @@ async fn main() -> Result<()> {
         serde_json::to_value(reaper_stats_for_api.snapshot()).unwrap_or(serde_json::Value::Null)
     });
 
+    // Decentralised Wraith coordinator election (read-only, gated off by
+    // default). Constructed ONLY when `[coordinator] wraith_election_enabled`
+    // is true; otherwise `None` and the service is inert (zero effect on the
+    // node). It computes/publishes the per-epoch draw — it activates NO
+    // coordinator role and changes no consensus message.
+    let coordinator_election = ghost_pool::coordinator_election::CoordinatorElection::maybe_new(
+        config.coordinator.wraith_election_enabled,
+        &identity,
+        &capabilities,
+        Arc::clone(&mesh),
+        Arc::clone(&rpc),
+    );
+    {
+        let coord_for_api = coordinator_election.clone();
+        verification_state = verification_state.with_coordinator_status(move || {
+            coord_for_api
+                .as_ref()
+                .map(|c| c.status_json())
+                .unwrap_or_else(ghost_pool::coordinator_election::disabled_status_json)
+        });
+    }
+
     // Configure archive handler if archive mode enabled
     if capabilities.archive_mode {
         let archive_handler = RpcArchiveHandler::new(Arc::clone(&rpc_for_verification));
@@ -5192,6 +5214,9 @@ async fn main() -> Result<()> {
     // Note: Job notifications to miners now handled by SRI via TDP
     let rm_notify = Arc::clone(&round_manager);
     let tp_for_template_events = Arc::clone(&template_processor);
+    // Coordinator-election recompute hook (read-only). `None` when the feature
+    // is off → the recompute below is skipped entirely.
+    let coord_for_events = coordinator_election.clone();
 
     tokio::spawn(async move {
         while let Ok(event) = template_events_early.recv().await {
@@ -5199,6 +5224,13 @@ async fn main() -> Result<()> {
                 TemplateEvent::NewWork { job_id: _, height } => {
                     // Start new round (SRI gets jobs via TDP automatically)
                     rm_notify.start_round(height);
+
+                    // Refresh the coordinator-election view if the epoch has
+                    // changed (cheap no-op within an epoch; a no-op entirely
+                    // when the feature is off). Read-only — activates nothing.
+                    if let Some(ref coord) = coord_for_events {
+                        coord.refresh_for_height(height).await;
+                    }
 
                     // M-MINE-1: Update template ID for share validation
                     // The template ID is the prev_block_hash which uniquely identifies the template

--- a/crates/ghost-common/src/config.rs
+++ b/crates/ghost-common/src/config.rs
@@ -114,6 +114,27 @@ pub struct NodeConfig {
     pub reaper: ReaperSettings,
     /// Registry configuration (optional, for load balancer registration)
     pub registry: Option<RegistryConfig>,
+    /// Decentralised Wraith coordinator-election configuration.
+    ///
+    /// Read-only and gated OFF by default: when `wraith_election_enabled` is
+    /// false the election service is never constructed and has zero effect on
+    /// the node (`tasks/plan_decentralised_coordinators.md`, increment 4).
+    #[serde(default)]
+    pub coordinator: CoordinatorConfig,
+}
+
+/// Decentralised Wraith coordinator-election settings.
+///
+/// This increment only *computes and exposes* the election read-only; it never
+/// activates a coordinator role, touches `coordinator_redundancy`, or changes
+/// any Wraith mixing or consensus message. With `wraith_election_enabled =
+/// false` (the default) it is inert.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct CoordinatorConfig {
+    /// Compute the per-epoch coordinator election and expose it read-only via
+    /// `GET /api/v1/pool/coordinator`. Default false — dead code when off.
+    #[serde(default)]
+    pub wraith_election_enabled: bool,
 }
 
 /// Configuration validation error

--- a/crates/ghost-verification/src/routes.rs
+++ b/crates/ghost-verification/src/routes.rs
@@ -226,6 +226,13 @@ pub fn create_router(state: Arc<VerificationState>) -> Router {
             "/api/v1/pool/recent_shares",
             get(api_pool_recent_shares_handler),
         )
+        // Read-only decentralised-coordinator election view. Returns
+        // `{enabled:false}` unless the operator turns on
+        // `[coordinator] wraith_election_enabled`.
+        .route(
+            "/api/v1/pool/coordinator",
+            get(api_pool_coordinator_handler),
+        )
         // Treasury + decentralisation-phase state for the Core page.
         // Exposes balance / 21-BTC threshold / decay year / fee split so
         // the website can render the Bootstrap → Decentralising →
@@ -7077,6 +7084,17 @@ async fn api_reaper_status_handler(
     State(state): State<Arc<VerificationState>>,
 ) -> impl IntoResponse {
     Json(state.reaper_stats())
+}
+
+/// Read-only decentralised-coordinator election view
+/// (`tasks/plan_decentralised_coordinators.md`). Returns
+/// `{enabled, epoch, seats, my_seat, elected:[hex node ids]}` when the operator
+/// has turned on `[coordinator] wraith_election_enabled`, else `{enabled:false}`.
+/// This endpoint activates nothing — it only reports the public election draw.
+async fn api_pool_coordinator_handler(
+    State(state): State<Arc<VerificationState>>,
+) -> impl IntoResponse {
+    Json(state.coordinator_status())
 }
 
 /// Detect whether the operator has installed the per-node mempool.space stack

--- a/crates/ghost-verification/src/server.rs
+++ b/crates/ghost-verification/src/server.rs
@@ -934,6 +934,11 @@ pub struct VerificationState {
     /// concrete `ReaperStats` type lives in `bins/ghost-pool` and we don't
     /// want a reverse dep from ghost-verification.
     get_reaper_stats: Option<Box<dyn Fn() -> serde_json::Value + Send + Sync>>,
+    /// Coordinator-election snapshot callback (pre-serialized JSON to avoid a
+    /// reverse-dependency on the `wraith-protocol`/`ghost-pool` election types).
+    /// Returns `{enabled, epoch, seats, my_seat, elected}` when the feature is
+    /// on, or `{enabled:false}` when off / not wired. Read-only.
+    get_coordinator_status: Option<Box<dyn Fn() -> serde_json::Value + Send + Sync>>,
     /// Mesh-wide deduplicated active miner count callback. Returns the size
     /// of the union of locally-active miner_id hashes and every connected
     /// peer's most-recent reported set, giving an exact pool-wide active
@@ -1125,6 +1130,7 @@ impl VerificationState {
             internal_auth: None,
             get_pool_peers: None,
             get_reaper_stats: None,
+            get_coordinator_status: None,
             get_mesh_active_miners: None,
             get_mesh_total_hashrate: None,
             get_local_hashrate: None,
@@ -1596,6 +1602,25 @@ impl VerificationState {
         f: impl Fn() -> serde_json::Value + Send + Sync + 'static,
     ) -> Self {
         self.get_reaper_stats = Some(Box::new(f));
+        self
+    }
+
+    /// Coordinator-election snapshot for `/api/v1/pool/coordinator`, or
+    /// `{enabled:false}` when the feature is off / not wired. Read-only.
+    pub fn coordinator_status(&self) -> serde_json::Value {
+        self.get_coordinator_status
+            .as_ref()
+            .map(|f| f())
+            .unwrap_or_else(|| serde_json::json!({ "enabled": false }))
+    }
+
+    /// Set the coordinator-election snapshot callback (pre-serialized JSON to
+    /// avoid a reverse-dependency on `wraith-protocol`/`ghost-pool`).
+    pub fn with_coordinator_status(
+        mut self,
+        f: impl Fn() -> serde_json::Value + Send + Sync + 'static,
+    ) -> Self {
+        self.get_coordinator_status = Some(Box::new(f));
         self
     }
 


### PR DESCRIPTION
Wires the pure `wraith-protocol` election engine into the live node as a **read-only, gated-off** service — increment 4 of `tasks/plan_decentralised_coordinators.md`. Foundation for decentralised Wraith mixing coordinators.

**What it does (when enabled):** computes the coordinator election from live state — roster = current Elder node IDs (`mesh.peers().get_elder_peers()` + self if elder, through `canonical_roster`), epoch = `height / 144`, beacon = `SHA256(domain ‖ epoch ‖ block_hash@epoch_start)` — recomputes the `CoordinatorView` on epoch change (hooked to the existing `NewWork` round-advance), and exposes it read-only at `GET /api/v1/pool/coordinator`.

**Safety — gated OFF by default, zero effect:**
- `[coordinator] wraith_election_enabled` (serde default **false**). When off, `maybe_new` returns `None` — no `CoordinatorView` is ever built, no RPC issued, no behaviour change.
- **Does NOT** activate any coordinator role, touch `coordinator_redundancy`/Wraith mixing, or add any consensus message. Worst case it's dead code behind a false flag. Purely additive (+527 lines).

**Known compromise (flagged, not hidden):** the beacon anchor is the block hash at the epoch-start height, not a BFT checkpoint (the L2 checkpoint table is keyed to a different epoch length). A miner who finds that block can grind among candidates → grinding-resistance is **bounded**, documented with a `// SECURITY:` comment. Adequate for a read-only, role-inactive view; the **threshold-VRF/DKG beacon (increment 5, audit-gated)** is the endgame and drops in without touching anything else (beacon is passed by value).

**Tests:** 8 unit tests (determinism, epoch advancement, disabled-is-inert, self-as-coordinator, empty roster) pass; build + clippy clean.

Increment 5 (role activation + real beacon + retiring the manual pool) is the follow-up; this lands the foundation safely.