### PR TITLE
wraith-wallet: Ghost Glyph screen (view / design / claim)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10538,6 +10538,7 @@ dependencies = [
  "secrecy",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "tempfile",
  "tokio",
  "tracing",

--- a/apps/wraith-wallet/cli/src/main.rs
+++ b/apps/wraith-wallet/cli/src/main.rs
@@ -1203,6 +1203,30 @@ mod unix {
                 println!("  spend_pubkey: {}", g.spend_public_key_hex);
                 std::process::ExitCode::SUCCESS
             }
+            Ok(Response::WalletGlyph(g)) => {
+                println!("ghost_id:     {}", g.ghost_id);
+                println!("status:       {}", g.status);
+                println!("bitmap_hash:  {}", g.bitmap_hash);
+                println!("commitment:   {}", g.commitment);
+                if let Some(txid) = &g.funding_txid {
+                    println!("funding_txid: {txid}");
+                }
+                if let Some(at) = g.registered_at {
+                    println!("registered_at:{at}");
+                }
+                println!("pixels:       {} bytes", g.pixels.len());
+                std::process::ExitCode::SUCCESS
+            }
+            Ok(Response::WalletGlyphClaimed(r)) => {
+                println!("status:       {}", r.status);
+                println!("bitmap_hash:  {}", r.bitmap_hash);
+                println!("commitment:   {}", r.commitment);
+                std::process::ExitCode::SUCCESS
+            }
+            Ok(Response::WalletGlyphChecked { available }) => {
+                println!("available: {available}");
+                std::process::ExitCode::SUCCESS
+            }
             Ok(Response::WalletShowMnemonic(m)) => {
                 println!("WARNING: anyone with these 24 words owns the wallet.\n");
                 println!("{}\n", m.mnemonic);

--- a/apps/wraith-wallet/core/src/chain/ghost_pay.rs
+++ b/apps/wraith-wallet/core/src/chain/ghost_pay.rs
@@ -268,6 +268,148 @@ impl GhostPayClient {
             .map_err(|e| ChainError::Malformed(e.to_string()))
     }
 
+    /// Fetch the registered Ghost Glyph for `ghost_id` via
+    /// `GET /api/v1/glyph/{ghost_id}`. Public route. Returns the raw
+    /// `GlyphInfoResponse` JSON; the daemon narrows it into a typed
+    /// struct. A 404 (no glyph yet) surfaces as `ChainError::Backend`.
+    pub async fn get_glyph(&self, ghost_id: &str) -> Result<serde_json::Value, ChainError> {
+        let mut last_err: Option<ChainError> = None;
+        for base in &self.base_urls {
+            match self.try_get_glyph(base, ghost_id).await {
+                Ok(v) => return Ok(v),
+                Err(e) => {
+                    tracing::debug!(url = %base, error = %e, "ghost-pay get_glyph failed, trying next");
+                    last_err = Some(e);
+                }
+            }
+        }
+        Err(last_err.unwrap_or_else(|| ChainError::Transport("no endpoints configured".into())))
+    }
+
+    /// Check whether a glyph bitmap is unclaimed via
+    /// `GET /api/v1/glyph/check/{bitmap_hash_hex}`. Public route.
+    /// Returns the raw `{ "available": bool }` JSON.
+    pub async fn check_glyph(
+        &self,
+        bitmap_hash_hex: &str,
+    ) -> Result<serde_json::Value, ChainError> {
+        let mut last_err: Option<ChainError> = None;
+        for base in &self.base_urls {
+            match self.try_check_glyph(base, bitmap_hash_hex).await {
+                Ok(v) => return Ok(v),
+                Err(e) => {
+                    tracing::debug!(url = %base, error = %e, "ghost-pay check_glyph failed, trying next");
+                    last_err = Some(e);
+                }
+            }
+        }
+        Err(last_err.unwrap_or_else(|| ChainError::Transport("no endpoints configured".into())))
+    }
+
+    /// Claim a glyph bitmap for `ghost_id` via
+    /// `POST /api/v1/glyph/claim`. Authenticated route — attaches the
+    /// `X-Internal-Auth` header when `with_internal_secret(...)` was
+    /// set, otherwise ghost-pay returns 401. Returns the raw
+    /// `GlyphClaimResponse` JSON.
+    pub async fn claim_glyph(
+        &self,
+        ghost_id: &str,
+        pixels: &[u8],
+    ) -> Result<serde_json::Value, ChainError> {
+        let mut last_err: Option<ChainError> = None;
+        for base in &self.base_urls {
+            match self.try_claim_glyph(base, ghost_id, pixels).await {
+                Ok(v) => return Ok(v),
+                Err(e) => {
+                    tracing::debug!(url = %base, error = %e, "ghost-pay claim_glyph failed, trying next");
+                    last_err = Some(e);
+                }
+            }
+        }
+        Err(last_err.unwrap_or_else(|| ChainError::Transport("no endpoints configured".into())))
+    }
+
+    async fn try_get_glyph(
+        &self,
+        base_url: &str,
+        ghost_id: &str,
+    ) -> Result<serde_json::Value, ChainError> {
+        let url = self.endpoint(base_url, &format!("/api/v1/glyph/{ghost_id}"));
+        let resp = self
+            .http
+            .get(&url)
+            .send()
+            .await
+            .map_err(|e| ChainError::Transport(e.to_string()))?;
+        let status = resp.status();
+        if !status.is_success() {
+            let detail = resp.text().await.unwrap_or_default();
+            return Err(ChainError::Backend(format!(
+                "ghost-pay glyph returned {}: {}",
+                status, detail
+            )));
+        }
+        resp.json::<serde_json::Value>()
+            .await
+            .map_err(|e| ChainError::Malformed(e.to_string()))
+    }
+
+    async fn try_check_glyph(
+        &self,
+        base_url: &str,
+        bitmap_hash_hex: &str,
+    ) -> Result<serde_json::Value, ChainError> {
+        let url = self.endpoint(base_url, &format!("/api/v1/glyph/check/{bitmap_hash_hex}"));
+        let resp = self
+            .http
+            .get(&url)
+            .send()
+            .await
+            .map_err(|e| ChainError::Transport(e.to_string()))?;
+        let status = resp.status();
+        if !status.is_success() {
+            let detail = resp.text().await.unwrap_or_default();
+            return Err(ChainError::Backend(format!(
+                "ghost-pay glyph check returned {}: {}",
+                status, detail
+            )));
+        }
+        resp.json::<serde_json::Value>()
+            .await
+            .map_err(|e| ChainError::Malformed(e.to_string()))
+    }
+
+    async fn try_claim_glyph(
+        &self,
+        base_url: &str,
+        ghost_id: &str,
+        pixels: &[u8],
+    ) -> Result<serde_json::Value, ChainError> {
+        let url = self.endpoint(base_url, "/api/v1/glyph/claim");
+        let mut req = self.http.post(&url).json(&serde_json::json!({
+            "ghost_id": ghost_id,
+            "pixels": pixels,
+        }));
+        if let Some(secret) = &self.internal_secret {
+            req = req.header("X-Internal-Auth", secret);
+        }
+        let resp = req
+            .send()
+            .await
+            .map_err(|e| ChainError::Transport(e.to_string()))?;
+        let status = resp.status();
+        if !status.is_success() {
+            let detail = resp.text().await.unwrap_or_default();
+            return Err(ChainError::Backend(format!(
+                "ghost-pay glyph claim returned {}: {}",
+                status, detail
+            )));
+        }
+        resp.json::<serde_json::Value>()
+            .await
+            .map_err(|e| ChainError::Malformed(e.to_string()))
+    }
+
     async fn try_status(&self, base_url: &str) -> Result<ChainStatus, ChainError> {
         let url = self.endpoint(base_url, "/api/v1/status");
         let resp = self

--- a/apps/wraith-wallet/daemon/Cargo.toml
+++ b/apps/wraith-wallet/daemon/Cargo.toml
@@ -28,6 +28,7 @@ secrecy = { workspace = true }
 hex = { workspace = true }
 rand = { workspace = true }
 reqwest = { workspace = true }
+sha2 = { workspace = true }
 
 [dev-dependencies]
 wraith-wallet-ipc = { workspace = true }

--- a/apps/wraith-wallet/daemon/src/main.rs
+++ b/apps/wraith-wallet/daemon/src/main.rs
@@ -59,13 +59,13 @@ mod unix {
     use wraith_wallet_ipc::{
         default_socket_path, ChainStatusResponse, CheckForUpdateResponse, DaemonEnvResponse,
         DetectedPaymentEntry, DoctorCheck, DoctorResponse, Envelope, ErrorResponse,
-        GspAuthResponse, GspPingResponse, GspSessionStatusResponse, HealthResponse,
-        LightBalanceResponse, LightDetectedResponse, LightHistoryEntry, LightHistoryResponse,
-        LightL1UtxoEntry, LightL1UtxosResponse, LightReceiveResponse, LightSentResponse,
-        LightUtxoEntry, LightUtxosResponse, LockEntry, LocksConfirmedResponse, LocksJumpedResponse,
-        LocksListResponse, LocksPreparedResponse, LocksRecoveredResponse, PsbtBroadcastResponse,
-        PsbtBumpFeeResponse, PsbtInputSummary, PsbtInspectResponse, PsbtOutputSummary,
-        PsbtSignResponse, ReleaseManifest, Request, Response, SignerInfoIpc,
+        GlyphClaimResult, GlyphInfo, GspAuthResponse, GspPingResponse, GspSessionStatusResponse,
+        HealthResponse, LightBalanceResponse, LightDetectedResponse, LightHistoryEntry,
+        LightHistoryResponse, LightL1UtxoEntry, LightL1UtxosResponse, LightReceiveResponse,
+        LightSentResponse, LightUtxoEntry, LightUtxosResponse, LockEntry, LocksConfirmedResponse,
+        LocksJumpedResponse, LocksListResponse, LocksPreparedResponse, LocksRecoveredResponse,
+        PsbtBroadcastResponse, PsbtBumpFeeResponse, PsbtInputSummary, PsbtInspectResponse,
+        PsbtOutputSummary, PsbtSignResponse, ReleaseManifest, Request, Response, SignerInfoIpc,
         WalletAuthInfoResponse, WalletCreateResponse, WalletDeriveResponse, WalletGhostIdResponse,
         WalletListEntry, WalletListResponse, WalletShowMnemonicResponse, WalletStatusResponse,
         WalletXpubResponse, WraithDiscoverResponse, WraithDiscoverTier, WraithMixCompletedResponse,
@@ -259,6 +259,40 @@ mod unix {
             // bitcoin 0.32 has more variants in non_exhaustive — default to Mainnet.
             _ => ghost_keys::GhostNetwork::Mainnet,
         }
+    }
+
+    /// Construct a fresh concrete `GhostPayClient` for the glyph
+    /// routes. `state.chain` is a `dyn ChainClient` trait object, so
+    /// it can't expose the inherent glyph methods — rebuild from the
+    /// daemon's configured ghost-pay URLs + proxy, attaching the
+    /// internal-auth secret (claim is an authenticated route).
+    fn build_ghost_pay_client(
+        state: &DaemonState,
+    ) -> Result<wraith_wallet_core::chain::GhostPayClient, String> {
+        let mut c = wraith_wallet_core::chain::GhostPayClient::with_urls_and_proxy(
+            state.ghost_pay_urls.clone(),
+            state.tor_proxy.as_deref(),
+        )
+        .map_err(|e| format!("ghost-pay client: {e}"))?;
+        if let Ok(secret) = std::env::var(GHOST_PAY_INTERNAL_AUTH_ENV) {
+            if !secret.is_empty() {
+                c = c.with_internal_secret(secret);
+            }
+        }
+        Ok(c)
+    }
+
+    /// Compute the glyph bitmap uniqueness hash exactly as
+    /// ghost-glyph defines it: hex(SHA256("GhostGlyphBitmap/v1" ||
+    /// pixels)). Must stay byte-for-byte identical to
+    /// `GhostGlyph::compute_bitmap_hash` or `check` queries the
+    /// wrong key.
+    fn glyph_bitmap_hash_hex(pixels: &[u8]) -> String {
+        use sha2::{Digest, Sha256};
+        let mut hasher = Sha256::new();
+        hasher.update(b"GhostGlyphBitmap/v1");
+        hasher.update(pixels);
+        hex::encode(hasher.finalize())
     }
 
     fn parse_network(s: &str) -> Option<bitcoin::Network> {
@@ -3040,6 +3074,52 @@ mod unix {
                     Err(message) => Response::Error(ErrorResponse { message }),
                 }
             }
+            Request::WalletGlyph { ghost_id } => match build_ghost_pay_client(state) {
+                Ok(client) => match client.get_glyph(&ghost_id).await {
+                    Ok(v) => match serde_json::from_value::<GlyphInfo>(v) {
+                        Ok(info) => Response::WalletGlyph(info),
+                        Err(e) => Response::Error(ErrorResponse {
+                            message: format!("glyph parse: {e}"),
+                        }),
+                    },
+                    Err(e) => Response::Error(ErrorResponse {
+                        message: format!("glyph: {e}"),
+                    }),
+                },
+                Err(message) => Response::Error(ErrorResponse { message }),
+            },
+            Request::WalletGlyphCheck { pixels } => match build_ghost_pay_client(state) {
+                Ok(client) => {
+                    let bitmap_hash_hex = glyph_bitmap_hash_hex(&pixels);
+                    match client.check_glyph(&bitmap_hash_hex).await {
+                        Ok(v) => {
+                            let available = v
+                                .get("available")
+                                .and_then(|b| b.as_bool())
+                                .unwrap_or(false);
+                            Response::WalletGlyphChecked { available }
+                        }
+                        Err(e) => Response::Error(ErrorResponse {
+                            message: format!("glyph check: {e}"),
+                        }),
+                    }
+                }
+                Err(message) => Response::Error(ErrorResponse { message }),
+            },
+            Request::WalletGlyphClaim { ghost_id, pixels } => match build_ghost_pay_client(state) {
+                Ok(client) => match client.claim_glyph(&ghost_id, &pixels).await {
+                    Ok(v) => match serde_json::from_value::<GlyphClaimResult>(v) {
+                        Ok(r) => Response::WalletGlyphClaimed(r),
+                        Err(e) => Response::Error(ErrorResponse {
+                            message: format!("glyph claim parse: {e}"),
+                        }),
+                    },
+                    Err(e) => Response::Error(ErrorResponse {
+                        message: format!("glyph claim: {e}"),
+                    }),
+                },
+                Err(message) => Response::Error(ErrorResponse { message }),
+            },
             Request::WalletAuthInfo => {
                 match with_active_wallet(state, |_, ks| {
                     let kp = auth::auth_keypair(ks).map_err(|e| format!("auth-info: {e}"))?;

--- a/apps/wraith-wallet/gui/src-tauri/src/lib.rs
+++ b/apps/wraith-wallet/gui/src-tauri/src/lib.rs
@@ -147,6 +147,27 @@ async fn wallet_ghost_id() -> Result<serde_json::Value, String> {
 }
 
 #[tauri::command]
+async fn wallet_glyph(ghost_id: String) -> Result<serde_json::Value, String> {
+    let resp = call_daemon(Request::WalletGlyph { ghost_id }).await?;
+    to_value(&resp)
+}
+
+#[tauri::command]
+async fn wallet_glyph_claim(
+    ghost_id: String,
+    pixels: Vec<u8>,
+) -> Result<serde_json::Value, String> {
+    let resp = call_daemon(Request::WalletGlyphClaim { ghost_id, pixels }).await?;
+    to_value(&resp)
+}
+
+#[tauri::command]
+async fn wallet_glyph_check(pixels: Vec<u8>) -> Result<serde_json::Value, String> {
+    let resp = call_daemon(Request::WalletGlyphCheck { pixels }).await?;
+    to_value(&resp)
+}
+
+#[tauri::command]
 async fn wallet_auth_info() -> Result<serde_json::Value, String> {
     let resp = call_daemon(Request::WalletAuthInfo).await?;
     to_value(&resp)
@@ -691,6 +712,9 @@ pub fn run() {
             wraith_coordinator_discover,
             wraith_mix_run,
             wallet_ghost_id,
+            wallet_glyph,
+            wallet_glyph_claim,
+            wallet_glyph_check,
             wallet_auth_info,
             gsp_register_scan_key,
             gsp_session_status,

--- a/apps/wraith-wallet/gui/src/App.tsx
+++ b/apps/wraith-wallet/gui/src/App.tsx
@@ -17,6 +17,7 @@ import { Send } from "./screens/Send";
 import { Sign } from "./screens/Sign";
 import { Cosigner } from "./screens/Cosigner";
 import { Mix } from "./screens/Mix";
+import { Glyph } from "./screens/Glyph";
 import { Merchant } from "./screens/Merchant";
 import { Reports } from "./screens/Reports";
 import { Locks } from "./screens/Locks";
@@ -35,6 +36,7 @@ type Screen =
   | "sign"
   | "cosigner"
   | "mix"
+  | "glyph"
   | "merchant"
   | "reports"
   | "locks"
@@ -49,6 +51,7 @@ const NAV: Array<{ id: Screen; label: string }> = [
   { id: "sign", label: "Sign" },
   { id: "cosigner", label: "Cosigner" },
   { id: "mix", label: "Mix" },
+  { id: "glyph", label: "Glyph" },
   { id: "merchant", label: "Merchant" },
   { id: "reports", label: "Reports" },
   { id: "locks", label: "Locks" },
@@ -215,6 +218,8 @@ export default function App() {
         return <Cosigner activeWallet={walletState.active} />;
       case "mix":
         return <Mix activeWallet={walletState.active} />;
+      case "glyph":
+        return <Glyph activeWallet={walletState.active} />;
       case "merchant":
         return (
           <Merchant

--- a/apps/wraith-wallet/gui/src/lib/tauri.ts
+++ b/apps/wraith-wallet/gui/src/lib/tauri.ts
@@ -287,6 +287,57 @@ export async function walletGhostId(): Promise<{
   }>(resp).payload;
 }
 
+// ----- Ghost Glyph -------------------------------------------------------
+
+export interface GlyphInfo {
+  ghost_id: string;
+  /// 256 palette indices (0..25), row-major.
+  pixels: number[];
+  /// SHA256("GhostGlyphBitmap/v1" || pixels), hex — uniqueness key.
+  bitmap_hash: string;
+  /// SHA256("GhostGlyph/v1" || pixels || ghost_id), hex — binding.
+  commitment: string;
+  /// Wraith deposit txid that funded the lock (null while pending).
+  funding_txid: string | null;
+  /// Unix timestamp the lock was funded (null while pending).
+  registered_at: number | null;
+  /// One of: "none" / "pending" / "registered".
+  status: string;
+}
+
+export interface GlyphClaimResult {
+  commitment: string;
+  bitmap_hash: string;
+  status: string;
+}
+
+/// Fetch the registered Ghost Glyph for `ghostId`. Throws if the
+/// daemon returns an error (e.g. ghost-pay 404 — no glyph yet); the
+/// caller treats that as "not yet designed".
+export async function getGlyph(ghostId: string): Promise<GlyphInfo> {
+  const resp = await invoke("wallet_glyph", { ghostId });
+  return unwrap<GlyphInfo>(resp).payload;
+}
+
+/// Claim a designed glyph. `pixels` is a 256-length array of palette
+/// indices (0..25). Authenticated at the daemon via internal-auth.
+export async function claimGlyph(
+  ghostId: string,
+  pixels: number[],
+): Promise<GlyphClaimResult> {
+  const resp = await invoke("wallet_glyph_claim", { ghostId, pixels });
+  return unwrap<GlyphClaimResult>(resp).payload;
+}
+
+/// Check whether the bitmap formed by `pixels` is unclaimed. The
+/// daemon computes the bitmap hash and queries ghost-pay.
+export async function checkGlyph(
+  pixels: number[],
+): Promise<{ available: boolean }> {
+  const resp = await invoke("wallet_glyph_check", { pixels });
+  return unwrap<{ available: boolean }>(resp).payload;
+}
+
 // ----- Light wallet (L2) -------------------------------------------------
 
 export interface LightBalanceResponse {

--- a/apps/wraith-wallet/gui/src/screens/Glyph.tsx
+++ b/apps/wraith-wallet/gui/src/screens/Glyph.tsx
@@ -1,0 +1,424 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  checkGlyph,
+  claimGlyph,
+  getGlyph,
+  walletGhostId,
+  type GlyphInfo,
+} from "../lib/tauri";
+
+interface GlyphProps {
+  activeWallet: string | null;
+}
+
+const GRID = 16;
+const PIXELS = GRID * GRID; // 256
+
+/// The 26-colour Ghost Glyph palette. Index → [r, g, b]. Copied
+/// byte-for-byte from `crates/ghost-glyph/src/palette.rs` — palette
+/// indices are what the bitmap (and its hash) are built from, so this
+/// must never drift from the crate.
+const PALETTE: [number, number, number][] = [
+  [0, 0, 0],
+  [255, 255, 255],
+  [28, 28, 36],
+  [48, 48, 64],
+  [80, 80, 104],
+  [128, 128, 160],
+  [192, 192, 212],
+  [24, 32, 80],
+  [40, 60, 140],
+  [64, 100, 200],
+  [120, 160, 230],
+  [16, 48, 32],
+  [32, 100, 64],
+  [80, 200, 120],
+  [160, 240, 180],
+  [80, 16, 16],
+  [160, 40, 24],
+  [220, 80, 40],
+  [255, 160, 80],
+  [48, 16, 80],
+  [100, 40, 160],
+  [160, 80, 220],
+  [200, 160, 255],
+  [255, 220, 60],
+  [0, 200, 200],
+  [255, 100, 160],
+];
+
+function rgb(idx: number): string {
+  const c = PALETTE[idx] ?? PALETTE[0];
+  return `rgb(${c[0]}, ${c[1]}, ${c[2]})`;
+}
+
+function blankPixels(): number[] {
+  return new Array<number>(PIXELS).fill(0);
+}
+
+function shortHash(h: string | null | undefined): string {
+  if (!h) return "—";
+  return h.length > 20 ? `${h.slice(0, 10)}…${h.slice(-8)}` : h;
+}
+
+export function Glyph({ activeWallet }: GlyphProps) {
+  const [ghostId, setGhostId] = useState<string | null>(null);
+  const [pixels, setPixels] = useState<number[]>(blankPixels);
+  const [selected, setSelected] = useState<number>(1); // white by default
+  const [info, setInfo] = useState<GlyphInfo | null>(null);
+  const [designed, setDesigned] = useState(false);
+
+  const [loading, setLoading] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const [avail, setAvail] = useState<boolean | null>(null);
+  const [claimMsg, setClaimMsg] = useState<string | null>(null);
+  const [painting, setPainting] = useState(false);
+
+  // Load the wallet's ghost_id, then its existing glyph (if any). A
+  // daemon error on getGlyph (ghost-pay 404 — no glyph registered)
+  // is the expected "not yet designed" path: start from a blank grid.
+  useEffect(() => {
+    if (!activeWallet) return;
+    let alive = true;
+    setLoading(true);
+    setErr(null);
+    setAvail(null);
+    setClaimMsg(null);
+    (async () => {
+      try {
+        const id = await walletGhostId();
+        if (!alive) return;
+        setGhostId(id.ghost_id);
+        try {
+          const g = await getGlyph(id.ghost_id);
+          if (!alive) return;
+          if (g.pixels && g.pixels.length === PIXELS && g.status !== "none") {
+            setInfo(g);
+            setPixels(g.pixels.slice());
+            setDesigned(true);
+          } else {
+            setInfo(g.status === "none" ? null : g);
+            setPixels(blankPixels());
+            setDesigned(false);
+          }
+        } catch {
+          // No glyph registered yet — blank canvas.
+          if (!alive) return;
+          setInfo(null);
+          setPixels(blankPixels());
+          setDesigned(false);
+        }
+      } catch (e) {
+        if (!alive) return;
+        setErr((e as Error).message ?? String(e));
+      } finally {
+        if (alive) setLoading(false);
+      }
+    })();
+    return () => {
+      alive = false;
+    };
+  }, [activeWallet]);
+
+  const paint = (i: number) => {
+    setPixels((prev) => {
+      if (prev[i] === selected) return prev;
+      const next = prev.slice();
+      next[i] = selected;
+      return next;
+    });
+    // Editing invalidates any prior availability / claim result.
+    setAvail(null);
+    setClaimMsg(null);
+  };
+
+  const onClear = () => {
+    setPixels(blankPixels());
+    setAvail(null);
+    setClaimMsg(null);
+  };
+
+  const onCheck = async () => {
+    setErr(null);
+    setAvail(null);
+    setClaimMsg(null);
+    setBusy(true);
+    try {
+      const r = await checkGlyph(pixels);
+      setAvail(r.available);
+    } catch (e) {
+      setErr((e as Error).message ?? String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onClaim = async () => {
+    setErr(null);
+    setClaimMsg(null);
+    if (!ghostId) {
+      setErr("Ghost ID not loaded yet — try again in a second.");
+      return;
+    }
+    setBusy(true);
+    try {
+      const r = await claimGlyph(ghostId, pixels);
+      setInfo((prev) => ({
+        ghost_id: ghostId,
+        pixels: pixels.slice(),
+        bitmap_hash: r.bitmap_hash,
+        commitment: r.commitment,
+        funding_txid: prev?.funding_txid ?? null,
+        registered_at: prev?.registered_at ?? null,
+        status: r.status,
+      }));
+      setDesigned(true);
+      setClaimMsg(
+        `Claimed — status ${r.status}. Pending until the lock funds (see Locks).`,
+      );
+    } catch (e) {
+      setErr((e as Error).message ?? String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const statusLabel = useMemo(() => {
+    const s = info?.status ?? (designed ? "pending" : "none");
+    if (s === "registered") return "registered";
+    if (s === "pending") return "pending";
+    return "not yet designed";
+  }, [info, designed]);
+
+  if (!activeWallet) {
+    return (
+      <div className="screen">
+        <h1>Glyph</h1>
+        <div className="card muted">
+          Select and unlock a wallet first to view or design its Ghost
+          Glyph.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="screen">
+      <div className="page-head">
+        <div>
+          <span className="eyebrow">identity · visual</span>
+          <h1>Ghost Glyph</h1>
+          <p className="lead">
+            A 16×16, 26-colour mark bound to your Ghost ID. Design one,
+            check it's unclaimed, then claim it — it locks in once its
+            funding lock confirms.
+          </p>
+        </div>
+      </div>
+
+      {err && <div className="card error-card">{err}</div>}
+
+      {claimMsg && (
+        <div className="card" style={{ borderColor: "var(--pass)" }}>
+          <p className="muted" style={{ margin: 0 }}>
+            {claimMsg}
+          </p>
+        </div>
+      )}
+
+      <div className="row" style={{ alignItems: "flex-start", gap: 16 }}>
+        {/* Editor */}
+        <div className="card" style={{ flex: 2 }}>
+          <div className="card-header">
+            <h2>Pixel editor</h2>
+            <span className="pill mute" title={`status: ${statusLabel}`}>
+              {statusLabel}
+            </span>
+          </div>
+          <p className="muted" style={{ margin: "0 0 12px", fontSize: 13 }}>
+            Click — or click and drag — to paint with the selected colour.
+          </p>
+          <div
+            className="glyph-grid"
+            style={{
+              display: "grid",
+              gridTemplateColumns: `repeat(${GRID}, 1fr)`,
+              gap: 1,
+              width: "100%",
+              maxWidth: 384,
+              aspectRatio: "1 / 1",
+              background: "var(--border, #333)",
+              border: "1px solid var(--border, #333)",
+              userSelect: "none",
+            }}
+            onMouseLeave={() => setPainting(false)}
+          >
+            {pixels.map((p, i) => (
+              <button
+                key={i}
+                type="button"
+                aria-label={`pixel ${i}`}
+                onMouseDown={() => {
+                  if (loading || busy) return;
+                  setPainting(true);
+                  paint(i);
+                }}
+                onMouseEnter={() => {
+                  if (painting && !loading && !busy) paint(i);
+                }}
+                onMouseUp={() => setPainting(false)}
+                disabled={loading || busy}
+                style={{
+                  background: rgb(p),
+                  border: 0,
+                  padding: 0,
+                  margin: 0,
+                  cursor: loading || busy ? "default" : "pointer",
+                  aspectRatio: "1 / 1",
+                }}
+              />
+            ))}
+          </div>
+
+          <div className="col" style={{ marginTop: 16 }}>
+            <label>Palette</label>
+            <div
+              style={{
+                display: "grid",
+                gridTemplateColumns: "repeat(13, 1fr)",
+                gap: 4,
+                maxWidth: 384,
+              }}
+            >
+              {PALETTE.map((_, idx) => (
+                <button
+                  key={idx}
+                  type="button"
+                  title={`colour ${idx}`}
+                  aria-label={`palette colour ${idx}`}
+                  onClick={() => setSelected(idx)}
+                  disabled={busy}
+                  style={{
+                    background: rgb(idx),
+                    aspectRatio: "1 / 1",
+                    border:
+                      selected === idx
+                        ? "2px solid var(--accent, #fff)"
+                        : "1px solid var(--border, #333)",
+                    borderRadius: 3,
+                    padding: 0,
+                    cursor: busy ? "default" : "pointer",
+                  }}
+                />
+              ))}
+            </div>
+            <p className="muted" style={{ margin: "8px 0 0", fontSize: 12 }}>
+              Selected: colour {selected}
+            </p>
+          </div>
+
+          <div className="row" style={{ marginTop: 16, gap: 8 }}>
+            <button
+              className="secondary"
+              onClick={onClear}
+              disabled={busy || loading}
+            >
+              Clear
+            </button>
+            <button
+              className="secondary"
+              onClick={onCheck}
+              disabled={busy || loading}
+            >
+              {busy ? "Working…" : "Check availability"}
+            </button>
+            <button
+              className="btn-primary"
+              onClick={onClaim}
+              disabled={busy || loading}
+            >
+              {busy ? "Working…" : "Claim glyph"}
+            </button>
+          </div>
+
+          {avail !== null && (
+            <p
+              className={`pill ${avail ? "pass" : "fail"}`}
+              style={{ marginTop: 12, display: "inline-block" }}
+            >
+              {avail ? "available — unclaimed" : "taken — pick another design"}
+            </p>
+          )}
+        </div>
+
+        {/* Preview + info */}
+        <div className="col" style={{ flex: 1, gap: 16 }}>
+          <div className="card">
+            <h2>Preview</h2>
+            <div
+              style={{
+                display: "grid",
+                gridTemplateColumns: `repeat(${GRID}, 1fr)`,
+                width: "100%",
+                maxWidth: 256,
+                aspectRatio: "1 / 1",
+                imageRendering: "pixelated",
+                border: "1px solid var(--border, #333)",
+              }}
+            >
+              {pixels.map((p, i) => (
+                <div
+                  key={i}
+                  style={{ background: rgb(p), aspectRatio: "1 / 1" }}
+                />
+              ))}
+            </div>
+          </div>
+
+          <div className="card">
+            <h2>Details</h2>
+            <div className="kv">
+              <div className="k">Ghost ID</div>
+              <div
+                className="v mono"
+                style={{ fontSize: 12, wordBreak: "break-all" }}
+              >
+                {ghostId ?? (loading ? "loading…" : "—")}
+              </div>
+              <div className="k">Status</div>
+              <div className="v">{statusLabel}</div>
+              <div className="k">Bitmap hash</div>
+              <div className="v mono" title={info?.bitmap_hash ?? ""}>
+                {shortHash(info?.bitmap_hash)}
+              </div>
+              <div className="k">Commitment</div>
+              <div className="v mono" title={info?.commitment ?? ""}>
+                {shortHash(info?.commitment)}
+              </div>
+              {info?.funding_txid && (
+                <>
+                  <div className="k">Funding txid</div>
+                  <div
+                    className="v mono"
+                    style={{ fontSize: 12, wordBreak: "break-all" }}
+                  >
+                    {info.funding_txid}
+                  </div>
+                </>
+              )}
+              {info?.registered_at != null && (
+                <>
+                  <div className="k">Registered</div>
+                  <div className="v">
+                    {new Date(info.registered_at * 1000).toLocaleString()}
+                  </div>
+                </>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/wraith-wallet/ipc/src/lib.rs
+++ b/apps/wraith-wallet/ipc/src/lib.rs
@@ -204,6 +204,23 @@ pub enum Request {
     WalletAuthInfo,
     /// Show the active wallet's BIP-352 Ghost ID (silent payment receive identity).
     WalletGhostId,
+    /// Fetch the registered Ghost Glyph for `ghost_id` from ghost-pay.
+    WalletGlyph {
+        ghost_id: String,
+    },
+    /// Claim a designed Ghost Glyph for `ghost_id`. `pixels` is a
+    /// 256-byte palette-index bitmap (values 0..25). Authenticated
+    /// against ghost-pay via the internal-auth shared secret.
+    WalletGlyphClaim {
+        ghost_id: String,
+        pixels: Vec<u8>,
+    },
+    /// Check whether a glyph bitmap is unclaimed. The daemon computes
+    /// the bitmap hash from `pixels` and queries ghost-pay's
+    /// availability endpoint.
+    WalletGlyphCheck {
+        pixels: Vec<u8>,
+    },
     /// Export the active wallet's extended public key at `path`,
     /// formatted for use as a BIP-380 descriptor key fragment.
     /// `mainnet=true` emits xpub, `mainnet=false` emits tpub.
@@ -524,6 +541,11 @@ pub enum Response {
     WalletDerive(WalletDeriveResponse),
     WalletAuthInfo(WalletAuthInfoResponse),
     WalletGhostId(WalletGhostIdResponse),
+    WalletGlyph(GlyphInfo),
+    WalletGlyphClaimed(GlyphClaimResult),
+    WalletGlyphChecked {
+        available: bool,
+    },
     WalletXpub(WalletXpubResponse),
     MultisigDescriptorInspected(MultisigDescriptorInspected),
     MultisigDescriptorSaved(MultisigDescriptorSaved),
@@ -1168,6 +1190,34 @@ pub struct WalletGhostIdResponse {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WalletShowMnemonicResponse {
     pub mnemonic: String,
+}
+
+/// The wallet's registered Ghost Glyph — a 16x16, 26-colour bitmap
+/// bound to its Ghost ID. Mirrors ghost-pay's `GlyphInfoResponse`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GlyphInfo {
+    pub ghost_id: String,
+    /// 256 palette indices (0..25), row-major.
+    pub pixels: Vec<u8>,
+    /// SHA256("GhostGlyphBitmap/v1" || pixels), hex — uniqueness key.
+    pub bitmap_hash: String,
+    /// SHA256("GhostGlyph/v1" || pixels || ghost_id), hex — binding.
+    pub commitment: String,
+    /// Wraith deposit txid that funded the lock (None while pending).
+    pub funding_txid: Option<String>,
+    /// Unix timestamp the lock was funded (None while pending).
+    pub registered_at: Option<u64>,
+    /// One of: "none" / "pending" / "registered".
+    pub status: String,
+}
+
+/// Result of claiming a Ghost Glyph. Mirrors ghost-pay's
+/// `GlyphClaimResponse`. The glyph stays `pending` until its lock funds.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GlyphClaimResult {
+    pub commitment: String,
+    pub bitmap_hash: String,
+    pub status: String,
 }
 
 /// One cosigner row inside a parsed descriptor — what


### PR DESCRIPTION
Adds the wallet GUI's **Ghost Glyph** screen — the last missing wallet screen. A glyph is a 16×16, 26-colour visual identity tied to a wallet's `ghost_id`. The backend (ghost-pay glyph endpoints + the `ghost-glyph` crate) already existed; this wires it end-to-end.

## Layers
- **core** — `GhostPayClient::{get_glyph, check_glyph, claim_glyph}` (base-URL failover; claim attaches `X-Internal-Auth`).
- **ipc** — `WalletGlyph` / `WalletGlyphClaim` / `WalletGlyphCheck` requests + matching responses + `GlyphInfo`/`GlyphClaimResult` DTOs.
- **daemon** — handlers forward to ghost-pay via a concrete client built with the existing internal-auth secret; `check` computes `hex(SHA256("GhostGlyphBitmap/v1" || pixels))`, matching `ghost-glyph` byte-for-byte. CLI gains print arms for the new variants.
- **gui** — Tauri commands + `tauri.ts` wrappers + `Glyph.tsx`: a 16×16 click/drag pixel editor, the 26-colour palette, pixelated preview, details panel, and Clear / Check-availability / Claim actions. Wired into the nav after Mix.

## Scope
Full view + design + claim, per the v1 call. Claim returns `status: pending` until the identity lock funds (via the Locks screen) — same model as the backend.

## Verified
`cargo check` (5 wallet crates) + `npx tsc --noEmit` both clean. Needs your eyes in the smoke-test for the visual/UX.