### PR TITLE
Wraith coordinator: decentralised node-discovery + in-process role activation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3413,6 +3413,7 @@ dependencies = [
  "anyhow",
  "async-channel 2.5.0",
  "async-trait",
+ "axum 0.7.9",
  "binary_sv2 5.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitcoin",
  "bs58 0.4.0",
@@ -3456,6 +3457,7 @@ dependencies = [
  "toml 0.8.2",
  "tracing",
  "tracing-subscriber",
+ "wraith-coordinator",
  "wraith-protocol",
 ]
 
@@ -10540,6 +10542,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "wraith-protocol",
  "wraith-wallet-core",
  "wraith-wallet-ipc",
 ]

--- a/apps/wraith-wallet/daemon/Cargo.toml
+++ b/apps/wraith-wallet/daemon/Cargo.toml
@@ -13,6 +13,8 @@ path = "src/main.rs"
 [dependencies]
 wraith-wallet-core = { workspace = true }
 wraith-wallet-ipc = { workspace = true }
+# Coordinator-seat sharding (shard_for) for resolving an elected coordinator.
+wraith-protocol = { workspace = true }
 ghost-gsp-proto = { workspace = true }
 ghost-keys = { workspace = true }
 bitcoin = { workspace = true }

--- a/apps/wraith-wallet/daemon/src/coordinator_resolve.rs
+++ b/apps/wraith-wallet/daemon/src/coordinator_resolve.rs
@@ -1,0 +1,90 @@
+//! Resolve which seated Wraith coordinator owns a wallet's mix, from the node's
+//! published election view — so a wallet can mix without being handed a
+//! coordinator URL.
+//!
+//! Inc 5 of `tasks/plan_coordinator_activation.md` — the daemon-side plumbing.
+//! This is the channel-agnostic *picker*: it takes the election JSON and returns
+//! the owning seat's endpoint. The wallet must obtain that JSON **through
+//! ghost-pay**, never by reaching the node's pool API directly (wallet hard rule,
+//! `apps/wraith-wallet/CLAUDE.md`) — so the fetch path is a small ghost-pay relay
+//! wired together with the GUI "use the network-elected coordinator" toggle (the
+//! explicitly-deferred next task). Hence `allow(dead_code)` for now: tested and
+//! ready, just not yet called.
+#![allow(dead_code)]
+
+use wraith_protocol::sortition::shard_for;
+
+/// Pick the coordinator endpoint that owns `shard_key` from a node's
+/// `/api/v1/pool/coordinator` JSON. Pure (no I/O) so it is unit-testable.
+///
+/// Shards across the node's *published* seat count, so the wallet and the node
+/// agree on the owner, and so all wallets that share a key (e.g. the same
+/// tier+epoch) converge on the same seat — a larger anonymity set, not load
+/// spreading. Returns `None` when the election is disabled/empty, or the owning
+/// seat hasn't advertised an endpoint yet (caller falls back).
+pub fn pick_seat_endpoint(status: &serde_json::Value, shard_key: &[u8; 32]) -> Option<String> {
+    if status.get("enabled").and_then(|v| v.as_bool()) != Some(true) {
+        return None;
+    }
+    let coords = status.get("coordinators")?.as_array()?;
+    if coords.is_empty() {
+        return None;
+    }
+    let seat = shard_for(shard_key, coords.len());
+    let owner = coords
+        .iter()
+        .find(|c| c.get("seat").and_then(|s| s.as_u64()) == Some(seat as u64))?;
+    owner
+        .get("endpoint")
+        .and_then(|e| e.as_str())
+        .filter(|e| !e.is_empty())
+        .map(String::from)
+}
+
+// NOTE: the *fetch* of the election JSON is deliberately not here. The wallet
+// must request it via ghost-pay (hard rule: never hit the node's pool API
+// directly), so the relay + the GUI toggle that supplies the shard key land
+// together in the next task. This module owns only the channel-agnostic pick.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn status(enabled: bool, coords: serde_json::Value) -> serde_json::Value {
+        json!({ "enabled": enabled, "coordinators": coords })
+    }
+
+    #[test]
+    fn picks_a_seated_endpoint_deterministically_for_a_key() {
+        let s = status(
+            true,
+            json!([
+                {"node_id":"aa","seat":0,"endpoint":"http://a:9100"},
+                {"node_id":"bb","seat":1,"endpoint":"http://b:9100"},
+            ]),
+        );
+        let key = [7u8; 32];
+        // Same key → same owner (so wallets converge), and it's one of the seats.
+        let a = pick_seat_endpoint(&s, &key);
+        assert_eq!(a, pick_seat_endpoint(&s, &key));
+        assert!(matches!(
+            a.as_deref(),
+            Some("http://a:9100") | Some("http://b:9100")
+        ));
+    }
+
+    #[test]
+    fn none_when_disabled_empty_or_unadvertised() {
+        // Disabled election.
+        assert_eq!(pick_seat_endpoint(&status(false, json!([])), &[0u8; 32]), None);
+        // No coordinators seated.
+        assert_eq!(pick_seat_endpoint(&status(true, json!([])), &[0u8; 32]), None);
+        // Single seat whose owner hasn't advertised an endpoint yet.
+        let s = status(true, json!([{"node_id":"aa","seat":0,"endpoint":null}]));
+        assert_eq!(pick_seat_endpoint(&s, &[0u8; 32]), None);
+        // Empty-string endpoint is treated as unadvertised.
+        let s = status(true, json!([{"node_id":"aa","seat":0,"endpoint":""}]));
+        assert_eq!(pick_seat_endpoint(&s, &[0u8; 32]), None);
+    }
+}

