### PR TITLE
dashboard: wire create-lock, withdraw, ghost-id, node-control wizards to real endpoints

### DIFF
--- a/dashboard/src/app/(dashboard)/settings/wizards/BuildRunWizard.tsx
+++ b/dashboard/src/app/(dashboard)/settings/wizards/BuildRunWizard.tsx
@@ -5,8 +5,13 @@ import { useWizard, WizardStep } from '@/hooks/useWizard';
 import { WizardDialog } from '@/components/ui/Wizard';
 import { Badge } from '@/components/ui/Badge';
 import { useToast } from '@/components/ui/Toast';
-import { useRestartNode } from '@/hooks/queries';
+import { useStartService, useStopService, useRestartService } from '@/hooks/queries';
 import { fetchApi } from '@/lib/api/client';
+
+// The dashboard's node-control wizard targets the ghost-pool service — the
+// primary node process the watchdog manages. This name must be one of the
+// watchdog's allowed services (ghost-pool, ghost-core, ghost-pay).
+const NODE_SERVICE = 'ghost-pool';
 
 interface PreflightCheck {
   label: string;
@@ -46,7 +51,9 @@ const ACTION_OPTIONS = [
 ];
 
 export default function BuildRunWizard({ isOpen, onClose }: BuildRunWizardProps) {
-  const restartNode = useRestartNode();
+  const startService = useStartService();
+  const stopService = useStopService();
+  const restartService = useRestartService();
   const toast = useToast();
 
   const [checks, setChecks] = useState<PreflightCheck[]>([
@@ -79,15 +86,32 @@ export default function BuildRunWizard({ isOpen, onClose }: BuildRunWizardProps)
       title: 'Confirm',
       description: 'Confirm the action to execute',
       onSubmit: async (data) => {
-        await restartNode.mutateAsync();
-        toast.success(
-          `Node ${data.action === 'start' ? 'Started' : data.action === 'restart' ? 'Restarted' : 'Stopped'}`,
-          `The node ${data.action} command has been executed successfully.`
-        );
-        onClose();
+        try {
+          const mutation =
+            data.action === 'start'
+              ? startService
+              : data.action === 'stop'
+                ? stopService
+                : restartService;
+          const result = await mutation.mutateAsync(NODE_SERVICE);
+          // The watchdog returns HTTP 200 with { success: false, message }
+          // when systemctl itself fails — surface that as an error.
+          if (!result.success) {
+            throw new Error(result.message || `Failed to ${data.action} the node`);
+          }
+          toast.success(
+            `Node ${data.action === 'start' ? 'Started' : data.action === 'restart' ? 'Restarted' : 'Stopped'}`,
+            result.message || `The node ${data.action} command has been executed successfully.`
+          );
+          onClose();
+        } catch (err) {
+          const message = err instanceof Error ? err.message : `Failed to ${data.action} the node`;
+          toast.error('Node Control Failed', message);
+          throw err;
+        }
       },
     },
-  ], [restartNode, toast, onClose]);
+  ], [startService, stopService, restartService, toast, onClose]);
 
   const wizard = useWizard<BuildRunData>({
     steps,

--- a/dashboard/src/app/(dashboard)/settings/wizards/CreateLockWizard.tsx
+++ b/dashboard/src/app/(dashboard)/settings/wizards/CreateLockWizard.tsx
@@ -5,9 +5,21 @@ import { WizardDialog } from '@/components/ui/Wizard';
 import { Input } from '@/components/ui/Input';
 import { Badge } from '@/components/ui/Badge';
 import { useToast } from '@/components/ui/Toast';
+import { useCreateLock } from '@/hooks/queries';
+import type { LockDenomination, TimelockTier } from '@/lib/api/ghostpay';
 
-type Denomination = 'micro' | 'tiny' | 'small' | 'medium' | 'large';
+type Denomination = LockDenomination;
 type Timelock = '1w' | '1m' | '3m' | '6m' | '1y';
+
+// ghost-pay exposes three timelock tiers; map the friendlier UI durations
+// onto them (shorter durations → short tier, longer → long tier).
+const TIMELOCK_TIERS: Record<Timelock, TimelockTier> = {
+  '1w': 'short',
+  '1m': 'standard',
+  '3m': 'standard',
+  '6m': 'long',
+  '1y': 'long',
+};
 
 interface CreateLockData {
   denomination: Denomination;
@@ -38,6 +50,7 @@ interface CreateLockWizardProps {
 
 export default function CreateLockWizard({ isOpen, onClose }: CreateLockWizardProps) {
   const toast = useToast();
+  const createLock = useCreateLock();
 
   const steps: WizardStep<CreateLockData>[] = [
     {
@@ -66,12 +79,22 @@ export default function CreateLockWizard({ isOpen, onClose }: CreateLockWizardPr
       title: 'Confirm',
       description: 'Review and create the lock',
       onSubmit: async (data) => {
-        const denom = DENOMINATIONS.find((d) => d.value === data.denomination);
-        toast.success(
-          'Ghost Lock Created',
-          `${denom?.label} lock (${denom?.sats}) created with ${data.timelock} timelock`
-        );
-        onClose();
+        try {
+          const result = await createLock.mutateAsync({
+            denomination: data.denomination,
+            timelock_tier: TIMELOCK_TIERS[data.timelock],
+          });
+          const denom = DENOMINATIONS.find((d) => d.value === data.denomination);
+          toast.success(
+            'Ghost Lock Created',
+            `${denom?.label} lock ${result.lock.id} created. Fund the address ${result.lock.address} to activate it.`
+          );
+          onClose();
+        } catch (err) {
+          const message = err instanceof Error ? err.message : 'Failed to create lock';
+          toast.error('Lock Creation Failed', message);
+          throw err;
+        }
       },
     },
   ];

--- a/dashboard/src/app/(dashboard)/settings/wizards/GhostIdWizard.tsx
+++ b/dashboard/src/app/(dashboard)/settings/wizards/GhostIdWizard.tsx
@@ -1,10 +1,12 @@
 'use client';
 
+import { useMutation } from '@tanstack/react-query';
 import { useWizard, WizardStep } from '@/hooks/useWizard';
 import { WizardDialog } from '@/components/ui/Wizard';
 import { Input } from '@/components/ui/Input';
 import { Badge } from '@/components/ui/Badge';
 import { useToast } from '@/components/ui/Toast';
+import { getGhostId } from '@/lib/api/ghostpay';
 
 interface GhostIdData {
   label: string;
@@ -17,12 +19,16 @@ interface GhostIdWizardProps {
 
 export default function GhostIdWizard({ isOpen, onClose }: GhostIdWizardProps) {
   const toast = useToast();
+  // The node's Ghost ID is deterministically derived from its keypair — there
+  // is no separate "generate"/"register" write endpoint. This wizard surfaces
+  // the real, already-derived identity via the read-only ghost-id route.
+  const revealGhostId = useMutation({ mutationFn: getGhostId });
 
   const steps: WizardStep<GhostIdData>[] = [
     {
       id: 'info',
       title: 'Ghost ID',
-      description: 'Create a pseudonymous L2 identity',
+      description: 'Reveal your pseudonymous L2 identity',
     },
     {
       id: 'generate',
@@ -38,13 +44,21 @@ export default function GhostIdWizard({ isOpen, onClose }: GhostIdWizardProps) {
     {
       id: 'confirm',
       title: 'Confirm',
-      description: 'Generate your Ghost ID',
-      onSubmit: async () => {
-        toast.success(
-          'Ghost ID Created',
-          'Your Ghost ID has been generated and is ready for L2 transactions'
-        );
-        onClose();
+      description: 'Reveal your Ghost ID',
+      onSubmit: async (data) => {
+        try {
+          const result = await revealGhostId.mutateAsync();
+          const labelSuffix = data.label ? ` (${data.label})` : '';
+          toast.success(
+            'Ghost ID Ready',
+            `Your node Ghost ID${labelSuffix} is ${result.ghost_id}`
+          );
+          onClose();
+        } catch (err) {
+          const message = err instanceof Error ? err.message : 'Failed to retrieve Ghost ID';
+          toast.error('Ghost ID Unavailable', message);
+          throw err;
+        }
       },
     },
   ];
@@ -119,7 +133,7 @@ export default function GhostIdWizard({ isOpen, onClose }: GhostIdWizardProps) {
           {wizard.currentStep === 2 && (
             <div className="space-y-4">
               <div className="p-4 rounded-lg bg-gray-800/50">
-                <h4 className="text-gray-100 font-medium mb-3">Ready to Generate</h4>
+                <h4 className="text-gray-100 font-medium mb-3">Ready to Reveal</h4>
                 <div className="space-y-2">
                   <div className="flex items-center justify-between">
                     <span className="text-gray-400">Label</span>
@@ -133,8 +147,8 @@ export default function GhostIdWizard({ isOpen, onClose }: GhostIdWizardProps) {
               </div>
               <div className="p-4 rounded-lg bg-orange-900/20 border border-orange-800">
                 <p className="text-sm text-orange-300">
-                  Click Finish to generate your Ghost ID. The ID will be derived from your
-                  node keypair and registered on the L2 network.
+                  Click Finish to reveal your Ghost ID. The ID is derived deterministically
+                  from your node keypair — it already exists and is ready for L2 transactions.
                 </p>
               </div>
             </div>

--- a/dashboard/src/app/(dashboard)/settings/wizards/WithdrawWizard.tsx
+++ b/dashboard/src/app/(dashboard)/settings/wizards/WithdrawWizard.tsx
@@ -5,8 +5,8 @@ import { WizardDialog } from '@/components/ui/Wizard';
 import { Input } from '@/components/ui/Input';
 import { Badge } from '@/components/ui/Badge';
 import { useToast } from '@/components/ui/Toast';
-
-type SettlementClass = 'standard' | 'priority' | 'batch';
+import { useReconcileLock } from '@/hooks/queries';
+import type { SettlementClass } from '@/lib/api/ghostpay';
 
 interface WithdrawData {
   lock_id: string;
@@ -14,10 +14,12 @@ interface WithdrawData {
   settlement_class: SettlementClass;
 }
 
+// Settlement classes accepted by ghost-pay's reconcile_lock handler:
+// "express" (highest fee, fastest), "standard", "economy" (lowest fee).
 const SETTLEMENT_CLASSES: { value: SettlementClass; label: string; desc: string }[] = [
+  { value: 'express', label: 'Express', desc: 'Highest priority, fastest inclusion' },
   { value: 'standard', label: 'Standard', desc: 'Next checkpoint (~10 min)' },
-  { value: 'priority', label: 'Priority', desc: 'Immediate inclusion' },
-  { value: 'batch', label: 'Batch', desc: 'Aggregate with others (lower fees)' },
+  { value: 'economy', label: 'Economy', desc: 'Aggregate with others (lower fees)' },
 ];
 
 function isValidBech32Address(addr: string): boolean {
@@ -31,6 +33,7 @@ interface WithdrawWizardProps {
 
 export default function WithdrawWizard({ isOpen, onClose }: WithdrawWizardProps) {
   const toast = useToast();
+  const reconcileLock = useReconcileLock();
 
   const steps: WizardStep<WithdrawData>[] = [
     {
@@ -68,12 +71,28 @@ export default function WithdrawWizard({ isOpen, onClose }: WithdrawWizardProps)
       title: 'Confirm',
       description: 'Review and submit withdrawal',
       onSubmit: async (data) => {
-        const cls = SETTLEMENT_CLASSES.find((c) => c.value === data.settlement_class);
-        toast.success(
-          'Withdrawal Submitted',
-          `Lock ${data.lock_id} withdrawal to ${data.destination_address.slice(0, 12)}... via ${cls?.label} settlement`
-        );
-        onClose();
+        try {
+          const result = await reconcileLock.mutateAsync({
+            lockId: data.lock_id.trim(),
+            destinationAddress: data.destination_address.trim(),
+            settlementClass: data.settlement_class,
+          });
+          // The reconcile route returns HTTP 200 with { success: false, error }
+          // for business failures (lock not active/funded, pending withdrawal).
+          if (!result.success) {
+            throw new Error(result.error || 'Lock reconciliation was rejected');
+          }
+          const cls = SETTLEMENT_CLASSES.find((c) => c.value === data.settlement_class);
+          toast.success(
+            'Withdrawal Submitted',
+            `Lock ${data.lock_id} settling ${result.settlement_amount ?? 0} sats to ${data.destination_address.slice(0, 12)}... via ${cls?.label} (fee ${result.fee_sats ?? 0} sats, withdrawal #${result.withdrawal_id ?? '?'})`
+          );
+          onClose();
+        } catch (err) {
+          const message = err instanceof Error ? err.message : 'Failed to submit withdrawal';
+          toast.error('Withdrawal Failed', message);
+          throw err;
+        }
       },
     },
   ];

--- a/dashboard/src/hooks/queries/useGhostPayQueries.ts
+++ b/dashboard/src/hooks/queries/useGhostPayQueries.ts
@@ -11,6 +11,14 @@ import {
   joinWraithSession,
   requestLockSettlement,
   useLockInMix as apiUseLockInMix,
+  createLock,
+  reconcileLock,
+  getGhostId,
+} from '@/lib/api/ghostpay';
+import type {
+  LockDenomination,
+  TimelockTier,
+  SettlementClass,
 } from '@/lib/api/ghostpay';
 import type { PayoutHistoryTimeFilter } from '@/types/api';
 
@@ -26,7 +34,17 @@ export const ghostPayKeys = {
   settlementStatus: () => [...ghostPayKeys.all, 'settlement-status'] as const,
   payoutHistory: (timeFilter: PayoutHistoryTimeFilter) =>
     [...ghostPayKeys.all, 'payout-history', timeFilter] as const,
+  ghostId: () => [...ghostPayKeys.all, 'ghost-id'] as const,
 };
+
+export function useGhostId(options?: { enabled?: boolean }) {
+  return useQuery({
+    queryKey: ghostPayKeys.ghostId(),
+    queryFn: getGhostId,
+    enabled: options?.enabled ?? true,
+    staleTime: Infinity,
+  });
+}
 
 export function useGhostPayStatus(options?: { refetchInterval?: number }) {
   return useQuery({
@@ -103,6 +121,42 @@ export function useUseLockInMix() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ghostPayKeys.locks() });
       queryClient.invalidateQueries({ queryKey: ghostPayKeys.wraith() });
+    },
+  });
+}
+
+export function useCreateLock() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (config: { denomination: LockDenomination; timelock_tier: TimelockTier }) =>
+      createLock(config),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ghostPayKeys.locks() });
+    },
+  });
+}
+
+export function useReconcileLock() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      lockId,
+      destinationAddress,
+      settlementClass,
+    }: {
+      lockId: string;
+      destinationAddress: string;
+      settlementClass: SettlementClass;
+    }) =>
+      reconcileLock(lockId, {
+        destination_address: destinationAddress,
+        settlement_class: settlementClass,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ghostPayKeys.locks() });
+      queryClient.invalidateQueries({ queryKey: ghostPayKeys.settlement() });
     },
   });
 }

--- a/dashboard/src/lib/api/ghostpay.ts
+++ b/dashboard/src/lib/api/ghostpay.ts
@@ -1,5 +1,5 @@
 // Ghost Pay API endpoints
-import { fetchApi } from './client';
+import { fetchApi, fetchWithTimeout } from './client';
 import type {
   GhostPayStatus,
   WraithSessionsResponse,
@@ -145,25 +145,145 @@ export async function getGhostPayPayoutHistory(
   );
 }
 
-// Lock reconciliation (settle lock to L1)
+// ---------------------------------------------------------------------------
+// Pay-node write routes
+//
+// Lock creation, lock reconciliation, L2 payment send and the read-only
+// ghost-id all live on the ghost-pay node (port 8800), reached through the
+// dashboard's `/api/ghostpay-proxy` route (which HMAC-signs the request).
+// This is a DIFFERENT backend from the read-only `/api/proxy` (ghost-pool,
+// port 8080) used by the getters above, so these functions must go through
+// their own proxy base — mirroring `glyph.ts`.
+// ---------------------------------------------------------------------------
+
+function getGhostPayProxyBase(): string {
+  if (typeof window !== 'undefined') {
+    return window.location.origin;
+  }
+  return 'http://localhost:3000';
+}
+
+async function fetchGhostPay<T>(endpoint: string, options?: RequestInit): Promise<T> {
+  const proxyUrl = `${getGhostPayProxyBase()}/api/ghostpay-proxy${endpoint}`;
+
+  const response = await fetchWithTimeout(proxyUrl, {
+    ...options,
+    headers: {
+      'Content-Type': 'application/json',
+      ...options?.headers,
+    },
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ error: 'Unknown error' }));
+    throw new Error(error.error || `API error: ${response.status}`);
+  }
+
+  return response.json();
+}
+
+/** Denomination tiers accepted by ghost-pay's `Denomination::from_sats`. */
+export type LockDenomination = 'micro' | 'tiny' | 'small' | 'medium' | 'large';
+
+/** Timelock tiers accepted by ghost-pay's lock creation route. */
+export type TimelockTier = 'short' | 'standard' | 'long';
+
+/** Settlement classes accepted by ghost-pay's `reconcile_lock` handler. */
+export type SettlementClass = 'express' | 'standard' | 'economy';
+
+const DENOMINATION_SATS: Record<LockDenomination, number> = {
+  micro: 10_000,
+  tiny: 100_000,
+  small: 1_000_000,
+  medium: 10_000_000,
+  large: 100_000_000,
+};
+
+/** Lock summary returned in the `lock` field of the create-lock response. */
+export interface CreatedLockInfo {
+  id: string;
+  state?: string;
+  amount_sats: number;
+  denomination?: string;
+  timelock_tier?: string;
+  address: string;
+  creation_height?: number;
+}
+
+export interface CreateLockResponse {
+  success: boolean;
+  lock: CreatedLockInfo;
+}
+
+// Create a Ghost Lock on the pay node.
+// POST /api/v1/locks/create  (ghost-pay)
+export async function createLock(config: {
+  denomination: LockDenomination;
+  timelock_tier: TimelockTier;
+}): Promise<CreateLockResponse> {
+  return fetchGhostPay<CreateLockResponse>('/api/v1/locks/create', {
+    method: 'POST',
+    body: JSON.stringify({
+      amount_sats: DENOMINATION_SATS[config.denomination],
+      timelock_tier: config.timelock_tier,
+    }),
+  });
+}
+
+export interface ReconcileLockResponse {
+  success: boolean;
+  error?: string;
+  withdrawal_id?: number;
+  lock_id?: string;
+  settlement_amount?: number;
+  fee_sats?: number;
+  settlement_class?: string;
+  destination_address?: string;
+  message?: string;
+}
+
+// Reconcile (settle) a Ghost Lock to an L1 address.
+// POST /api/v1/locks/:id/reconcile  (ghost-pay)
 export async function reconcileLock(lockId: string, config: {
   destination_address: string;
-  settlement_class?: 'standard' | 'batched';
-}): Promise<{ success: boolean; withdrawal_id?: number; message: string }> {
-  return fetchApi(`/api/v1/locks/${lockId}/reconcile`, {
+  settlement_class?: SettlementClass;
+}): Promise<ReconcileLockResponse> {
+  return fetchGhostPay<ReconcileLockResponse>(`/api/v1/locks/${lockId}/reconcile`, {
+    method: 'POST',
+    body: JSON.stringify({
+      destination_address: config.destination_address,
+      settlement_class: config.settlement_class ?? 'standard',
+    }),
+  });
+}
+
+export interface SendL2PaymentResponse {
+  success: boolean;
+  payment_id?: string;
+  message?: string;
+}
+
+// Send an L2 instant payment.
+// POST /api/v1/payments/send  (ghost-pay)
+export async function sendL2Payment(config: {
+  recipient: string;
+  amount_sats: number;
+  memo?: string;
+}): Promise<SendL2PaymentResponse> {
+  return fetchGhostPay<SendL2PaymentResponse>('/api/v1/payments/send', {
     method: 'POST',
     body: JSON.stringify(config),
   });
 }
 
-// Send L2 instant payment
-export async function sendL2Payment(config: {
-  recipient: string;
-  amount_sats: number;
-  memo?: string;
-}): Promise<{ success: boolean; payment_id?: string; message: string }> {
-  return fetchApi('/api/v1/payments/send', {
-    method: 'POST',
-    body: JSON.stringify(config),
-  });
+export interface GhostIdInfo {
+  ghost_id: string;
+  scan_pubkey: string;
+  spend_pubkey: string;
+}
+
+// Read the node's Ghost ID (derived from the operator's keys).
+// GET /api/v1/keys/ghost-id  (ghost-pay, read-only)
+export async function getGhostId(): Promise<GhostIdInfo> {
+  return fetchGhostPay<GhostIdInfo>('/api/v1/keys/ghost-id');
 }


### PR DESCRIPTION
The four action wizards previously showed a fake success toast with no backend call. Now wired to real endpoints with real response feedback and error handling:
- CreateLock → `POST /api/v1/locks/create`
- Withdraw → `POST /api/v1/locks/:id/reconcile` (settlement classes corrected to express/standard/economy)
- GhostId → `GET /api/v1/keys/ghost-id` (reveal — no generation endpoint exists; ID is derived from node keypair)
- BuildRun → `POST /api/v1/watchdog/{start|stop|restart}/ghost-pool` (fixed a bug where it always restarted)

`tsc --noEmit` clean. Business-failure (200 + success:false) handled.