### PR TITLE
chore: bump workspace version to 1.10.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-ghost-tests"
-version = "1.10.3"
+version = "1.10.4"
 dependencies = [
  "bitcoin",
  "chrono",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin_core_sv2"
-version = "1.10.3"
+version = "1.10.4"
 dependencies = [
  "async-channel 1.9.0",
  "bitcoin-capnp-types",
@@ -3083,7 +3083,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-accounting"
-version = "1.10.3"
+version = "1.10.4"
 dependencies = [
  "bitcoin",
  "ghost-common",
@@ -3097,7 +3097,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-buds"
-version = "1.10.3"
+version = "1.10.4"
 dependencies = [
  "bitcoin",
  "ghost-common",
@@ -3111,7 +3111,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-cli"
-version = "1.10.3"
+version = "1.10.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3129,7 +3129,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-common"
-version = "1.10.3"
+version = "1.10.4"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -3162,7 +3162,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-consensus"
-version = "1.10.3"
+version = "1.10.4"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3193,7 +3193,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-glyph"
-version = "1.10.3"
+version = "1.10.4"
 dependencies = [
  "hex",
  "serde",
@@ -3204,7 +3204,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-gsp"
-version = "1.10.3"
+version = "1.10.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3266,7 +3266,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-gsp-proto"
-version = "1.10.3"
+version = "1.10.4"
 dependencies = [
  "bitcoin",
  "chrono",
@@ -3283,7 +3283,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-keys"
-version = "1.10.3"
+version = "1.10.4"
 dependencies = [
  "bech32",
  "bitcoin",
@@ -3305,7 +3305,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-locks"
-version = "1.10.3"
+version = "1.10.4"
 dependencies = [
  "bitcoin",
  "getrandom 0.2.17",
@@ -3348,7 +3348,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-pay"
-version = "1.10.3"
+version = "1.10.4"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3395,7 +3395,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-policy"
-version = "1.10.3"
+version = "1.10.4"
 dependencies = [
  "bitcoin",
  "ghost-buds",
@@ -3408,7 +3408,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-pool"
-version = "1.10.3"
+version = "1.10.4"
 dependencies = [
  "anyhow",
  "async-channel 2.5.0",
@@ -3461,7 +3461,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-reaper"
-version = "1.10.3"
+version = "1.10.4"
 dependencies = [
  "bitcoin",
  "hex",
@@ -3473,7 +3473,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-reconciliation"
-version = "1.10.3"
+version = "1.10.4"
 dependencies = [
  "async-trait",
  "bitcoin",
@@ -3499,7 +3499,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-registry"
-version = "1.10.3"
+version = "1.10.4"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -3534,7 +3534,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-setup"
-version = "1.10.3"
+version = "1.10.4"
 dependencies = [
  "clap",
  "dirs 5.0.1",
@@ -3545,7 +3545,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-storage"
-version = "1.10.3"
+version = "1.10.4"
 dependencies = [
  "base64 0.22.1",
  "chacha20poly1305",
@@ -3566,7 +3566,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-tap-core"
-version = "1.10.3"
+version = "1.10.4"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3608,7 +3608,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-tap-desktop"
-version = "1.10.3"
+version = "1.10.4"
 dependencies = [
  "dirs 6.0.0",
  "getrandom 0.2.17",
@@ -3634,7 +3634,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-tap-integration"
-version = "1.10.3"
+version = "1.10.4"
 dependencies = [
  "ghost-gsp-proto",
  "ghost-tap-core",
@@ -3648,7 +3648,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-template"
-version = "1.10.3"
+version = "1.10.4"
 dependencies = [
  "bitcoin",
  "ghost-buds",
@@ -3664,7 +3664,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-verification"
-version = "1.10.3"
+version = "1.10.4"
 dependencies = [
  "axum 0.7.9",
  "bitcoin",
@@ -4636,7 +4636,7 @@ dependencies = [
 
 [[package]]
 name = "jd_client_sv2"
-version = "1.10.3"
+version = "1.10.4"
 dependencies = [
  "async-channel 1.9.0",
  "bitcoin_core_sv2",
@@ -4652,7 +4652,7 @@ dependencies = [
 
 [[package]]
 name = "jd_server_sv2"
-version = "1.10.3"
+version = "1.10.4"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -6153,7 +6153,7 @@ dependencies = [
 
 [[package]]
 name = "pool_sv2"
-version = "1.10.3"
+version = "1.10.4"
 dependencies = [
  "async-channel 1.9.0",
  "bitcoin_core_sv2",
@@ -7877,7 +7877,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stratum-apps"
-version = "1.10.3"
+version = "1.10.4"
 dependencies = [
  "async-channel 1.9.0",
  "axum 0.8.9",
@@ -9090,7 +9090,7 @@ dependencies = [
 
 [[package]]
 name = "translator_sv2"
-version = "1.10.3"
+version = "1.10.4"
 dependencies = [
  "async-channel 1.9.0",
  "clap",
@@ -10421,7 +10421,7 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "wraith-coordinator"
-version = "1.10.3"
+version = "1.10.4"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -10452,7 +10452,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-protocol"
-version = "1.10.3"
+version = "1.10.4"
 dependencies = [
  "bitcoin",
  "getrandom 0.2.17",
@@ -10473,7 +10473,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-cli"
-version = "1.10.3"
+version = "1.10.4"
 dependencies = [
  "clap",
  "clap_complete",
@@ -10486,7 +10486,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-core"
-version = "1.10.3"
+version = "1.10.4"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -10523,7 +10523,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-daemon"
-version = "1.10.3"
+version = "1.10.4"
 dependencies = [
  "axum 0.7.9",
  "base64 0.22.1",
@@ -10546,7 +10546,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-gui"
-version = "1.10.3"
+version = "1.10.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -10560,7 +10560,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-ipc"
-version = "1.10.3"
+version = "1.10.4"
 dependencies = [
  "libc",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ exclude = []
 # Use scripts/build-all-wallets.sh to build all wallet types.
 
 [workspace.package]
-version = "1.10.3"
+version = "1.10.4"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Bitcoin Ghost Team"]


### PR DESCRIPTION
Version bump rolling up the 23 commits merged to `main` since the `v1.10.3` release (2026-06-25).

## Highlights since v1.10.3
- **reaper**: dust-flood vector `-ghostreaper-rejectdustflood`, surfaced in node config + operator dashboard (#87 / #88 / #92). Deployed fleet-wide — mempool filtering now at ~Knots level with zero false positives.
- **pool**: best-hash records converge across the mesh; web records temporal latch + correct payout count (#80).
- **translator**: opt-in TLS stratum listener (#81).
- **pool**: gated read-only coordinator-election service (#82).
- **scripts**: one-command public node installer (pinned checksum + signing key, ghostd-sync gating).
- **ci**: quarantine 2 flaky heavy integration tests on macOS (#86).
- headless end-to-end smoke test for the Wraith wallet (#85).

SV2 crates inherit the workspace version. No API change.

## Release step
Once this merges, tag `v1.10.4` on `main` to trigger `release.yml` (signed `SHA256SUMS.txt.asc` + draft release), then publish the draft.