### PR TITLE
sv2: open V1+V2 firewall on public-mining nodes + fix miner docs

### DIFF
--- a/ghost-web/miners.html
+++ b/ghost-web/miners.html
@@ -259,7 +259,7 @@
         <div class="qs-n">1</div>
         <div class="qs-body">
           <div class="qs-title">Pick an endpoint</div>
-          <div class="qs-desc">Connect to any public-mining Ghost node. SV1: <code>stratum+tcp://&lt;node-host&gt;:3333</code>. SV2: <code>stratum+tcp://&lt;node-host&gt;:34255</code>. Your own node works too if you're running ghost-pool locally.</div>
+          <div class="qs-desc">Connect to any public-mining Ghost node — or <code>pool.bitcoinghost.org</code>, which round-robins across all the public nodes. <strong>Stratum&nbsp;V1</strong> (works on any ASIC): point your miner at <code>stratum+tcp://pool.bitcoinghost.org:3333</code>. <strong>Stratum&nbsp;V2</strong> (encrypted, for miners with native SV2 firmware): host <code>pool.bitcoinghost.org</code>, port <code>34255</code> — plus the two SV2 settings noted below. Running your own node with public mining on? It works the same way.</div>
         </div>
       </li>
       <li>
@@ -286,10 +286,21 @@
     </ol>
 
     <div class="pending-note">
-      Using the aggregated translator (default in most miners) or running
-      SV2 with the <code>aggregate_channels = false</code> setting both
-      work — in either case your shares are attributed to the exact
-      <code>address.worker</code> string your ASIC authorised with.
+      <strong>Stratum&nbsp;V2 settings.</strong> Most ASICs default to V1 and
+      need nothing extra. For native SV2 (e.g. a Bitaxe on AxeOS), set
+      <strong>Protocol</strong> = Stratum&nbsp;V2,
+      <strong>Channel&nbsp;type</strong> = Extended (the pool sends the coinbase
+      template, so your miner can verify it), and paste the
+      <strong>Authority&nbsp;public&nbsp;key</strong>:
+      <code>9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72</code> — the Ghost
+      network authority key, identical on every public node. Username is the same
+      <code>address.worker</code> as V1; the password is ignored.
+    </div>
+
+    <div class="pending-note">
+      Whichever you use — the aggregated translator (the V1 default) or native
+      SV2 with per-miner channels — your shares are attributed to the exact
+      <code>address.worker</code> string your miner authorised with.
     </div>
   </div>
 </section>

--- a/scripts/install-node.sh
+++ b/scripts/install-node.sh
@@ -338,14 +338,61 @@ ufw allow 8333/tcp      >/dev/null 2>&1   # bitcoin P2P
 ufw allow 8080/tcp      >/dev/null 2>&1   # ghost API
 ufw allow 8442/tcp      >/dev/null 2>&1   # TDP
 ufw allow 8555:8562/tcp >/dev/null 2>&1   # mesh consensus
-# Stratum ports are exposed ONLY when this node accepts public miners. Open
-# Stratum V1 and V2 together so any ASIC connects — legacy V1 hardware on 3333,
-# native SV2 firmware (encrypted) on 34255. A private/solo node opens neither.
-if [[ "$PUBLIC_MINING" == "true" ]]; then
-  ufw allow 3333/tcp    >/dev/null 2>&1   # stratum v1
-  ufw allow 34255/tcp   >/dev/null 2>&1   # stratum v2
-fi
 ufw --force enable      >/dev/null 2>&1
