### PR TITLE
wraith-wallet: resolve elected coordinator through ghost-pay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10538,6 +10538,7 @@ dependencies = [
  "secrecy",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "tempfile",
  "tokio",
  "tracing",

--- a/apps/wraith-wallet/cli/src/main.rs
+++ b/apps/wraith-wallet/cli/src/main.rs
@@ -1272,6 +1272,18 @@ mod unix {
                 }
                 std::process::ExitCode::SUCCESS
             }
+            Ok(Response::WraithCoordinatorResolved { endpoint, epoch }) => {
+                match endpoint {
+                    Some(ep) => println!("endpoint: {ep}"),
+                    None => {
+                        println!("endpoint: (none — election off/pending; use a manual URL)")
+                    }
+                }
+                if let Some(e) = epoch {
+                    println!("epoch:    {e}");
+                }
+                std::process::ExitCode::SUCCESS
+            }
             Ok(Response::Error(e)) => {
                 eprintln!("wraithd error: {}", e.message);
                 std::process::ExitCode::FAILURE

--- a/apps/wraith-wallet/core/src/chain/ghost_pay.rs
+++ b/apps/wraith-wallet/core/src/chain/ghost_pay.rs
@@ -203,6 +203,44 @@ impl GhostPayClient {
         Err(last_err.unwrap_or_else(|| ChainError::Transport("no endpoints configured".into())))
     }
 
+    /// `GET /api/v1/pool/coordinator` — the node's decentralised-coordinator
+    /// election view, relayed by ghost-pay (the wallet never hits the node's pool
+    /// API directly; wallet hard rule). Returns the raw election JSON; the daemon
+    /// resolves which seat owns a given (tier, epoch) shard from it. ghost-pay
+    /// returns the inert `{"enabled": false}` shape when the node has the feature
+    /// off or is unreachable, so the wallet falls back to a manual coordinator URL.
+    pub async fn coordinator_election(&self) -> Result<serde_json::Value, ChainError> {
+        let mut last_err: Option<ChainError> = None;
+        for base in &self.base_urls {
+            match self.try_coordinator_election(base).await {
+                Ok(v) => return Ok(v),
+                Err(e) => {
+                    tracing::debug!(url = %base, error = %e, "ghost-pay coordinator_election failed, trying next");
+                    last_err = Some(e);
+                }
+            }
+        }
+        Err(last_err.unwrap_or_else(|| ChainError::Transport("no endpoints configured".into())))
+    }
+
+    async fn try_coordinator_election(
+        &self,
+        base_url: &str,
+    ) -> Result<serde_json::Value, ChainError> {
+        let url = self.endpoint(base_url, "/api/v1/pool/coordinator");
+        let resp = self
+            .http
+            .get(&url)
+            .send()
+            .await
+            .map_err(|e| ChainError::Transport(e.to_string()))?
+            .error_for_status()
+            .map_err(|e| ChainError::Backend(e.to_string()))?;
+        resp.json::<serde_json::Value>()
+            .await
+            .map_err(|e| ChainError::Malformed(e.to_string()))
+    }
+
     async fn try_broadcast_tx(&self, base_url: &str, tx_hex: &str) -> Result<String, ChainError> {
         let url = self.endpoint(base_url, "/api/v1/tx/broadcast");
         let mut req = self.http.post(&url).json(&serde_json::json!({

--- a/apps/wraith-wallet/daemon/Cargo.toml
+++ b/apps/wraith-wallet/daemon/Cargo.toml
@@ -15,6 +15,8 @@ wraith-wallet-core = { workspace = true }
 wraith-wallet-ipc = { workspace = true }
 # Coordinator-seat sharding (shard_for) for resolving an elected coordinator.
 wraith-protocol = { workspace = true }
+# Shard-key derivation (SHA256) for coordinator resolution.
+sha2 = { workspace = true }
 ghost-gsp-proto = { workspace = true }
 ghost-keys = { workspace = true }
 bitcoin = { workspace = true }

--- a/apps/wraith-wallet/daemon/src/coordinator_resolve.rs
+++ b/apps/wraith-wallet/daemon/src/coordinator_resolve.rs
@@ -3,16 +3,17 @@
 //! coordinator URL.
 //!
 //! Inc 5 of `tasks/plan_coordinator_activation.md` — the daemon-side plumbing.
-//! This is the channel-agnostic *picker*: it takes the election JSON and returns
-//! the owning seat's endpoint. The wallet must obtain that JSON **through
-//! ghost-pay**, never by reaching the node's pool API directly (wallet hard rule,
-//! `apps/wraith-wallet/CLAUDE.md`) — so the fetch path is a small ghost-pay relay
-//! wired together with the GUI "use the network-elected coordinator" toggle (the
-//! explicitly-deferred next task). Hence `allow(dead_code)` for now: tested and
-//! ready, just not yet called.
-#![allow(dead_code)]
+//! The wallet obtains the election JSON **through ghost-pay** (never the node's
+//! pool API directly; wallet hard rule, `apps/wraith-wallet/CLAUDE.md`) via
+//! `GhostPayClient::coordinator_election`, then resolves the owning seat here.
+//! The `WraithResolveCoordinator` IPC request exposes it; the GUI "use the
+//! network-elected coordinator" toggle that calls it is the deferred next task.
 
+use sha2::{Digest, Sha256};
 use wraith_protocol::sortition::shard_for;
+
+/// Domain separator for the coordinator shard key.
+const SHARD_KEY_DOMAIN: &[u8] = b"ghost/wraith/coordinator-shard/v1";
 
 /// Pick the coordinator endpoint that owns `shard_key` from a node's
 /// `/api/v1/pool/coordinator` JSON. Pure (no I/O) so it is unit-testable.
@@ -41,10 +42,33 @@ pub fn pick_seat_endpoint(status: &serde_json::Value, shard_key: &[u8; 32]) -> O
         .map(String::from)
 }
 
-// NOTE: the *fetch* of the election JSON is deliberately not here. The wallet
-// must request it via ghost-pay (hard rule: never hit the node's pool API
-// directly), so the relay + the GUI toggle that supplies the shard key land
-// together in the next task. This module owns only the channel-agnostic pick.
+/// Derive the shard key a wallet uses to pick its coordinator seat, from the mix
+/// `(tier_id, epoch)`. Sharding on (tier, epoch) — rather than a per-mix session
+/// id, which doesn't exist until the coordinator creates it — makes every wallet
+/// wanting the same denomination in the same epoch converge on the SAME seat, for
+/// a larger anonymity set. `SHA256(domain || tier_le || epoch_le)`.
+pub fn shard_key_for_tier_epoch(tier_id: u32, epoch: u64) -> [u8; 32] {
+    let mut h = Sha256::new();
+    h.update(SHARD_KEY_DOMAIN);
+    h.update(tier_id.to_le_bytes());
+    h.update(epoch.to_le_bytes());
+    h.finalize().into()
+}
+
+/// Resolve the coordinator endpoint for a mix of `tier_id` from a node's election
+/// JSON (as relayed by ghost-pay). Returns `(endpoint, epoch)`: `endpoint` is
+/// `None` when the election is disabled/empty, the epoch is missing, or the owning
+/// seat hasn't advertised yet — the caller then falls back to a manual URL. Pure
+/// (no I/O) so the daemon handler is a thin fetch around it.
+pub fn resolve_from_election(
+    election: &serde_json::Value,
+    tier_id: u32,
+) -> (Option<String>, Option<u64>) {
+    let epoch = election.get("epoch").and_then(|e| e.as_u64());
+    let endpoint =
+        epoch.and_then(|ep| pick_seat_endpoint(election, &shard_key_for_tier_epoch(tier_id, ep)));
+    (endpoint, epoch)
+}
 
 #[cfg(test)]
 mod tests {
@@ -92,5 +116,48 @@ mod tests {
         // Empty-string endpoint is treated as unadvertised.
         let s = status(true, json!([{"node_id":"aa","seat":0,"endpoint":""}]));
         assert_eq!(pick_seat_endpoint(&s, &[0u8; 32]), None);
+    }
+
+    #[test]
+    fn shard_key_is_deterministic_and_separates_tier_and_epoch() {
+        // Stable for the same (tier, epoch) → wallets converge.
+        assert_eq!(
+            shard_key_for_tier_epoch(2, 100),
+            shard_key_for_tier_epoch(2, 100)
+        );
+        // Different tier OR epoch → different key.
+        assert_ne!(
+            shard_key_for_tier_epoch(2, 100),
+            shard_key_for_tier_epoch(3, 100)
+        );
+        assert_ne!(
+            shard_key_for_tier_epoch(2, 100),
+            shard_key_for_tier_epoch(2, 101)
+        );
+    }
+
+    #[test]
+    fn resolve_from_election_uses_epoch_and_falls_back() {
+        let s = json!({
+            "enabled": true,
+            "epoch": 42,
+            "coordinators": [
+                {"node_id":"aa","seat":0,"endpoint":"http://a:9100"},
+                {"node_id":"bb","seat":1,"endpoint":"http://b:9100"},
+            ]
+        });
+        let (ep, epoch) = resolve_from_election(&s, 2);
+        assert_eq!(epoch, Some(42));
+        assert!(matches!(
+            ep.as_deref(),
+            Some("http://a:9100") | Some("http://b:9100")
+        ));
+
+        // No epoch (election pending) → no endpoint, caller falls back.
+        let pending = json!({ "enabled": true, "epoch": null, "coordinators": [] });
+        assert_eq!(resolve_from_election(&pending, 2), (None, None));
+        // Disabled → nothing.
+        let off = json!({ "enabled": false });
+        assert_eq!(resolve_from_election(&off, 2), (None, None));
     }
 }

--- a/apps/wraith-wallet/daemon/src/coordinator_resolve.rs
+++ b/apps/wraith-wallet/daemon/src/coordinator_resolve.rs
@@ -46,11 +46,12 @@ pub fn pick_seat_endpoint(status: &serde_json::Value, shard_key: &[u8; 32]) -> O
 /// `(tier_id, epoch)`. Sharding on (tier, epoch) — rather than a per-mix session
 /// id, which doesn't exist until the coordinator creates it — makes every wallet
 /// wanting the same denomination in the same epoch converge on the SAME seat, for
-/// a larger anonymity set. `SHA256(domain || tier_le || epoch_le)`.
-pub fn shard_key_for_tier_epoch(tier_id: u32, epoch: u64) -> [u8; 32] {
+/// a larger anonymity set. `tier_id` is the protocol's string tier id.
+/// `SHA256(domain || tier_id_bytes || epoch_le)`.
+pub fn shard_key_for_tier_epoch(tier_id: &str, epoch: u64) -> [u8; 32] {
     let mut h = Sha256::new();
     h.update(SHARD_KEY_DOMAIN);
-    h.update(tier_id.to_le_bytes());
+    h.update(tier_id.as_bytes());
     h.update(epoch.to_le_bytes());
     h.finalize().into()
 }
@@ -62,7 +63,7 @@ pub fn shard_key_for_tier_epoch(tier_id: u32, epoch: u64) -> [u8; 32] {
 /// (no I/O) so the daemon handler is a thin fetch around it.
 pub fn resolve_from_election(
     election: &serde_json::Value,
-    tier_id: u32,
+    tier_id: &str,
 ) -> (Option<String>, Option<u64>) {
     let epoch = election.get("epoch").and_then(|e| e.as_u64());
     let endpoint =
@@ -122,17 +123,17 @@ mod tests {
     fn shard_key_is_deterministic_and_separates_tier_and_epoch() {
         // Stable for the same (tier, epoch) → wallets converge.
         assert_eq!(
-            shard_key_for_tier_epoch(2, 100),
-            shard_key_for_tier_epoch(2, 100)
+            shard_key_for_tier_epoch("0.01btc", 100),
+            shard_key_for_tier_epoch("0.01btc", 100)
         );
         // Different tier OR epoch → different key.
         assert_ne!(
-            shard_key_for_tier_epoch(2, 100),
-            shard_key_for_tier_epoch(3, 100)
+            shard_key_for_tier_epoch("0.01btc", 100),
+            shard_key_for_tier_epoch("0.1btc", 100)
         );
         assert_ne!(
-            shard_key_for_tier_epoch(2, 100),
-            shard_key_for_tier_epoch(2, 101)
+            shard_key_for_tier_epoch("0.01btc", 100),
+            shard_key_for_tier_epoch("0.01btc", 101)
         );
     }
 
@@ -146,7 +147,7 @@ mod tests {
                 {"node_id":"bb","seat":1,"endpoint":"http://b:9100"},
             ]
         });
-        let (ep, epoch) = resolve_from_election(&s, 2);
+        let (ep, epoch) = resolve_from_election(&s, "0.01btc");
         assert_eq!(epoch, Some(42));
         assert!(matches!(
             ep.as_deref(),
@@ -155,9 +156,9 @@ mod tests {
 
         // No epoch (election pending) → no endpoint, caller falls back.
         let pending = json!({ "enabled": true, "epoch": null, "coordinators": [] });
-        assert_eq!(resolve_from_election(&pending, 2), (None, None));
+        assert_eq!(resolve_from_election(&pending, "0.01btc"), (None, None));
         // Disabled → nothing.
         let off = json!({ "enabled": false });
-        assert_eq!(resolve_from_election(&off, 2), (None, None));
+        assert_eq!(resolve_from_election(&off, "0.01btc"), (None, None));
     }
 }

--- a/apps/wraith-wallet/daemon/src/main.rs
+++ b/apps/wraith-wallet/daemon/src/main.rs
@@ -3407,7 +3407,7 @@ mod unix {
                     ) {
                         Ok(client) => match client.coordinator_election().await {
                             Ok(election) => crate::coordinator_resolve::resolve_from_election(
-                                &election, tier_id,
+                                &election, &tier_id,
                             ),
                             Err(e) => {
                                 tracing::debug!(error = %e, "resolve coordinator: election fetch failed");

--- a/apps/wraith-wallet/daemon/src/main.rs
+++ b/apps/wraith-wallet/daemon/src/main.rs
@@ -3395,6 +3395,32 @@ mod unix {
                     }),
                 }
             }
+            Request::WraithResolveCoordinator { tier_id } => {
+                // Fetch the node's election view THROUGH ghost-pay (wallet hard
+                // rule: never the pool API directly), then resolve the seat that
+                // owns this tier. Any failure → (None, None) so the caller falls
+                // back to a manually-configured coordinator URL.
+                let (endpoint, epoch) =
+                    match wraith_wallet_core::chain::GhostPayClient::with_urls_and_proxy(
+                        state.ghost_pay_urls.clone(),
+                        None,
+                    ) {
+                        Ok(client) => match client.coordinator_election().await {
+                            Ok(election) => crate::coordinator_resolve::resolve_from_election(
+                                &election, tier_id,
+                            ),
+                            Err(e) => {
+                                tracing::debug!(error = %e, "resolve coordinator: election fetch failed");
+                                (None, None)
+                            }
+                        },
+                        Err(e) => {
+                            tracing::debug!(error = %e, "resolve coordinator: ghost-pay client build failed");
+                            (None, None)
+                        }
+                    };
+                Response::WraithCoordinatorResolved { endpoint, epoch }
+            }
             Request::WraithMixOneShot {
                 coordinator_url,
                 socks5_proxy,

--- a/apps/wraith-wallet/ipc/src/lib.rs
+++ b/apps/wraith-wallet/ipc/src/lib.rs
@@ -349,7 +349,7 @@ pub enum Request {
     /// seat. Reply: [`Response::WraithCoordinatorResolved`]. Falls back to a
     /// manual coordinator URL when this yields no endpoint.
     WraithResolveCoordinator {
-        tier_id: u32,
+        tier_id: String,
     },
     WraithMixOneShot {
         coordinator_url: String,

--- a/apps/wraith-wallet/ipc/src/lib.rs
+++ b/apps/wraith-wallet/ipc/src/lib.rs
@@ -342,6 +342,15 @@ pub enum Request {
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         coordinator_peers: Vec<String>,
     },
+    /// Resolve an elected coordinator endpoint for a mix of `tier_id` from the
+    /// node's decentralised-election view (fetched THROUGH ghost-pay, never the
+    /// pool API directly — wallet hard rule). The wallet shards on (tier, epoch)
+    /// so all wallets wanting the same denomination this epoch converge on one
+    /// seat. Reply: [`Response::WraithCoordinatorResolved`]. Falls back to a
+    /// manual coordinator URL when this yields no endpoint.
+    WraithResolveCoordinator {
+        tier_id: u32,
+    },
     WraithMixOneShot {
         coordinator_url: String,
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -548,6 +557,14 @@ pub enum Response {
     /// unsigned bitcoin transaction + the metadata the caller needs
     /// to compute its own input witness.
     WraithCoordinatorDiscover(WraithDiscoverResponse),
+    /// Reply to [`Request::WraithResolveCoordinator`]. `endpoint` is the elected
+    /// coordinator to dial for the requested tier, or `None` when the election is
+    /// off/pending/unadvertised (caller falls back to a manual URL). `epoch` is
+    /// the election epoch the resolution was sharded on, when known.
+    WraithCoordinatorResolved {
+        endpoint: Option<String>,
+        epoch: Option<u64>,
+    },
     WraithMixPrepared(WraithMixPreparedResponse),
     /// Reply to [`Request::WraithMixSubmit`]. Carries the broadcast
     /// txid and the index of the wallet's mixed output.


### PR DESCRIPTION
Wires the **wallet side** of decentralised coordinator discovery, consuming the ghost-pay relay (#96). Completes the backend chain — only the GUI toggle remains. (Recreated cleanly against `main` after #95 merged; was #97.)

## Chain
1. **core** — `GhostPayClient::coordinator_election()` fetches the node election view via ghost-pay's relay (`GET /api/v1/pool/coordinator`), multi-URL failover. Wallet never hits the node pool API directly (hard rule).
2. **daemon** — `coordinator_resolve` gains `shard_key_for_tier_epoch()` (shard on (tier, epoch) → wallets converge on one seat = bigger anonymity set) and `resolve_from_election()`. The `pick_seat_endpoint` picker is now consumed, so its `allow(dead_code)` is removed.
3. **ipc** — `Request::WraithResolveCoordinator { tier_id }` + `Response::WraithCoordinatorResolved { endpoint, epoch }`; daemon handler fetches via ghost-pay and resolves, `None` on failure → caller falls back to a manual URL.

## Tests
4 `coordinator_resolve` unit tests pass (shard key deterministic + separates tier/epoch; resolve uses epoch and falls back when pending/disabled).

## Pairs with
The ghost-pay relay (#96). GUI "use the network-elected coordinator" toggle is the next piece.