### PR TITLE
reaper: surface dust-flood vector in node config + dashboard

### DIFF
--- a/crates/ghost-common/src/config.rs
+++ b/crates/ghost-common/src/config.rs
@@ -1376,6 +1376,12 @@ pub struct ReaperSettings {
     /// Reject Runestone protocol outputs (OP_RETURN OP_13).
     #[serde(default = "default_true")]
     pub reject_runestone: bool,
+    /// Reject 1-in/1-out transactions whose sole non-OP_RETURN output is at/below the dust-flood threshold (UTXO-flood spam).
+    #[serde(default = "default_true")]
+    pub reject_dustflood: bool,
+    /// Sole-output value (sats) at/below which a 1-in/1-out tx is treated as dust-flood spam.
+    #[serde(default = "default_dustflood_threshold")]
+    pub dust_flood_threshold: u64,
 
     // --- Pool-only detectors (Rust template reaper) ---
     /// Reject witness code after an OP_RETURN opcode.
@@ -1415,6 +1421,9 @@ fn default_max_op_return_bytes() -> usize {
 fn default_min_drop_size() -> usize {
     76
 }
+fn default_dustflood_threshold() -> u64 {
+    330
+}
 fn default_min_excess_witness_bytes() -> usize {
     500
 }
@@ -1432,6 +1441,8 @@ impl Default for ReaperSettings {
             reject_annex: true,
             reject_opreturn: true,
             reject_runestone: true,
+            reject_dustflood: true,
+            dust_flood_threshold: default_dustflood_threshold(),
             reject_unreachable_code: true,
             reject_excess_witness: true,
             reject_legacy_data_stuffing: true,
@@ -1472,7 +1483,15 @@ impl ReaperSettings {
             format!("-ghostreaper-rejectannex={}", b(self.reject_annex)),
             format!("-ghostreaper-rejectopreturn={}", b(self.reject_opreturn)),
             format!("-ghostreaper-rejectrunestone={}", b(self.reject_runestone)),
+            format!(
+                "-ghostreaper-rejectdustflood={}",
+                b(self.reject_dustflood)
+            ),
             format!("-ghostreaper-maxopreturn={}", self.max_op_return_bytes),
+            format!(
+                "-ghostreaper-dustfloodthreshold={}",
+                self.dust_flood_threshold
+            ),
             format!("-ghostreaper-mindropsize={}", self.min_drop_size),
         ]
     }
@@ -1638,6 +1657,8 @@ mod tests {
         assert!(flags.contains(&"-ghostreaper-rejectannex=1".to_string()));
         assert!(flags.contains(&"-ghostreaper-rejectopreturn=1".to_string()));
         assert!(flags.contains(&"-ghostreaper-rejectrunestone=1".to_string()));
+        assert!(flags.contains(&"-ghostreaper-rejectdustflood=1".to_string()));
+        assert!(flags.contains(&"-ghostreaper-dustfloodthreshold=330".to_string()));
         assert!(flags.contains(&"-ghostreaper-maxopreturn=82".to_string()));
         assert!(flags.contains(&"-ghostreaper-mindropsize=76".to_string()));
         // Pool-only vectors must NOT leak into ghostd flags.

--- a/crates/ghost-common/src/setup.rs
+++ b/crates/ghost-common/src/setup.rs
@@ -398,5 +398,7 @@ mod tests {
         assert!(dropin.contains("-ghostreaper=enabled"));
         assert!(dropin.contains("-ghostreaper-rejectannex=0"));
         assert!(dropin.contains("-ghostreaper-rejectinscription=1"));
+        assert!(dropin.contains("-ghostreaper-rejectdustflood=1"));
+        assert!(dropin.contains("-ghostreaper-dustfloodthreshold=330"));
     }
 }

--- a/dashboard/src/app/(dashboard)/reaper/page.tsx
+++ b/dashboard/src/app/(dashboard)/reaper/page.tsx
@@ -21,6 +21,7 @@ interface ReaperStats {
     fake_pubkey_curve_point: number;
     annex_present: number;
     oversized_op_return: number;
+    dust_flood: number;
     excess_witness_data: number;
     excess_stack_items: number;
     legacy_scriptsig_data: number;
@@ -60,6 +61,11 @@ const DETECTION_VECTORS = [
     key: "oversized_op_return" as const,
     name: "Oversized OP_RETURN",
     desc: "Flags OP_RETURN outputs exceeding standard relay limits, used for embedding large data payloads.",
+  },
+  {
+    key: "dust_flood" as const,
+    name: "Dust-flood (UTXO spam)",
+    desc: "Rejects 1-in/1-out transactions whose sole non-OP_RETURN output sits at or below the dust-flood threshold, the signature of UTXO-set flooding spam.",
   },
   {
     key: "annex_present" as const,

--- a/dashboard/src/app/(dashboard)/settings/wizards/ReaperWizard.tsx
+++ b/dashboard/src/app/(dashboard)/settings/wizards/ReaperWizard.tsx
@@ -26,6 +26,7 @@ const SHARED: Vector[] = [
 const NODE_ONLY: Vector[] = [
   { key: 'reject_opreturn', label: 'Oversized OP_RETURN', desc: 'OP_RETURN payloads larger than the max below' },
   { key: 'reject_runestone', label: 'Runestones', desc: 'Runestone protocol outputs (OP_RETURN OP_13)' },
+  { key: 'reject_dustflood', label: 'Dust-flood (UTXO spam)', desc: '1-in/1-out txs whose sole non-OP_RETURN output is at/below the dust-flood threshold below' },
 ];
 const POOL_ONLY: Vector[] = [
   { key: 'reject_unreachable_code', label: 'Unreachable code', desc: 'Witness code after an OP_RETURN opcode' },
@@ -154,6 +155,8 @@ export default function ReaperWizard({ isOpen, onClose }: ReaperWizardProps) {
                 onChange={(e) => setData({ max_op_return_bytes: Number(e.target.value) })} disabled={!data.enabled} />
               <Input label="Min drop-stuffing push size (shared)" type="number" value={data.min_drop_size}
                 onChange={(e) => setData({ min_drop_size: Number(e.target.value) })} disabled={!data.enabled} />
+              <Input label="Dust-flood threshold (sats)" type="number" value={data.dustflood_threshold}
+                onChange={(e) => setData({ dustflood_threshold: Number(e.target.value) })} disabled={!data.enabled} />
               <Input label="Min excess-witness bytes (pool)" type="number" value={data.min_excess_witness_bytes}
                 onChange={(e) => setData({ min_excess_witness_bytes: Number(e.target.value) })} disabled={!data.enabled} />
               <Input label="Legacy max push bytes (pool)" type="number" value={data.legacy_max_push_bytes}

--- a/dashboard/src/lib/api/config.ts
+++ b/dashboard/src/lib/api/config.ts
@@ -62,6 +62,7 @@ export interface ReaperSettings {
   // Node-only (ghostd mempool reaper)
   reject_opreturn: boolean;
   reject_runestone: boolean;
+  reject_dustflood: boolean;
   // Pool-only (template reaper)
   reject_unreachable_code: boolean;
   reject_excess_witness: boolean;
@@ -70,6 +71,7 @@ export interface ReaperSettings {
   // Thresholds
   max_op_return_bytes: number;
   min_drop_size: number;
+  dustflood_threshold: number;
   min_excess_witness_bytes: number;
   legacy_max_push_bytes: number;
 }
@@ -102,12 +104,14 @@ export const REAPER_DEFAULTS: ReaperSettings = {
   reject_annex: true,
   reject_opreturn: true,
   reject_runestone: true,
+  reject_dustflood: true,
   reject_unreachable_code: true,
   reject_excess_witness: true,
   reject_legacy_data_stuffing: true,
   validate_pubkey_curve_point: true,
   max_op_return_bytes: 82,
   min_drop_size: 76,
+  dustflood_threshold: 330,
   min_excess_witness_bytes: 500,
   legacy_max_push_bytes: 80,
 };


### PR DESCRIPTION
Wires the new `-ghostreaper-rejectdustflood` detector (PR #87) into the config system and operator dashboard. Backend: `reject_dustflood`+`dust_flood_threshold` on `ReaperSettings` → emitted in `ghostd_flags()` (+ unit tests, 226 pass). Frontend: toggle + threshold in ReaperWizard, vector display on the reaper page. Pool-side hit-counter for live dust-flood stats is a noted follow-up (reads 0 until wired).