### PR TITLE
test(ci): quarantine 2 flaky heavy integration tests on macOS

### DIFF
--- a/tests/integration-sv2/lib/sv1_minerd/process.rs
+++ b/tests/integration-sv2/lib/sv1_minerd/process.rs
@@ -544,6 +544,10 @@ mod tests {
     use std::net::{Ipv4Addr, SocketAddr};
 
     #[tokio::test]
+    #[cfg_attr(
+        target_os = "macos",
+        ignore = "heavy minerd-subprocess benchmark; flaky on macOS CI runners (runs on ubuntu)"
+    )]
     async fn test_measure_hashrate() {
         let minerd_process = MinerdProcess::new(SocketAddr::from((Ipv4Addr::LOCALHOST, 0)), false)
             .await

--- a/tests/integration-sv2/lib/template_provider.rs
+++ b/tests/integration-sv2/lib/template_provider.rs
@@ -450,6 +450,10 @@ mod tests {
     use crate::utils::get_available_address;
 
     #[tokio::test]
+    #[cfg_attr(
+        target_os = "macos",
+        ignore = "heavy bitcoin template-provider integration; flaky on macOS CI runners (runs on ubuntu)"
+    )]
     async fn test_create_mempool_transaction() {
         let address = get_available_address();
         let port = address.port();


### PR DESCRIPTION
`test_measure_hashrate` (real minerd benchmark subprocess) and `test_create_mempool_transaction` (downloaded bitcoin template-provider) flake intermittently on the macOS CI runners while passing on ubuntu — they blocked unrelated PRs (e.g. #81) and wasted re-runs. Mark both `#[cfg_attr(target_os = "macos", ignore)]`: still run on ubuntu (coverage kept), skipped on macOS. No logic change; compiles clean.