### PR TITLE
ghost-gsp: fix cargo doc collision between binary and library crates

### DIFF
--- a/bins/ghost-gsp/Cargo.toml
+++ b/bins/ghost-gsp/Cargo.toml
@@ -32,6 +32,10 @@ readme = "README.md"
 [[bin]]
 name = "ghost-gsp"
 path = "src/main.rs"
+# The library crate `ghost-gsp` (crates/ghost-gsp) also documents as `ghost_gsp`,
+# so documenting this binary target collides on target/doc/ghost_gsp/ and races
+# `cargo doc` to an I/O error. Binary entry-points carry no useful rustdoc; skip them.
+doc = false
 
 [dependencies]
 # Workspace crates


### PR DESCRIPTION
The `Documentation` CI job fails intermittently while building rustdoc.

## Root cause
The binary target `ghost-gsp` (package `ghost-gsp-bin`, `bins/ghost-gsp`) and the library crate `ghost-gsp` (`crates/ghost-gsp`) both document under the same path `target/doc/ghost_gsp/`. `cargo doc` runs the two units in parallel, so they race to create/write that directory and one of them dies with:

```
warning: output filename collision at target/doc/ghost_gsp/index.html
error: couldn't generate documentation: I/O error
error: could not document `ghost-gsp-bin`
```

The collision warning is present on every run (including the passing ones on `main`); the I/O failure is the race surfacing, which is why it only fails some of the time.

## Fix
Set `doc = false` on the binary target in `bins/ghost-gsp/Cargo.toml`. Binary entry-points carry no useful rustdoc, and the library crate keeps documenting at `ghost_gsp/`. This removes the duplicate output path entirely, so the race can no longer occur.

## Verification
`RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p ghost-gsp -p ghost-gsp-bin` now documents only the library, with no collision warning and a clean exit.