### PR TITLE
dashboard: add Send Payment and Glyph wizards

### DIFF
--- a/dashboard/src/app/(dashboard)/settings/wizards/GlyphWizard.tsx
+++ b/dashboard/src/app/(dashboard)/settings/wizards/GlyphWizard.tsx
@@ -1,0 +1,398 @@
+'use client';
+
+import { useState, useRef, useCallback, useEffect } from 'react';
+import { useWizard, WizardStep } from '@/hooks/useWizard';
+import { WizardDialog } from '@/components/ui/Wizard';
+import { Input } from '@/components/ui/Input';
+import { Badge } from '@/components/ui/Badge';
+import { useToast } from '@/components/ui/Toast';
+import { GLYPH_PALETTE, computeBitmapHash, checkGlyphAvailability } from '@/lib/api/glyph';
+import { useClaimGlyph, useGhostId } from '@/hooks/queries';
+
+const GRID_SIZE = 16;
+const CELL_SIZE = 20;
+const PREVIEW_SIZE = 128;
+const PREVIEW_CELL = PREVIEW_SIZE / GRID_SIZE; // 8
+
+function paletteToHex(r: number, g: number, b: number): string {
+  return `#${r.toString(16).padStart(2, '0')}${g.toString(16).padStart(2, '0')}${b.toString(16).padStart(2, '0')}`;
+}
+
+interface GlyphData {
+  ghost_id: string;
+}
+
+interface GlyphWizardProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export default function GlyphWizard({ isOpen, onClose }: GlyphWizardProps) {
+  const toast = useToast();
+  const claimMutation = useClaimGlyph();
+  const ghostIdQuery = useGhostId({ enabled: isOpen });
+
+  // Canvas / palette state lives in the wizard (not in wizard data) because
+  // the 256-entry pixel array is large and only the claim step needs it.
+  const [pixels, setPixels] = useState<number[]>(() => new Array(256).fill(0));
+  const [selectedColor, setSelectedColor] = useState(1);
+  const [painting, setPainting] = useState(false);
+  const [availability, setAvailability] = useState<{ checked: boolean; available: boolean; hash: string } | null>(null);
+  const [checking, setChecking] = useState(false);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  // Reset transient editor state whenever the wizard is (re)opened.
+  useEffect(() => {
+    if (isOpen) {
+      setPixels(new Array(256).fill(0));
+      setSelectedColor(1);
+      setAvailability(null);
+      setChecking(false);
+    }
+  }, [isOpen]);
+
+  // Painting an empty design conveys nothing; the check/claim steps require
+  // at least one non-background pixel.
+  const isBlank = pixels.every((p) => p === 0);
+
+  const renderPreview = useCallback((px: number[]) => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    ctx.clearRect(0, 0, PREVIEW_SIZE, PREVIEW_SIZE);
+    for (let i = 0; i < 256; i++) {
+      const colorIdx = px[i] ?? 0;
+      const color = GLYPH_PALETTE[colorIdx] ?? GLYPH_PALETTE[0];
+      ctx.fillStyle = paletteToHex(color.r, color.g, color.b);
+      const x = (i % GRID_SIZE) * PREVIEW_CELL;
+      const y = Math.floor(i / GRID_SIZE) * PREVIEW_CELL;
+      ctx.fillRect(x, y, PREVIEW_CELL, PREVIEW_CELL);
+    }
+  }, []);
+
+  useEffect(() => {
+    renderPreview(pixels);
+  }, [pixels, renderPreview]);
+
+  const paintCell = useCallback((index: number) => {
+    setPixels((prev) => {
+      if (prev[index] === selectedColor) return prev;
+      const next = [...prev];
+      next[index] = selectedColor;
+      return next;
+    });
+    // Any edit invalidates a prior availability check.
+    setAvailability(null);
+  }, [selectedColor]);
+
+  const handleMouseDown = useCallback((index: number) => {
+    setPainting(true);
+    paintCell(index);
+  }, [paintCell]);
+
+  const handleMouseEnter = useCallback((index: number) => {
+    if (painting) paintCell(index);
+  }, [painting, paintCell]);
+
+  const handleMouseUp = useCallback(() => {
+    setPainting(false);
+  }, []);
+
+  const handleClear = useCallback(() => {
+    setPixels(new Array(256).fill(0));
+    setAvailability(null);
+  }, []);
+
+  const runAvailabilityCheck = useCallback(async () => {
+    setChecking(true);
+    try {
+      const hash = await computeBitmapHash(pixels);
+      const result = await checkGlyphAvailability(hash);
+      setAvailability({ checked: true, available: result.available, hash });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Availability check failed';
+      toast.error('Check Failed', message);
+      setAvailability(null);
+    } finally {
+      setChecking(false);
+    }
+  }, [pixels, toast]);
+
+  const steps: WizardStep<GlyphData>[] = [
+    {
+      id: 'intro',
+      title: 'About',
+      description: 'What is a Ghost Glyph?',
+    },
+    {
+      id: 'design',
+      title: 'Design',
+      description: 'Draw your 16x16 glyph',
+      validate: () => {
+        if (isBlank) {
+          return 'Paint at least one pixel before continuing';
+        }
+        return null;
+      },
+    },
+    {
+      id: 'availability',
+      title: 'Availability',
+      description: 'Confirm the design is unclaimed',
+      validate: () => {
+        if (!availability?.checked) {
+          return 'Check availability before continuing';
+        }
+        if (!availability.available) {
+          return 'This design is already claimed — edit it and re-check';
+        }
+        return null;
+      },
+    },
+    {
+      id: 'claim',
+      title: 'Claim',
+      description: 'Bind this glyph to your Ghost ID',
+      validate: (data) => {
+        if (!data.ghost_id.trim()) {
+          return 'A Ghost ID is required to claim';
+        }
+        return null;
+      },
+      onSubmit: async (data) => {
+        try {
+          const result = await claimMutation.mutateAsync({
+            ghostId: data.ghost_id.trim(),
+            pixels,
+          });
+          toast.success(
+            'Glyph Claimed',
+            `Bound to ${data.ghost_id.trim().slice(0, 14)}... — commitment ${result.commitment.slice(0, 16)}...`
+          );
+          onClose();
+        } catch (err) {
+          const message = err instanceof Error ? err.message : 'Failed to claim glyph';
+          toast.error('Claim Failed', message);
+          throw err;
+        }
+      },
+    },
+  ];
+
+  const wizard = useWizard<GlyphData>({
+    steps,
+    initialData: {
+      ghost_id: '',
+    },
+  });
+
+  // The canvas is remounted whenever the active step changes, so redraw it
+  // after each step transition (the pixels-driven effect won't fire because
+  // the pixel array is unchanged across the navigation).
+  useEffect(() => {
+    renderPreview(pixels);
+  }, [wizard.currentStep, pixels, renderPreview]);
+
+  // Prefill the Ghost ID from the node once it loads (only if untouched).
+  useEffect(() => {
+    if (isOpen && ghostIdQuery.data?.ghost_id && !wizard.data.ghost_id) {
+      wizard.setData({ ghost_id: ghostIdQuery.data.ghost_id });
+    }
+  }, [isOpen, ghostIdQuery.data, wizard]);
+
+  return (
+    <WizardDialog
+      isOpen={isOpen}
+      onClose={onClose}
+      title="Claim a Ghost Glyph"
+      wizard={wizard}
+      size="xl"
+    >
+      {(data, setData) => (
+        <div className="space-y-6" onMouseUp={handleMouseUp} onMouseLeave={handleMouseUp}>
+          {/* Step 1: Intro */}
+          {wizard.currentStep === 0 && (
+            <div className="space-y-4">
+              <div className="p-4 rounded-lg bg-gray-800/50 space-y-3">
+                <p className="text-sm text-gray-300">
+                  A Ghost Glyph is a small 16x16 pixel image that becomes the visual
+                  identity for your Ghost ID. Once claimed it is bound permanently to
+                  your identity and cannot be transferred.
+                </p>
+                <ul className="text-sm text-gray-400 list-disc list-inside space-y-1">
+                  <li>Design a unique bitmap from the Ghost palette.</li>
+                  <li>Each design hashes to a unique fingerprint — duplicates are rejected.</li>
+                  <li>Claiming binds the bitmap hash to your Ghost ID.</li>
+                </ul>
+              </div>
+              <div className="p-4 rounded-lg bg-orange-900/20 border border-orange-800">
+                <p className="text-sm text-orange-300">
+                  Claiming a glyph is permanent. Take your time on the design step.
+                </p>
+              </div>
+            </div>
+          )}
+
+          {/* Step 2: Design */}
+          {wizard.currentStep === 1 && (
+            <div className="flex flex-col lg:flex-row gap-6">
+              {/* Grid */}
+              <div className="flex flex-col gap-3">
+                <div
+                  className="inline-grid border border-gray-700 select-none"
+                  style={{
+                    gridTemplateColumns: `repeat(${GRID_SIZE}, ${CELL_SIZE}px)`,
+                    gridTemplateRows: `repeat(${GRID_SIZE}, ${CELL_SIZE}px)`,
+                  }}
+                >
+                  {pixels.map((colorIdx, i) => {
+                    const color = GLYPH_PALETTE[colorIdx] ?? GLYPH_PALETTE[0];
+                    return (
+                      <div
+                        key={i}
+                        className="border border-gray-800/50 cursor-crosshair hover:opacity-80"
+                        style={{
+                          backgroundColor: paletteToHex(color.r, color.g, color.b),
+                          width: CELL_SIZE,
+                          height: CELL_SIZE,
+                        }}
+                        onMouseDown={() => handleMouseDown(i)}
+                        onMouseEnter={() => handleMouseEnter(i)}
+                      />
+                    );
+                  })}
+                </div>
+                <button
+                  type="button"
+                  onClick={handleClear}
+                  className="self-start px-3 py-1.5 text-sm bg-gray-700 hover:bg-gray-600 text-gray-200 rounded transition-colors"
+                >
+                  Clear
+                </button>
+              </div>
+
+              {/* Palette + preview */}
+              <div className="flex flex-col gap-4 flex-1">
+                <div>
+                  <h4 className="text-sm font-medium text-gray-400 mb-2">Palette</h4>
+                  <div className="flex flex-wrap gap-1">
+                    {GLYPH_PALETTE.map((color) => (
+                      <button
+                        key={color.index}
+                        type="button"
+                        title={color.name}
+                        className={`w-6 h-6 rounded-sm border-2 transition-all ${
+                          selectedColor === color.index
+                            ? 'border-white scale-110'
+                            : 'border-gray-700 hover:border-gray-500'
+                        }`}
+                        style={{ backgroundColor: paletteToHex(color.r, color.g, color.b) }}
+                        onClick={() => setSelectedColor(color.index)}
+                      />
+                    ))}
+                  </div>
+                  <p className="text-xs text-gray-500 mt-1">
+                    Selected: {GLYPH_PALETTE[selectedColor]?.name ?? 'Unknown'}
+                  </p>
+                </div>
+                <div>
+                  <h4 className="text-sm font-medium text-gray-400 mb-2">Preview</h4>
+                  <canvas
+                    ref={canvasRef}
+                    width={PREVIEW_SIZE}
+                    height={PREVIEW_SIZE}
+                    className="border border-gray-700 rounded bg-black"
+                    style={{ imageRendering: 'pixelated' }}
+                  />
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Step 3: Availability */}
+          {wizard.currentStep === 2 && (
+            <div className="space-y-4">
+              <div className="p-4 rounded-lg bg-gray-800/50">
+                <div className="flex items-start gap-6">
+                  <canvas
+                    ref={canvasRef}
+                    width={PREVIEW_SIZE}
+                    height={PREVIEW_SIZE}
+                    className="border border-gray-700 rounded bg-black shrink-0"
+                    style={{ imageRendering: 'pixelated' }}
+                  />
+                  <div className="space-y-3 flex-1">
+                    <p className="text-sm text-gray-300">
+                      Each glyph design must be unique. Check whether this bitmap has
+                      already been claimed before proceeding.
+                    </p>
+                    <button
+                      type="button"
+                      onClick={runAvailabilityCheck}
+                      disabled={checking}
+                      className="px-3 py-1.5 text-sm bg-blue-600 hover:bg-blue-500 text-white rounded transition-colors disabled:opacity-50"
+                    >
+                      {checking ? 'Checking…' : 'Check Availability'}
+                    </button>
+                    {availability?.checked && (
+                      <div className="space-y-2">
+                        <div className="flex items-center gap-2">
+                          {availability.available ? (
+                            <Badge variant="success">Available</Badge>
+                          ) : (
+                            <Badge variant="error">Already claimed</Badge>
+                          )}
+                        </div>
+                        <p className="text-xs text-gray-500 font-mono break-all">
+                          {availability.hash.slice(0, 32)}…
+                        </p>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Step 4: Claim */}
+          {wizard.currentStep === 3 && (
+            <div className="space-y-4">
+              <div className="p-4 rounded-lg bg-gray-800/50">
+                <div className="flex items-start gap-6">
+                  <canvas
+                    ref={canvasRef}
+                    width={PREVIEW_SIZE}
+                    height={PREVIEW_SIZE}
+                    className="border border-gray-700 rounded bg-black shrink-0"
+                    style={{ imageRendering: 'pixelated' }}
+                  />
+                  <div className="flex-1">
+                    <Input
+                      label="Ghost ID"
+                      type="text"
+                      value={data.ghost_id}
+                      onChange={(e) => setData({ ghost_id: e.target.value })}
+                      placeholder="ghost1..."
+                    />
+                    <p className="text-sm text-gray-400 mt-2">
+                      The Ghost identity this glyph will be bound to. Prefilled from this
+                      node when available.
+                    </p>
+                  </div>
+                </div>
+              </div>
+              <div className="p-4 rounded-lg bg-orange-900/20 border border-orange-800">
+                <p className="text-sm text-orange-300">
+                  Click Finish to claim this glyph. The binding is permanent and cannot
+                  be undone.
+                </p>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </WizardDialog>
+  );
+}

--- a/dashboard/src/app/(dashboard)/settings/wizards/SendPaymentWizard.tsx
+++ b/dashboard/src/app/(dashboard)/settings/wizards/SendPaymentWizard.tsx
@@ -1,0 +1,314 @@
+'use client';
+
+import { useWizard, WizardStep } from '@/hooks/useWizard';
+import { WizardDialog } from '@/components/ui/Wizard';
+import { Input } from '@/components/ui/Input';
+import { Badge } from '@/components/ui/Badge';
+import { useToast } from '@/components/ui/Toast';
+import { useGhostId, useGhostPayStatus, useSendL2Payment } from '@/hooks/queries';
+
+interface SendPaymentData {
+  recipient: string;
+  label: string;
+  amount: string;
+  memo: string;
+}
+
+interface ParsedRecipient {
+  address: string;
+  label: string | null;
+  valid: boolean;
+}
+
+// A Ghost ID is a bech32m identity string. Mainnet uses the `ghost1...`
+// human-readable prefix; test networks prepend the network name
+// (e.g. `signetghost1...`, `testghost1...`). An optional `?l=N` query hint
+// carries a label index the sender can attach to the payment.
+function parseRecipient(raw: string): ParsedRecipient {
+  const trimmed = raw.trim();
+  let address = trimmed;
+  let label: string | null = null;
+
+  const queryIndex = trimmed.indexOf('?');
+  if (queryIndex !== -1) {
+    address = trimmed.slice(0, queryIndex);
+    const query = new URLSearchParams(trimmed.slice(queryIndex + 1));
+    const l = query.get('l');
+    if (l !== null && l.trim() !== '') {
+      label = l.trim();
+    }
+  }
+
+  // bech32m Ghost ID: an optional lowercase network prefix, then `ghost1`,
+  // then the bech32 data part (lowercase alphanumeric, excluding 1/b/i/o).
+  const valid = /^[a-z]*ghost1[ac-hj-np-z02-9]{6,}$/.test(address);
+
+  return { address, label, valid };
+}
+
+interface SendPaymentWizardProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export default function SendPaymentWizard({ isOpen, onClose }: SendPaymentWizardProps) {
+  const toast = useToast();
+  const sendPayment = useSendL2Payment();
+  const ghostIdQuery = useGhostId({ enabled: isOpen });
+  const statusQuery = useGhostPayStatus();
+
+  const availableSats = statusQuery.data?.total_balances ?? null;
+
+  const steps: WizardStep<SendPaymentData>[] = [
+    {
+      id: 'recipient',
+      title: 'Recipient',
+      description: "Enter the recipient's Ghost ID",
+      validate: (data) => {
+        const parsed = parseRecipient(data.recipient);
+        if (!parsed.address) {
+          return 'Enter a recipient Ghost ID';
+        }
+        if (!parsed.valid) {
+          return 'Invalid Ghost ID (must be a bech32m identity, e.g. ghost1...)';
+        }
+        return null;
+      },
+    },
+    {
+      id: 'amount',
+      title: 'Amount',
+      description: 'Enter the amount to send',
+      validate: (data) => {
+        const amount = Number(data.amount);
+        if (!data.amount.trim() || !Number.isFinite(amount)) {
+          return 'Enter an amount in satoshis';
+        }
+        if (!Number.isInteger(amount) || amount <= 0) {
+          return 'Amount must be a whole number of satoshis greater than 0';
+        }
+        if (availableSats !== null && amount > availableSats) {
+          return `Amount exceeds your available L2 balance (${availableSats.toLocaleString()} sats)`;
+        }
+        if (data.memo.length > 59) {
+          return 'Memo cannot exceed 59 characters';
+        }
+        return null;
+      },
+    },
+    {
+      id: 'review',
+      title: 'Review',
+      description: 'Review the payment details',
+    },
+    {
+      id: 'confirm',
+      title: 'Confirm',
+      description: 'Send the payment',
+      onSubmit: async (data) => {
+        const parsed = parseRecipient(data.recipient);
+        const senderGhostId = ghostIdQuery.data?.ghost_id;
+        if (!senderGhostId) {
+          throw new Error('Could not determine this node’s Ghost ID');
+        }
+        try {
+          const result = await sendPayment.mutateAsync({
+            senderGhostId,
+            recipient: parsed.address,
+            amountSats: Number(data.amount),
+            memo: data.memo.trim() || undefined,
+          });
+          // The send route returns HTTP 200 with { success: false, error }
+          // for business failures (insufficient balance, zero amount, etc.).
+          if (!result.success) {
+            const detail =
+              result.available_sats !== undefined && result.requested_sats !== undefined
+                ? `${result.error ?? 'Payment rejected'} (have ${result.available_sats.toLocaleString()} sats, need ${result.requested_sats.toLocaleString()})`
+                : result.error || 'Payment was rejected';
+            throw new Error(detail);
+          }
+          toast.success(
+            'Payment Sent',
+            `${Number(data.amount).toLocaleString()} sats to ${parsed.address.slice(0, 14)}... — payment ${result.payment_id ?? '(pending)'} (${result.status ?? 'pending'})`
+          );
+          onClose();
+        } catch (err) {
+          const message = err instanceof Error ? err.message : 'Failed to send payment';
+          toast.error('Payment Failed', message);
+          throw err;
+        }
+      },
+    },
+  ];
+
+  const wizard = useWizard<SendPaymentData>({
+    steps,
+    initialData: {
+      recipient: '',
+      label: '',
+      amount: '',
+      memo: '',
+    },
+  });
+
+  const parsed = parseRecipient(wizard.data.recipient);
+
+  return (
+    <WizardDialog
+      isOpen={isOpen}
+      onClose={onClose}
+      title="Send L2 Payment"
+      wizard={wizard}
+      size="lg"
+    >
+      {(data, setData) => (
+        <div className="space-y-6">
+          {/* Step 1: Recipient */}
+          {wizard.currentStep === 0 && (
+            <div className="space-y-4">
+              <div className="p-4 rounded-lg bg-gray-800/50">
+                <Input
+                  label="Recipient Ghost ID"
+                  type="text"
+                  value={data.recipient}
+                  onChange={(e) => setData({ recipient: e.target.value })}
+                  placeholder="ghost1..."
+                />
+                <p className="text-sm text-gray-400 mt-2">
+                  A bech32m Ghost identity. An optional <code>?l=N</code> label hint is
+                  recognised and stripped automatically.
+                </p>
+                {parsed.label !== null && parsed.address && (
+                  <p className="text-sm text-gray-300 mt-2">
+                    Label hint detected: <Badge variant="info">{parsed.label}</Badge>
+                  </p>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* Step 2: Amount */}
+          {wizard.currentStep === 1 && (
+            <div className="space-y-4">
+              <div className="p-4 rounded-lg bg-gray-800/50">
+                <div className="flex items-center justify-between mb-3">
+                  <span className="text-gray-400 text-sm">Available L2 balance</span>
+                  <span className="text-gray-100 font-mono text-sm">
+                    {statusQuery.isLoading
+                      ? 'Loading…'
+                      : availableSats !== null
+                        ? `${availableSats.toLocaleString()} sats`
+                        : 'Unavailable'}
+                  </span>
+                </div>
+                <Input
+                  label="Amount (sats)"
+                  type="number"
+                  min={1}
+                  step={1}
+                  value={data.amount}
+                  onChange={(e) => setData({ amount: e.target.value })}
+                  placeholder="e.g. 10000"
+                />
+                <div className="mt-4">
+                  <Input
+                    label="Memo (optional)"
+                    type="text"
+                    value={data.memo}
+                    onChange={(e) => setData({ memo: e.target.value })}
+                    placeholder="Up to 59 characters"
+                  />
+                  <p className="text-sm text-gray-400 mt-2">
+                    Attached to the payment for your reference. Maximum 59 characters.
+                  </p>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Step 3: Review */}
+          {wizard.currentStep === 2 && (
+            <div className="space-y-4">
+              <div className="p-4 rounded-lg bg-gray-800/50">
+                <h4 className="text-gray-100 font-medium mb-3">Payment Summary</h4>
+                <div className="space-y-2">
+                  <div className="flex items-center justify-between">
+                    <span className="text-gray-400">Recipient</span>
+                    <span className="text-gray-100 font-mono text-sm">
+                      {parsed.address.slice(0, 18)}...
+                    </span>
+                  </div>
+                  {parsed.label !== null && (
+                    <div className="flex items-center justify-between">
+                      <span className="text-gray-400">Label</span>
+                      <Badge variant="info">{parsed.label}</Badge>
+                    </div>
+                  )}
+                  <div className="flex items-center justify-between">
+                    <span className="text-gray-400">Amount</span>
+                    <span className="text-gray-100 font-mono">
+                      {Number(data.amount || 0).toLocaleString()} sats
+                    </span>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span className="text-gray-400">Network fee</span>
+                    <span className="text-gray-100">
+                      None (off-chain L2 transfer)
+                    </span>
+                  </div>
+                  {data.memo.trim() && (
+                    <div className="flex items-center justify-between">
+                      <span className="text-gray-400">Memo</span>
+                      <span className="text-gray-100 text-sm">{data.memo.trim()}</span>
+                    </div>
+                  )}
+                </div>
+              </div>
+              <div className="p-4 rounded-lg bg-gray-800/50">
+                <div className="flex items-center justify-between">
+                  <span className="text-gray-400 text-sm">Paying from (this node)</span>
+                  <span className="text-gray-100 font-mono text-sm">
+                    {ghostIdQuery.data?.ghost_id
+                      ? `${ghostIdQuery.data.ghost_id.slice(0, 18)}...`
+                      : ghostIdQuery.isLoading
+                        ? 'Loading…'
+                        : 'Unavailable'}
+                  </span>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Step 4: Confirm */}
+          {wizard.currentStep === 3 && (
+            <div className="space-y-4">
+              <div className="p-4 rounded-lg bg-gray-800/50">
+                <h4 className="text-gray-100 font-medium mb-3">Ready to Send</h4>
+                <div className="space-y-2">
+                  <div className="flex items-center justify-between">
+                    <span className="text-gray-400">Amount</span>
+                    <span className="text-gray-100 font-mono">
+                      {Number(data.amount || 0).toLocaleString()} sats
+                    </span>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span className="text-gray-400">Recipient</span>
+                    <span className="text-gray-100 font-mono text-sm">
+                      {parsed.address.slice(0, 18)}...
+                    </span>
+                  </div>
+                </div>
+              </div>
+              <div className="p-4 rounded-lg bg-orange-900/20 border border-orange-800">
+                <p className="text-sm text-orange-300">
+                  Click Finish to send this instant L2 payment. The transfer is recorded
+                  immediately and cannot be reversed.
+                </p>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </WizardDialog>
+  );
+}

--- a/dashboard/src/app/(dashboard)/settings/wizards/page.tsx
+++ b/dashboard/src/app/(dashboard)/settings/wizards/page.tsx
@@ -15,6 +15,8 @@ import MempoolPolicyWizard from "./MempoolPolicyWizard";
 import GhostIdWizard from "./GhostIdWizard";
 import CreateLockWizard from "./CreateLockWizard";
 import WithdrawWizard from "./WithdrawWizard";
+import SendPaymentWizard from "./SendPaymentWizard";
+import GlyphWizard from "./GlyphWizard";
 
 export default function WizardsSettingsPage() {
   const [initialSetupOpen, setInitialSetupOpen] = useState(false);
@@ -29,6 +31,8 @@ export default function WizardsSettingsPage() {
   const [ghostIdOpen, setGhostIdOpen] = useState(false);
   const [createLockOpen, setCreateLockOpen] = useState(false);
   const [withdrawOpen, setWithdrawOpen] = useState(false);
+  const [sendPaymentOpen, setSendPaymentOpen] = useState(false);
+  const [glyphOpen, setGlyphOpen] = useState(false);
 
   return (
     <>
@@ -71,6 +75,12 @@ export default function WizardsSettingsPage() {
           <Button variant="outline" size="lg" onClick={() => setWithdrawOpen(true)} className="w-full">
             Withdraw
           </Button>
+          <Button variant="outline" size="lg" onClick={() => setSendPaymentOpen(true)} className="w-full">
+            Send Payment
+          </Button>
+          <Button variant="outline" size="lg" onClick={() => setGlyphOpen(true)} className="w-full">
+            Glyph
+          </Button>
         </div>
       </Card>
 
@@ -86,6 +96,8 @@ export default function WizardsSettingsPage() {
       <GhostIdWizard isOpen={ghostIdOpen} onClose={() => setGhostIdOpen(false)} />
       <CreateLockWizard isOpen={createLockOpen} onClose={() => setCreateLockOpen(false)} />
       <WithdrawWizard isOpen={withdrawOpen} onClose={() => setWithdrawOpen(false)} />
+      <SendPaymentWizard isOpen={sendPaymentOpen} onClose={() => setSendPaymentOpen(false)} />
+      <GlyphWizard isOpen={glyphOpen} onClose={() => setGlyphOpen(false)} />
     </>
   );
 }

--- a/dashboard/src/hooks/queries/useGhostPayQueries.ts
+++ b/dashboard/src/hooks/queries/useGhostPayQueries.ts
@@ -11,6 +11,8 @@ import {
   joinWraithSession,
   requestLockSettlement,
   useLockInMix as apiUseLockInMix,
+  getGhostId,
+  sendL2Payment,
 } from '@/lib/api/ghostpay';
 import type { PayoutHistoryTimeFilter } from '@/types/api';
 
@@ -26,7 +28,17 @@ export const ghostPayKeys = {
   settlementStatus: () => [...ghostPayKeys.all, 'settlement-status'] as const,
   payoutHistory: (timeFilter: PayoutHistoryTimeFilter) =>
     [...ghostPayKeys.all, 'payout-history', timeFilter] as const,
+  ghostId: () => [...ghostPayKeys.all, 'ghost-id'] as const,
 };
+
+export function useGhostId(options?: { enabled?: boolean }) {
+  return useQuery({
+    queryKey: ghostPayKeys.ghostId(),
+    queryFn: getGhostId,
+    enabled: options?.enabled ?? true,
+    staleTime: Infinity,
+  });
+}
 
 export function useGhostPayStatus(options?: { refetchInterval?: number }) {
   return useQuery({
@@ -103,6 +115,29 @@ export function useUseLockInMix() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ghostPayKeys.locks() });
       queryClient.invalidateQueries({ queryKey: ghostPayKeys.wraith() });
+    },
+  });
+}
+
+export function useSendL2Payment() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (config: {
+      senderGhostId: string;
+      recipient: string;
+      amountSats: number;
+      memo?: string;
+    }) =>
+      sendL2Payment({
+        sender_ghost_id: config.senderGhostId,
+        recipient: config.recipient,
+        amount_sats: config.amountSats,
+        memo: config.memo,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ghostPayKeys.payments() });
+      queryClient.invalidateQueries({ queryKey: ghostPayKeys.status() });
     },
   });
 }

--- a/dashboard/src/lib/api/ghostpay.ts
+++ b/dashboard/src/lib/api/ghostpay.ts
@@ -1,5 +1,5 @@
 // Ghost Pay API endpoints
-import { fetchApi } from './client';
+import { fetchApi, fetchWithTimeout } from './client';
 import type {
   GhostPayStatus,
   WraithSessionsResponse,
@@ -156,14 +156,96 @@ export async function reconcileLock(lockId: string, config: {
   });
 }
 
-// Send L2 instant payment
+// ---------------------------------------------------------------------------
+// Pay-node write routes
+//
+// The L2 payment-send and read-only ghost-id routes live on the ghost-pay
+// node (port 8800), reached through the dashboard's `/api/ghostpay-proxy`
+// route (which HMAC-signs the request). This is a DIFFERENT backend from the
+// read-only `/api/proxy` (ghost-pool, port 8080) used by the getters above,
+// so these functions must go through their own proxy base — mirroring the
+// helper in `glyph.ts`.
+// ---------------------------------------------------------------------------
+
+function getGhostPayProxyBase(): string {
+  if (typeof window !== 'undefined') {
+    return window.location.origin;
+  }
+  return 'http://localhost:3000';
+}
+
+async function fetchGhostPay<T>(endpoint: string, options?: RequestInit): Promise<T> {
+  const proxyUrl = `${getGhostPayProxyBase()}/api/ghostpay-proxy${endpoint}`;
+
+  const response = await fetchWithTimeout(proxyUrl, {
+    ...options,
+    headers: {
+      'Content-Type': 'application/json',
+      ...options?.headers,
+    },
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ error: 'Unknown error' }));
+    throw new Error(error.error || `API error: ${response.status}`);
+  }
+
+  return response.json();
+}
+
+export interface GhostIdInfo {
+  ghost_id: string;
+  scan_pubkey: string;
+  spend_pubkey: string;
+}
+
+// Read the node's Ghost ID (derived from the operator's keys).
+// GET /api/v1/keys/ghost-id  (ghost-pay, read-only)
+export async function getGhostId(): Promise<GhostIdInfo> {
+  return fetchGhostPay<GhostIdInfo>('/api/v1/keys/ghost-id');
+}
+
+export interface SendL2PaymentResponse {
+  success: boolean;
+  error?: string;
+  payment_id?: string;
+  sender?: string;
+  recipient?: string;
+  amount_sats?: number;
+  memo?: string | null;
+  status?: string;
+  proof_required?: boolean;
+  message?: string;
+  // Returned on the "insufficient balance" business failure.
+  available_sats?: number;
+  requested_sats?: number;
+}
+
+// Send an L2 instant payment.
+//
+// POST /api/v1/payments/send  (ghost-pay, port 8800 via the ghostpay-proxy).
+// This is a ONE-SHOT call — the L2 transfer is recorded immediately; there
+// is no prepare→submit handshake (an off-chain transfer produces no on-chain
+// tx and needs no per-payment sighash). The handler returns HTTP 200 with
+// `{ success: false, error }` for business failures (insufficient balance,
+// zero amount, missing recipient/keys), so callers must check `success`.
+//
+// `sender_ghost_id` identifies the paying wallet; the dashboard supplies the
+// node's own Ghost ID (read via `getGhostId`) since the operator pays from
+// their node's Ghost Pay balance.
 export async function sendL2Payment(config: {
+  sender_ghost_id: string;
   recipient: string;
   amount_sats: number;
   memo?: string;
-}): Promise<{ success: boolean; payment_id?: string; message: string }> {
-  return fetchApi('/api/v1/payments/send', {
+}): Promise<SendL2PaymentResponse> {
+  return fetchGhostPay<SendL2PaymentResponse>('/api/v1/payments/send', {
     method: 'POST',
-    body: JSON.stringify(config),
+    body: JSON.stringify({
+      sender_ghost_id: config.sender_ghost_id,
+      recipient: config.recipient,
+      amount_sats: config.amount_sats,
+      memo: config.memo,
+    }),
   });
 }


### PR DESCRIPTION
Two new operator-dashboard wizards.
- **Send Payment** → `POST /api/v1/payments/send` (one-shot off-chain L2 transfer; body `{sender_ghost_id, recipient, amount_sats, memo}`). Recipient accepts `ghost1…?l=N` label hints; amount step shows the node's L2 balance.
- **Glyph** → reuses the glyph canvas; `GET /api/v1/glyph/check/:hash` then `POST /api/v1/glyph/claim`. Replaces a previously dead wizard reference.

Also fixes `sendL2Payment` which targeted the read-only ghost-pool proxy (:8080) instead of the auth-gated ghost-pay node (:8800) and omitted `sender_ghost_id`. `tsc --noEmit` + eslint clean.

NOTE: overlaps PR #89 in `ghostpay.ts`, `useGhostPayQueries.ts`, `wizards/page.tsx` — should be merged after #89 (will rebase to resolve).