### PR TITLE
fix: remove duplicate sha2 dep that red-lit main

### DIFF
--- a/apps/wraith-wallet/daemon/Cargo.toml
+++ b/apps/wraith-wallet/daemon/Cargo.toml
@@ -30,7 +30,6 @@ secrecy = { workspace = true }
 hex = { workspace = true }
 rand = { workspace = true }
 reqwest = { workspace = true }
-sha2 = { workspace = true }
 
 [dev-dependencies]
 wraith-wallet-ipc = { workspace = true }


### PR DESCRIPTION
Hotfix for a broken `main`.

#98 and #99 each added `sha2 = { workspace = true }` to `apps/wraith-wallet/daemon/Cargo.toml` — green individually (their bases lacked it), but together on main that is a **duplicate key** (`error: duplicate key` at Cargo.toml:33). It fails to *load* the workspace manifest, so every Rust job (Format/Clippy/Test/MSRV/Docs) fails — on main and on every PR branched off it (e.g. #102). One-line fix: drop the duplicate; one `sha2` dep remains.

Verified locally: `cargo check` across the wallet crates is clean.