### PR TITLE
dashboard: drop fake avg-time placeholders + log silent stat errors

### DIFF
--- a/dashboard/src/lib/api/ghostpay.ts
+++ b/dashboard/src/lib/api/ghostpay.ts
@@ -122,11 +122,13 @@ export async function getWraithStats(): Promise<WraithStats> {
       avg_fill_rate: sessions.sessions?.length > 0
         ? sessions.sessions.reduce((sum, s) => sum + (s.fill_percentage ?? 0), 0) / sessions.sessions.length / 100
         : 0,
-      avg_completion_time_secs: 180, // Placeholder
       your_participations: sessions.stats?.your_participations ?? 0,
       your_completed: sessions.stats?.your_completed ?? 0,
     };
-  } catch {
+  } catch (e) {
+    // Don't fail silently — a fetch error here previously rendered as all-zeros,
+    // indistinguishable from "no activity". Log so operators can diagnose.
+    console.error("getWraithStats: failed to fetch wraith sessions", e);
     return {
       total_sessions: 0,
       active_sessions: 0,
@@ -134,7 +136,6 @@ export async function getWraithStats(): Promise<WraithStats> {
       sessions_expired: 0,
       total_participants: 0,
       avg_fill_rate: 0,
-      avg_completion_time_secs: 0,
       your_participations: 0,
       your_completed: 0,
     };
@@ -156,9 +157,10 @@ export async function getSettlementStatus(): Promise<SettlementStatus> {
       avg_batch_size: (settlement.batches?.length ?? 0) > 0
         ? settlement.batches!.reduce((sum, b) => sum + b.participant_count, 0) / settlement.batches!.length
         : 0,
-      avg_confirmation_time_mins: 30, // Placeholder
     };
-  } catch {
+  } catch (e) {
+    // See getWraithStats — log instead of silently returning all-zeros.
+    console.error("getSettlementStatus: failed to fetch settlement status", e);
     return {
       l1_available: false,
       l1_height: 0,
@@ -168,7 +170,6 @@ export async function getSettlementStatus(): Promise<SettlementStatus> {
       total_settled_24h: 0,
       current_epoch: 0,
       avg_batch_size: 0,
-      avg_confirmation_time_mins: 0,
     };
   }
 }

--- a/dashboard/src/types/api.ts
+++ b/dashboard/src/types/api.ts
@@ -440,7 +440,6 @@ export interface WraithStats {
   sessions_expired?: number;
   total_participants?: number;
   avg_fill_rate?: number;
-  avg_completion_time_secs?: number;
   your_participations?: number;
   your_completed?: number;
 }
@@ -591,7 +590,6 @@ export interface SettlementStatus {
   total_settled_24h?: number;
   current_epoch?: number;
   avg_batch_size?: number;
-  avg_confirmation_time_mins?: number;
 }
 
 // Jump Queue types


### PR DESCRIPTION
Two small honesty fixes from the v1 dashboard punch-list (the dashboard is otherwise in good shape post-#91).

- **Fake avg-times removed**: `getWraithStats`/`getSettlementStatus` returned hardcoded `avg_completion_time_secs: 180` and `avg_confirmation_time_mins: 30` placeholders. They were never actually rendered, so the values are gone from the returns + the `WraithStats`/`SettlementStatus` types — no fake data lingering in code.
- **Silent catches now log**: both functions caught fetch failures with a bare `catch {}` returning all-zeros (indistinguishable from real "no activity"). They now `console.error` the failure so an operator can tell a backend outage from idleness. Zero-fallback UI behaviour unchanged.

Verified: `tsc --noEmit` clean. Audited the other punch-list items — dead buttons are gone or wired (prune-profile, watchdog cache-clear are real), and the swarm "Configure Node" dialog is honest read-only — so no further changes needed there.