+
+# Stratum V1 (3333) + V2 (34255) are exposed ONLY when this node accepts public
+# miners. Instead of a static rule baked at install time, a tiny reconcile
+# service follows `mining_mode` in pool.toml, and a .path unit re-runs it
+# whenever the config changes — so toggling public mining later (dashboard /
+# ghost-setup / hand edit) updates the firewall live, with no manual ufw step.
+log "Installing mining-firewall reconcile (stratum ports follow mining_mode)"
+cat > /opt/ghost/bin/reconcile-mining-firewall.sh <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+CONF="${GHOST_POOL_CONF:-/etc/ghost/pool.toml}"
+PORTS=(3333 34255)
+public="no"
+if [[ -r "$CONF" ]]; then
+  if grep -qE '^[[:space:]]*public_mining[[:space:]]*=[[:space:]]*true([[:space:]]|$)' "$CONF" 2>/dev/null \
+   || grep -qE '^[[:space:]]*mining_mode[[:space:]]*=[[:space:]]*"?public_pool"?' "$CONF" 2>/dev/null; then
+    public="yes"
+  fi
+fi
+if [[ "$public" == "yes" ]]; then
+  for p in "${PORTS[@]}"; do ufw allow "${p}/tcp" >/dev/null 2>&1 || true; done
+  logger -t ghost-mining-firewall "public mining ON -> Stratum 3333+34255 OPEN"
+else
+  for p in "${PORTS[@]}"; do ufw delete allow "${p}/tcp" >/dev/null 2>&1 || true; done
+  logger -t ghost-mining-firewall "public mining OFF -> Stratum 3333+34255 CLOSED"
+fi
+EOF
+chmod 755 /opt/ghost/bin/reconcile-mining-firewall.sh
+
+cat > /etc/systemd/system/ghost-mining-firewall.service <<'EOF'
+[Unit]
+Description=Ghost mining firewall reconcile (Stratum V1+V2 ports follow mining_mode)
+After=ufw.service network-online.target
+Wants=network-online.target
+[Service]
+Type=oneshot
+ExecStart=/opt/ghost/bin/reconcile-mining-firewall.sh
+[Install]
+WantedBy=multi-user.target
+EOF
+
+cat > /etc/systemd/system/ghost-mining-firewall.path <<'EOF'
+[Unit]
+Description=Watch pool.toml and reconcile the Stratum firewall when mining_mode changes
+[Path]
+PathModified=/etc/ghost/pool.toml
+Unit=ghost-mining-firewall.service
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl daemon-reload >/dev/null 2>&1
+systemctl enable --now ghost-mining-firewall.path >/dev/null 2>&1
+/opt/ghost/bin/reconcile-mining-firewall.sh >/dev/null 2>&1 || true   # apply initial state
 
 # ─────────────────────────────── 11. start ───────────────────────────────────
 log "Starting services"

--- a/scripts/install-node.sh
+++ b/scripts/install-node.sh
@@ -335,10 +335,16 @@ EOF
 log "Configuring firewall"
 ufw allow 22/tcp        >/dev/null 2>&1   # ssh FIRST so we don't lock out
 ufw allow 8333/tcp      >/dev/null 2>&1   # bitcoin P2P
-ufw allow 3333/tcp      >/dev/null 2>&1   # stratum v1
 ufw allow 8080/tcp      >/dev/null 2>&1   # ghost API
 ufw allow 8442/tcp      >/dev/null 2>&1   # TDP
 ufw allow 8555:8562/tcp >/dev/null 2>&1   # mesh consensus
+# Stratum ports are exposed ONLY when this node accepts public miners. Open
+# Stratum V1 and V2 together so any ASIC connects — legacy V1 hardware on 3333,
+# native SV2 firmware (encrypted) on 34255. A private/solo node opens neither.
+if [[ "$PUBLIC_MINING" == "true" ]]; then
+  ufw allow 3333/tcp    >/dev/null 2>&1   # stratum v1
+  ufw allow 34255/tcp   >/dev/null 2>&1   # stratum v2
+fi
 ufw --force enable      >/dev/null 2>&1
 
 # ─────────────────────────────── 11. start ───────────────────────────────────