--- a/apps/wraith-wallet/daemon/src/coordinator_resolve.rs
+++ b/apps/wraith-wallet/daemon/src/coordinator_resolve.rs
@@ -77,9 +77,15 @@ mod tests {
     #[test]
     fn none_when_disabled_empty_or_unadvertised() {
         // Disabled election.
-        assert_eq!(pick_seat_endpoint(&status(false, json!([])), &[0u8; 32]), None);
+        assert_eq!(
+            pick_seat_endpoint(&status(false, json!([])), &[0u8; 32]),
+            None
+        );
         // No coordinators seated.
-        assert_eq!(pick_seat_endpoint(&status(true, json!([])), &[0u8; 32]), None);
+        assert_eq!(
+            pick_seat_endpoint(&status(true, json!([])), &[0u8; 32]),
+            None
+        );
         // Single seat whose owner hasn't advertised an endpoint yet.
         let s = status(true, json!([{"node_id":"aa","seat":0,"endpoint":null}]));
         assert_eq!(pick_seat_endpoint(&s, &[0u8; 32]), None);

--- a/apps/wraith-wallet/daemon/src/main.rs
+++ b/apps/wraith-wallet/daemon/src/main.rs
@@ -9,6 +9,10 @@
 //! `WalletSelect`, and lost when the daemon restarts. Wallet-scoped commands
 //! (`WalletDerive`, `WalletAuthInfo`, `LightReceive`) target the active wallet.
 
+/// Channel-agnostic picker for resolving an elected coordinator's endpoint
+/// (fetch path lands with the GUI toggle; see the module docs).
+mod coordinator_resolve;
+
 #[cfg(not(unix))]
 fn main() {
     eprintln!("wraithd: only Unix-like platforms are supported in phase 0");

--- a/bins/ghost-pool/Cargo.toml
+++ b/bins/ghost-pool/Cargo.toml
@@ -52,11 +52,15 @@ ghost-accounting = { workspace = true }
 ghost-reconciliation = { workspace = true }
 ghost-verification = { workspace = true }
 wraith-protocol = { workspace = true }
+# Embedded in-process Wraith coordinator, run when this node is elected a seat.
+wraith-coordinator = { path = "../wraith-coordinator" }
 ghost-template = { workspace = true }
 ghost-glyph = { workspace = true }
 
 # Async runtime
 tokio = { workspace = true }
+# HTTP server for the embedded coordinator (axum::serve + build_router).
+axum = { workspace = true }
 
 # CLI
 clap = { workspace = true }

--- a/bins/ghost-pool/src/coordinator_election.rs
+++ b/bins/ghost-pool/src/coordinator_election.rs
@@ -51,7 +51,14 @@ pub const COORDINATOR_EPOCH_BLOCKS: u64 = 144;
 
 /// Target number of concurrent coordinator seats per epoch. Sessions are
 /// sharded across these seats so no single coordinator owns every round.
+/// (Demand-driven sizing replaces this fixed target in a later increment.)
 pub const COORDINATOR_SEATS: usize = 5;
+
+/// Freshness window for an advertised coordinator endpoint: a peer must have
+/// pinged within this window to be electable, since a stale endpoint a wallet
+/// can't reach is worse than not seating it. ~5 min, matching the mesh
+/// active-miner freshness.
+const COORDINATOR_PEER_FRESHNESS_SECS: u64 = 300;
 
 /// Domain separator for the beacon hash so it can never collide with any other
 /// hash in the system. Versioned for forward changes.
@@ -117,11 +124,18 @@ struct Cached {
 /// needs to (re)compute a `CoordinatorView` each time the epoch changes, and
 /// caches the latest view for the read-only accessors and the HTTP endpoint.
 pub struct CoordinatorElection {
-    /// This node's own id, and whether it is itself an elder (so it can be in
-    /// the roster). `[u8; 32]`, matches `wraith_protocol`'s `CoordinatorNodeId`.
+    /// This node's own id. `[u8; 32]`, matches `wraith_protocol`'s
+    /// `CoordinatorNodeId`.
     self_id: CoordinatorNodeId,
-    self_is_elder: bool,
-    /// Mesh handle — source of the elder roster (`peers().get_elder_peers()`).
+    /// Whether THIS node opted in as a coordinator (`NodeCapabilities.coordinator`,
+    /// the same opt-in model as `public_mining`). Only opted-in nodes that also
+    /// advertise an endpoint enter the roster.
+    self_coordinator: bool,
+    /// This node's own advertised coordinator endpoint (public `host:port` or a
+    /// `.onion`). Included in the roster + endpoint map only when
+    /// `self_coordinator` and non-empty.
+    self_endpoint: Option<String>,
+    /// Mesh handle — source of the opted-in coordinator peers + their endpoints.
     mesh: Arc<MeshNetwork>,
     /// Ghost Core RPC — source of the beacon anchor (block hash at a height).
     rpc: Arc<BitcoinRpc>,
@@ -135,12 +149,14 @@ impl CoordinatorElection {
     pub fn new(
         identity: &NodeIdentity,
         capabilities: &NodeCapabilities,
+        self_endpoint: Option<String>,
         mesh: Arc<MeshNetwork>,
         rpc: Arc<BitcoinRpc>,
     ) -> Self {
         Self {
             self_id: identity.node_id(),
-            self_is_elder: capabilities.elder_status,
+            self_coordinator: capabilities.coordinator,
+            self_endpoint,
             mesh,
             rpc,
             cached: RwLock::new(None),
@@ -153,30 +169,52 @@ impl CoordinatorElection {
         enabled: bool,
         identity: &NodeIdentity,
         capabilities: &NodeCapabilities,
+        self_endpoint: Option<String>,
         mesh: Arc<MeshNetwork>,
         rpc: Arc<BitcoinRpc>,
     ) -> Option<Arc<Self>> {
         if !enabled {
             return None;
         }
-        Some(Arc::new(Self::new(identity, capabilities, mesh, rpc)))
+        Some(Arc::new(Self::new(
+            identity,
+            capabilities,
+            self_endpoint,
+            mesh,
+            rpc,
+        )))
     }
 
-    /// The qualified roster for this epoch: the current elder node ids, plus
-    /// self when self is an elder. Canonicalised (dedup + sort) so every node
-    /// derives the byte-identical roster from the same membership.
-    fn roster(&self) -> Vec<CoordinatorNodeId> {
-        let mut ids: Vec<CoordinatorNodeId> = self
+    /// The opted-in, reachable coordinator roster for this epoch, plus the
+    /// endpoint map. A peer is eligible iff it (a) advertises the `coordinator`
+    /// capability AND (b) advertised a non-empty endpoint in a recent health
+    /// ping (so a wallet can actually dial it). Self is included iff it opted in
+    /// and has its own advertised endpoint. The roster is canonicalised (dedup +
+    /// sort) so every node derives the byte-identical set + map from the same
+    /// mesh membership.
+    fn roster_with_endpoints(&self) -> (Vec<CoordinatorNodeId>, EndpointMap) {
+        let mut endpoints = EndpointMap::new();
+        let mut ids: Vec<CoordinatorNodeId> = Vec::new();
+        for p in self
             .mesh
             .peers()
-            .get_elder_peers()
-            .into_iter()
-            .map(|p| p.node_id)
-            .collect();
-        if self.self_is_elder {
-            ids.push(self.self_id);
+            .get_connected_peers(COORDINATOR_PEER_FRESHNESS_SECS)
+        {
+            if !p.capabilities.coordinator {
+                continue;
+            }
+            if let Some(ep) = p.coordinator_endpoint.filter(|e| !e.is_empty()) {
+                endpoints.insert(p.node_id, ep);
+                ids.push(p.node_id);
+            }
         }
-        canonical_roster(&ids)
+        if self.self_coordinator {
+            if let Some(ep) = self.self_endpoint.as_deref().filter(|e| !e.is_empty()) {
+                endpoints.insert(self.self_id, ep.to_string());
+                ids.push(self.self_id);
+            }
+        }
+        (canonical_roster(&ids), endpoints)
     }
 
     /// Fetch the beacon for `epoch` by anchoring on the epoch-start block hash
@@ -212,17 +250,10 @@ impl CoordinatorElection {
             // Anchor not reachable yet — keep the last good view.
             return epoch;
         };
-        let roster = self.roster();
-        // Endpoint map stays empty for this read-only increment: node→endpoint
-        // discovery (so a wallet can dial the owning coordinator) is a later
-        // layer. The election itself (who is seated) is unaffected by it.
-        let view = CoordinatorView::build(
-            epoch,
-            &beacon,
-            &roster,
-            EndpointMap::new(),
-            COORDINATOR_SEATS,
-        );
+        // Roster = opted-in coordinators advertising a reachable endpoint (+ self
+        // when opted in), with the endpoint map a wallet uses to dial the owner.
+        let (roster, endpoints) = self.roster_with_endpoints();
+        let view = CoordinatorView::build(epoch, &beacon, &roster, endpoints, COORDINATOR_SEATS);
         *self.cached.write() = Some(Cached { epoch, view });
         epoch
     }
@@ -239,8 +270,11 @@ impl CoordinatorElection {
     }
 
     /// A JSON snapshot of the cached election for the read-only HTTP endpoint:
-    /// `{enabled, epoch, seats, my_seat, elected: [hex node ids]}`. Pre-
-    /// serialised so `ghost-verification` needn't depend on `wraith-protocol`.
+    /// `{enabled, epoch, seats, my_seat, elected: [hex ids], coordinators:
+    /// [{node_id, seat, endpoint}]}`. The `coordinators` array is what a wallet
+    /// reads to dial the seat that owns its session; `elected` is kept as the
+    /// flat hex list for existing consumers. Pre-serialised so
+    /// `ghost-verification` needn't depend on `wraith-protocol`.
     pub fn status_json(&self) -> serde_json::Value {
         let guard = self.cached.read();
         let Some(c) = guard.as_ref() else {
@@ -252,33 +286,30 @@ impl CoordinatorElection {
                 "seats": 0,
                 "my_seat": serde_json::Value::Null,
                 "elected": [],
+                "coordinators": [],
             });
         };
 
-        let elected = self.elected_hex(&c.view);
+        let seated = c.view.seated();
+        let elected: Vec<String> = seated.iter().map(|s| hex::encode(s.node_id)).collect();
+        let coordinators: Vec<serde_json::Value> = seated
+            .iter()
+            .map(|s| {
+                serde_json::json!({
+                    "node_id": hex::encode(s.node_id),
+                    "seat": s.seat,
+                    "endpoint": s.endpoint,
+                })
+            })
+            .collect();
         serde_json::json!({
             "enabled": true,
             "epoch": c.view.epoch(),
             "seats": c.view.seats(),
             "my_seat": c.view.my_seat(&self.self_id),
             "elected": elected,
+            "coordinators": coordinators,
         })
-    }
-
-    /// The elected coordinators' node ids, hex-encoded in seat order. Derived by
-    /// re-querying the view per seat via the session-sharding map is not exposed,
-    /// so reconstruct the seated set from the public seat predicate over the
-    /// roster (the same roster the view was built from).
-    fn elected_hex(&self, view: &CoordinatorView) -> Vec<String> {
-        // The view exposes seats() and per-id predicates, not the raw set, so
-        // walk the roster and keep the seated ids ordered by seat index.
-        let roster = self.roster();
-        let mut seated: Vec<(u32, CoordinatorNodeId)> = roster
-            .into_iter()
-            .filter_map(|id| view.my_seat(&id).map(|seat| (seat, id)))
-            .collect();
-        seated.sort_unstable_by_key(|(seat, _)| *seat);
-        seated.into_iter().map(|(_, id)| hex::encode(id)).collect()
     }
 }
 

--- a/bins/ghost-pool/src/coordinator_election.rs
+++ b/bins/ghost-pool/src/coordinator_election.rs
@@ -60,6 +60,32 @@ pub const COORDINATOR_SEATS: usize = 5;
 /// active-miner freshness.
 const COORDINATOR_PEER_FRESHNESS_SECS: u64 = 300;
 
+/// Demand-driven seat sizing. Recent mixing sessions per seat before another
+/// seat is added; minimum seats whenever any coordinator is eligible (so there
+/// is always at least one, for liveness); and a hard ceiling. All tunable.
+const TARGET_SESSIONS_PER_SEAT: u64 = 50;
+const MIN_SEATS: usize = 1;
+const MAX_SEATS: usize = 16;
+
+/// Size the coordinator seat count for an epoch from the frozen, mesh-summed
+/// recent session `demand` and the number of `eligible` coordinators.
+///
+/// `ceil(demand / TARGET_SESSIONS_PER_SEAT)`, floored at `MIN_SEATS` and capped
+/// by both `MAX_SEATS` and the eligible set (can't seat more coordinators than
+/// exist). Coarse buckets (one seat per `TARGET_SESSIONS_PER_SEAT`) make the
+/// result robust to small per-node differences in the demand snapshot: nodes
+/// only disagree on the count near a bucket edge, and even then the only cost is
+/// a briefly-suboptimal session spread, never a safety issue (the CoinJoin is
+/// atomic + blind-signed whichever seat runs it). Pure + deterministic so every
+/// node computes the same seats from the same frozen inputs.
+pub fn seats_for_demand(demand: u64, eligible: usize) -> usize {
+    if eligible == 0 {
+        return 0;
+    }
+    let by_demand = (demand.div_ceil(TARGET_SESSIONS_PER_SEAT) as usize).max(MIN_SEATS);
+    by_demand.min(MAX_SEATS).min(eligible)
+}
+
 /// Domain separator for the beacon hash so it can never collide with any other
 /// hash in the system. Versioned for forward changes.
 const BEACON_DOMAIN: &[u8] = b"ghost/wraith/coordinator-beacon/v1";
@@ -192,9 +218,13 @@ impl CoordinatorElection {
     /// and has its own advertised endpoint. The roster is canonicalised (dedup +
     /// sort) so every node derives the byte-identical set + map from the same
     /// mesh membership.
-    fn roster_with_endpoints(&self) -> (Vec<CoordinatorNodeId>, EndpointMap) {
+    /// Returns the canonical roster, the endpoint map, and the summed recent
+    /// session `demand` across the eligible set (incl. self) — the frozen input
+    /// to [`seats_for_demand`].
+    fn roster_with_endpoints(&self) -> (Vec<CoordinatorNodeId>, EndpointMap, u64) {
         let mut endpoints = EndpointMap::new();
         let mut ids: Vec<CoordinatorNodeId> = Vec::new();
+        let mut demand: u64 = 0;
         for p in self
             .mesh
             .peers()
@@ -203,18 +233,21 @@ impl CoordinatorElection {
             if !p.capabilities.coordinator {
                 continue;
             }
+            let sessions = p.coordinator_sessions;
             if let Some(ep) = p.coordinator_endpoint.filter(|e| !e.is_empty()) {
                 endpoints.insert(p.node_id, ep);
                 ids.push(p.node_id);
+                demand = demand.saturating_add(sessions as u64);
             }
         }
         if self.self_coordinator {
             if let Some(ep) = self.self_endpoint.as_deref().filter(|e| !e.is_empty()) {
                 endpoints.insert(self.self_id, ep.to_string());
                 ids.push(self.self_id);
+                demand = demand.saturating_add(self.mesh.coordinator_sessions() as u64);
             }
         }
-        (canonical_roster(&ids), endpoints)
+        (canonical_roster(&ids), endpoints, demand)
     }
 
     /// Fetch the beacon for `epoch` by anchoring on the epoch-start block hash
@@ -252,8 +285,12 @@ impl CoordinatorElection {
         };
         // Roster = opted-in coordinators advertising a reachable endpoint (+ self
         // when opted in), with the endpoint map a wallet uses to dial the owner.
-        let (roster, endpoints) = self.roster_with_endpoints();
-        let view = CoordinatorView::build(epoch, &beacon, &roster, endpoints, COORDINATOR_SEATS);
+        // Seats are sized from the frozen, mesh-summed recent session demand —
+        // this recompute only runs when the epoch flips, so the snapshot is the
+        // per-epoch freeze.
+        let (roster, endpoints, demand) = self.roster_with_endpoints();
+        let seats = seats_for_demand(demand, roster.len());
+        let view = CoordinatorView::build(epoch, &beacon, &roster, endpoints, seats);
         *self.cached.write() = Some(Cached { epoch, view });
         epoch
     }
@@ -449,5 +486,29 @@ mod tests {
         let view = CoordinatorView::build(1, &beacon, &[], EndpointMap::new(), COORDINATOR_SEATS);
         assert_eq!(view.seats(), 0);
         assert!(!view.am_i_coordinator(&node(0)));
+    }
+
+    #[test]
+    fn seats_scale_with_demand_and_clamp() {
+        // No eligible coordinators → no seats, regardless of demand.
+        assert_eq!(seats_for_demand(1000, 0), 0);
+        // Any eligibility floors at MIN_SEATS even at zero demand.
+        assert_eq!(seats_for_demand(0, 5), MIN_SEATS);
+        // One seat per TARGET_SESSIONS_PER_SEAT, rounding up at the bucket edge.
+        assert_eq!(seats_for_demand(TARGET_SESSIONS_PER_SEAT, 10), 1);
+        assert_eq!(seats_for_demand(TARGET_SESSIONS_PER_SEAT + 1, 10), 2);
+        assert_eq!(seats_for_demand(TARGET_SESSIONS_PER_SEAT * 2, 10), 2);
+        // Capped by the eligible set …
+        assert_eq!(seats_for_demand(10_000, 3), 3);
+        // … and by MAX_SEATS when plenty are eligible.
+        assert_eq!(seats_for_demand(10_000_000, 100), MAX_SEATS);
+    }
+
+    #[test]
+    fn seats_for_demand_is_deterministic() {
+        // Same frozen inputs → identical seats on every node (no path dependence).
+        for (d, e) in [(0u64, 1usize), (75, 8), (260, 4), (999, 50)] {
+            assert_eq!(seats_for_demand(d, e), seats_for_demand(d, e));
+        }
     }
 }

--- a/bins/ghost-pool/src/coordinator_supervisor.rs
+++ b/bins/ghost-pool/src/coordinator_supervisor.rs
@@ -138,7 +138,9 @@ impl CoordinatorSupervisor {
                     }
                 },
                 (Some(_), None) => {
-                    error!("coordinator: bond_ledger_url set without bond_ledger_token; not activating");
+                    error!(
+                    "coordinator: bond_ledger_url set without bond_ledger_token; not activating"
+                );
                     return;
                 }
                 _ => None,
@@ -210,7 +212,11 @@ impl CoordinatorSupervisor {
 mod tests {
     use super::*;
 
-    fn cfg(enabled: bool, network: Network, bond_ledger_url: Option<&str>) -> CoordinatorRoleConfig {
+    fn cfg(
+        enabled: bool,
+        network: Network,
+        bond_ledger_url: Option<&str>,
+    ) -> CoordinatorRoleConfig {
         CoordinatorRoleConfig {
             enabled,
             network,
@@ -229,7 +235,9 @@ mod tests {
         // Refused: activating on mainnet with no bond ledger.
         assert!(mainnet_activation_refusal(&cfg(true, Network::Bitcoin, None)).is_some());
         // Allowed: mainnet WITH a bond ledger.
-        assert!(mainnet_activation_refusal(&cfg(true, Network::Bitcoin, Some("http://bond"))).is_none());
+        assert!(
+            mainnet_activation_refusal(&cfg(true, Network::Bitcoin, Some("http://bond"))).is_none()
+        );
         // Allowed: not activating (disabled) — gate doesn't apply.
         assert!(mainnet_activation_refusal(&cfg(false, Network::Bitcoin, None)).is_none());
         // Allowed: test nets may run without a real bond ledger.

--- a/bins/ghost-pool/src/coordinator_supervisor.rs
+++ b/bins/ghost-pool/src/coordinator_supervisor.rs
@@ -1,0 +1,239 @@
+//! In-process Wraith coordinator activation — Inc 4 of
+//! `tasks/plan_coordinator_activation.md`.
+//!
+//! When this node is elected a coordinator seat (per the deterministic
+//! [`crate::coordinator_election`] view), it must actually RUN the coordinator
+//! so wallets can mix with it. The `wraith-coordinator` crate is a library
+//! (`build_router` + `CoordinatorState`), so we run it in-process on a spawned
+//! axum task rather than managing a subprocess.
+//!
+//! Lifecycle is reconciled against the election each epoch flip:
+//! - elected & not running → build state (production bond ledger + ghostd
+//!   broadcaster) and serve on the coordinator port;
+//! - not elected & running → graceful shutdown (a lost seat next epoch).
+//!
+//! ## Gating + secure-by-default
+//! Activation is OFF unless `coordinator_role_enabled`. On mainnet it is REFUSED
+//! at construction unless a real ghost-pay bond ledger is configured — a
+//! coordinator that can't verify participant bonds lets them grief rounds for
+//! free (DoS). This mirrors the `wraith-coordinator` binary's mainnet guards.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use bitcoin::Network;
+use parking_lot::Mutex;
+use tokio::sync::Notify;
+use tokio::task::JoinHandle;
+use tracing::{error, info, warn};
+
+use ghost_consensus::mesh::MeshNetwork;
+use wraith_coordinator::bond_ledger_http::GhostPayBondLedger;
+use wraith_coordinator::broadcaster::{Broadcaster, GhostdBroadcaster};
+use wraith_coordinator::{build_router, CoordinatorState};
+use wraith_protocol::{BondLedger, RandomSessionIdGenerator, SystemClock};
+
+/// Everything the supervisor needs to construct + run a coordinator. Built from
+/// `[coordinator]` + `[bitcoin]` config.
+pub struct CoordinatorRoleConfig {
+    /// Run the coordinator when elected (`coordinator_role_enabled`).
+    pub enabled: bool,
+    pub network: Network,
+    /// Address the embedded coordinator binds (`0.0.0.0:coordinator_port`).
+    pub listen: SocketAddr,
+    pub bond_ledger_url: Option<String>,
+    pub bond_ledger_token: Option<String>,
+    pub fee_address: Option<String>,
+    /// ghostd RPC the broadcaster pushes merged round txs to (reused from
+    /// `[bitcoin]`).
+    pub ghostd_rpc_url: String,
+    pub ghostd_rpc_user: String,
+    pub ghostd_rpc_password: String,
+}
+
+/// The secure-by-default refusal reason for activating a coordinator, if any.
+/// Pure so it is unit-testable without a live mesh: a mainnet coordinator that
+/// can't verify participant bonds (no `bond_ledger_url`) is refused — an
+/// unbonded coordinator lets participants grief rounds for free. Only applies
+/// when activation is actually requested.
+fn mainnet_activation_refusal(cfg: &CoordinatorRoleConfig) -> Option<String> {
+    if cfg.enabled && cfg.network == Network::Bitcoin && cfg.bond_ledger_url.is_none() {
+        return Some(
+            "MAINNET REFUSAL: [coordinator] coordinator_role_enabled requires bond_ledger_url \
+             (+ bond_ledger_token) so the coordinator can verify participant bonds; an unbonded \
+             coordinator allows free round-griefing"
+                .to_string(),
+        );
+    }
+    None
+}
+
+/// A live coordinator instance: the serving task + its graceful-shutdown signal
+/// + the shared state we read the session count from.
+struct Running {
+    shutdown: Arc<Notify>,
+    handle: JoinHandle<()>,
+    state: Arc<CoordinatorState>,
+}
+
+/// Starts/stops the in-process coordinator to track the election.
+pub struct CoordinatorSupervisor {
+    cfg: CoordinatorRoleConfig,
+    mesh: Arc<MeshNetwork>,
+    running: Mutex<Option<Running>>,
+}
+
+impl CoordinatorSupervisor {
+    /// Construct the supervisor, or `None` when role activation is disabled.
+    /// Returns `Err` if activation is requested on mainnet without a real bond
+    /// ledger (secure-by-default refusal).
+    pub fn maybe_new(
+        cfg: CoordinatorRoleConfig,
+        mesh: Arc<MeshNetwork>,
+    ) -> Result<Option<Arc<Self>>, String> {
+        if !cfg.enabled {
+            return Ok(None);
+        }
+        if let Some(reason) = mainnet_activation_refusal(&cfg) {
+            return Err(reason);
+        }
+        Ok(Some(Arc::new(Self {
+            cfg,
+            mesh,
+            running: Mutex::new(None),
+        })))
+    }
+
+    /// Reconcile the running coordinator against the election: start when newly
+    /// elected, stop when the seat is lost, and refresh the advertised session
+    /// count while running. No-op when role activation is disabled.
+    pub async fn reconcile(&self, am_i_coordinator: bool) {
+        if !self.cfg.enabled {
+            return;
+        }
+        let is_running = self.running.lock().is_some();
+        match (am_i_coordinator, is_running) {
+            (true, false) => self.start().await,
+            (false, true) => self.stop(),
+            _ => {}
+        }
+        // While serving, publish the live session count so the mesh can size
+        // seats by demand (the source for `seats_for_demand`).
+        if let Some(r) = self.running.lock().as_ref() {
+            self.mesh
+                .set_coordinator_sessions(r.state.sessions.len() as u32);
+        }
+    }
+
+    async fn start(&self) {
+        // Production bond ledger. On mainnet its presence was already enforced
+        // in `maybe_new`; off mainnet a node may run without one (test nets).
+        let bond_ledger: Option<Arc<dyn BondLedger>> =
+            match (&self.cfg.bond_ledger_url, &self.cfg.bond_ledger_token) {
+                (Some(url), Some(token)) => match GhostPayBondLedger::new(url, token) {
+                    Ok(l) => Some(Arc::new(l)),
+                    Err(e) => {
+                        error!(error = %e, "coordinator: bond ledger init failed; not activating");
+                        return;
+                    }
+                },
+                (Some(_), None) => {
+                    error!("coordinator: bond_ledger_url set without bond_ledger_token; not activating");
+                    return;
+                }
+                _ => None,
+            };
+
+        let broadcaster: Option<Arc<dyn Broadcaster>> = match GhostdBroadcaster::new(
+            self.cfg.ghostd_rpc_url.clone(),
+            &self.cfg.ghostd_rpc_user,
+            &self.cfg.ghostd_rpc_password,
+        ) {
+            Ok(b) => Some(Arc::new(b)),
+            Err(e) => {
+                error!(error = %e, "coordinator: broadcaster init failed; not activating");
+                return;
+            }
+        };
+
+        let state = Arc::new(CoordinatorState::with_components(
+            self.cfg.network,
+            Arc::new(SystemClock),
+            Arc::new(RandomSessionIdGenerator),
+            bond_ledger,
+            self.cfg.fee_address.clone(),
+            broadcaster,
+        ));
+
+        let listener = match tokio::net::TcpListener::bind(self.cfg.listen).await {
+            Ok(l) => l,
+            Err(e) => {
+                error!(addr = %self.cfg.listen, error = %e, "coordinator: bind failed; not activating");
+                return;
+            }
+        };
+
+        let app = build_router(Arc::clone(&state));
+        let shutdown = Arc::new(Notify::new());
+        let shutdown_for_task = Arc::clone(&shutdown);
+        let handle = tokio::spawn(async move {
+            let served = axum::serve(listener, app)
+                .with_graceful_shutdown(async move { shutdown_for_task.notified().await })
+                .await;
+            if let Err(e) = served {
+                warn!(error = %e, "coordinator: server exited with error");
+            }
+        });
+
+        info!(addr = %self.cfg.listen, "coordinator: ELECTED — activated in-process");
+        *self.running.lock() = Some(Running {
+            shutdown,
+            handle,
+            state,
+        });
+    }
+
+    fn stop(&self) {
+        if let Some(r) = self.running.lock().take() {
+            // Signal graceful shutdown; abort as a backstop so a stuck server
+            // can't keep the seat's port held into the next epoch.
+            r.shutdown.notify_waiters();
+            r.handle.abort();
+            info!("coordinator: seat lost — stopped");
+        }
+        // No longer coordinating → stop contributing to mesh demand.
+        self.mesh.set_coordinator_sessions(0);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg(enabled: bool, network: Network, bond_ledger_url: Option<&str>) -> CoordinatorRoleConfig {
+        CoordinatorRoleConfig {
+            enabled,
+            network,
+            listen: "0.0.0.0:9100".parse().unwrap(),
+            bond_ledger_url: bond_ledger_url.map(String::from),
+            bond_ledger_token: bond_ledger_url.map(|_| "tok".to_string()),
+            fee_address: None,
+            ghostd_rpc_url: "http://127.0.0.1:8332".to_string(),
+            ghostd_rpc_user: "u".to_string(),
+            ghostd_rpc_password: "p".to_string(),
+        }
+    }
+
+    #[test]
+    fn mainnet_without_bond_ledger_is_refused_only_when_activating() {
+        // Refused: activating on mainnet with no bond ledger.
+        assert!(mainnet_activation_refusal(&cfg(true, Network::Bitcoin, None)).is_some());
+        // Allowed: mainnet WITH a bond ledger.
+        assert!(mainnet_activation_refusal(&cfg(true, Network::Bitcoin, Some("http://bond"))).is_none());
+        // Allowed: not activating (disabled) — gate doesn't apply.
+        assert!(mainnet_activation_refusal(&cfg(false, Network::Bitcoin, None)).is_none());
+        // Allowed: test nets may run without a real bond ledger.
+        assert!(mainnet_activation_refusal(&cfg(true, Network::Signet, None)).is_none());
+        assert!(mainnet_activation_refusal(&cfg(true, Network::Regtest, None)).is_none());
+    }
+}

--- a/bins/ghost-pool/src/lib.rs
+++ b/bins/ghost-pool/src/lib.rs
@@ -119,4 +119,6 @@ pub mod reaper_stats;
 /// `wraith-protocol`; activates no role and changes no consensus message.
 pub mod coordinator_election;
 
+pub mod coordinator_supervisor;
+
 // L2 uses NullifierRouteHandler from ghost-consensus (sender-side proofs).

--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -3453,6 +3453,9 @@ async fn main() -> Result<()> {
         config.coordinator.wraith_election_enabled,
         &identity,
         &capabilities,
+        // Self's advertised endpoint enters the roster only when this node opted
+        // in (capabilities.coordinator); harmless to pass through otherwise.
+        config.coordinator.advertised_endpoint.clone(),
         Arc::clone(&mesh),
         Arc::clone(&rpc),
     );

--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -3469,6 +3469,43 @@ async fn main() -> Result<()> {
         });
     }
 
+    // In-process coordinator activation (Inc 4). Off unless
+    // `[coordinator] coordinator_role_enabled`; on mainnet it is refused unless a
+    // real bond ledger is configured (secure-by-default). When elected, the node
+    // runs the coordinator on `coordinator_port`; the supervisor is reconciled
+    // against the election each epoch flip below.
+    let coordinator_supervisor = {
+        let coord_network = match config.bitcoin.network {
+            ghost_common::config::BitcoinNetwork::Mainnet => bitcoin::Network::Bitcoin,
+            ghost_common::config::BitcoinNetwork::Signet => bitcoin::Network::Signet,
+            ghost_common::config::BitcoinNetwork::Testnet => bitcoin::Network::Testnet,
+            ghost_common::config::BitcoinNetwork::Regtest => bitcoin::Network::Regtest,
+        };
+        let listen: std::net::SocketAddr =
+            format!("0.0.0.0:{}", config.coordinator.coordinator_port)
+                .parse()
+                .map_err(|e| anyhow::anyhow!("invalid coordinator listen addr: {e}"))?;
+        let role_cfg = ghost_pool::coordinator_supervisor::CoordinatorRoleConfig {
+            enabled: config.coordinator.coordinator_role_enabled,
+            network: coord_network,
+            listen,
+            bond_ledger_url: config.coordinator.bond_ledger_url.clone(),
+            bond_ledger_token: config.coordinator.bond_ledger_token.clone(),
+            fee_address: config.coordinator.coordinator_fee_address.clone(),
+            ghostd_rpc_url: format!(
+                "http://{}:{}",
+                config.bitcoin.rpc_host, config.bitcoin.rpc_port
+            ),
+            ghostd_rpc_user: config.bitcoin.rpc_user.clone(),
+            ghostd_rpc_password: config.bitcoin.rpc_password.clone(),
+        };
+        ghost_pool::coordinator_supervisor::CoordinatorSupervisor::maybe_new(
+            role_cfg,
+            Arc::clone(&mesh),
+        )
+        .map_err(|e| anyhow::anyhow!(e))?
+    };
+
     // Configure archive handler if archive mode enabled
     if capabilities.archive_mode {
         let archive_handler = RpcArchiveHandler::new(Arc::clone(&rpc_for_verification));
@@ -5228,6 +5265,10 @@ async fn main() -> Result<()> {
     // Coordinator-election recompute hook (read-only). `None` when the feature
     // is off → the recompute below is skipped entirely.
     let coord_for_events = coordinator_election.clone();
+    // Activation supervisor — reconciled against the election so an elected node
+    // runs the coordinator (and a node that lost its seat stops). `None` when
+    // role activation is off.
+    let supervisor_for_events = coordinator_supervisor.clone();
 
     tokio::spawn(async move {
         while let Ok(event) = template_events_early.recv().await {
@@ -5241,6 +5282,12 @@ async fn main() -> Result<()> {
                     // when the feature is off). Read-only — activates nothing.
                     if let Some(ref coord) = coord_for_events {
                         coord.refresh_for_height(height).await;
+                        // Start/stop the in-process coordinator to match the
+                        // freshly-recomputed election (no-op when role activation
+                        // is off or the seat is unchanged).
+                        if let Some(ref sup) = supervisor_for_events {
+                            sup.reconcile(coord.am_i_coordinator()).await;
+                        }
                     }
 
                     // M-MINE-1: Update template ID for share validation

--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -983,6 +983,13 @@ async fn main() -> Result<()> {
             .unwrap_or_else(|| "127.0.0.1".to_string()),
         ports: config.network.p2p.clone(),
         capabilities,
+        // Advertise a coordinator endpoint ONLY when opted in — otherwise a
+        // stray config value would falsely mark us coordinator-reachable.
+        advertised_coordinator_endpoint: if config.coordinator.coordinator_enabled {
+            config.coordinator.advertised_endpoint.clone()
+        } else {
+            None
+        },
         // C-1: Noise Protocol configuration for encrypted P2P
         // Read from config (mainnet validation ensures this is true on mainnet)
         noise_enabled: config.network.noise_enabled,

--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -824,6 +824,7 @@ async fn main() -> Result<()> {
         public_mining: is_public_mining, // Derived from mining_mode
         reaper: config.reaper.enabled,
         elder_status: false,
+        coordinator: config.coordinator.coordinator_enabled, // opt-in Wraith coordinator role
     };
 
     // Register node with database

--- a/crates/ghost-common/src/config.rs
+++ b/crates/ghost-common/src/config.rs
@@ -151,6 +151,24 @@ pub struct CoordinatorConfig {
     /// Port the in-process coordinator binds when this node is elected to a seat.
     #[serde(default = "default_coordinator_port")]
     pub coordinator_port: u16,
+    /// Actually RUN the coordinator when elected (vs. only advertising + being
+    /// electable). Separate from `coordinator_enabled` so discovery can be on
+    /// without auto-activating. SECURE-BY-DEFAULT: on mainnet, activation is
+    /// refused unless a real ghost-pay bond ledger is configured (an unbonded
+    /// coordinator lets participants grief rounds for free). Default false.
+    #[serde(default)]
+    pub coordinator_role_enabled: bool,
+    /// ghost-pay L2 bond-ledger base URL the coordinator calls to verify/refund/
+    /// slash participant bonds. REQUIRED to activate on mainnet.
+    #[serde(default)]
+    pub bond_ledger_url: Option<String>,
+    /// Bearer token for the bond-ledger API.
+    #[serde(default)]
+    pub bond_ledger_token: Option<String>,
+    /// Destination address for this coordinator's per-round service fee
+    /// (`service_fee_bps`). Without it rounds run fee-less.
+    #[serde(default)]
+    pub coordinator_fee_address: Option<String>,
 }
 
 /// Default port for the in-process Wraith coordinator (matches the standalone
@@ -166,6 +184,10 @@ impl Default for CoordinatorConfig {
             coordinator_enabled: false,
             advertised_endpoint: None,
             coordinator_port: default_coordinator_port(),
+            coordinator_role_enabled: false,
+            bond_ledger_url: None,
+            bond_ledger_token: None,
+            coordinator_fee_address: None,
         }
     }
 }

--- a/crates/ghost-common/src/config.rs
+++ b/crates/ghost-common/src/config.rs
@@ -129,12 +129,45 @@ pub struct NodeConfig {
 /// activates a coordinator role, touches `coordinator_redundancy`, or changes
 /// any Wraith mixing or consensus message. With `wraith_election_enabled =
 /// false` (the default) it is inert.
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CoordinatorConfig {
     /// Compute the per-epoch coordinator election and expose it read-only via
     /// `GET /api/v1/pool/coordinator`. Default false — dead code when off.
     #[serde(default)]
     pub wraith_election_enabled: bool,
+    /// Opt in to being an eligible Wraith coordinator — the same opt-in model as
+    /// `public_mining` for miners. When true the node advertises itself as
+    /// coordinator-capable to the mesh and may be elected. Earns the mixing
+    /// service fee, not 5-4-3-2-1 shares. Default false.
+    #[serde(default)]
+    pub coordinator_enabled: bool,
+    /// The reachable coordinator endpoint this node advertises: a public
+    /// `host:port` or a `.onion` hidden service. Operator-controlled so home
+    /// operators can advertise Tor instead of doxxing an IP. Required (non-empty)
+    /// before the node can actually be elected — no endpoint means wallets have
+    /// nowhere to dial.
+    #[serde(default)]
+    pub advertised_endpoint: Option<String>,
+    /// Port the in-process coordinator binds when this node is elected to a seat.
+    #[serde(default = "default_coordinator_port")]
+    pub coordinator_port: u16,
+}
+
+/// Default port for the in-process Wraith coordinator (matches the standalone
+/// `wraith-coordinator` binary's default).
+fn default_coordinator_port() -> u16 {
+    9100
+}
+
+impl Default for CoordinatorConfig {
+    fn default() -> Self {
+        Self {
+            wraith_election_enabled: false,
+            coordinator_enabled: false,
+            advertised_endpoint: None,
+            coordinator_port: default_coordinator_port(),
+        }
+    }
 }
 
 /// Configuration validation error

--- a/crates/ghost-common/src/types.rs
+++ b/crates/ghost-common/src/types.rs
@@ -59,6 +59,13 @@ pub struct NodeCapabilities {
     pub reaper: bool,
     /// Elder status (+1 share)
     pub elder_status: bool,
+    /// Wraith coordinator role opted in. Earns the mixing service fee, NOT
+    /// 5-4-3-2-1 shares — so it is deliberately excluded from `total_shares()`
+    /// and needs no verification challenge. `#[serde(default)]` so health pings
+    /// from peers on pre-coordinator builds (which omit the field) still
+    /// deserialize as `coordinator = false`.
+    #[serde(default)]
+    pub coordinator: bool,
 }
 
 impl NodeCapabilities {
@@ -116,6 +123,7 @@ impl NodeCapabilities {
             || self.public_mining
             || self.reaper
             || self.elder_status
+            || self.coordinator
     }
 }
 
@@ -822,6 +830,44 @@ mod tests {
         caps.ghost_pay = true;
         caps.elder_status = true;
         assert_eq!(caps.total_shares(), 15); // 5 + 3 + 2 + 4 + 1
+    }
+
+    #[test]
+    fn test_coordinator_earns_no_shares_but_counts_as_a_capability() {
+        // Coordinator is fee-incentivised, not share-bearing — it must add 0 to
+        // the 5-4-3-2-1 total even when every share-bearing capability is set.
+        let mut caps = NodeCapabilities {
+            archive_mode: true,
+            ghost_pay: true,
+            public_mining: true,
+            reaper: true,
+            elder_status: true,
+            coordinator: true,
+        };
+        assert_eq!(caps.total_shares(), 15, "coordinator must not change the share total");
+
+        // But a coordinator-only node still "has a capability".
+        caps = NodeCapabilities::new();
+        caps.coordinator = true;
+        assert_eq!(caps.total_shares(), 0);
+        assert!(caps.has_any());
+    }
+
+    #[test]
+    fn test_node_capabilities_coordinator_serde_default() {
+        // A health ping from a pre-coordinator build omits the field entirely;
+        // it must still deserialize (as coordinator = false), not error.
+        let legacy = r#"{"archive_mode":true,"ghost_pay":false,"public_mining":true,"reaper":false,"elder_status":false}"#;
+        let caps: NodeCapabilities = serde_json::from_str(legacy).expect("legacy caps must deserialize");
+        assert!(!caps.coordinator);
+        assert!(caps.archive_mode && caps.public_mining);
+
+        // Round-trips with the field present.
+        let mut on = caps;
+        on.coordinator = true;
+        let json = serde_json::to_string(&on).expect("serialize");
+        let back: NodeCapabilities = serde_json::from_str(&json).expect("deserialize");
+        assert!(back.coordinator);
     }
 
     #[test]

--- a/crates/ghost-common/src/types.rs
+++ b/crates/ghost-common/src/types.rs
@@ -860,7 +860,11 @@ mod tests {
             elder_status: true,
             coordinator: true,
         };
-        assert_eq!(caps.total_shares(), 15, "coordinator must not change the share total");
+        assert_eq!(
+            caps.total_shares(),
+            15,
+            "coordinator must not change the share total"
+        );
 
         // But a coordinator-only node still "has a capability".
         caps = NodeCapabilities::new();
@@ -874,7 +878,8 @@ mod tests {
         // A health ping from a pre-coordinator build omits the field entirely;
         // it must still deserialize (as coordinator = false), not error.
         let legacy = r#"{"archive_mode":true,"ghost_pay":false,"public_mining":true,"reaper":false,"elder_status":false}"#;
-        let caps: NodeCapabilities = serde_json::from_str(legacy).expect("legacy caps must deserialize");
+        let caps: NodeCapabilities =
+            serde_json::from_str(legacy).expect("legacy caps must deserialize");
         assert!(!caps.coordinator);
         assert!(caps.archive_mode && caps.public_mining);
 
@@ -1092,7 +1097,10 @@ mod tests {
         ping.coordinator_endpoint = Some("abc123def456.onion:9100".to_string());
         let back: HealthPing =
             serde_json::from_str(&serde_json::to_string(&ping).unwrap()).unwrap();
-        assert_eq!(back.coordinator_endpoint.as_deref(), Some("abc123def456.onion:9100"));
+        assert_eq!(
+            back.coordinator_endpoint.as_deref(),
+            Some("abc123def456.onion:9100")
+        );
 
         // An older node's ping omits the field entirely → defaults to None,
         // proving the wire change is additive.

--- a/crates/ghost-common/src/types.rs
+++ b/crates/ghost-common/src/types.rs
@@ -468,6 +468,13 @@ pub struct HealthPing {
     /// that haven't opted in. `#[serde(default)]` for backward compatibility.
     #[serde(default)]
     pub coordinator_endpoint: Option<String>,
+    /// If this node is an active coordinator, the number of Wraith mixing
+    /// sessions it handled over a recent trailing window. Summed across the mesh
+    /// at each epoch boundary to size the next epoch's coordinator seat count
+    /// (demand-driven scaling). 0 for non-coordinators and idle coordinators.
+    /// `#[serde(default)]` for backward compatibility.
+    #[serde(default)]
+    pub coordinator_sessions: u32,
 }
 
 /// One node's best (rarest) valid share in a public records window.
@@ -1065,6 +1072,7 @@ mod tests {
                 miner_id_redacted: "bc1q7z…y492.avalon1".to_string(),
             }],
             coordinator_endpoint: None,
+            coordinator_sessions: 0,
         }
     }
 

--- a/crates/ghost-common/src/types.rs
+++ b/crates/ghost-common/src/types.rs
@@ -459,6 +459,15 @@ pub struct HealthPing {
     /// empty Vec, and newer nodes simply ignore peers that omit it.
     #[serde(default)]
     pub best_records: Vec<WindowBestRecord>,
+    /// If this node has opted in as a Wraith coordinator
+    /// (`capabilities.coordinator`), the reachable endpoint a wallet should dial
+    /// to mix with it: a public `host:port` or a `.onion`. This is a DELIBERATE,
+    /// operator-chosen advertisement (unlike `public_address`, which is withheld
+    /// per S-7) — a coordinator is useless if unreachable, and operators wanting
+    /// privacy advertise a Tor hidden service instead of an IP. `None` for nodes
+    /// that haven't opted in. `#[serde(default)]` for backward compatibility.
+    #[serde(default)]
+    pub coordinator_endpoint: Option<String>,
 }
 
 /// One node's best (rarest) valid share in a public records window.
@@ -1055,6 +1064,7 @@ mod tests {
                 timestamp: 1,
                 miner_id_redacted: "bc1q7z…y492.avalon1".to_string(),
             }],
+            coordinator_endpoint: None,
         }
     }
 
@@ -1065,6 +1075,23 @@ mod tests {
         let back: HealthPing = serde_json::from_str(&json).unwrap();
         assert_eq!(back.local_hashrate_th, 4.0);
         assert_eq!(back.active_miner_id_hashes.len(), 2);
+    }
+
+    #[test]
+    fn health_ping_coordinator_endpoint_roundtrip_and_back_compat() {
+        // Present-and-set survives a round-trip.
+        let mut ping = sample_health_ping();
+        ping.coordinator_endpoint = Some("abc123def456.onion:9100".to_string());
+        let back: HealthPing =
+            serde_json::from_str(&serde_json::to_string(&ping).unwrap()).unwrap();
+        assert_eq!(back.coordinator_endpoint.as_deref(), Some("abc123def456.onion:9100"));
+
+        // An older node's ping omits the field entirely → defaults to None,
+        // proving the wire change is additive.
+        let mut v = serde_json::to_value(&sample_health_ping()).unwrap();
+        v.as_object_mut().unwrap().remove("coordinator_endpoint");
+        let back: HealthPing = serde_json::from_value(v).unwrap();
+        assert_eq!(back.coordinator_endpoint, None);
     }
 
     #[test]

--- a/crates/ghost-consensus/src/health_handler.rs
+++ b/crates/ghost-consensus/src/health_handler.rs
@@ -855,8 +855,12 @@ impl HealthPingHandler {
 
         // Update miner_count and capabilities from the health ping on every tick,
         // even when the peer address hasn't changed — these are live metrics.
-        self.peers
-            .update_health_metrics(&envelope.sender, ping.miner_count, ping.capabilities);
+        self.peers.update_health_metrics(
+            &envelope.sender,
+            ping.miner_count,
+            ping.capabilities,
+            ping.coordinator_endpoint.clone(),
+        );
         // Active miner_id hashes (mesh-wide dedup count) + this node's own
         // realized hashrate (summed across the mesh for the pool total).
         self.peers.update_active_miner_hashes(

--- a/crates/ghost-consensus/src/health_handler.rs
+++ b/crates/ghost-consensus/src/health_handler.rs
@@ -860,6 +860,7 @@ impl HealthPingHandler {
             ping.miner_count,
             ping.capabilities,
             ping.coordinator_endpoint.clone(),
+            ping.coordinator_sessions,
         );
         // Active miner_id hashes (mesh-wide dedup count) + this node's own
         // realized hashrate (summed across the mesh for the pool total).

--- a/crates/ghost-consensus/src/mesh.rs
+++ b/crates/ghost-consensus/src/mesh.rs
@@ -253,6 +253,10 @@ pub struct MeshNetwork {
     /// `0` means we haven't computed it yet (mesh started before capacity
     /// init); peers treat it as unknown and skip utilisation routing for us.
     max_capacity: AtomicU32,
+    /// Wraith mixing sessions this node handled over a recent window, advertised
+    /// in health pings so the mesh can size coordinator seats by demand. 0 until
+    /// this node activates a coordinator role and starts reporting (Inc 4).
+    coordinator_sessions: AtomicU32,
 }
 
 /// Message identifier for deduplication
@@ -1064,6 +1068,7 @@ impl MeshNetwork {
             local_hashrate_fn: None,
             best_records_fn: None,
             max_capacity: AtomicU32::new(0),
+            coordinator_sessions: AtomicU32::new(0),
         })
     }
 
@@ -1072,6 +1077,19 @@ impl MeshNetwork {
     /// re-called if the operator throttle (`network.max_miners`) changes.
     pub fn set_max_capacity(&self, value: u32) {
         self.max_capacity.store(value, Ordering::Relaxed);
+    }
+
+    /// Set the recent Wraith-coordinator session count advertised in health
+    /// pings. Called by the in-process coordinator (Inc 4) as rounds complete;
+    /// stays 0 on nodes that aren't active coordinators.
+    pub fn set_coordinator_sessions(&self, value: u32) {
+        self.coordinator_sessions.store(value, Ordering::Relaxed);
+    }
+
+    /// This node's currently-advertised coordinator session count (for the
+    /// election's demand sum, which includes self).
+    pub fn coordinator_sessions(&self) -> u32 {
+        self.coordinator_sessions.load(Ordering::Relaxed)
     }
 
     /// Set a callback that provides the real connected-miner count for health pings.
@@ -2706,6 +2724,7 @@ impl MeshNetwork {
                 // Static, operator-chosen advertisement (read from config, never
                 // mutated at runtime), so reading from self.config is fine.
                 coordinator_endpoint: self.config.advertised_coordinator_endpoint.clone(),
+                coordinator_sessions: self.coordinator_sessions.load(Ordering::Relaxed),
             };
 
             match self.create_envelope(

--- a/crates/ghost-consensus/src/mesh.rs
+++ b/crates/ghost-consensus/src/mesh.rs
@@ -92,6 +92,11 @@ pub struct MeshConfig {
     pub max_seen_messages: usize,
     /// Node capabilities to advertise in health pings
     pub capabilities: ghost_common::types::NodeCapabilities,
+    /// Wraith coordinator endpoint to advertise in health pings when this node
+    /// has opted in (`coordinator` capability). A public `host:port` or a
+    /// `.onion`. `None` for nodes that haven't opted in — they advertise no
+    /// endpoint and so are never elected.
+    pub advertised_coordinator_endpoint: Option<String>,
     /// C-1: Enable Noise Protocol for transport encryption
     ///
     /// When enabled, sensitive P2P messages (shares, blocks, votes, payouts)
@@ -155,6 +160,7 @@ impl Default for MeshConfig {
             health_ping_interval_secs: 10,
             max_seen_messages: 100_000, // Cap at 100k messages (~3.2MB with 32-byte IDs)
             capabilities: ghost_common::types::NodeCapabilities::default(),
+            advertised_coordinator_endpoint: None,
             // C-1: Enable Noise by default for secure-by-default operation
             noise_enabled: true,
             noise_port: DEFAULT_NOISE_PORT,
@@ -2697,6 +2703,9 @@ impl MeshNetwork {
                 local_hashrate_th,
                 max_capacity: self.max_capacity.load(Ordering::Relaxed),
                 best_records,
+                // Static, operator-chosen advertisement (read from config, never
+                // mutated at runtime), so reading from self.config is fine.
+                coordinator_endpoint: self.config.advertised_coordinator_endpoint.clone(),
             };
 
             match self.create_envelope(

--- a/crates/ghost-consensus/src/peer.rs
+++ b/crates/ghost-consensus/src/peer.rs
@@ -156,6 +156,9 @@ impl PeerManager {
             if merged.coordinator_endpoint.is_none() {
                 merged.coordinator_endpoint = existing.coordinator_endpoint.clone();
             }
+            if merged.coordinator_sessions == 0 {
+                merged.coordinator_sessions = existing.coordinator_sessions;
+            }
             merged.first_seen = merged.first_seen.min(existing.first_seen);
             peers.insert(merged.node_id, merged);
             return;
@@ -283,6 +286,7 @@ impl PeerManager {
         miner_count: u32,
         capabilities: ghost_common::types::NodeCapabilities,
         coordinator_endpoint: Option<String>,
+        coordinator_sessions: u32,
     ) {
         if let Some(peer) = self.peers.write().get_mut(node_id) {
             peer.miner_count = miner_count;
@@ -293,6 +297,11 @@ impl PeerManager {
             if coordinator_endpoint.is_some() {
                 peer.coordinator_endpoint = coordinator_endpoint;
             }
+            // Session load is a live gauge — always take the latest, including 0
+            // (an active coordinator that went idle legitimately reports 0). The
+            // upsert/re-announce path preserves it instead, so a bare re-announce
+            // can't reset it to 0 between pings.
+            peer.coordinator_sessions = coordinator_sessions;
         }
     }
 
@@ -445,6 +454,11 @@ pub struct Peer {
     /// of the coordinator-election `EndpointMap`. `None` until the peer advertises
     /// one (or for peers that haven't opted in).
     pub coordinator_endpoint: Option<String>,
+    /// If this peer is an active coordinator, the Wraith mixing sessions it
+    /// reported handling recently (most recent health ping). Summed across the
+    /// eligible set at the epoch boundary to size the seat count. 0 when idle or
+    /// not a coordinator.
+    pub coordinator_sessions: u32,
 }
 
 impl Peer {
@@ -470,6 +484,7 @@ impl Peer {
             max_capacity: 0,
             best_records: Vec::new(),
             coordinator_endpoint: None,
+            coordinator_sessions: 0,
         }
     }
 
@@ -717,7 +732,7 @@ mod tests {
         // A health ping populates the gossip metrics.
         let hashes = vec![[1u8; 16], [2u8; 16], [3u8; 16]];
         mgr.update_active_miner_hashes(&pid, hashes.clone(), 4.5);
-        mgr.update_health_metrics(&pid, 3, NodeCapabilities::default(), None);
+        mgr.update_health_metrics(&pid, 3, NodeCapabilities::default(), None, 0);
         mgr.update_max_capacity(&pid, 64);
         let records = vec![WindowBestRecord {
             window: "day".to_string(),

--- a/crates/ghost-consensus/src/peer.rs
+++ b/crates/ghost-consensus/src/peer.rs
@@ -153,6 +153,9 @@ impl PeerManager {
             if merged.best_records.is_empty() {
                 merged.best_records = existing.best_records.clone();
             }
+            if merged.coordinator_endpoint.is_none() {
+                merged.coordinator_endpoint = existing.coordinator_endpoint.clone();
+            }
             merged.first_seen = merged.first_seen.min(existing.first_seen);
             peers.insert(merged.node_id, merged);
             return;
@@ -279,10 +282,17 @@ impl PeerManager {
         node_id: &NodeId,
         miner_count: u32,
         capabilities: ghost_common::types::NodeCapabilities,
+        coordinator_endpoint: Option<String>,
     ) {
         if let Some(peer) = self.peers.write().get_mut(node_id) {
             peer.miner_count = miner_count;
             peer.capabilities = capabilities;
+            // Only overwrite a known endpoint with a freshly-advertised one;
+            // never clobber a good endpoint with `None` (a ping where the peer
+            // momentarily omitted it / hasn't re-advertised yet).
+            if coordinator_endpoint.is_some() {
+                peer.coordinator_endpoint = coordinator_endpoint;
+            }
         }
     }
 
@@ -430,6 +440,11 @@ pub struct Peer {
     /// peer's) so the `/api/v1/pool/records` endpoint returns the mesh-wide
     /// rarest record per window. Empty for older peers that don't report it.
     pub best_records: Vec<WindowBestRecord>,
+    /// If this peer opted in as a Wraith coordinator, the endpoint it advertised
+    /// in its most recent health ping (public `host:port` or a `.onion`). Source
+    /// of the coordinator-election `EndpointMap`. `None` until the peer advertises
+    /// one (or for peers that haven't opted in).
+    pub coordinator_endpoint: Option<String>,
 }
 
 impl Peer {
@@ -454,6 +469,7 @@ impl Peer {
             local_hashrate_th: 0.0,
             max_capacity: 0,
             best_records: Vec::new(),
+            coordinator_endpoint: None,
         }
     }
 
@@ -701,7 +717,7 @@ mod tests {
         // A health ping populates the gossip metrics.
         let hashes = vec![[1u8; 16], [2u8; 16], [3u8; 16]];
         mgr.update_active_miner_hashes(&pid, hashes.clone(), 4.5);
-        mgr.update_health_metrics(&pid, 3, NodeCapabilities::default());
+        mgr.update_health_metrics(&pid, 3, NodeCapabilities::default(), None);
         mgr.update_max_capacity(&pid, 64);
         let records = vec![WindowBestRecord {
             window: "day".to_string(),

--- a/crates/ghost-consensus/src/peer.rs
+++ b/crates/ghost-consensus/src/peer.rs
@@ -812,6 +812,7 @@ mod tests {
             public_mining: true,
             reaper: true,
             elder_status: true,
+            coordinator: false,
         };
         // Set first_seen far in the past for max reliability (30+ days)
         peer.first_seen = peer.first_seen.saturating_sub(86400 * 31);
@@ -868,6 +869,7 @@ mod tests {
             public_mining: true,
             reaper: true,
             elder_status: true,
+            coordinator: false,
         };
         peer_high.first_seen = peer_high.first_seen.saturating_sub(86400 * 31);
 

--- a/crates/ghost-storage/src/queries.rs
+++ b/crates/ghost-storage/src/queries.rs
@@ -5548,6 +5548,10 @@ impl Database {
             public_mining: stratum_qualified,
             reaper: policy_qualified,
             elder_status: elder_qualified,
+            // Coordinator is a live, opt-in mesh role (advertised via health
+            // pings), not a verified/persisted capability — qualification never
+            // sets it. Always false on the qualified-capabilities path.
+            coordinator: false,
         })
     }
 

--- a/crates/wraith-protocol/src/service.rs
+++ b/crates/wraith-protocol/src/service.rs
@@ -25,6 +25,19 @@ use crate::sortition::CoordinatorNodeId;
 /// (e.g. `https://node.example:9100`). Sourced from the node-discovery layer.
 pub type EndpointMap = BTreeMap<CoordinatorNodeId, String>;
 
+/// One seated coordinator with its reachable endpoint — the unit the read-only
+/// status endpoint publishes and the wallet resolves against.
+#[derive(Debug, Clone)]
+pub struct SeatedCoordinator {
+    /// The elected node's id.
+    pub node_id: CoordinatorNodeId,
+    /// Seat index `0..seats`; sessions shard onto seats via `shard_for`.
+    pub seat: u32,
+    /// The endpoint a wallet dials for this seat, or `None` if the owner hasn't
+    /// advertised one yet (the wallet then waits or picks another epoch).
+    pub endpoint: Option<String>,
+}
+
 /// The resolved coordinator assignment for one epoch, with endpoints attached.
 #[derive(Debug, Clone)]
 pub struct CoordinatorView {
@@ -65,6 +78,24 @@ impl CoordinatorView {
     /// Number of coordinators seated this epoch.
     pub fn seats(&self) -> usize {
         self.coords.seats()
+    }
+
+    /// The seated coordinators in seat order, each with its advertised endpoint
+    /// (`None` when the owner hasn't advertised one). Drives the read-only status
+    /// endpoint and the wallet's "which endpoint owns my session" resolution.
+    pub fn seated(&self) -> Vec<SeatedCoordinator> {
+        let mut out: Vec<SeatedCoordinator> = self
+            .coords
+            .coordinators
+            .iter()
+            .map(|c| SeatedCoordinator {
+                node_id: c.node_id,
+                seat: c.seat,
+                endpoint: self.endpoints.get(&c.node_id).cloned(),
+            })
+            .collect();
+        out.sort_unstable_by_key(|s| s.seat);
+        out
     }
 
     // ── node-side ────────────────────────────────────────────────────────────
@@ -204,5 +235,33 @@ mod tests {
         assert_eq!(v.seats(), 0);
         assert!(!v.am_i_coordinator(&node(0)));
         assert_eq!(v.endpoint_for_session(&[9u8; 32]), None);
+    }
+
+    #[test]
+    fn seated_lists_every_seat_with_its_endpoint_in_order() {
+        let (v, _q) = view(5);
+        let seated = v.seated();
+        assert_eq!(seated.len(), 5);
+        for (i, s) in seated.iter().enumerate() {
+            assert_eq!(s.seat as usize, i, "seats must be 0..n in order");
+            assert!(s
+                .endpoint
+                .as_deref()
+                .expect("every seated coordinator has an endpoint here")
+                .starts_with("https://node"));
+        }
+    }
+
+    #[test]
+    fn seated_endpoint_is_none_when_owner_has_not_advertised() {
+        let q = qualified(12);
+        let mut eps = endpoints(&q);
+        let full = CoordinatorView::build(3, &beacon(7), &q, eps.clone(), 5);
+        let owner = full.seated()[0].node_id;
+        eps.remove(&owner);
+        let v = CoordinatorView::build(3, &beacon(7), &q, eps, 5);
+        // Still seated (owner known) but no endpoint to dial.
+        assert_eq!(v.seated()[0].node_id, owner);
+        assert_eq!(v.seated()[0].endpoint, None);
     }
 }


### PR DESCRIPTION
Turns the read-only coordinator election (PRs #70–#82) into a **working decentralised coordinator** — the Wraith-mixing v1 blocker. Any node can opt in, advertise a reachable endpoint, get elected by the existing deterministic sortition, and actually **run the coordinator in-process** when seated. Plan: `tasks/plan_coordinator_activation.md`.

All increments are additive, gated **off** by default, and `-j2` green; the full workspace compiles (all targets). No behaviour change until an operator opts in.

## Design (decided with the maintainer)
- **Any node coordinates**, not just elders — opt in via a `coordinator` capability, same model as `public_mining`.
- **Self-advertised endpoints** (public `host:port` or a `.onion`) so home operators aren't doxxed; participants reach over Tor; coordinator can't link in↔out (blind sigs).
- **Demand-driven seats**, frozen per epoch.
- **Fee-incentivised role** (keeps `service_fee_bps`) — no 5-4-3-2-1 shares, so no verification challenge to game.
- **Secure-by-default activation**: on mainnet a coordinator won't run without a real ghost-pay bond ledger (an unbonded coordinator lets participants grief rounds for free).

## Increments (one commit each)
1. **Capability + config** — `NodeCapabilities.coordinator` (0 shares, serde-default); `[coordinator]` config. Opt-in rides the health ping for free.
2. **Endpoint wire** — `coordinator_endpoint` on `HealthPing`/`Peer`, advertised when opted in; preserve-on-default merge.
3. **Election** — roster = opted-in coordinators advertising a fresh endpoint (was elders-only); `/api/v1/pool/coordinator` returns `coordinators:[{node_id,seat,endpoint}]`; `CoordinatorView::seated()`.
4. **Demand-driven seats** — `coordinator_sessions` on ping/`Peer` + mesh atomic; `seats_for_demand()` clamped + bucketed (cross-node disagreement only costs mixing efficiency, never safety — the CoinJoin is atomic + blind-signed whichever seat runs it).
5. **In-process activation** — `CoordinatorSupervisor` runs `wraith-coordinator` (a library: `build_router` + `CoordinatorState`) on an axum task when elected; graceful-stops on seat loss; reports session count to the mesh (closes the demand loop). Mainnet bond-ledger refusal is a pure, unit-tested gate.
6. **Wallet picker** — `coordinator_resolve::pick_seat_endpoint(json, shard_key)`; shards on (tier, epoch) so wallets converge on one seat (bigger anonymity set).

## Not in this PR (deliberately next)
- **ghost-pay election relay + GUI "use the network-elected coordinator" toggle.** The wallet must fetch the election **through ghost-pay**, never the node's pool API directly (`apps/wraith-wallet/CLAUDE.md`), so the fetch path ships with the GUI work. This PR ships only the channel-agnostic picker.
- Threshold-VRF beacon (post-v1, external-audit-gated; the interim commit-reveal beacon stays).

## Tests
New unit tests per increment: zero-share carve-out + serde back-compat; endpoint round-trip; `seated()` endpoints; `seats_for_demand` scaling/clamps/determinism; mainnet activation refusal; seat-endpoint picker determinism + None cases.