### PR TITLE
ghost-common: fix cargo fmt on dust-flood flag emission

### DIFF
--- a/crates/ghost-common/src/config.rs
+++ b/crates/ghost-common/src/config.rs
@@ -1483,10 +1483,7 @@ impl ReaperSettings {
             format!("-ghostreaper-rejectannex={}", b(self.reject_annex)),
             format!("-ghostreaper-rejectopreturn={}", b(self.reject_opreturn)),
             format!("-ghostreaper-rejectrunestone={}", b(self.reject_runestone)),
-            format!(
-                "-ghostreaper-rejectdustflood={}",
-                b(self.reject_dustflood)
-            ),
+            format!("-ghostreaper-rejectdustflood={}", b(self.reject_dustflood)),
             format!("-ghostreaper-maxopreturn={}", self.max_op_return_bytes),
             format!(
                 "-ghostreaper-dustfloodthreshold={}",


### PR DESCRIPTION
Trivial `cargo fmt` fix — the dust-flood `format!` line in `ReaperSettings::ghostd_flags` (PR #88) was committed unformatted and broke the Format CI check on main. Compresses it to one line. No behaviour change.