--- a/scripts/reconcile-mining-firewall.sh
+++ b/scripts/reconcile-mining-firewall.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Reconcile the Stratum firewall ports to the node's mining mode.
+#
+# Opens BOTH Stratum V1 (3333) and V2 (34255) when the node is a public pool;
+# closes them for a private / solo node. Driven entirely by `mining_mode` in
+# /etc/ghost/pool.toml, so the firewall follows the operator's public-mining
+# choice however it is changed — dashboard, `ghost-setup`, or a hand edit.
+#
+# Run by `ghost-mining-firewall.service`, which is triggered at boot and by
+# `ghost-mining-firewall.path` whenever pool.toml changes. Idempotent.
+set -euo pipefail
+
+CONF="${GHOST_POOL_CONF:-/etc/ghost/pool.toml}"
+PORTS=(3333 34255)
+
+# Public mining is ON if EITHER form is set: the production boolean
+# `public_mining = true`, or the installer's `mining_mode = "public_pool"`.
+# (The two provisioning paths use different keys; accept both.)
+public="no"
+if [[ -r "$CONF" ]]; then
+  if grep -qE '^[[:space:]]*public_mining[[:space:]]*=[[:space:]]*true([[:space:]]|$)' "$CONF" 2>/dev/null \
+   || grep -qE '^[[:space:]]*mining_mode[[:space:]]*=[[:space:]]*"?public_pool"?' "$CONF" 2>/dev/null; then
+    public="yes"
+  fi
+fi
+
+if [[ "$public" == "yes" ]]; then
+  for p in "${PORTS[@]}"; do
+    ufw allow "${p}/tcp" >/dev/null 2>&1 || true
+  done
+  logger -t ghost-mining-firewall "public mining ON -> Stratum 3333+34255 OPEN"
+else
+  # Private/solo (or unset/unreadable): don't expose stratum to the network.
+  for p in "${PORTS[@]}"; do
+    ufw delete allow "${p}/tcp" >/dev/null 2>&1 || true
+  done
+  logger -t ghost-mining-firewall "public mining OFF -> Stratum 3333+34255 CLOSED"
+fi

--- a/scripts/systemd/ghost-mining-firewall.path
+++ b/scripts/systemd/ghost-mining-firewall.path
@@ -1,0 +1,12 @@
+[Unit]
+Description=Watch pool.toml and reconcile the Stratum firewall when mining_mode changes
+
+[Path]
+# Fires ghost-mining-firewall.service whenever the pool config is rewritten —
+# so toggling public mining (via the dashboard, ghost-setup, or by hand) updates
+# the V1+V2 firewall ports live, with no manual ufw step.
+PathModified=/etc/ghost/pool.toml
+Unit=ghost-mining-firewall.service
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/systemd/ghost-mining-firewall.service
+++ b/scripts/systemd/ghost-mining-firewall.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Ghost mining firewall reconcile (Stratum V1+V2 ports follow mining_mode)
+Documentation=https://bitcoinghost.org/miners.html
+# ufw must be up before we add/remove rules; want the network for good measure.
+After=ufw.service network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/opt/ghost/bin/reconcile-mining-firewall.sh
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
After validating native SV2 end-to-end with a bitaxe, expose SV2 the same way SV1 is — operator-controlled via the public-mining flag.

- **`install-node.sh`**: stratum firewall ports now open **only when public mining is enabled**, and **V1 (3333) + V2 (34255) open together**. Before, 3333 was opened unconditionally and 34255 never — so public nodes couldn't accept native SV2 miners, and a `--no-public-mining` node still exposed 3333.
- **`miners.html`**: the quickstart described SV2 as `stratum+tcp://…:34255` (SV1 syntax). Rewrote it — V1 stays a one-liner; V2 now lists the real settings a native miner needs: Protocol = Stratum V2, Channel = Extended, and the Ghost network **Authority public key** (`9auqWEzQ…`, the same on every public node). Same `address.worker`, password ignored.

Operationally already done: `34255` opened on all 4 production VMs (they run public mining), so `pool.bitcoinghost.org` round-robins SV2 too. The website still needs deploying to the live host.