### PR TITLE
security: re-derive Archive+Policy verification verdicts (close node-reward griefing)

### DIFF
--- a/bins/ghost-pool/src/lib.rs
+++ b/bins/ghost-pool/src/lib.rs
@@ -121,4 +121,9 @@ pub mod coordinator_election;
 
 pub mod coordinator_supervisor;
 
+/// CONSENSUS SECURITY: re-derives peer-broadcast capability verdicts against
+/// this node's own Bitcoin Core, so a colluding minority of challengers cannot
+/// fabricate a FAIL (to grief an honest node under the 95% gate) or a PASS.
+pub mod verification_reverify;
+
 // L2 uses NullifierRouteHandler from ghost-consensus (sender-side proofs).

--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -1488,10 +1488,16 @@ async fn main() -> Result<()> {
 
     // Create and register verification result handler for P2P verification results
     // HIGH-VER-4: Use with_peers to validate challengers are known nodes before recording
-    let verification_result_handler = Arc::new(VerificationResultHandler::with_peers(
-        Arc::clone(&db),
-        Arc::clone(mesh.peers()),
-    ));
+    // CONSENSUS SECURITY: re-derive peer-broadcast Archive verdicts against our
+    // own Bitcoin Core + the target's signed response, so a colluding minority of
+    // challengers cannot fabricate a FAIL (to grief an honest node under the 95%
+    // gate) or a PASS. `rpc` is the node's Bitcoin Core RPC client (see above).
+    let verification_result_handler = Arc::new(
+        VerificationResultHandler::with_peers(Arc::clone(&db), Arc::clone(mesh.peers()))
+            .with_rederivation(Arc::new(
+                ghost_pool::verification_reverify::ChainReVerifier::new(Arc::clone(&rpc)),
+            )),
+    );
     mesh.register_handler(Arc::clone(&verification_result_handler)
         as Arc<dyn ghost_consensus::mesh::MessageHandler + Send + Sync>);
 
@@ -5152,6 +5158,7 @@ async fn main() -> Result<()> {
                 timestamp: broadcast.timestamp,
                 challenge_data: broadcast.challenge_data,
                 response_data: broadcast.response_data,
+                target_signed_response: broadcast.target_signed_response,
                 signature,
             };
 

--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -1495,7 +1495,10 @@ async fn main() -> Result<()> {
     let verification_result_handler = Arc::new(
         VerificationResultHandler::with_peers(Arc::clone(&db), Arc::clone(mesh.peers()))
             .with_rederivation(Arc::new(
-                ghost_pool::verification_reverify::ChainReVerifier::new(Arc::clone(&rpc)),
+                ghost_pool::verification_reverify::ChainReVerifier::new(
+                    Arc::clone(&rpc),
+                    policy.clone(),
+                ),
             )),
     );
     mesh.register_handler(Arc::clone(&verification_result_handler)
@@ -5092,6 +5095,7 @@ async fn main() -> Result<()> {
         Ok(verification_task) => {
             let verification_task = verification_task
                 .with_rpc(Arc::clone(&rpc))
+                .with_policy(policy.clone())
                 .with_broadcast(verification_tx);
 
             let mut verification_shutdown = shutdown_tx.subscribe();

--- a/bins/ghost-pool/src/verification_reverify.rs
+++ b/bins/ghost-pool/src/verification_reverify.rs
@@ -7,7 +7,7 @@
 //! sign `passed=false` against an honest node, drag it under the 95% gate, and
 //! steal its reward share.
 //!
-//! [`ChainReVerifier`] closes this by RE-DERIVING the Archive verdict from:
+//! `ChainReVerifier` closes this by RE-DERIVING the Archive verdict from:
 //!   1. the TARGET's own signed `ArchiveResponse` (the only trustworthy input —
 //!      `challenge_data`/`response_data` are authored by the adversarial
 //!      challenger and are NOT in the signed tuple), and
@@ -16,7 +16,7 @@
 //! ([`ghost_verification::challenge::validate_archive_response`]) so there is
 //! zero logic divergence.
 //!
-//! Verdict semantics (see [`ReVerdict`]):
+//! Verdict semantics (see `ReVerdict`):
 //!   - `Pass`         — target's signed block data matches our chain.
 //!   - `Fail`         — target's signed block data contradicts our chain.
 //!   - `Unverifiable` — we cannot judge (no/invalid target signature,

--- a/bins/ghost-pool/src/verification_reverify.rs
+++ b/bins/ghost-pool/src/verification_reverify.rs
@@ -1,0 +1,393 @@
+//! CONSENSUS SECURITY: recipient-side re-derivation of peer-broadcast
+//! capability verdicts (Increment 1: Archive).
+//!
+//! Node-reward 5-4-3-2-1 shares are paid on peer-VERIFIED capabilities. The
+//! consensus handler (`ghost_consensus::verification_handler`) used to store the
+//! challenger's `passed` flag verbatim. A >5% colluding minority could therefore
+//! sign `passed=false` against an honest node, drag it under the 95% gate, and
+//! steal its reward share.
+//!
+//! [`ChainReVerifier`] closes this by RE-DERIVING the Archive verdict from:
+//!   1. the TARGET's own signed `ArchiveResponse` (the only trustworthy input —
+//!      `challenge_data`/`response_data` are authored by the adversarial
+//!      challenger and are NOT in the signed tuple), and
+//!   2. THIS node's own Bitcoin Core (ground truth),
+//! using the SAME comparator the challenger runs
+//! ([`ghost_verification::challenge::validate_archive_response`]) so there is
+//! zero logic divergence.
+//!
+//! Verdict semantics (see [`ReVerdict`]):
+//!   - `Pass`         — target's signed block data matches our chain.
+//!   - `Fail`         — target's signed block data contradicts our chain.
+//!   - `Unverifiable` — we cannot judge (no/invalid target signature,
+//!     unparseable response, RPC error, or our node lacks the block). NEVER a
+//!     false `Fail`: an unverifiable result must not be usable to grief.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use ghost_common::identity::verify_signature;
+use ghost_common::rpc::BitcoinRpc;
+use ghost_common::types::NodeId;
+use ghost_consensus::verification_handler::{ReVerdict, ResultReVerifier};
+use ghost_verification::challenge::{validate_archive_response, ArchiveResponse, SignedResponse};
+
+/// Read-only view of the recipient's own chain. Abstracted behind a trait so the
+/// re-derivation logic can be unit-tested with a stub instead of a live node.
+#[async_trait]
+trait ChainOracle: Send + Sync {
+    /// Current validated chain tip height (`None` on RPC error).
+    async fn block_count(&self) -> Option<u64>;
+    /// Block hash at `height` (`None` if missing / RPC error).
+    async fn block_hash(&self, height: u64) -> Option<String>;
+    /// Merkle root of the block identified by `hash` (`None` on error).
+    async fn merkle_root(&self, hash: &str) -> Option<String>;
+}
+
+/// [`ChainOracle`] backed by the node's real Bitcoin Core RPC.
+struct RpcOracle(Arc<BitcoinRpc>);
+
+#[async_trait]
+impl ChainOracle for RpcOracle {
+    async fn block_count(&self) -> Option<u64> {
+        self.0.get_block_count().await.ok()
+    }
+
+    async fn block_hash(&self, height: u64) -> Option<String> {
+        self.0.get_block_hash(height).await.ok()
+    }
+
+    async fn merkle_root(&self, hash: &str) -> Option<String> {
+        self.0
+            .get_block_header(hash)
+            .await
+            .ok()
+            .map(|h| h.merkleroot)
+    }
+}
+
+/// Re-derives Archive verdicts against the node's own Bitcoin Core.
+pub struct ChainReVerifier {
+    rpc: Arc<BitcoinRpc>,
+}
+
+impl ChainReVerifier {
+    /// Create a re-verifier bound to the node's Bitcoin Core RPC client.
+    pub fn new(rpc: Arc<BitcoinRpc>) -> Self {
+        Self { rpc }
+    }
+}
+
+#[async_trait]
+impl ResultReVerifier for ChainReVerifier {
+    async fn reverify_archive(
+        &self,
+        target_node_id: &NodeId,
+        target_signed_response: Option<&str>,
+    ) -> ReVerdict {
+        let oracle = RpcOracle(Arc::clone(&self.rpc));
+        reverify_archive_impl(&oracle, target_node_id, target_signed_response).await
+    }
+}
+
+/// Core Archive re-derivation, generic over the chain source for testability.
+///
+/// SECURITY: every value the verdict turns on comes from a trustworthy source —
+/// `height`/`hash`/`merkle_root` from inside the TARGET-signed payload, and the
+/// ground-truth hash/merkle from the recipient's OWN node. Nothing from the
+/// challenger is consulted.
+async fn reverify_archive_impl<O: ChainOracle + ?Sized>(
+    oracle: &O,
+    target_node_id: &NodeId,
+    target_signed_response: Option<&str>,
+) -> ReVerdict {
+    // 1. No signed response at all — we cannot judge.
+    let raw = match target_signed_response {
+        Some(s) if !s.trim().is_empty() => s,
+        _ => return ReVerdict::Unverifiable,
+    };
+
+    // 2. Parse the TARGET's signed response. A malformed blob is not a FAIL.
+    let signed: SignedResponse<ArchiveResponse> = match serde_json::from_str(raw) {
+        Ok(s) => s,
+        Err(_) => return ReVerdict::Unverifiable,
+    };
+
+    // 3a. The signer MUST be the target. A response signed by anyone else (or a
+    //     proxied response) tells us nothing about the target.
+    let target_hex = hex::encode(target_node_id);
+    if !signed.signer.eq_ignore_ascii_case(&target_hex) {
+        return ReVerdict::Unverifiable;
+    }
+
+    // 3b. Verify the target's Ed25519 signature + freshness (timestamp bounds are
+    //     enforced inside `SignedResponse::verify`). A bad/absent signature is
+    //     Unverifiable, NOT Fail — a forged or stale signature must not let a
+    //     challenger grief the target.
+    let verify_result = signed.verify(|signer_hex, message_hash, signature_bytes| {
+        let pk_bytes = match hex::decode(signer_hex) {
+            Ok(b) if b.len() == 32 => b,
+            _ => return false,
+        };
+        let mut pk = [0u8; 32];
+        pk.copy_from_slice(&pk_bytes);
+        let sig: [u8; 64] = match signature_bytes.try_into() {
+            Ok(s) => s,
+            Err(_) => return false,
+        };
+        verify_signature(&pk, message_hash, &sig).unwrap_or(false)
+    });
+    if verify_result.is_err() {
+        return ReVerdict::Unverifiable;
+    }
+
+    // 4. Take the height from inside the TARGET-signed payload — NEVER from the
+    //    challenger's challenge_data. (Taking height from challenge_data would let
+    //    a colluder pair a valid signed response with a mismatched height to force
+    //    a false FAIL.)
+    let block_data = match signed.payload.block_data.as_ref() {
+        Some(bd) => bd,
+        None => return ReVerdict::Unverifiable,
+    };
+    let height = block_data.height;
+
+    // 5. Ground truth from the recipient's OWN node. If we are behind / lack the
+    //    block / hit an RPC error, we cannot judge — do not grief a lagging node.
+    let tip = match oracle.block_count().await {
+        Some(h) => h,
+        None => return ReVerdict::Unverifiable,
+    };
+    if height > tip {
+        return ReVerdict::Unverifiable;
+    }
+    let real_hash = match oracle.block_hash(height).await {
+        Some(h) => h,
+        None => return ReVerdict::Unverifiable,
+    };
+    let real_merkle = match oracle.merkle_root(&real_hash).await {
+        Some(m) => m,
+        None => return ReVerdict::Unverifiable,
+    };
+
+    // 6. Same comparator the challenger uses — zero divergence. The target's
+    //    claimed hash/merkle are checked against OUR hash/merkle for OUR height.
+    let (passed, _detail) =
+        validate_archive_response(&signed.payload, &real_hash, height, Some(&real_merkle));
+    if passed {
+        ReVerdict::Pass
+    } else {
+        ReVerdict::Fail
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ghost_common::identity::NodeIdentity;
+    use ghost_verification::challenge::BlockData;
+
+    /// Stub chain that returns a fixed `(hash, merkle)` for a single height.
+    struct StubOracle {
+        tip: u64,
+        height: u64,
+        hash: String,
+        merkle: String,
+        /// When true, all lookups fail (simulates RPC error / IBD).
+        broken: bool,
+    }
+
+    #[async_trait]
+    impl ChainOracle for StubOracle {
+        async fn block_count(&self) -> Option<u64> {
+            if self.broken {
+                None
+            } else {
+                Some(self.tip)
+            }
+        }
+        async fn block_hash(&self, height: u64) -> Option<String> {
+            if self.broken || height != self.height {
+                None
+            } else {
+                Some(self.hash.clone())
+            }
+        }
+        async fn merkle_root(&self, hash: &str) -> Option<String> {
+            if self.broken || hash != self.hash {
+                None
+            } else {
+                Some(self.merkle.clone())
+            }
+        }
+    }
+
+    const REAL_HASH: &str = "00000000000000000001a2b3c4d5e6f70809102030405060708090a0b0c0d0e0";
+    const REAL_MERKLE: &str = "1111111111111111111111111111111111111111111111111111111111111111";
+
+    fn good_oracle() -> StubOracle {
+        StubOracle {
+            tip: 1_000,
+            height: 500,
+            hash: REAL_HASH.to_string(),
+            merkle: REAL_MERKLE.to_string(),
+            broken: false,
+        }
+    }
+
+    /// Build a `SignedResponse<ArchiveResponse>` JSON signed by `identity` for the
+    /// given block fields.
+    fn make_signed_response(
+        identity: &NodeIdentity,
+        height: u64,
+        hash: &str,
+        merkle: &str,
+        success: bool,
+    ) -> String {
+        let resp = ArchiveResponse {
+            success,
+            block_data: Some(BlockData {
+                hash: hash.to_string(),
+                height,
+                timestamp: 1_600_000_000, // safely in the past
+                tx_count: 2,
+                merkle_root: merkle.to_string(),
+            }),
+            tx_data: None,
+            error: None,
+        };
+        let signer_hex = identity.node_id_hex();
+        let signed = SignedResponse::new(resp, signer_hex, |msg| identity.sign(msg), None);
+        serde_json::to_string(&signed).expect("serialize signed response")
+    }
+
+    /// FRAUD: target signs a wrong hash for the height; our RPC disagrees => Fail,
+    /// regardless of what the challenger claimed.
+    #[tokio::test]
+    async fn fraud_wrong_hash_is_fail() {
+        let target = NodeIdentity::generate();
+        let bogus_hash = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef0";
+        let raw = make_signed_response(&target, 500, bogus_hash, REAL_MERKLE, true);
+
+        let verdict = reverify_archive_impl(&good_oracle(), &target.node_id(), Some(&raw)).await;
+        assert_eq!(verdict, ReVerdict::Fail);
+    }
+
+    /// FRAUD: target signs a wrong merkle root => Fail.
+    #[tokio::test]
+    async fn fraud_wrong_merkle_is_fail() {
+        let target = NodeIdentity::generate();
+        let bogus_merkle = "2222222222222222222222222222222222222222222222222222222222222222";
+        let raw = make_signed_response(&target, 500, REAL_HASH, bogus_merkle, true);
+
+        let verdict = reverify_archive_impl(&good_oracle(), &target.node_id(), Some(&raw)).await;
+        assert_eq!(verdict, ReVerdict::Fail);
+    }
+
+    /// GRIEFING (priority): challenger claimed `passed=false`, but the target's
+    /// signed response matches our ground truth => Pass (override to true). The
+    /// challenger's claim never reaches this function — the verdict is derived
+    /// purely from the signature + our chain.
+    #[tokio::test]
+    async fn honest_response_overrides_grief_to_pass() {
+        let target = NodeIdentity::generate();
+        let raw = make_signed_response(&target, 500, REAL_HASH, REAL_MERKLE, true);
+
+        let verdict = reverify_archive_impl(&good_oracle(), &target.node_id(), Some(&raw)).await;
+        assert_eq!(verdict, ReVerdict::Pass);
+    }
+
+    /// Verdict equals what the shared comparator returns: a response with
+    /// `success=false` (genuinely wrong) is a Fail even with the right hash.
+    #[tokio::test]
+    async fn unsuccessful_response_is_fail() {
+        let target = NodeIdentity::generate();
+        let raw = make_signed_response(&target, 500, REAL_HASH, REAL_MERKLE, false);
+
+        let verdict = reverify_archive_impl(&good_oracle(), &target.node_id(), Some(&raw)).await;
+        assert_eq!(verdict, ReVerdict::Fail);
+
+        // Cross-check: the free comparator agrees on the same payload.
+        let signed: SignedResponse<ArchiveResponse> = serde_json::from_str(&raw).unwrap();
+        let (passed, _) =
+            validate_archive_response(&signed.payload, REAL_HASH, 500, Some(REAL_MERKLE));
+        assert!(!passed);
+    }
+
+    /// No signed response => Unverifiable (and the handler stores nothing).
+    #[tokio::test]
+    async fn missing_response_is_unverifiable() {
+        let target = NodeIdentity::generate();
+        assert_eq!(
+            reverify_archive_impl(&good_oracle(), &target.node_id(), None).await,
+            ReVerdict::Unverifiable
+        );
+        assert_eq!(
+            reverify_archive_impl(&good_oracle(), &target.node_id(), Some("   ")).await,
+            ReVerdict::Unverifiable
+        );
+    }
+
+    /// Unparseable signed response => Unverifiable.
+    #[tokio::test]
+    async fn unparseable_response_is_unverifiable() {
+        let target = NodeIdentity::generate();
+        assert_eq!(
+            reverify_archive_impl(&good_oracle(), &target.node_id(), Some("{not json")).await,
+            ReVerdict::Unverifiable
+        );
+    }
+
+    /// Signed by the WRONG key (not the target) => Unverifiable, NOT Fail.
+    #[tokio::test]
+    async fn wrong_signer_is_unverifiable() {
+        let target = NodeIdentity::generate();
+        let imposter = NodeIdentity::generate();
+        // Imposter signs (signer field = imposter), but we judge it as `target`.
+        let raw = make_signed_response(&imposter, 500, REAL_HASH, REAL_MERKLE, true);
+
+        let verdict = reverify_archive_impl(&good_oracle(), &target.node_id(), Some(&raw)).await;
+        assert_eq!(verdict, ReVerdict::Unverifiable);
+    }
+
+    /// Tampered signature (signer claims target, but bytes don't verify) =>
+    /// Unverifiable.
+    #[tokio::test]
+    async fn invalid_signature_is_unverifiable() {
+        let target = NodeIdentity::generate();
+        let mut raw = make_signed_response(&target, 500, REAL_HASH, REAL_MERKLE, true);
+        // Corrupt the signature hex in-place (flip a nibble) while keeping length.
+        let mut value: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        let sig = value["signature"].as_str().unwrap().to_string();
+        let mut chars: Vec<char> = sig.chars().collect();
+        chars[0] = if chars[0] == 'a' { 'b' } else { 'a' };
+        value["signature"] = serde_json::Value::String(chars.into_iter().collect());
+        raw = serde_json::to_string(&value).unwrap();
+
+        let verdict = reverify_archive_impl(&good_oracle(), &target.node_id(), Some(&raw)).await;
+        assert_eq!(verdict, ReVerdict::Unverifiable);
+    }
+
+    /// RPC error (node behind / IBD) => Unverifiable, never a grief-FAIL.
+    #[tokio::test]
+    async fn rpc_error_is_unverifiable() {
+        let target = NodeIdentity::generate();
+        let raw = make_signed_response(&target, 500, REAL_HASH, REAL_MERKLE, true);
+        let mut oracle = good_oracle();
+        oracle.broken = true;
+
+        let verdict = reverify_archive_impl(&oracle, &target.node_id(), Some(&raw)).await;
+        assert_eq!(verdict, ReVerdict::Unverifiable);
+    }
+
+    /// Height beyond our tip (we lack the block) => Unverifiable.
+    #[tokio::test]
+    async fn height_above_tip_is_unverifiable() {
+        let target = NodeIdentity::generate();
+        // Sign a response for height 5000 while our tip is only 1000.
+        let raw = make_signed_response(&target, 5_000, REAL_HASH, REAL_MERKLE, true);
+
+        let verdict = reverify_archive_impl(&good_oracle(), &target.node_id(), Some(&raw)).await;
+        assert_eq!(verdict, ReVerdict::Unverifiable);
+    }
+}

--- a/bins/ghost-pool/src/verification_reverify.rs
+++ b/bins/ghost-pool/src/verification_reverify.rs
@@ -31,7 +31,11 @@ use ghost_common::identity::verify_signature;
 use ghost_common::rpc::BitcoinRpc;
 use ghost_common::types::NodeId;
 use ghost_consensus::verification_handler::{ReVerdict, ResultReVerifier};
-use ghost_verification::challenge::{validate_archive_response, ArchiveResponse, SignedResponse};
+use ghost_policy::{PolicyEngine, PolicyProfile};
+use ghost_verification::challenge::{
+    validate_archive_response, validate_policy_response, ArchiveResponse, PolicyResponse,
+    SignedResponse,
+};
 
 /// Read-only view of the recipient's own chain. Abstracted behind a trait so the
 /// re-derivation logic can be unit-tested with a stub instead of a live node.
@@ -67,15 +71,21 @@ impl ChainOracle for RpcOracle {
     }
 }
 
-/// Re-derives Archive verdicts against the node's own Bitcoin Core.
+/// Re-derives Archive verdicts against the node's own Bitcoin Core, and Policy
+/// verdicts against the node's own [`PolicyEngine`].
 pub struct ChainReVerifier {
     rpc: Arc<BitcoinRpc>,
+    /// The node's configured policy profile — the recipient's ground truth for
+    /// re-classifying a policy-challenge tx. A fresh [`PolicyEngine`] is built per
+    /// call (`evaluate` takes `&mut self`).
+    policy: PolicyProfile,
 }
 
 impl ChainReVerifier {
-    /// Create a re-verifier bound to the node's Bitcoin Core RPC client.
-    pub fn new(rpc: Arc<BitcoinRpc>) -> Self {
-        Self { rpc }
+    /// Create a re-verifier bound to the node's Bitcoin Core RPC client and its
+    /// configured policy profile.
+    pub fn new(rpc: Arc<BitcoinRpc>, policy: PolicyProfile) -> Self {
+        Self { rpc, policy }
     }
 }
 
@@ -88,6 +98,20 @@ impl ResultReVerifier for ChainReVerifier {
     ) -> ReVerdict {
         let oracle = RpcOracle(Arc::clone(&self.rpc));
         reverify_archive_impl(&oracle, target_node_id, target_signed_response).await
+    }
+
+    async fn reverify_policy(
+        &self,
+        target_node_id: &NodeId,
+        challenge_data: &str,
+        target_signed_response: Option<&str>,
+    ) -> ReVerdict {
+        reverify_policy_impl(
+            &self.policy,
+            target_node_id,
+            challenge_data,
+            target_signed_response,
+        )
     }
 }
 
@@ -174,6 +198,103 @@ async fn reverify_archive_impl<O: ChainOracle + ?Sized>(
     //    claimed hash/merkle are checked against OUR hash/merkle for OUR height.
     let (passed, _detail) =
         validate_archive_response(&signed.payload, &real_hash, height, Some(&real_merkle));
+    if passed {
+        ReVerdict::Pass
+    } else {
+        ReVerdict::Fail
+    }
+}
+
+/// Core Policy re-derivation. Pure (no RPC) so it can be unit-tested with a real
+/// [`PolicyProfile`] + real transactions.
+///
+/// SECURITY: every value the verdict turns on comes from a trustworthy source —
+/// the classification from inside the TARGET-signed payload, and the ground-truth
+/// `(tier, accepted)` from the recipient's OWN policy engine over the SAME tx. The
+/// only thing read from the (adversarial) challenger is the `tx_hex`, and it is
+/// BOUND to the signature: the recompiled txid must equal the signed `tx_txid`,
+/// so a colluder cannot pair a valid signed classification with a different tx to
+/// force a mismatch and grief the target.
+fn reverify_policy_impl(
+    policy: &PolicyProfile,
+    target_node_id: &NodeId,
+    challenge_data: &str,
+    target_signed_response: Option<&str>,
+) -> ReVerdict {
+    // 1. No signed response at all — we cannot judge.
+    let raw = match target_signed_response {
+        Some(s) if !s.trim().is_empty() => s,
+        _ => return ReVerdict::Unverifiable,
+    };
+
+    // 2. Parse the TARGET's signed response. A malformed blob is not a FAIL.
+    let signed: SignedResponse<PolicyResponse> = match serde_json::from_str(raw) {
+        Ok(s) => s,
+        Err(_) => return ReVerdict::Unverifiable,
+    };
+
+    // 3a. The signer MUST be the target. A response signed by anyone else tells us
+    //     nothing about the target.
+    let target_hex = hex::encode(target_node_id);
+    if !signed.signer.eq_ignore_ascii_case(&target_hex) {
+        return ReVerdict::Unverifiable;
+    }
+
+    // 3b. Verify the target's Ed25519 signature + freshness. A bad/absent/stale
+    //     signature is Unverifiable, NOT Fail.
+    let verify_result = signed.verify(|signer_hex, message_hash, signature_bytes| {
+        let pk_bytes = match hex::decode(signer_hex) {
+            Ok(b) if b.len() == 32 => b,
+            _ => return false,
+        };
+        let mut pk = [0u8; 32];
+        pk.copy_from_slice(&pk_bytes);
+        let sig: [u8; 64] = match signature_bytes.try_into() {
+            Ok(s) => s,
+            Err(_) => return false,
+        };
+        verify_signature(&pk, message_hash, &sig).unwrap_or(false)
+    });
+    if verify_result.is_err() {
+        return ReVerdict::Unverifiable;
+    }
+
+    // 4. Extract the tx_hex the challenger broadcast and reconstruct the tx. A
+    //    missing / undecodable / undeserializable tx_hex is Unverifiable.
+    let tx_hex = match serde_json::from_str::<serde_json::Value>(challenge_data)
+        .ok()
+        .and_then(|v| v.get("tx_hex").and_then(|t| t.as_str()).map(String::from))
+    {
+        Some(h) => h,
+        None => return ReVerdict::Unverifiable,
+    };
+    let tx_bytes = match hex::decode(&tx_hex) {
+        Ok(b) => b,
+        Err(_) => return ReVerdict::Unverifiable,
+    };
+    let tx: bitcoin::Transaction = match bitcoin::consensus::deserialize(&tx_bytes) {
+        Ok(t) => t,
+        Err(_) => return ReVerdict::Unverifiable,
+    };
+
+    // 5. BINDING: the tx the challenger gave us MUST be the tx the target signed.
+    //    If the signed payload has no txid, or it doesn't match, the challenger
+    //    swapped the tx — we cannot judge, so we must NOT grief the target.
+    match signed.payload.tx_txid.as_deref() {
+        Some(signed_txid) if signed_txid == tx.compute_txid().to_string() => {}
+        _ => return ReVerdict::Unverifiable,
+    }
+
+    // 6. Re-classify with the recipient's OWN engine — ground truth. `evaluate`
+    //    needs `&mut self`, so build a fresh engine per call.
+    let decision = PolicyEngine::new(policy.clone()).evaluate(&tx);
+    let our_tier = decision.tier().to_string();
+    let our_accepted = decision.is_accepted();
+
+    // 7. Same comparator the challenger uses — zero divergence. The target's
+    //    signed classification is checked against OUR engine's classification of
+    //    the SAME tx.
+    let (passed, _detail) = validate_policy_response(&signed.payload, &our_tier, our_accepted);
     if passed {
         ReVerdict::Pass
     } else {
@@ -389,5 +510,366 @@ mod tests {
 
         let verdict = reverify_archive_impl(&good_oracle(), &target.node_id(), Some(&raw)).await;
         assert_eq!(verdict, ReVerdict::Unverifiable);
+    }
+
+    // =================================================================
+    // Policy (Bitcoin Pure) re-derivation tests. Real txs + a real
+    // bitcoin_pure PolicyProfile so classification is genuine, not faked.
+    // =================================================================
+
+    use ghost_verification::challenge::PolicyClassification;
+
+    /// A clean single-output P2WPKH payment — `bitcoin_pure` classifies it T0 and
+    /// accepts it.
+    fn clean_tx() -> bitcoin::Transaction {
+        use bitcoin::hashes::Hash;
+        use bitcoin::locktime::absolute::LockTime;
+        use bitcoin::script::{Builder, ScriptBuf};
+        use bitcoin::transaction::{Transaction, Version};
+        use bitcoin::{Amount, OutPoint, Sequence, TxIn, TxOut, Txid, Witness};
+
+        let p2wpkh = Builder::new()
+            .push_int(0)
+            .push_slice([7u8; 20])
+            .into_script();
+        Transaction {
+            version: Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: Txid::all_zeros(),
+                    vout: 0,
+                },
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
+            }],
+            output: vec![TxOut {
+                value: Amount::from_sat(50_000),
+                script_pubkey: p2wpkh,
+            }],
+        }
+    }
+
+    /// A data-carrier tx with a 100-byte OP_RETURN — `bitcoin_pure`
+    /// (`max_op_return_size = 0`) classifies it non-T0 and refuses it.
+    fn dirty_tx() -> bitcoin::Transaction {
+        use bitcoin::hashes::Hash;
+        use bitcoin::locktime::absolute::LockTime;
+        use bitcoin::script::{Builder, PushBytesBuf, ScriptBuf};
+        use bitcoin::transaction::{Transaction, Version};
+        use bitcoin::{Amount, OutPoint, Sequence, TxIn, TxOut, Txid, Witness};
+
+        let p2wpkh = Builder::new()
+            .push_int(0)
+            .push_slice([9u8; 20])
+            .into_script();
+        let payload = PushBytesBuf::try_from(vec![0x42u8; 100]).unwrap();
+        let op_return = Builder::new()
+            .push_opcode(bitcoin::opcodes::all::OP_RETURN)
+            .push_slice(&payload)
+            .into_script();
+        Transaction {
+            version: Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: Txid::all_zeros(),
+                    vout: 0,
+                },
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
+            }],
+            output: vec![
+                TxOut {
+                    value: Amount::from_sat(10_000),
+                    script_pubkey: p2wpkh,
+                },
+                TxOut {
+                    value: Amount::from_sat(0),
+                    script_pubkey: op_return,
+                },
+            ],
+        }
+    }
+
+    fn pure() -> PolicyProfile {
+        PolicyProfile::bitcoin_pure()
+    }
+
+    /// `{"tx_hex": "<consensus hex of tx>"}` — exactly what the challenger broadcasts.
+    fn challenge_data_for(tx: &bitcoin::Transaction) -> String {
+        let hex = bitcoin::consensus::encode::serialize_hex(tx);
+        serde_json::json!({ "tx_hex": hex }).to_string()
+    }
+
+    /// Classify `tx` with the recipient's own bitcoin_pure engine -> `(tier, accepted)`.
+    fn classify(tx: &bitcoin::Transaction) -> (String, bool) {
+        let decision = PolicyEngine::new(pure()).evaluate(tx);
+        (decision.tier().to_string(), decision.is_accepted())
+    }
+
+    /// Build a `SignedResponse<PolicyResponse>` JSON signed by `identity`.
+    fn make_signed_policy_response(
+        identity: &NodeIdentity,
+        tier: &str,
+        accepted: bool,
+        tx_txid: Option<String>,
+        success: bool,
+    ) -> String {
+        let resp = PolicyResponse {
+            success,
+            profile: "bitcoin_pure".to_string(),
+            classification: Some(PolicyClassification {
+                tier: tier.to_string(),
+                reason: "test".to_string(),
+                features: vec![],
+            }),
+            accepted,
+            rejection_reason: None,
+            tx_txid,
+            error: None,
+        };
+        let signer_hex = identity.node_id_hex();
+        let signed = SignedResponse::new(resp, signer_hex, |msg| identity.sign(msg), None);
+        serde_json::to_string(&signed).expect("serialize signed policy response")
+    }
+
+    /// FRAUD: target signs tier="T0"/accepted=true bound to a DIRTY data-carrier
+    /// tx; our engine classifies it non-T0/reject => Fail.
+    #[test]
+    fn fraud_dirty_tx_claimed_t0_is_fail() {
+        let target = NodeIdentity::generate();
+        let tx = dirty_tx();
+        let signed = make_signed_policy_response(
+            &target,
+            "T0",
+            true,
+            Some(tx.compute_txid().to_string()),
+            true,
+        );
+        let verdict = reverify_policy_impl(
+            &pure(),
+            &target.node_id(),
+            &challenge_data_for(&tx),
+            Some(&signed),
+        );
+        assert_eq!(verdict, ReVerdict::Fail);
+    }
+
+    /// GRIEFING (priority): the target's signed classification MATCHES our own
+    /// classification of the bound tx => Pass (overrides any challenger
+    /// `passed=false`). The challenger's claim never reaches this function.
+    #[test]
+    fn honest_classification_overrides_grief_to_pass() {
+        let target = NodeIdentity::generate();
+        let tx = clean_tx();
+        let (tier, accepted) = classify(&tx);
+        let signed = make_signed_policy_response(
+            &target,
+            &tier,
+            accepted,
+            Some(tx.compute_txid().to_string()),
+            true,
+        );
+        let verdict = reverify_policy_impl(
+            &pure(),
+            &target.node_id(),
+            &challenge_data_for(&tx),
+            Some(&signed),
+        );
+        assert_eq!(verdict, ReVerdict::Pass);
+    }
+
+    /// No-regression: honest correct classification => Pass, and the verdict
+    /// equals what the shared comparator returns on the same inputs.
+    #[test]
+    fn honest_matches_shared_comparator() {
+        let target = NodeIdentity::generate();
+        let tx = clean_tx();
+        let (tier, accepted) = classify(&tx);
+        let signed_raw = make_signed_policy_response(
+            &target,
+            &tier,
+            accepted,
+            Some(tx.compute_txid().to_string()),
+            true,
+        );
+        let verdict = reverify_policy_impl(
+            &pure(),
+            &target.node_id(),
+            &challenge_data_for(&tx),
+            Some(&signed_raw),
+        );
+        assert_eq!(verdict, ReVerdict::Pass);
+
+        // Cross-check: the free comparator agrees on the same payload.
+        let signed: SignedResponse<PolicyResponse> = serde_json::from_str(&signed_raw).unwrap();
+        let (passed, _) = validate_policy_response(&signed.payload, &tier, accepted);
+        assert!(passed);
+    }
+
+    /// TX-SWAP: the signed response is valid (signed for the CLEAN tx), but the
+    /// challenger pairs it with a DIFFERENT tx_hex (the dirty tx) => the recomputed
+    /// txid won't match the signed `tx_txid` => Unverifiable (no grief).
+    #[test]
+    fn tx_swap_is_unverifiable() {
+        let target = NodeIdentity::generate();
+        let clean = clean_tx();
+        let dirty = dirty_tx();
+        let (tier, accepted) = classify(&clean);
+        // Signature commits to the CLEAN tx's txid.
+        let signed = make_signed_policy_response(
+            &target,
+            &tier,
+            accepted,
+            Some(clean.compute_txid().to_string()),
+            true,
+        );
+        // But the challenge_data carries the DIRTY tx.
+        let verdict = reverify_policy_impl(
+            &pure(),
+            &target.node_id(),
+            &challenge_data_for(&dirty),
+            Some(&signed),
+        );
+        assert_eq!(verdict, ReVerdict::Unverifiable);
+    }
+
+    /// Payload with no `tx_txid` (nothing to bind to) => Unverifiable.
+    #[test]
+    fn missing_tx_txid_is_unverifiable() {
+        let target = NodeIdentity::generate();
+        let tx = clean_tx();
+        let (tier, accepted) = classify(&tx);
+        let signed = make_signed_policy_response(&target, &tier, accepted, None, true);
+        let verdict = reverify_policy_impl(
+            &pure(),
+            &target.node_id(),
+            &challenge_data_for(&tx),
+            Some(&signed),
+        );
+        assert_eq!(verdict, ReVerdict::Unverifiable);
+    }
+
+    /// No signed response / blank => Unverifiable.
+    #[test]
+    fn policy_missing_response_is_unverifiable() {
+        let target = NodeIdentity::generate();
+        let tx = clean_tx();
+        let cd = challenge_data_for(&tx);
+        assert_eq!(
+            reverify_policy_impl(&pure(), &target.node_id(), &cd, None),
+            ReVerdict::Unverifiable
+        );
+        assert_eq!(
+            reverify_policy_impl(&pure(), &target.node_id(), &cd, Some("   ")),
+            ReVerdict::Unverifiable
+        );
+    }
+
+    /// Unparseable signed response => Unverifiable.
+    #[test]
+    fn policy_unparseable_response_is_unverifiable() {
+        let target = NodeIdentity::generate();
+        let cd = challenge_data_for(&clean_tx());
+        assert_eq!(
+            reverify_policy_impl(&pure(), &target.node_id(), &cd, Some("{not json")),
+            ReVerdict::Unverifiable
+        );
+    }
+
+    /// Signed by the WRONG key (not the target) => Unverifiable, NOT Fail.
+    #[test]
+    fn policy_wrong_signer_is_unverifiable() {
+        let target = NodeIdentity::generate();
+        let imposter = NodeIdentity::generate();
+        let tx = clean_tx();
+        let (tier, accepted) = classify(&tx);
+        let signed = make_signed_policy_response(
+            &imposter,
+            &tier,
+            accepted,
+            Some(tx.compute_txid().to_string()),
+            true,
+        );
+        let verdict = reverify_policy_impl(
+            &pure(),
+            &target.node_id(),
+            &challenge_data_for(&tx),
+            Some(&signed),
+        );
+        assert_eq!(verdict, ReVerdict::Unverifiable);
+    }
+
+    /// Tampered signature => Unverifiable.
+    #[test]
+    fn policy_invalid_signature_is_unverifiable() {
+        let target = NodeIdentity::generate();
+        let tx = clean_tx();
+        let (tier, accepted) = classify(&tx);
+        let raw = make_signed_policy_response(
+            &target,
+            &tier,
+            accepted,
+            Some(tx.compute_txid().to_string()),
+            true,
+        );
+        // Flip a nibble of the signature hex in-place.
+        let mut value: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        let sig = value["signature"].as_str().unwrap().to_string();
+        let mut chars: Vec<char> = sig.chars().collect();
+        chars[0] = if chars[0] == 'a' { 'b' } else { 'a' };
+        value["signature"] = serde_json::Value::String(chars.into_iter().collect());
+        let tampered = serde_json::to_string(&value).unwrap();
+
+        let verdict = reverify_policy_impl(
+            &pure(),
+            &target.node_id(),
+            &challenge_data_for(&tx),
+            Some(&tampered),
+        );
+        assert_eq!(verdict, ReVerdict::Unverifiable);
+    }
+
+    /// Missing `tx_hex` in challenge_data => Unverifiable.
+    #[test]
+    fn policy_missing_tx_hex_is_unverifiable() {
+        let target = NodeIdentity::generate();
+        let tx = clean_tx();
+        let (tier, accepted) = classify(&tx);
+        let signed = make_signed_policy_response(
+            &target,
+            &tier,
+            accepted,
+            Some(tx.compute_txid().to_string()),
+            true,
+        );
+        let verdict = reverify_policy_impl(&pure(), &target.node_id(), "{}", Some(&signed));
+        assert_eq!(verdict, ReVerdict::Unverifiable);
+    }
+
+    /// Undeserializable `tx_hex` (valid hex, not a tx) => Unverifiable.
+    #[test]
+    fn policy_undeserializable_tx_hex_is_unverifiable() {
+        let target = NodeIdentity::generate();
+        let tx = clean_tx();
+        let (tier, accepted) = classify(&tx);
+        let signed = make_signed_policy_response(
+            &target,
+            &tier,
+            accepted,
+            Some(tx.compute_txid().to_string()),
+            true,
+        );
+        let cd = serde_json::json!({ "tx_hex": "00" }).to_string();
+        let verdict = reverify_policy_impl(&pure(), &target.node_id(), &cd, Some(&signed));
+        assert_eq!(verdict, ReVerdict::Unverifiable);
+
+        // Non-hex tx_hex also => Unverifiable.
+        let cd2 = serde_json::json!({ "tx_hex": "zzzz" }).to_string();
+        let verdict2 = reverify_policy_impl(&pure(), &target.node_id(), &cd2, Some(&signed));
+        assert_eq!(verdict2, ReVerdict::Unverifiable);
     }
 }

--- a/crates/ghost-common/src/constants.rs
+++ b/crates/ghost-common/src/constants.rs
@@ -176,11 +176,26 @@ pub const ARCHIVE_PASS_RATE: f64 = 0.95;
 /// PROTOCOL CONSTANT — DO NOT MODIFY AFTER MAINNET
 pub const POLICY_PASS_RATE: f64 = 0.95;
 
-/// Stratum challenge pass rate threshold
+/// Stratum challenge pass rate threshold.
+///
+/// CONSENSUS SECURITY: this per-challenge percentage gate NO LONGER governs
+/// stratum qualification. Stratum (and GhostPay) are liveness probes with no
+/// chain ground truth, so they cannot be re-derived like Archive/Policy. They
+/// are instead gated by a per-challenger MAJORITY (one vote per distinct
+/// challenger; see `get_stratum_challenger_majority` in `ghost-storage`), which
+/// a sub-50% colluding minority cannot flip and a flood cannot inflate. This
+/// constant is retained because the legacy per-challenge path
+/// (`get_qualified_capabilities`) and Archive/Policy still share the pattern.
 /// PROTOCOL CONSTANT — DO NOT MODIFY AFTER MAINNET
 pub const STRATUM_PASS_RATE: f64 = 0.95;
 
-/// Ghost Pay challenge pass rate threshold
+/// Ghost Pay challenge pass rate threshold.
+///
+/// CONSENSUS SECURITY: like `STRATUM_PASS_RATE`, this per-challenge percentage
+/// gate NO LONGER governs GhostPay qualification. GhostPay now qualifies on a
+/// per-challenger MAJORITY (see `get_ghostpay_challenger_majority` in
+/// `ghost-storage`). Retained for the legacy per-challenge path and the shared
+/// Archive/Policy pattern.
 /// PROTOCOL CONSTANT — DO NOT MODIFY AFTER MAINNET
 pub const GHOSTPAY_PASS_RATE: f64 = 0.90;
 

--- a/crates/ghost-consensus/src/message.rs
+++ b/crates/ghost-consensus/src/message.rs
@@ -490,6 +490,15 @@ pub struct VerificationResultMessage {
     pub challenge_data: String,
     /// Response details (JSON, capability-specific)
     pub response_data: Option<String>,
+    /// The TARGET's own signed response (`SignedResponse<…>` JSON), when the
+    /// target returned one. This — not `response_data` (which the challenger
+    /// authors) — is what lets a recipient RE-DERIVE the verdict against its own
+    /// ground truth: the recipient verifies this is signed by `target_node_id`,
+    /// then checks the attested response against its own Bitcoin Core / policy
+    /// engine and overrides `passed`. `#[serde(default)]` so older peers that
+    /// omit it still deserialize (backward-compatible fleet deploy).
+    #[serde(default)]
+    pub target_signed_response: Option<String>,
     /// Timestamp when challenge was issued
     pub timestamp: i64,
     /// Challenger's signature over (target_node_id || capability || passed || timestamp)

--- a/crates/ghost-consensus/src/verification_handler.rs
+++ b/crates/ghost-consensus/src/verification_handler.rs
@@ -47,12 +47,81 @@ const VERIFICATION_RATE_REFILL: u32 = 1;
 
 use ghost_common::error::GhostResult;
 use ghost_common::identity::verify_signature;
+use ghost_common::types::NodeId;
 use ghost_storage::Database;
 
 use crate::mesh::MessageHandler;
 use crate::message::{CapabilityType, MessageEnvelope, MessageType, VerificationResultMessage};
 use crate::peer::PeerManager;
 use crate::vote_handler::RateLimiter;
+
+/// Re-derived verdict for a peer-broadcast verification result.
+///
+/// A colluding minority of challengers cannot be trusted to report `passed`
+/// honestly: a >5% group can sign `passed=false` against an honest target,
+/// drag it under the 95% gate, and steal its node-reward share. The recipient
+/// therefore RE-DERIVES the verdict from its OWN ground truth (Bitcoin Core)
+/// plus the TARGET's own signed response, and overrides the challenger's claim.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReVerdict {
+    /// The target's signed response matches the recipient's own ground truth.
+    Pass,
+    /// The target's signed response contradicts the recipient's ground truth
+    /// (e.g. wrong block hash / merkle root for the claimed height).
+    Fail,
+    /// The recipient cannot judge: no/invalid target signature, unparseable
+    /// response, RPC error, or the recipient's node lacks the block (IBD /
+    /// behind). This is NEVER recorded as a FAIL — an unverifiable result must
+    /// not be usable to grief an honest node.
+    Unverifiable,
+}
+
+/// Re-derives the verdict of a peer-broadcast verification result against the
+/// recipient's own ground truth, so a node never stores a challenger-supplied
+/// `passed` verbatim for a capability it can independently check.
+///
+/// Implemented by `ghost-pool` (which has the Bitcoin Core RPC + policy engine);
+/// `ghost-consensus` only owns the trait so it stays free of those dependencies.
+#[async_trait]
+pub trait ResultReVerifier: Send + Sync {
+    /// Re-derive an Archive verdict from the TARGET's signed `ArchiveResponse`
+    /// and the recipient's own chain. `target_signed_response` is the raw
+    /// `SignedResponse<ArchiveResponse>` JSON authored (and signed) by the
+    /// target — the only trustworthy input, since `challenge_data` /
+    /// `response_data` are authored by the (adversarial) challenger.
+    async fn reverify_archive(
+        &self,
+        target_node_id: &NodeId,
+        target_signed_response: Option<&str>,
+    ) -> ReVerdict;
+}
+
+/// Extract `(block_height, block_hash)` from the TARGET-signed archive response
+/// JSON (`SignedResponse<ArchiveResponse>`) for the informational DB columns.
+///
+/// SECURITY: this is used ONLY to populate the diagnostic height/hash columns;
+/// the stored `passed` verdict comes from [`ResultReVerifier::reverify_archive`].
+/// The height/hash are read from inside the target's signed `payload.block_data`
+/// (not from the challenger's `challenge_data`).
+fn parse_signed_archive_height_hash(signed: Option<&str>) -> (Option<u64>, Option<String>) {
+    let raw = match signed {
+        Some(s) if !s.trim().is_empty() => s,
+        _ => return (None, None),
+    };
+    let value: serde_json::Value = match serde_json::from_str(raw) {
+        Ok(v) => v,
+        Err(_) => return (None, None),
+    };
+    let block_data = value.get("payload").and_then(|p| p.get("block_data"));
+    let height = block_data
+        .and_then(|b| b.get("height"))
+        .and_then(|h| h.as_u64());
+    let hash = block_data
+        .and_then(|b| b.get("hash"))
+        .and_then(|h| h.as_str())
+        .map(String::from);
+    (height, hash)
+}
 
 /// Handler for verification result messages
 pub struct VerificationResultHandler {
@@ -62,6 +131,11 @@ pub struct VerificationResultHandler {
     peers: Option<Arc<PeerManager>>,
     /// Per-challenger rate limiter to prevent DB flooding
     rate_limiter: RateLimiter,
+    /// Optional re-deriver that recomputes capability verdicts against the
+    /// recipient's own ground truth, overriding the challenger-supplied
+    /// `passed`. When `None`, the legacy "trust the challenger" behaviour is
+    /// preserved (used by unit tests / the no-dependencies path).
+    reverifier: Option<Arc<dyn ResultReVerifier>>,
 }
 
 impl VerificationResultHandler {
@@ -71,6 +145,7 @@ impl VerificationResultHandler {
             db,
             peers: None,
             rate_limiter: RateLimiter::new(VERIFICATION_RATE_LIMIT_BURST, VERIFICATION_RATE_REFILL),
+            reverifier: None,
         }
     }
 
@@ -84,7 +159,18 @@ impl VerificationResultHandler {
             db,
             peers: Some(peers),
             rate_limiter: RateLimiter::new(VERIFICATION_RATE_LIMIT_BURST, VERIFICATION_RATE_REFILL),
+            reverifier: None,
         }
+    }
+
+    /// Attach a [`ResultReVerifier`] so peer-broadcast verdicts are re-derived
+    /// against this node's own ground truth instead of being trusted verbatim.
+    ///
+    /// SECURITY: without this, a colluding minority of challengers can sign
+    /// `passed=false` against an honest node and steal its node-reward share.
+    pub fn with_rederivation(mut self, reverifier: Arc<dyn ResultReVerifier>) -> Self {
+        self.reverifier = Some(reverifier);
+        self
     }
 
     /// Handle an incoming verification result message
@@ -251,25 +337,74 @@ impl VerificationResultHandler {
         // Use idempotent storage - ignore if already exists (based on challenger + target + timestamp)
         match msg.capability {
             CapabilityType::Archive => {
-                // For archive challenges, extract block height from challenge_data
-                let block_height = serde_json::from_str::<serde_json::Value>(&msg.challenge_data)
-                    .ok()
-                    .and_then(|v| v.get("block_height").and_then(|h| h.as_u64()))
+                // SECURITY (consensus): never store the challenger-supplied
+                // `passed` verbatim. When a re-deriver is configured, recompute
+                // the verdict from THIS node's own Bitcoin Core and the TARGET's
+                // own signed response, so a colluding challenger cannot fabricate
+                // a FAIL (to grief) or a PASS (to inflate a peer).
+                let stored_passed = if let Some(ref reverifier) = self.reverifier {
+                    match reverifier
+                        .reverify_archive(
+                            &msg.target_node_id,
+                            msg.target_signed_response.as_deref(),
+                        )
+                        .await
+                    {
+                        ReVerdict::Pass => true,
+                        ReVerdict::Fail => false,
+                        ReVerdict::Unverifiable => {
+                            // We cannot independently judge this result (no/invalid
+                            // target signature, unparseable response, RPC error, or
+                            // our node lacks the block). Record NOTHING — never a
+                            // false FAIL, never an unverified PASS.
+                            debug!(
+                                challenger = %short_challenger,
+                                target = %short_target,
+                                "Archive verdict unverifiable - not recording (no grief)"
+                            );
+                            return Ok(());
+                        }
+                    }
+                } else {
+                    // Legacy path (unit tests / no re-deriver wired): preserve the
+                    // prior behaviour of trusting the challenger's verdict.
+                    msg.passed
+                };
+
+                // Informational DB columns only. Prefer the height/hash from the
+                // TARGET-signed response (trustworthy); fall back to the
+                // challenger's challenge_data. The stored `passed` above — NOT
+                // these — is what gates the payout.
+                let (signed_height, signed_hash) =
+                    parse_signed_archive_height_hash(msg.target_signed_response.as_deref());
+
+                let block_height = signed_height
+                    .or_else(|| {
+                        serde_json::from_str::<serde_json::Value>(&msg.challenge_data)
+                            .ok()
+                            .and_then(|v| v.get("block_height").and_then(|h| h.as_u64()))
+                    })
                     .unwrap_or(0);
 
-                let expected_hash = serde_json::from_str::<serde_json::Value>(&msg.challenge_data)
-                    .ok()
-                    .and_then(|v| {
-                        v.get("expected_hash")
-                            .and_then(|h| h.as_str())
-                            .map(String::from)
+                let expected_hash = signed_hash
+                    .clone()
+                    .or_else(|| {
+                        serde_json::from_str::<serde_json::Value>(&msg.challenge_data)
+                            .ok()
+                            .and_then(|v| {
+                                v.get("block_hash")
+                                    .and_then(|h| h.as_str())
+                                    .map(String::from)
+                            })
                     })
                     .unwrap_or_default();
 
-                let response_hash = msg.response_data.as_ref().and_then(|rd| {
-                    serde_json::from_str::<serde_json::Value>(rd)
-                        .ok()
-                        .and_then(|v| v.get("hash").and_then(|h| h.as_str()).map(String::from))
+                let response_hash = signed_hash.or_else(|| {
+                    msg.response_data.as_ref().and_then(|rd| {
+                        serde_json::from_str::<serde_json::Value>(rd)
+                            .ok()
+                            .and_then(|v| v.get("hash").and_then(|h| h.as_str()).map(String::from))
+                    })
                 });
 
                 if let Err(e) = self.db.insert_archive_challenge(
@@ -278,7 +413,7 @@ impl VerificationResultHandler {
                     block_height,
                     &expected_hash,
                     response_hash.as_deref(),
-                    msg.passed,
+                    stored_passed,
                 ) {
                     warn!(error = %e, "Failed to store archive challenge result");
                 }
@@ -444,5 +579,128 @@ mod tests {
             handler_with_peers.peers.is_some(),
             "Handler with peers should have Some"
         );
+    }
+
+    // =================================================================
+    // CONSENSUS SECURITY: re-derivation override tests
+    // =================================================================
+
+    use ghost_common::identity::NodeIdentity;
+
+    /// Stub re-verifier that returns a fixed verdict, ignoring its inputs.
+    /// Lets us test the handler's verdict-mapping without a live Bitcoin Core.
+    struct StubReverifier(ReVerdict);
+
+    #[async_trait]
+    impl ResultReVerifier for StubReverifier {
+        async fn reverify_archive(
+            &self,
+            _target_node_id: &NodeId,
+            _target_signed_response: Option<&str>,
+        ) -> ReVerdict {
+            self.0
+        }
+    }
+
+    /// Build a properly-signed Archive `VerificationResultMessage` envelope.
+    /// `msg_passed` is the (untrusted) challenger-claimed verdict.
+    fn build_archive_envelope(
+        challenger: &NodeIdentity,
+        target: NodeId,
+        msg_passed: bool,
+    ) -> MessageEnvelope {
+        let mut msg = VerificationResultMessage {
+            target_node_id: target,
+            challenger_id: challenger.node_id(),
+            capability: CapabilityType::Archive,
+            passed: msg_passed,
+            challenge_data: r#"{"block_hash":"00ff","block_height":500}"#.to_string(),
+            response_data: Some(r#"{"hash":"00ff"}"#.to_string()),
+            target_signed_response: Some("{\"stub\":true}".to_string()),
+            timestamp: Utc::now().timestamp(),
+            signature: [0u8; 64],
+        };
+        let signing_data = msg.signing_data();
+        msg.signature = challenger.sign(&signing_data);
+        let payload = serde_json::to_vec(&msg).expect("serialize VRM");
+        MessageEnvelope::new(
+            MessageType::VerificationResult,
+            challenger.node_id(),
+            payload,
+            1,
+            [0u8; 64],
+        )
+    }
+
+    /// GRIEF OVERRIDE: challenger claims `passed=false` but our re-derivation says
+    /// Pass — the handler must store the re-derived PASS, not the challenger claim.
+    #[tokio::test]
+    async fn handler_stores_rederived_pass_over_grief() {
+        let db = Arc::new(Database::in_memory().unwrap());
+        let challenger = NodeIdentity::generate();
+        let target = [9u8; 32];
+        let env = build_archive_envelope(&challenger, target, false);
+
+        let handler = VerificationResultHandler::new(Arc::clone(&db))
+            .with_rederivation(Arc::new(StubReverifier(ReVerdict::Pass)));
+        handler.handle_verification_result(&env).await.unwrap();
+
+        let (passed, total) = db.get_archive_pass_rate(&hex::encode(target), 0).unwrap();
+        assert_eq!(total, 1, "result must be recorded");
+        assert_eq!(passed, 1, "stored verdict must be the re-derived PASS");
+    }
+
+    /// FRAUD OVERRIDE: challenger claims `passed=true` but our re-derivation says
+    /// Fail — the handler must store the re-derived FAIL.
+    #[tokio::test]
+    async fn handler_stores_rederived_fail_over_inflation() {
+        let db = Arc::new(Database::in_memory().unwrap());
+        let challenger = NodeIdentity::generate();
+        let target = [8u8; 32];
+        let env = build_archive_envelope(&challenger, target, true);
+
+        let handler = VerificationResultHandler::new(Arc::clone(&db))
+            .with_rederivation(Arc::new(StubReverifier(ReVerdict::Fail)));
+        handler.handle_verification_result(&env).await.unwrap();
+
+        let (passed, total) = db.get_archive_pass_rate(&hex::encode(target), 0).unwrap();
+        assert_eq!(total, 1, "result must be recorded");
+        assert_eq!(passed, 0, "stored verdict must be the re-derived FAIL");
+    }
+
+    /// UNVERIFIABLE: the handler must store NOTHING (never a false FAIL), even
+    /// though the challenger claimed `passed=true`.
+    #[tokio::test]
+    async fn handler_stores_nothing_on_unverifiable() {
+        let db = Arc::new(Database::in_memory().unwrap());
+        let challenger = NodeIdentity::generate();
+        let target = [7u8; 32];
+        let env = build_archive_envelope(&challenger, target, true);
+
+        let handler = VerificationResultHandler::new(Arc::clone(&db))
+            .with_rederivation(Arc::new(StubReverifier(ReVerdict::Unverifiable)));
+        handler.handle_verification_result(&env).await.unwrap();
+
+        let (_passed, total) = db.get_archive_pass_rate(&hex::encode(target), 0).unwrap();
+        assert_eq!(total, 0, "unverifiable result must NOT be recorded");
+    }
+
+    /// LEGACY: with no re-verifier wired, the handler preserves the old behaviour
+    /// of storing the challenger-supplied `passed` verbatim (so existing tests and
+    /// the no-dependency path are unaffected).
+    #[tokio::test]
+    async fn handler_without_rederivation_stores_msg_passed() {
+        let db = Arc::new(Database::in_memory().unwrap());
+        let challenger = NodeIdentity::generate();
+        let target = [6u8; 32];
+
+        // passed=true is stored as-is when no re-verifier is configured.
+        let env = build_archive_envelope(&challenger, target, true);
+        let handler = VerificationResultHandler::new(Arc::clone(&db));
+        handler.handle_verification_result(&env).await.unwrap();
+
+        let (passed, total) = db.get_archive_pass_rate(&hex::encode(target), 0).unwrap();
+        assert_eq!(total, 1);
+        assert_eq!(passed, 1, "legacy path stores msg.passed unchanged");
     }
 }

--- a/crates/ghost-consensus/src/verification_handler.rs
+++ b/crates/ghost-consensus/src/verification_handler.rs
@@ -94,6 +94,23 @@ pub trait ResultReVerifier: Send + Sync {
         target_node_id: &NodeId,
         target_signed_response: Option<&str>,
     ) -> ReVerdict;
+
+    /// Re-derive a Policy (Bitcoin Pure) verdict from the TARGET's signed
+    /// `PolicyResponse` and the recipient's OWN policy engine.
+    ///
+    /// `challenge_data` is the challenger-authored JSON; the recipient reads only
+    /// the `tx_hex` from it (the exact transaction the target classified) — every
+    /// value the verdict turns on otherwise comes from the TARGET-signed payload
+    /// (the classification) or the recipient's own engine (ground truth). The
+    /// recipient BINDS the two: it recomputes the txid of `tx_hex` and requires it
+    /// to equal the signed `tx_txid`, so a colluder cannot pair a valid signed
+    /// classification with a different `tx_hex` to grief the target.
+    async fn reverify_policy(
+        &self,
+        target_node_id: &NodeId,
+        challenge_data: &str,
+        target_signed_response: Option<&str>,
+    ) -> ReVerdict;
 }
 
 /// Extract `(block_height, block_hash)` from the TARGET-signed archive response
@@ -121,6 +138,42 @@ fn parse_signed_archive_height_hash(signed: Option<&str>) -> (Option<u64>, Optio
         .and_then(|h| h.as_str())
         .map(String::from);
     (height, hash)
+}
+
+/// Extract `(tx_txid, response_tier)` from the TARGET-signed policy response JSON
+/// (`SignedResponse<PolicyResponse>`) for the informational DB columns.
+///
+/// SECURITY: this is used ONLY to populate the diagnostic txid/tier columns; the
+/// stored `passed` verdict comes from [`ResultReVerifier::reverify_policy`]. The
+/// txid/tier are read from inside the target's signed `payload` (not from the
+/// challenger's `challenge_data`). `response_tier` maps the tier string to the
+/// 0..=3 BUDS integer used by `insert_policy_challenge`.
+fn parse_signed_policy_fields(signed: Option<&str>) -> (Option<String>, Option<i32>) {
+    let raw = match signed {
+        Some(s) if !s.trim().is_empty() => s,
+        _ => return (None, None),
+    };
+    let value: serde_json::Value = match serde_json::from_str(raw) {
+        Ok(v) => v,
+        Err(_) => return (None, None),
+    };
+    let payload = value.get("payload");
+    let txid = payload
+        .and_then(|p| p.get("tx_txid"))
+        .and_then(|t| t.as_str())
+        .map(String::from);
+    let response_tier = payload
+        .and_then(|p| p.get("classification"))
+        .and_then(|c| c.get("tier"))
+        .and_then(|t| t.as_str())
+        .and_then(|t| match t {
+            "T0" => Some(0),
+            "T1" => Some(1),
+            "T2" => Some(2),
+            "T3" => Some(3),
+            _ => None,
+        });
+    (txid, response_tier)
 }
 
 /// Handler for verification result messages
@@ -419,9 +472,56 @@ impl VerificationResultHandler {
                 }
             }
             CapabilityType::Policy => {
-                let txid = serde_json::from_str::<serde_json::Value>(&msg.challenge_data)
-                    .ok()
-                    .and_then(|v| v.get("txid").and_then(|t| t.as_str()).map(String::from))
+                // SECURITY (consensus): never store the challenger-supplied
+                // `passed` verbatim. When a re-deriver is configured, recompute
+                // the verdict from THIS node's own policy engine and the TARGET's
+                // own signed classification (bound to the challenger's tx_hex by a
+                // txid recompute), so a colluding challenger cannot fabricate a
+                // FAIL (to grief) or a PASS (to inflate a peer).
+                let stored_passed = if let Some(ref reverifier) = self.reverifier {
+                    match reverifier
+                        .reverify_policy(
+                            &msg.target_node_id,
+                            &msg.challenge_data,
+                            msg.target_signed_response.as_deref(),
+                        )
+                        .await
+                    {
+                        ReVerdict::Pass => true,
+                        ReVerdict::Fail => false,
+                        ReVerdict::Unverifiable => {
+                            // We cannot independently judge this result (no/invalid
+                            // target signature, unparseable response, tx_hex
+                            // missing/undeserializable, or txid binding mismatch).
+                            // Record NOTHING — never a false FAIL, never an
+                            // unverified PASS.
+                            debug!(
+                                challenger = %short_challenger,
+                                target = %short_target,
+                                "Policy verdict unverifiable - not recording (no grief)"
+                            );
+                            return Ok(());
+                        }
+                    }
+                } else {
+                    // Legacy path (unit tests / no re-deriver wired): preserve the
+                    // prior behaviour of trusting the challenger's verdict.
+                    msg.passed
+                };
+
+                // Informational DB columns only. Prefer the txid/tier from inside
+                // the TARGET-signed response (trustworthy); fall back to the
+                // challenger-authored fields. The stored `passed` above — NOT
+                // these — is what gates the payout.
+                let (signed_txid, signed_tier) =
+                    parse_signed_policy_fields(msg.target_signed_response.as_deref());
+
+                let txid = signed_txid
+                    .or_else(|| {
+                        serde_json::from_str::<serde_json::Value>(&msg.challenge_data)
+                            .ok()
+                            .and_then(|v| v.get("txid").and_then(|t| t.as_str()).map(String::from))
+                    })
                     .unwrap_or_default();
 
                 let expected_tier = serde_json::from_str::<serde_json::Value>(&msg.challenge_data)
@@ -429,11 +529,13 @@ impl VerificationResultHandler {
                     .and_then(|v| v.get("expected_tier").and_then(|t| t.as_i64()))
                     .unwrap_or(0) as i32;
 
-                let response_tier = msg.response_data.as_ref().and_then(|rd| {
-                    serde_json::from_str::<serde_json::Value>(rd)
-                        .ok()
-                        .and_then(|v| v.get("tier").and_then(|t| t.as_i64()))
-                        .map(|t| t as i32)
+                let response_tier = signed_tier.or_else(|| {
+                    msg.response_data.as_ref().and_then(|rd| {
+                        serde_json::from_str::<serde_json::Value>(rd)
+                            .ok()
+                            .and_then(|v| v.get("tier").and_then(|t| t.as_i64()))
+                            .map(|t| t as i32)
+                    })
                 });
 
                 if let Err(e) = self.db.insert_policy_challenge(
@@ -442,7 +544,7 @@ impl VerificationResultHandler {
                     &txid,
                     expected_tier,
                     response_tier,
-                    msg.passed,
+                    stored_passed,
                 ) {
                     warn!(error = %e, "Failed to store policy challenge result");
                 }
@@ -600,6 +702,15 @@ mod tests {
         ) -> ReVerdict {
             self.0
         }
+
+        async fn reverify_policy(
+            &self,
+            _target_node_id: &NodeId,
+            _challenge_data: &str,
+            _target_signed_response: Option<&str>,
+        ) -> ReVerdict {
+            self.0
+        }
     }
 
     /// Build a properly-signed Archive `VerificationResultMessage` envelope.
@@ -700,6 +811,107 @@ mod tests {
         handler.handle_verification_result(&env).await.unwrap();
 
         let (passed, total) = db.get_archive_pass_rate(&hex::encode(target), 0).unwrap();
+        assert_eq!(total, 1);
+        assert_eq!(passed, 1, "legacy path stores msg.passed unchanged");
+    }
+
+    // ---- Policy (Bitcoin Pure) re-derivation, handler level ----
+
+    /// Build a properly-signed Policy `VerificationResultMessage` envelope.
+    fn build_policy_envelope(
+        challenger: &NodeIdentity,
+        target: NodeId,
+        msg_passed: bool,
+    ) -> MessageEnvelope {
+        let mut msg = VerificationResultMessage {
+            target_node_id: target,
+            challenger_id: challenger.node_id(),
+            capability: CapabilityType::Policy,
+            passed: msg_passed,
+            challenge_data: r#"{"tx_type":"T0","expected_tier":"T0","tx_hex":"00"}"#.to_string(),
+            response_data: Some(r#"{"tier":"T0","accepted":true}"#.to_string()),
+            target_signed_response: Some("{\"stub\":true}".to_string()),
+            timestamp: Utc::now().timestamp(),
+            signature: [0u8; 64],
+        };
+        let signing_data = msg.signing_data();
+        msg.signature = challenger.sign(&signing_data);
+        let payload = serde_json::to_vec(&msg).expect("serialize VRM");
+        MessageEnvelope::new(
+            MessageType::VerificationResult,
+            challenger.node_id(),
+            payload,
+            1,
+            [0u8; 64],
+        )
+    }
+
+    /// GRIEF OVERRIDE (priority): challenger claims `passed=false` but our
+    /// re-derivation says Pass — the handler stores the re-derived PASS.
+    #[tokio::test]
+    async fn handler_stores_rederived_policy_pass_over_grief() {
+        let db = Arc::new(Database::in_memory().unwrap());
+        let challenger = NodeIdentity::generate();
+        let target = [19u8; 32];
+        let env = build_policy_envelope(&challenger, target, false);
+
+        let handler = VerificationResultHandler::new(Arc::clone(&db))
+            .with_rederivation(Arc::new(StubReverifier(ReVerdict::Pass)));
+        handler.handle_verification_result(&env).await.unwrap();
+
+        let (passed, total) = db.get_policy_pass_rate(&hex::encode(target), 0).unwrap();
+        assert_eq!(total, 1, "result must be recorded");
+        assert_eq!(passed, 1, "stored verdict must be the re-derived PASS");
+    }
+
+    /// FRAUD OVERRIDE: challenger claims `passed=true` but our re-derivation says
+    /// Fail — the handler stores the re-derived FAIL.
+    #[tokio::test]
+    async fn handler_stores_rederived_policy_fail_over_inflation() {
+        let db = Arc::new(Database::in_memory().unwrap());
+        let challenger = NodeIdentity::generate();
+        let target = [18u8; 32];
+        let env = build_policy_envelope(&challenger, target, true);
+
+        let handler = VerificationResultHandler::new(Arc::clone(&db))
+            .with_rederivation(Arc::new(StubReverifier(ReVerdict::Fail)));
+        handler.handle_verification_result(&env).await.unwrap();
+
+        let (passed, total) = db.get_policy_pass_rate(&hex::encode(target), 0).unwrap();
+        assert_eq!(total, 1, "result must be recorded");
+        assert_eq!(passed, 0, "stored verdict must be the re-derived FAIL");
+    }
+
+    /// UNVERIFIABLE: the handler must store NOTHING (never a false FAIL), even
+    /// though the challenger claimed `passed=true`.
+    #[tokio::test]
+    async fn handler_stores_nothing_on_unverifiable_policy() {
+        let db = Arc::new(Database::in_memory().unwrap());
+        let challenger = NodeIdentity::generate();
+        let target = [17u8; 32];
+        let env = build_policy_envelope(&challenger, target, true);
+
+        let handler = VerificationResultHandler::new(Arc::clone(&db))
+            .with_rederivation(Arc::new(StubReverifier(ReVerdict::Unverifiable)));
+        handler.handle_verification_result(&env).await.unwrap();
+
+        let (_passed, total) = db.get_policy_pass_rate(&hex::encode(target), 0).unwrap();
+        assert_eq!(total, 0, "unverifiable policy result must NOT be recorded");
+    }
+
+    /// LEGACY: with no re-verifier wired, the policy path preserves the old
+    /// behaviour of storing the challenger-supplied `passed` verbatim.
+    #[tokio::test]
+    async fn handler_without_rederivation_stores_policy_msg_passed() {
+        let db = Arc::new(Database::in_memory().unwrap());
+        let challenger = NodeIdentity::generate();
+        let target = [16u8; 32];
+
+        let env = build_policy_envelope(&challenger, target, true);
+        let handler = VerificationResultHandler::new(Arc::clone(&db));
+        handler.handle_verification_result(&env).await.unwrap();
+
+        let (passed, total) = db.get_policy_pass_rate(&hex::encode(target), 0).unwrap();
         assert_eq!(total, 1);
         assert_eq!(passed, 1, "legacy path stores msg.passed unchanged");
     }

--- a/crates/ghost-storage/src/queries.rs
+++ b/crates/ghost-storage/src/queries.rs
@@ -5302,6 +5302,113 @@ impl Database {
         })
     }
 
+    // =========================================================================
+    // PER-CHALLENGER MAJORITY QUERIES (anti-griefing for liveness probes)
+    //
+    // CONSENSUS SECURITY: Stratum and GhostPay are liveness checks with NO
+    // chain ground truth, so a stored verdict cannot be re-derived the way
+    // Archive/Policy now are. A colluding minority that is merely >5% of a
+    // target's challengers could otherwise sign `passed=0` and drag an honest
+    // node under the per-challenge percentage gate to deny its rewards.
+    //
+    // These queries collapse the verdict to ONE VOTE PER DISTINCT CHALLENGER:
+    // each challenger's vote is the majority of THAT challenger's own results,
+    // then we count how many distinct challengers voted pass vs total. The
+    // caller (`get_qualified_capabilities_with_rates`) then requires a STRICT
+    // majority of distinct challengers. This makes a <50% colluding minority
+    // unable to grief OR inflate, and is flood-resistant: a single challenger
+    // spamming thousands of rows still contributes exactly one vote.
+    // =========================================================================
+
+    /// Per-challenger majority verdict for the stratum capability.
+    ///
+    /// Returns `(challengers_pass, challengers_total)` where:
+    /// - `challengers_total` is the number of DISTINCT challengers that issued
+    ///   at least one stratum challenge against `node_id` since `since`.
+    /// - `challengers_pass` is how many of those distinct challengers had a
+    ///   MAJORITY of their own results pass (`SUM(passed) * 2 >= COUNT(*)`).
+    ///
+    /// One vote per challenger: a single challenger flooding the table cannot
+    /// inflate or suppress the count beyond its own one vote.
+    pub fn get_stratum_challenger_majority(
+        &self,
+        node_id: &str,
+        since: i64,
+    ) -> GhostResult<(u32, u32)> {
+        self.with_connection(|conn| {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT
+                        SUM(CASE WHEN c_pass * 2 >= c_total THEN 1 ELSE 0 END) AS challengers_pass,
+                        COUNT(*) AS challengers_total
+                     FROM (
+                        SELECT challenger_id,
+                               SUM(CASE WHEN passed = 1 THEN 1 ELSE 0 END) AS c_pass,
+                               COUNT(*) AS c_total
+                        FROM stratum_challenges
+                        WHERE node_id = ?1 AND timestamp >= ?2
+                        GROUP BY challenger_id
+                     )",
+                )
+                .map_err(|e| GhostError::Database(e.to_string()))?;
+
+            let result = stmt
+                .query_row(params![node_id, since], |row| {
+                    let pass: Option<i64> = row.get(0)?;
+                    let total: i64 = row.get(1)?;
+                    Ok((
+                        i64_to_u32_count(pass.unwrap_or(0), "stratum_challengers_pass")?,
+                        i64_to_u32_count(total, "stratum_challengers_total")?,
+                    ))
+                })
+                .map_err(|e| GhostError::Database(e.to_string()))?;
+
+            Ok(result)
+        })
+    }
+
+    /// Per-challenger majority verdict for the GhostPay capability.
+    ///
+    /// Identical aggregation to [`Self::get_stratum_challenger_majority`] over
+    /// the `ghostpay_challenges` table. Returns `(challengers_pass,
+    /// challengers_total)`.
+    pub fn get_ghostpay_challenger_majority(
+        &self,
+        node_id: &str,
+        since: i64,
+    ) -> GhostResult<(u32, u32)> {
+        self.with_connection(|conn| {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT
+                        SUM(CASE WHEN c_pass * 2 >= c_total THEN 1 ELSE 0 END) AS challengers_pass,
+                        COUNT(*) AS challengers_total
+                     FROM (
+                        SELECT challenger_id,
+                               SUM(CASE WHEN passed = 1 THEN 1 ELSE 0 END) AS c_pass,
+                               COUNT(*) AS c_total
+                        FROM ghostpay_challenges
+                        WHERE node_id = ?1 AND timestamp >= ?2
+                        GROUP BY challenger_id
+                     )",
+                )
+                .map_err(|e| GhostError::Database(e.to_string()))?;
+
+            let result = stmt
+                .query_row(params![node_id, since], |row| {
+                    let pass: Option<i64> = row.get(0)?;
+                    let total: i64 = row.get(1)?;
+                    Ok((
+                        i64_to_u32_count(pass.unwrap_or(0), "ghostpay_challengers_pass")?,
+                        i64_to_u32_count(total, "ghostpay_challengers_total")?,
+                    ))
+                })
+                .map_err(|e| GhostError::Database(e.to_string()))?;
+
+            Ok(result)
+        })
+    }
+
     /// Record an uptime sample for a node
     pub fn record_uptime_sample(
         &self,
@@ -5490,10 +5597,18 @@ impl Database {
 
     /// M-16 FIX: Get qualified capabilities with per-capability pass rates
     ///
-    /// A capability is qualified if:
+    /// Archive and Policy are qualified if:
     /// 1. Node passes uptime gatekeeper (95% over lookback period)
     /// 2. Capability has min_challenges or more challenges
     /// 3. Pass rate is >= the capability-specific threshold
+    ///
+    /// CONSENSUS SECURITY: Stratum and GhostPay (liveness probes with no chain
+    /// ground truth) instead qualify on a per-CHALLENGER MAJORITY — at least
+    /// `min_challenges` DISTINCT challengers reported AND a strict majority of
+    /// those distinct challengers voted pass. The `stratum_pass_rate` and
+    /// `ghostpay_pass_rate` arguments therefore no longer gate those two (they
+    /// remain in the signature for the legacy uniform-rate caller and the
+    /// Archive/Policy path).
     ///
     /// H-4: This function safely handles division by zero by checking total > 0
     /// before computing pass rate. If total is 0, the capability is not qualified.
@@ -5517,7 +5632,13 @@ impl Database {
             total > 0 && total >= min_challenges && (passed as f64 / total as f64) >= min_rate
         };
 
-        // M-16 FIX: Check each capability with its own pass rate threshold
+        // M-16 FIX: Check each capability with its own pass rate threshold.
+        //
+        // Archive and Policy keep the per-challenge percentage gate: every
+        // stored verdict for those two is RE-DERIVED by the recipient from the
+        // target's own signed response against chain/engine ground truth
+        // (anti-griefing Increments 1 & 2), so an individual `passed` flag is
+        // already trustworthy and the SUM/COUNT rate is honest.
         let archive_qualified = {
             let (passed, total) = self.get_archive_pass_rate(node_id, since)?;
             is_qualified(passed, total, archive_pass_rate)
@@ -5528,14 +5649,30 @@ impl Database {
             is_qualified(passed, total, policy_pass_rate)
         };
 
+        // CONSENSUS SECURITY: Stratum and GhostPay are liveness probes with no
+        // chain ground truth — a stored verdict cannot be re-derived — so the
+        // per-challenge SUM/COUNT gate is replaced by a per-CHALLENGER MAJORITY.
+        // A capability qualifies iff a STRICT majority of the DISTINCT
+        // challengers that probed this node voted pass (and at least
+        // `min_challenges` distinct challengers reported). This denies a <50%
+        // colluding minority the ability to grief (sign `passed=0` to drag an
+        // honest node under) or inflate, and is flood-resistant (one vote per
+        // challenger). `stratum_pass_rate`/`ghostpay_pass_rate` no longer gate
+        // these two; see `STRATUM_PASS_RATE`/`GHOSTPAY_PASS_RATE` in
+        // `ghost-common`. The `min_unique_challengers` Sybil check in
+        // `qualification.rs` still applies on top of this.
+        let _ = (stratum_pass_rate, ghostpay_pass_rate);
+
         let stratum_qualified = {
-            let (passed, total) = self.get_stratum_pass_rate(node_id, since)?;
-            is_qualified(passed, total, stratum_pass_rate)
+            let (challengers_pass, challengers_total) =
+                self.get_stratum_challenger_majority(node_id, since)?;
+            challengers_total >= min_challenges && challengers_pass * 2 > challengers_total
         };
 
         let ghostpay_qualified = {
-            let (passed, total) = self.get_ghostpay_pass_rate(node_id, since)?;
-            is_qualified(passed, total, ghostpay_pass_rate)
+            let (challengers_pass, challengers_total) =
+                self.get_ghostpay_challenger_majority(node_id, since)?;
+            challengers_total >= min_challenges && challengers_pass * 2 > challengers_total
         };
 
         // Elder status is based on is_elder flag in the nodes table
@@ -10595,5 +10732,221 @@ mod tests {
         let cm2 = test_commitment(&pixels, "ghost1bob");
         db.insert_glyph_claim("ghost1bob", &pixels, &bh, &cm2, now + 90001)
             .expect("Re-claim should succeed after expiry");
+    }
+
+    // =========================================================================
+    // PER-CHALLENGER MAJORITY (anti-griefing for stratum / ghostpay)
+    // =========================================================================
+
+    /// Insert a raw stratum_challenges row with an explicit timestamp so tests
+    /// can place rows on distinct days (the daily unique index requires it).
+    fn insert_stratum_row(db: &Database, node: &str, challenger: &str, passed: bool, ts: i64) {
+        db.with_connection(|conn| {
+            conn.execute(
+                "INSERT INTO stratum_challenges
+                 (node_id, challenger_id, connected, latency_ms, passed, timestamp)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                params![node, challenger, passed, 1i64, passed, ts],
+            )
+            .map_err(|e| GhostError::Database(e.to_string()))?;
+            Ok(())
+        })
+        .expect("insert stratum row");
+    }
+
+    /// Insert a raw ghostpay_challenges row with an explicit timestamp.
+    fn insert_ghostpay_row(db: &Database, node: &str, challenger: &str, passed: bool, ts: i64) {
+        db.with_connection(|conn| {
+            conn.execute(
+                "INSERT INTO ghostpay_challenges
+                 (node_id, challenger_id, endpoint, response_valid, passed, timestamp)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                params![node, challenger, "ghostpay", passed, passed, ts],
+            )
+            .map_err(|e| GhostError::Database(e.to_string()))?;
+            Ok(())
+        })
+        .expect("insert ghostpay row");
+    }
+
+    #[test]
+    fn test_stratum_challenger_majority_griefing_defeated() {
+        // 10 honest challengers (passed=1) + 2 colluders (passed=0).
+        // Honest majority must win: the <50% colluding minority cannot grief.
+        let db = Database::in_memory().expect("db");
+        let node = "a".repeat(64);
+        let now = chrono::Utc::now().timestamp();
+        let since = now - 7 * 86_400;
+
+        for i in 0..10 {
+            insert_stratum_row(&db, &node, &format!("honest{i}"), true, now);
+        }
+        for i in 0..2 {
+            insert_stratum_row(&db, &node, &format!("colluder{i}"), false, now);
+        }
+
+        let (pass, total) = db
+            .get_stratum_challenger_majority(&node, since)
+            .expect("majority query");
+        assert_eq!(
+            (pass, total),
+            (10, 12),
+            "10 honest pass, 12 total challengers"
+        );
+        assert!(
+            pass * 2 > total,
+            "strict majority of challengers passed -> qualified"
+        );
+
+        // Now flip the balance: 7 colluders vs 5 honest on a different node.
+        let node2 = "b".repeat(64);
+        for i in 0..5 {
+            insert_stratum_row(&db, &node2, &format!("honest{i}"), true, now);
+        }
+        for i in 0..7 {
+            insert_stratum_row(&db, &node2, &format!("colluder{i}"), false, now);
+        }
+        let (pass2, total2) = db
+            .get_stratum_challenger_majority(&node2, since)
+            .expect("majority query");
+        assert_eq!((pass2, total2), (5, 12), "5 honest pass, 12 total");
+        assert!(pass2 * 2 <= total2, "no strict majority -> NOT qualified");
+    }
+
+    #[test]
+    fn test_ghostpay_challenger_majority_griefing_defeated() {
+        // GhostPay equivalent of the stratum griefing test.
+        let db = Database::in_memory().expect("db");
+        let node = "c".repeat(64);
+        let now = chrono::Utc::now().timestamp();
+        let since = now - 7 * 86_400;
+
+        for i in 0..10 {
+            insert_ghostpay_row(&db, &node, &format!("honest{i}"), true, now);
+        }
+        for i in 0..2 {
+            insert_ghostpay_row(&db, &node, &format!("colluder{i}"), false, now);
+        }
+        let (pass, total) = db
+            .get_ghostpay_challenger_majority(&node, since)
+            .expect("majority query");
+        assert_eq!((pass, total), (10, 12));
+        assert!(pass * 2 > total, "honest majority -> qualified");
+
+        // 7 colluders vs 5 honest -> not qualified.
+        let node2 = "d".repeat(64);
+        for i in 0..5 {
+            insert_ghostpay_row(&db, &node2, &format!("honest{i}"), true, now);
+        }
+        for i in 0..7 {
+            insert_ghostpay_row(&db, &node2, &format!("colluder{i}"), false, now);
+        }
+        let (pass2, total2) = db
+            .get_ghostpay_challenger_majority(&node2, since)
+            .expect("majority query");
+        assert_eq!((pass2, total2), (5, 12));
+        assert!(
+            pass2 * 2 <= total2,
+            "minority cannot grief but cannot pass either"
+        );
+    }
+
+    #[test]
+    fn test_stratum_challenger_majority_flood_resistance() {
+        // ONE colluder floods 100 passed=0 rows (across 100 distinct days),
+        // 3 honest challengers each cast one passed=1. Per-challenger
+        // aggregation = the flood is exactly ONE vote.
+        let db = Database::in_memory().expect("db");
+        let node = "e".repeat(64);
+        let now = chrono::Utc::now().timestamp();
+        // Wide window so all 100 daily rows fall inside it.
+        let since = now - 200 * 86_400;
+
+        for i in 0..100 {
+            // Distinct day per row to satisfy the (node, challenger, day) index.
+            insert_stratum_row(&db, &node, "flooder", false, now - i * 86_400);
+        }
+        for i in 0..3 {
+            insert_stratum_row(&db, &node, &format!("honest{i}"), true, now);
+        }
+
+        let (pass, total) = db
+            .get_stratum_challenger_majority(&node, since)
+            .expect("majority query");
+        assert_eq!(
+            (pass, total),
+            (3, 4),
+            "flooder counts as 1 (failing) challenger; 3 honest pass -> (3,4)"
+        );
+        assert!(pass * 2 > total, "flood cannot suppress -> qualified");
+    }
+
+    #[test]
+    fn test_stratum_challenger_majority_fraud_down_node() {
+        // A genuinely-down node: every honest challenger observes "down"
+        // (passed=0). Majority fail -> NOT qualified (fraud closed).
+        let db = Database::in_memory().expect("db");
+        let node = "f".repeat(64);
+        let now = chrono::Utc::now().timestamp();
+        let since = now - 7 * 86_400;
+
+        for i in 0..10 {
+            insert_stratum_row(&db, &node, &format!("honest{i}"), false, now);
+        }
+        let (pass, total) = db
+            .get_stratum_challenger_majority(&node, since)
+            .expect("majority query");
+        assert_eq!((pass, total), (0, 10));
+        assert!(
+            pass * 2 <= total,
+            "down node fails the majority -> NOT qualified"
+        );
+    }
+
+    #[test]
+    fn test_qualified_capabilities_uses_stratum_majority() {
+        // End-to-end: get_qualified_capabilities_with_rates must qualify
+        // public_mining off the per-challenger MAJORITY, not a percentage gate.
+        // 7 honest (passed=1) + 5 colluders (passed=0) -> 12 challengers, 7 pass.
+        // Per-challenge SUM/COUNT would be 7/12 = 58% (below the old 95% gate),
+        // yet the strict per-challenger majority (7 of 12) qualifies it.
+        let db = Database::in_memory().expect("db");
+        let node = "1".repeat(64);
+        let now = chrono::Utc::now().timestamp();
+        let since = now - 7 * 86_400;
+
+        for i in 0..7 {
+            insert_stratum_row(&db, &node, &format!("honest{i}"), true, now);
+        }
+        for i in 0..5 {
+            insert_stratum_row(&db, &node, &format!("colluder{i}"), false, now);
+        }
+
+        // min_challenges = 5 (>= would be satisfied by 12 distinct challengers).
+        let caps = db
+            .get_qualified_capabilities_with_rates(&node, since, 5, 0.95, 0.90, 0.95, 0.95)
+            .expect("qualify");
+        assert!(
+            caps.public_mining,
+            "majority of distinct challengers passed -> public_mining qualified"
+        );
+        assert!(!caps.ghost_pay, "no ghostpay challenges -> not qualified");
+        assert!(!caps.archive_mode, "no archive challenges -> not qualified");
+
+        // Same node, but flip to a colluding majority: 5 honest vs 7 colluders.
+        let node2 = "2".repeat(64);
+        for i in 0..5 {
+            insert_stratum_row(&db, &node2, &format!("honest{i}"), true, now);
+        }
+        for i in 0..7 {
+            insert_stratum_row(&db, &node2, &format!("colluder{i}"), false, now);
+        }
+        let caps2 = db
+            .get_qualified_capabilities_with_rates(&node2, since, 5, 0.95, 0.90, 0.95, 0.95)
+            .expect("qualify");
+        assert!(
+            !caps2.public_mining,
+            "no strict majority of challengers -> public_mining NOT qualified"
+        );
     }
 }

--- a/crates/ghost-verification/src/challenge.rs
+++ b/crates/ghost-verification/src/challenge.rs
@@ -237,8 +237,81 @@ pub struct PolicyResponse {
     pub accepted: bool,
     /// Rejection reason (if not accepted)
     pub rejection_reason: Option<String>,
+    /// CONSENSUS SECURITY: Bitcoin txid (`tx.compute_txid()`) of the transaction
+    /// the target actually classified. Set by the server INSIDE the signed
+    /// payload so a recipient can BIND this classification to the exact tx the
+    /// challenger broadcast: the recipient recomputes the txid of the challenger-
+    /// supplied `tx_hex` and requires it to equal `tx_txid` before trusting the
+    /// verdict. Without this, a colluder could pair a valid target-signed
+    /// classification with a DIFFERENT `tx_hex` to force a spurious mismatch and
+    /// grief the target. `#[serde(default)]` for backward-compatible deserialization
+    /// of responses from peers that predate this field.
+    #[serde(default)]
+    pub tx_txid: Option<String>,
     /// Error message (if failed)
     pub error: Option<String>,
+}
+
+/// CONSENSUS SECURITY: Compare a TARGET-signed [`PolicyResponse`] against the
+/// caller's own ground-truth classification of the SAME transaction.
+///
+/// Returns `(passed, validation_details)`.
+///
+/// This is the single source of truth for policy verdict comparison, mirroring
+/// [`validate_archive_response`]. It is called both by the CHALLENGER (`task.rs`,
+/// against its own [`ghost_policy::PolicyEngine`] at challenge time) and by
+/// RECIPIENTS of a broadcast result (`ghost-pool`'s `ChainReVerifier`, against
+/// their own engine when re-deriving the verdict). Both paths run identical
+/// logic, so there is zero divergence between the verdict a challenger records
+/// and the verdict a recipient re-derives.
+///
+/// The target classified correctly (`passed = true`) iff:
+///   1. it reported `success = true`,
+///   2. its classification tier equals the caller's `recipient_tier`, and
+///   3. its `accepted` flag equals the caller's `recipient_accepted`.
+///
+/// SECURITY: `recipient_tier` and `recipient_accepted` MUST be the caller's OWN
+/// classification of the same transaction (from its own policy engine), never a
+/// value taken from the untrusted party whose response is being judged.
+pub fn validate_policy_response(
+    target_resp: &PolicyResponse,
+    recipient_tier: &str,
+    recipient_accepted: bool,
+) -> (bool, String) {
+    // The target must claim success — a failed evaluation tells us nothing.
+    if !target_resp.success {
+        return (false, "Response indicates failure".to_string());
+    }
+
+    // The target must have produced a classification.
+    let target_tier = match target_resp.classification.as_ref() {
+        Some(c) => c.tier.as_str(),
+        None => return (false, "No classification in response".to_string()),
+    };
+
+    // Tier must match the caller's own classification of the same tx.
+    if !target_tier.eq_ignore_ascii_case(recipient_tier) {
+        return (
+            false,
+            format!(
+                "Tier mismatch: target classified {}, our engine classified {}",
+                target_tier, recipient_tier
+            ),
+        );
+    }
+
+    // Accept/reject decision must match the caller's own decision.
+    if target_resp.accepted != recipient_accepted {
+        return (
+            false,
+            format!(
+                "Accept decision mismatch: target accepted={}, our engine accepted={}",
+                target_resp.accepted, recipient_accepted
+            ),
+        );
+    }
+
+    (true, "Validation passed".to_string())
 }
 
 /// Policy classification result

--- a/crates/ghost-verification/src/challenge.rs
+++ b/crates/ghost-verification/src/challenge.rs
@@ -102,6 +102,119 @@ pub struct TxData {
     pub output_count: usize,
 }
 
+/// C-2 FIX: Validate an archive response against expected ground-truth values.
+///
+/// Returns `(passed, validation_details)`.
+///
+/// This is the single source of truth for archive verdict comparison. It is
+/// called both by the CHALLENGER (`task.rs`, against its own RPC at challenge
+/// time) and by RECIPIENTS of a broadcast result (`ghost-pool`'s
+/// `ChainReVerifier`, against their own RPC when re-deriving the verdict). Both
+/// paths run identical logic so there is zero divergence between the verdict a
+/// challenger records and the verdict a recipient re-derives.
+///
+/// SECURITY: `expected_hash`, `expected_height` and `expected_merkle_root` MUST
+/// come from the caller's own trusted source (its Bitcoin Core), never from the
+/// untrusted party whose response is being judged.
+pub fn validate_archive_response(
+    resp: &ArchiveResponse,
+    expected_hash: &str,
+    expected_height: u64,
+    expected_merkle_root: Option<&str>,
+) -> (bool, String) {
+    // Basic check: response must indicate success
+    if !resp.success {
+        return (false, "Response indicates failure".to_string());
+    }
+
+    // C-2 FIX: Block data must be present
+    let block_data = match &resp.block_data {
+        Some(data) => data,
+        None => {
+            return (false, "C-2: No block data in response".to_string());
+        }
+    };
+
+    // C-2 FIX: Block hash must match what we requested
+    if block_data.hash.to_lowercase() != expected_hash.to_lowercase() {
+        return (
+            false,
+            format!(
+                "C-2: Block hash mismatch: got {}, expected {}",
+                block_data.hash, expected_hash
+            ),
+        );
+    }
+
+    // C-2 FIX: Height must match
+    if block_data.height != expected_height {
+        return (
+            false,
+            format!(
+                "C-2: Block height mismatch: got {}, expected {}",
+                block_data.height, expected_height
+            ),
+        );
+    }
+
+    // C-2 FIX: Validate merkle root format (64 hex chars)
+    if block_data.merkle_root.len() != 64
+        || !block_data
+            .merkle_root
+            .chars()
+            .all(|c| c.is_ascii_hexdigit())
+    {
+        return (
+            false,
+            format!(
+                "C-2: Invalid merkle root format: {}",
+                block_data.merkle_root
+            ),
+        );
+    }
+
+    // C-2 FIX: If we have expected merkle root from our RPC, cross-check it
+    if let Some(expected_mr) = expected_merkle_root {
+        if block_data.merkle_root.to_lowercase() != expected_mr.to_lowercase() {
+            return (
+                false,
+                format!(
+                    "C-2: Merkle root mismatch: got {}, expected {}",
+                    block_data.merkle_root, expected_mr
+                ),
+            );
+        }
+    }
+
+    // C-2 FIX: Validate tx_count is reasonable (at least 1 for coinbase)
+    if block_data.tx_count == 0 {
+        return (false, "C-2: Block has zero transactions".to_string());
+    }
+
+    // C-2 FIX + LOW-VER-4 FIX: Validate timestamp for historical blocks
+    // Archive verification is for HISTORICAL blocks, so timestamps must be in the past.
+    // The 2-hour future tolerance was for new blocks being mined, but archive challenges
+    // request blocks that already exist in the chain - they cannot have future timestamps.
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+
+    // LOW-VER-4 FIX: Historical blocks must have timestamp <= now
+    // Only allow minimal clock skew (60 seconds) to account for verification timing
+    if block_data.timestamp > now + 60 {
+        return (
+            false,
+            format!(
+                "LOW-VER-4: Historical block timestamp {} is in the future (now: {})",
+                block_data.timestamp, now
+            ),
+        );
+    }
+
+    (true, "Validation passed".to_string())
+}
+
 /// Policy challenge request
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PolicyChallenge {

--- a/crates/ghost-verification/src/client.rs
+++ b/crates/ghost-verification/src/client.rs
@@ -633,18 +633,22 @@ impl VerificationClient {
         }
     }
 
-    /// Verify policy capability
+    /// Verify policy capability.
+    ///
+    /// Returns `(PolicyResponse, Option<raw_signed_json>)`. We request a SIGNED
+    /// response (no `unsigned=true`) so recipients of the broadcast can RE-DERIVE
+    /// the verdict against their own policy engine + the target's signature
+    /// instead of trusting the challenger's `passed`. The second element is the
+    /// raw `SignedResponse<PolicyResponse>` JSON verbatim (when the target signed),
+    /// so the target's signature stays verifiable end-to-end.
     pub async fn verify_policy(
         &self,
         node_address: &str,
         tx_hex: &str,
-    ) -> GhostResult<PolicyResponse> {
+    ) -> GhostResult<(PolicyResponse, Option<String>)> {
         let url = self.build_url(
             node_address,
-            &format!(
-                "/verify/policy?tx={}&unsigned=true",
-                urlencoding::encode(tx_hex)
-            ),
+            &format!("/verify/policy?tx={}", urlencoding::encode(tx_hex)),
         )?;
 
         debug!(url = %url, "Verifying policy capability");
@@ -654,23 +658,54 @@ impl VerificationClient {
             GhostError::VerificationTimeout("Policy verification request failed".to_string())
         })?;
 
-        // Policy endpoint returns {"signed": bool, "response": PolicyResponse}
+        // Policy endpoint returns {"signed": bool, "response": <T>} where T is a
+        // `SignedResponse<PolicyResponse>` when signed==true, else a bare
+        // `PolicyResponse`.
         let wrapper: serde_json::Value = response.json().await.map_err(|e| {
             debug!("Policy verification response parse error: {}", e);
             GhostError::InvalidVerificationResponse("Invalid policy response format".to_string())
         })?;
 
-        // Extract the inner response object
+        let signed_flag = wrapper
+            .get("signed")
+            .and_then(|s| s.as_bool())
+            .unwrap_or(false);
+
         let inner = wrapper.get("response").ok_or_else(|| {
             GhostError::InvalidVerificationResponse("Missing 'response' field".to_string())
         })?;
 
-        let result: PolicyResponse = serde_json::from_value(inner.clone()).map_err(|e| {
-            debug!("Policy response deserialization error: {}", e);
-            GhostError::InvalidVerificationResponse("Invalid policy response data".to_string())
-        })?;
+        if signed_flag {
+            // `inner` is a SignedResponse<PolicyResponse>; the PolicyResponse is
+            // its `payload`. Capture the raw signed JSON verbatim so the target's
+            // signature stays verifiable end-to-end by recipients.
+            let raw_signed = serde_json::to_string(inner).map_err(|e| {
+                debug!("Policy signed response re-serialization error: {}", e);
+                GhostError::InvalidVerificationResponse(
+                    "Invalid signed policy response".to_string(),
+                )
+            })?;
 
-        Ok(result)
+            let payload = inner.get("payload").ok_or_else(|| {
+                GhostError::InvalidVerificationResponse(
+                    "Signed policy response missing 'payload'".to_string(),
+                )
+            })?;
+
+            let result: PolicyResponse = serde_json::from_value(payload.clone()).map_err(|e| {
+                debug!("Policy payload deserialization error: {}", e);
+                GhostError::InvalidVerificationResponse("Invalid policy response data".to_string())
+            })?;
+
+            Ok((result, Some(raw_signed)))
+        } else {
+            let result: PolicyResponse = serde_json::from_value(inner.clone()).map_err(|e| {
+                debug!("Policy response deserialization error: {}", e);
+                GhostError::InvalidVerificationResponse("Invalid policy response data".to_string())
+            })?;
+
+            Ok((result, None))
+        }
     }
 
     /// Verify stratum capability
@@ -847,7 +882,7 @@ impl VerificationClient {
         if result.claimed_capabilities.reaper {
             if let Some(tx) = test_tx_hex {
                 match self.verify_policy(node_address, tx).await {
-                    Ok(resp) => result.policy_verified = resp.success,
+                    Ok((resp, _signed)) => result.policy_verified = resp.success,
                     Err(e) => result.errors.push(format!("Policy: {}", e)),
                 }
             }

--- a/crates/ghost-verification/src/client.rs
+++ b/crates/ghost-verification/src/client.rs
@@ -544,14 +544,24 @@ impl VerificationClient {
         Ok(health)
     }
 
-    /// Verify archive capability
+    /// Verify archive capability.
+    ///
+    /// Returns the parsed [`ArchiveResponse`] together with the RAW
+    /// `SignedResponse<ArchiveResponse>` JSON when the target returned a signed
+    /// response (`Some`), or `None` when it returned an unsigned one.
+    ///
+    /// SECURITY: unlike the other capability probes, the archive path requests
+    /// the SIGNED response (it does NOT pass `unsigned=true`). The raw signed
+    /// JSON is threaded into the broadcast so that every recipient can RE-DERIVE
+    /// the verdict from the target's own signature instead of trusting the
+    /// challenger's `passed` flag (see `ghost-pool` `ChainReVerifier`).
     pub async fn verify_archive(
         &self,
         node_address: &str,
         block_hash: Option<&str>,
         txid: Option<&str>,
-    ) -> GhostResult<ArchiveResponse> {
-        let mut params = vec!["unsigned=true".to_string()];
+    ) -> GhostResult<(ArchiveResponse, Option<String>)> {
+        let mut params: Vec<String> = Vec::new();
         if let Some(hash) = block_hash {
             params.push(format!("block={}", hash));
         }
@@ -559,10 +569,12 @@ impl VerificationClient {
             params.push(format!("tx={}", tx));
         }
 
-        let url = self.build_url(
-            node_address,
-            &format!("/verify/archive?{}", params.join("&")),
-        )?;
+        let path = if params.is_empty() {
+            "/verify/archive".to_string()
+        } else {
+            format!("/verify/archive?{}", params.join("&"))
+        };
+        let url = self.build_url(node_address, &path)?;
 
         debug!(url = %url, "Verifying archive capability");
 
@@ -571,22 +583,54 @@ impl VerificationClient {
             GhostError::VerificationTimeout("Archive verification request failed".to_string())
         })?;
 
-        // Archive endpoint returns {"signed": bool, "response": ArchiveResponse}
+        // Archive endpoint returns {"signed": bool, "response": <T>} where T is a
+        // `SignedResponse<ArchiveResponse>` when signed==true, else a bare
+        // `ArchiveResponse`.
         let wrapper: serde_json::Value = response.json().await.map_err(|e| {
             debug!("Archive verification response parse error: {}", e);
             GhostError::InvalidVerificationResponse("Invalid archive response format".to_string())
         })?;
 
+        let signed_flag = wrapper
+            .get("signed")
+            .and_then(|s| s.as_bool())
+            .unwrap_or(false);
+
         let inner = wrapper.get("response").ok_or_else(|| {
             GhostError::InvalidVerificationResponse("Missing 'response' field".to_string())
         })?;
 
-        let result: ArchiveResponse = serde_json::from_value(inner.clone()).map_err(|e| {
-            debug!("Archive response deserialization error: {}", e);
-            GhostError::InvalidVerificationResponse("Invalid archive response data".to_string())
-        })?;
+        if signed_flag {
+            // `inner` is a SignedResponse<ArchiveResponse>; the ArchiveResponse is
+            // its `payload`. Capture the raw signed JSON verbatim so the target's
+            // signature stays verifiable end-to-end by recipients.
+            let raw_signed = serde_json::to_string(inner).map_err(|e| {
+                debug!("Archive signed response re-serialization error: {}", e);
+                GhostError::InvalidVerificationResponse(
+                    "Invalid signed archive response".to_string(),
+                )
+            })?;
 
-        Ok(result)
+            let payload = inner.get("payload").ok_or_else(|| {
+                GhostError::InvalidVerificationResponse(
+                    "Signed archive response missing 'payload'".to_string(),
+                )
+            })?;
+
+            let result: ArchiveResponse = serde_json::from_value(payload.clone()).map_err(|e| {
+                debug!("Archive payload deserialization error: {}", e);
+                GhostError::InvalidVerificationResponse("Invalid archive response data".to_string())
+            })?;
+
+            Ok((result, Some(raw_signed)))
+        } else {
+            let result: ArchiveResponse = serde_json::from_value(inner.clone()).map_err(|e| {
+                debug!("Archive response deserialization error: {}", e);
+                GhostError::InvalidVerificationResponse("Invalid archive response data".to_string())
+            })?;
+
+            Ok((result, None))
+        }
     }
 
     /// Verify policy capability
@@ -793,7 +837,7 @@ impl VerificationClient {
         if result.claimed_capabilities.archive_mode {
             if let Some(hash) = test_block_hash {
                 match self.verify_archive(node_address, Some(hash), None).await {
-                    Ok(resp) => result.archive_verified = resp.success,
+                    Ok((resp, _signed)) => result.archive_verified = resp.success,
                     Err(e) => result.errors.push(format!("Archive: {}", e)),
                 }
             }

--- a/crates/ghost-verification/src/client.rs
+++ b/crates/ghost-verification/src/client.rs
@@ -514,6 +514,119 @@ impl VerificationClient {
         Ok(format!("{}://{}{}", self.scheme(), host, path))
     }
 
+    /// Extract the bare host (no port) from a `host:port` style address.
+    ///
+    /// Handles IPv4 (`1.2.3.4:8080` -> `1.2.3.4`), bracketed IPv6
+    /// (`[2001:db8::1]:8080` -> `2001:db8::1`), bare IPv6 (`2001:db8::1` kept
+    /// whole), and bare hostnames. Returns `None` when no host can be
+    /// determined (empty input).
+    fn extract_host_part(address: &str) -> Option<&str> {
+        let addr = address.trim();
+        if addr.is_empty() {
+            return None;
+        }
+        let host = if addr.starts_with('[') {
+            // Bracketed IPv6, possibly with a trailing :port
+            addr.trim_start_matches('[')
+                .split(']')
+                .next()
+                .unwrap_or(addr)
+        } else if addr.contains("::") || addr.matches(':').count() > 1 {
+            // Bare IPv6 (multiple colons) — there is no host:port split here,
+            // the whole thing is the host.
+            addr
+        } else {
+            // IPv4 or hostname, optionally with :port
+            addr.split(':').next().unwrap_or(addr)
+        };
+        let host = host.trim();
+        if host.is_empty() {
+            None
+        } else {
+            Some(host)
+        }
+    }
+
+    /// CONSENSUS SECURITY: Independent stratum-port reachability probe.
+    ///
+    /// This replaces the old self-attestation path, where the challenger asked
+    /// the target's `/verify/stratum` HTTP endpoint and the TARGET scanned its
+    /// OWN `/proc/net/tcp` for a LISTEN socket — a lying target could simply
+    /// self-report "up". Here the CHALLENGER itself opens a TCP connection to
+    /// the target's public stratum port and directly observes reachability, so
+    /// the verdict reflects the truth the challenger sees, not a relayed claim.
+    ///
+    /// `node_address` is the peer's mesh/HTTP address (`host:port` form); only
+    /// the host is used, combined with the supplied public stratum `port`
+    /// (Stratum V1 `3333`). The probe uses the client's configured timeout.
+    ///
+    /// Returns:
+    /// - `Some(true)`  — TCP connect succeeded ⇒ reachable ⇒ pass.
+    /// - `Some(false)` — connection refused or timed out ⇒ unreachable ⇒ fail
+    ///   (a genuinely-down node must fail).
+    /// - `None`        — INCONCLUSIVE: the target host could not be determined
+    ///   or resolved (challenger-side / unknown address). The caller MUST NOT
+    ///   record a verdict in this case — it mirrors the RPC-unavailable archive
+    ///   path which skips rather than recording a false fail.
+    pub async fn probe_stratum_port(&self, node_address: &str, port: u16) -> Option<bool> {
+        use tokio::net::TcpStream;
+
+        // Determine the target host. An undeterminable host is inconclusive.
+        let host = match Self::extract_host_part(node_address) {
+            Some(h) => h,
+            None => {
+                debug!(
+                    address = %node_address,
+                    "Stratum probe: could not determine target host (inconclusive, skipping)"
+                );
+                return None;
+            }
+        };
+
+        // Resolve host:port to concrete socket addresses. A resolution failure
+        // is a challenger-side / unknown-address condition: inconclusive, never
+        // a false fail.
+        let target = format!("{host}:{port}");
+        let addrs = match tokio::net::lookup_host(&target).await {
+            Ok(iter) => iter.collect::<Vec<_>>(),
+            Err(e) => {
+                debug!(
+                    target = %target,
+                    error = %e,
+                    "Stratum probe: host resolution failed (inconclusive, skipping)"
+                );
+                return None;
+            }
+        };
+        let addr = match addrs.into_iter().next() {
+            Some(a) => a,
+            None => {
+                debug!(
+                    target = %target,
+                    "Stratum probe: host resolved to no addresses (inconclusive, skipping)"
+                );
+                return None;
+            }
+        };
+
+        // Open a real TCP connection. Success ⇒ reachable; a definitive connect
+        // failure (refused) or a timeout ⇒ unreachable ⇒ fail.
+        match tokio::time::timeout(self.config.timeout, TcpStream::connect(addr)).await {
+            Ok(Ok(_stream)) => {
+                debug!(target = %target, "Stratum probe: reachable (TCP connect succeeded)");
+                Some(true)
+            }
+            Ok(Err(e)) => {
+                debug!(target = %target, error = %e, "Stratum probe: unreachable (connect failed)");
+                Some(false)
+            }
+            Err(_elapsed) => {
+                debug!(target = %target, "Stratum probe: unreachable (connect timed out)");
+                Some(false)
+            }
+        }
+    }
+
     /// Get health status of a node
     pub async fn health(&self, node_address: &str) -> GhostResult<HealthResponse> {
         let url = self.build_url(node_address, "/health?unsigned=true")?;
@@ -1235,6 +1348,80 @@ mod tests {
         assert!(!VerificationClient::is_internal_address(
             "2001:4860:4860::8888"
         )); // Google DNS
+    }
+
+    #[test]
+    fn test_extract_host_part() {
+        // IPv4 with and without port
+        assert_eq!(
+            VerificationClient::extract_host_part("1.2.3.4:8080"),
+            Some("1.2.3.4")
+        );
+        assert_eq!(
+            VerificationClient::extract_host_part("1.2.3.4"),
+            Some("1.2.3.4")
+        );
+        // Bracketed IPv6 with port
+        assert_eq!(
+            VerificationClient::extract_host_part("[2001:db8::1]:8080"),
+            Some("2001:db8::1")
+        );
+        // Bare IPv6 (no port) kept whole
+        assert_eq!(
+            VerificationClient::extract_host_part("2001:db8::1"),
+            Some("2001:db8::1")
+        );
+        // Hostname with port
+        assert_eq!(
+            VerificationClient::extract_host_part("node.example.org:8080"),
+            Some("node.example.org")
+        );
+        // Empty -> None (inconclusive)
+        assert_eq!(VerificationClient::extract_host_part(""), None);
+        assert_eq!(VerificationClient::extract_host_part("   "), None);
+    }
+
+    #[tokio::test]
+    async fn test_probe_stratum_port_reachable_and_refused() {
+        use tokio::net::TcpListener;
+
+        // CONSENSUS SECURITY: the independent probe must return TRUE for a
+        // listening socket (reachable) and FALSE for a closed port (refused).
+        let client = VerificationClient::new().unwrap();
+
+        // Bind a throwaway listener on an ephemeral loopback port.
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let listen_port = listener.local_addr().unwrap().port();
+
+        // Positive: a real LISTEN socket is observed as reachable.
+        let reachable = client.probe_stratum_port("127.0.0.1", listen_port).await;
+        assert_eq!(
+            reachable,
+            Some(true),
+            "a listening socket must probe as reachable (pass)"
+        );
+
+        // Negative: drop the listener so the port is closed, then probe it.
+        // connect() to a closed loopback port is refused immediately -> false.
+        drop(listener);
+        let refused = client.probe_stratum_port("127.0.0.1", listen_port).await;
+        assert_eq!(
+            refused,
+            Some(false),
+            "a closed port must probe as unreachable (fail)"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_probe_stratum_port_inconclusive_on_empty_host() {
+        // An undeterminable target host is INCONCLUSIVE -> None, never a false
+        // fail (the caller must skip rather than record passed=false).
+        let client = VerificationClient::new().unwrap();
+        let inconclusive = client.probe_stratum_port("", 3333).await;
+        assert_eq!(
+            inconclusive, None,
+            "empty address -> inconclusive (None), not a false fail"
+        );
     }
 
     #[test]

--- a/crates/ghost-verification/src/routes.rs
+++ b/crates/ghost-verification/src/routes.rs
@@ -1170,6 +1170,7 @@ async fn policy_handler(
                     classification: None,
                     accepted: false,
                     rejection_reason: Some("Input too large".to_string()),
+                    tx_txid: None,
                     error: Some(format!(
                         "Transaction hex too large: {} bytes (max {})",
                         query.tx.len(),
@@ -1221,6 +1222,7 @@ async fn policy_handler(
                         classification: None,
                         accepted: false,
                         rejection_reason: None,
+                        tx_txid: None,
                         error: Some(e.to_string()),
                     }
                 })),

--- a/crates/ghost-verification/src/server.rs
+++ b/crates/ghost-verification/src/server.rs
@@ -1889,6 +1889,11 @@ impl VerificationState {
             classification,
             accepted,
             rejection_reason,
+            // CONSENSUS SECURITY: bind this classification to the exact tx we
+            // evaluated. This goes inside the SIGNED payload, so a recipient can
+            // verify the challenger paired our signature with the correct tx_hex
+            // (txid recompute must match) before trusting the verdict.
+            tx_txid: Some(tx.compute_txid().to_string()),
             error: None,
         })
     }

--- a/crates/ghost-verification/src/task.rs
+++ b/crates/ghost-verification/src/task.rs
@@ -1585,7 +1585,18 @@ impl VerificationTask {
         Ok(())
     }
 
-    /// Verify stratum capability
+    /// Verify stratum capability via an INDEPENDENT probe.
+    ///
+    /// CONSENSUS SECURITY: the challenger itself opens a TCP connection to the
+    /// peer's public Stratum V1 port and observes reachability directly, rather
+    /// than relaying the target's self-attestation (the target scanning its own
+    /// `/proc/net/tcp`). A lying target can no longer self-report "up": only
+    /// what THIS challenger can actually reach becomes the recorded `passed`.
+    ///
+    /// An INCONCLUSIVE probe (target host undeterminable / unresolvable, i.e. a
+    /// challenger-side condition) is SKIPPED — no row is stored and nothing is
+    /// broadcast — mirroring the RPC-unavailable archive path. We never record
+    /// a false fail for an inconclusive probe.
     ///
     /// CRIT-VER-3: Returns Result - DB write failures are propagated to caller
     async fn verify_stratum(
@@ -1595,40 +1606,51 @@ impl VerificationTask {
         our_id_hex: &str,
         timestamp: i64,
     ) -> Result<(), String> {
-        use crate::challenge::StratumProtocol;
+        use ghost_common::constants::SV1_STRATUM_PORT;
+
+        let short_id = &peer_id_hex[..8];
 
         let challenge_data = serde_json::json!({
-            "protocol": "sv2",
+            "protocol": "sv1",
+            "probe": "independent_tcp_connect",
+            "port": SV1_STRATUM_PORT,
         })
         .to_string();
 
-        let result = self
+        // Independent reachability probe by THIS challenger.
+        let start = std::time::Instant::now();
+        let probe = self
             .client
-            .verify_stratum(&peer.http_address, StratumProtocol::Sv2)
+            .probe_stratum_port(&peer.http_address, SV1_STRATUM_PORT)
             .await;
+        let latency_ms = Some(start.elapsed().as_millis() as u32);
 
-        let short_id = &peer_id_hex[..8];
-        let (passed, connected, latency_ms, response_data) = match result {
-            Ok(resp) => (
-                resp.success && resp.connected,
-                resp.connected,
-                resp.latency_ms,
-                Some(
-                    serde_json::json!({
-                        "success": resp.success,
-                        "connected": resp.connected,
-                        "latency_ms": resp.latency_ms,
-                    })
-                    .to_string(),
-                ),
-            ),
-            Err(e) => {
-                warn!(peer = %short_id, error = %e, "Stratum verification failed");
-                (false, false, None, Some(format!("{{\"error\":\"{}\"}}", e)))
+        let (passed, connected) = match probe {
+            Some(reachable) => (reachable, reachable),
+            None => {
+                // Inconclusive (challenger-side / unknown address). Do NOT
+                // record a verdict — skip this cycle, exactly like the
+                // RPC-unavailable archive path.
+                warn!(
+                    peer = %short_id,
+                    address = %peer.http_address,
+                    "Stratum probe inconclusive (target address undeterminable) - skipping, no verdict recorded"
+                );
+                return Ok(());
             }
         };
 
-        info!(peer = %short_id, passed = passed, connected = connected, "Stratum verification complete");
+        let response_data = Some(
+            serde_json::json!({
+                "reachable": connected,
+                "port": SV1_STRATUM_PORT,
+                "probe": "independent_tcp_connect",
+                "latency_ms": latency_ms,
+            })
+            .to_string(),
+        );
+
+        info!(peer = %short_id, passed = passed, connected = connected, "Stratum verification complete (independent probe)");
 
         // H-1 FIX: Verify identity before DB write to prevent challenger ID spoofing
         self.require_identity_verified()?;

--- a/crates/ghost-verification/src/task.rs
+++ b/crates/ghost-verification/src/task.rs
@@ -114,6 +114,12 @@ pub struct VerificationBroadcast {
     pub response_data: Option<String>,
     /// Timestamp
     pub timestamp: i64,
+    /// The TARGET's own signed response (`SignedResponse<…>` JSON) for
+    /// capabilities that support recipient-side re-derivation (currently
+    /// archive). `None` for all other capabilities. Threaded into the
+    /// `VerificationResultMessage.target_signed_response` field at broadcast.
+    #[serde(default)]
+    pub target_signed_response: Option<String>,
 }
 
 /// CRIT-VER-2: Signed verification broadcast for P2P transmission
@@ -1220,9 +1226,12 @@ impl VerificationTask {
             .verify_archive(&peer.http_address, Some(&block_hash), None)
             .await;
 
-        // C-2 FIX: Validate block data authenticity, not just success flag
-        let (passed, response_data) = match result {
-            Ok(resp) => {
+        // C-2 FIX: Validate block data authenticity, not just success flag.
+        // `target_signed_response` is the TARGET's own signed `ArchiveResponse`
+        // JSON; it is threaded into the broadcast so recipients can re-derive the
+        // verdict against their own chain instead of trusting our `passed`.
+        let (passed, response_data, target_signed_response) = match result {
+            Ok((resp, signed_raw)) => {
                 // C-2 FIX: Perform merkle root validation
                 let validation_result = self.validate_archive_response(
                     &resp,
@@ -1239,11 +1248,15 @@ impl VerificationTask {
                     "validation": validation_result.1,
                 });
 
-                (validation_result.0, Some(response_json.to_string()))
+                (
+                    validation_result.0,
+                    Some(response_json.to_string()),
+                    signed_raw,
+                )
             }
             Err(e) => {
                 debug!(error = %e, "Archive verification failed");
-                (false, Some(format!("{{\"error\":\"{}\"}}", e)))
+                (false, Some(format!("{{\"error\":\"{}\"}}", e)), None)
             }
         };
 
@@ -1282,6 +1295,7 @@ impl VerificationTask {
             challenge_data,
             response_data,
             timestamp,
+            target_signed_response,
         )
         .await;
 
@@ -1357,7 +1371,10 @@ impl VerificationTask {
 
     /// C-2 FIX: Validate archive response against expected values
     ///
-    /// Returns (passed, validation_details)
+    /// Returns (passed, validation_details). Delegates to the shared
+    /// [`crate::challenge::validate_archive_response`] free function so the
+    /// challenger path and the recipient re-derivation path (`ghost-pool`'s
+    /// `ChainReVerifier`) run byte-identical comparison logic.
     fn validate_archive_response(
         &self,
         resp: &crate::challenge::ArchiveResponse,
@@ -1365,97 +1382,12 @@ impl VerificationTask {
         expected_height: u64,
         expected_merkle_root: Option<&str>,
     ) -> (bool, String) {
-        // Basic check: response must indicate success
-        if !resp.success {
-            return (false, "Response indicates failure".to_string());
-        }
-
-        // C-2 FIX: Block data must be present
-        let block_data = match &resp.block_data {
-            Some(data) => data,
-            None => {
-                return (false, "C-2: No block data in response".to_string());
-            }
-        };
-
-        // C-2 FIX: Block hash must match what we requested
-        if block_data.hash.to_lowercase() != expected_hash.to_lowercase() {
-            return (
-                false,
-                format!(
-                    "C-2: Block hash mismatch: got {}, expected {}",
-                    block_data.hash, expected_hash
-                ),
-            );
-        }
-
-        // C-2 FIX: Height must match
-        if block_data.height != expected_height {
-            return (
-                false,
-                format!(
-                    "C-2: Block height mismatch: got {}, expected {}",
-                    block_data.height, expected_height
-                ),
-            );
-        }
-
-        // C-2 FIX: Validate merkle root format (64 hex chars)
-        if block_data.merkle_root.len() != 64
-            || !block_data
-                .merkle_root
-                .chars()
-                .all(|c| c.is_ascii_hexdigit())
-        {
-            return (
-                false,
-                format!(
-                    "C-2: Invalid merkle root format: {}",
-                    block_data.merkle_root
-                ),
-            );
-        }
-
-        // C-2 FIX: If we have expected merkle root from our RPC, cross-check it
-        if let Some(expected_mr) = expected_merkle_root {
-            if block_data.merkle_root.to_lowercase() != expected_mr.to_lowercase() {
-                return (
-                    false,
-                    format!(
-                        "C-2: Merkle root mismatch: got {}, expected {}",
-                        block_data.merkle_root, expected_mr
-                    ),
-                );
-            }
-        }
-
-        // C-2 FIX: Validate tx_count is reasonable (at least 1 for coinbase)
-        if block_data.tx_count == 0 {
-            return (false, "C-2: Block has zero transactions".to_string());
-        }
-
-        // C-2 FIX + LOW-VER-4 FIX: Validate timestamp for historical blocks
-        // Archive verification is for HISTORICAL blocks, so timestamps must be in the past.
-        // The 2-hour future tolerance was for new blocks being mined, but archive challenges
-        // request blocks that already exist in the chain - they cannot have future timestamps.
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs();
-
-        // LOW-VER-4 FIX: Historical blocks must have timestamp <= now
-        // Only allow minimal clock skew (60 seconds) to account for verification timing
-        if block_data.timestamp > now + 60 {
-            return (
-                false,
-                format!(
-                    "LOW-VER-4: Historical block timestamp {} is in the future (now: {})",
-                    block_data.timestamp, now
-                ),
-            );
-        }
-
-        (true, "Validation passed".to_string())
+        crate::challenge::validate_archive_response(
+            resp,
+            expected_hash,
+            expected_height,
+            expected_merkle_root,
+        )
     }
 
     /// Verify policy capability
@@ -1590,6 +1522,7 @@ impl VerificationTask {
             challenge_data,
             response_data,
             timestamp,
+            None,
         )
         .await;
 
@@ -1665,6 +1598,7 @@ impl VerificationTask {
             challenge_data,
             response_data,
             timestamp,
+            None,
         )
         .await;
 
@@ -1808,6 +1742,7 @@ impl VerificationTask {
             challenge_data,
             response_data,
             timestamp,
+            None,
         )
         .await;
 
@@ -2004,6 +1939,7 @@ impl VerificationTask {
     /// Broadcast a verification result via P2P
     ///
     /// MED-VER-7/VER-4: Validates timestamp before broadcasting to prevent stale/future results
+    #[allow(clippy::too_many_arguments)]
     async fn broadcast_result(
         &self,
         target_node_id: NodeId,
@@ -2012,6 +1948,7 @@ impl VerificationTask {
         challenge_data: String,
         response_data: Option<String>,
         timestamp: i64,
+        target_signed_response: Option<String>,
     ) {
         // MED-VER-7/VER-4 FIX: Clock sanity check before broadcasting
         // VER-4: Standardized on 30 seconds max future tolerance (matches verification_handler.rs)
@@ -2054,6 +1991,7 @@ impl VerificationTask {
                 challenge_data,
                 response_data,
                 timestamp,
+                target_signed_response,
             };
 
             if let Err(e) = tx.send(broadcast).await {
@@ -2102,6 +2040,7 @@ mod tests {
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap()
                 .as_secs() as i64,
+            target_signed_response: None,
         };
 
         let signed = SignedVerificationBroadcast::new(broadcast.clone(), test_signing_fn);
@@ -2144,6 +2083,7 @@ mod tests {
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap()
                 .as_secs() as i64,
+            target_signed_response: None,
         };
 
         let mut signed = SignedVerificationBroadcast::new(broadcast, test_signing_fn);
@@ -2180,6 +2120,7 @@ mod tests {
             challenge_data: r#"{"block_hash":"hash1","block_height":100}"#.to_string(),
             response_data: None,
             timestamp,
+            target_signed_response: None,
         };
 
         let broadcast2 = VerificationBroadcast {
@@ -2190,6 +2131,7 @@ mod tests {
             challenge_data: r#"{"block_hash":"hash2","block_height":200}"#.to_string(),
             response_data: None,
             timestamp,
+            target_signed_response: None,
         };
 
         let signed1 = SignedVerificationBroadcast::new(broadcast1, test_signing_fn);
@@ -2223,6 +2165,7 @@ mod tests {
                 .unwrap()
                 .as_secs() as i64
                 + 300, // 5 minutes in the future
+            target_signed_response: None,
         };
 
         let signed = SignedVerificationBroadcast::new(broadcast, test_signing_fn);
@@ -2301,6 +2244,7 @@ mod tests {
                 .unwrap()
                 .as_secs() as i64
                 - 700, // 11+ minutes in the past
+            target_signed_response: None,
         };
 
         let signed = SignedVerificationBroadcast::new(broadcast, test_signing_fn);

--- a/crates/ghost-verification/src/task.rs
+++ b/crates/ghost-verification/src/task.rs
@@ -36,6 +36,7 @@ use tracing::{debug, info, warn};
 
 use ghost_common::rpc::BitcoinRpc;
 use ghost_common::types::NodeId;
+use ghost_policy::PolicyProfile;
 use ghost_storage::Database;
 
 use crate::client::VerificationClient;
@@ -620,6 +621,15 @@ pub struct VerificationTask {
     broadcast_tx: Option<VerificationBroadcastSender>,
     /// Bitcoin RPC for fetching real block data
     rpc: Option<Arc<BitcoinRpc>>,
+    /// CONSENSUS SECURITY: policy profile used to classify our own policy-challenge
+    /// transactions. The challenger derives its OWN ground-truth `(tier, accepted)`
+    /// from this engine and compares the target's signed classification against it
+    /// via [`crate::challenge::validate_policy_response`] — the SAME comparator a
+    /// recipient runs when re-deriving the verdict, so challenger and recipients
+    /// agree exactly on a homogeneous fleet. Defaults to `bitcoin_pure` (the policy
+    /// the +2 BitcoinPure capability attests); overridden per-node via
+    /// [`VerificationTask::with_policy`] from the node's configured profile.
+    policy: PolicyProfile,
     /// LOW-VER-3: Track challenges per target for even distribution
     challenge_tracker: std::sync::Mutex<ChallengeTracker>,
 }
@@ -659,6 +669,7 @@ impl VerificationTask {
             config: VerificationTaskConfig::default(),
             broadcast_tx: None,
             rpc: None,
+            policy: PolicyProfile::bitcoin_pure(),
             challenge_tracker: std::sync::Mutex::new(ChallengeTracker::new()),
         })
     }
@@ -703,6 +714,7 @@ impl VerificationTask {
             config: VerificationTaskConfig::default(),
             broadcast_tx: None,
             rpc: None,
+            policy: PolicyProfile::bitcoin_pure(),
             challenge_tracker: std::sync::Mutex::new(ChallengeTracker::new()),
         })
     }
@@ -741,6 +753,7 @@ impl VerificationTask {
             config: VerificationTaskConfig::default(),
             broadcast_tx: None,
             rpc: None,
+            policy: PolicyProfile::bitcoin_pure(),
             challenge_tracker: std::sync::Mutex::new(ChallengeTracker::new()),
         })
     }
@@ -782,6 +795,7 @@ impl VerificationTask {
             config: VerificationTaskConfig::default(),
             broadcast_tx: None,
             rpc: None,
+            policy: PolicyProfile::bitcoin_pure(),
             challenge_tracker: std::sync::Mutex::new(ChallengeTracker::new()),
         })
     }
@@ -806,6 +820,7 @@ impl VerificationTask {
             config,
             broadcast_tx: None,
             rpc: None,
+            policy: PolicyProfile::bitcoin_pure(),
             challenge_tracker: std::sync::Mutex::new(ChallengeTracker::new()),
         })
     }
@@ -846,6 +861,15 @@ impl VerificationTask {
     /// Set the Bitcoin RPC client for fetching real block data
     pub fn with_rpc(mut self, rpc: Arc<BitcoinRpc>) -> Self {
         self.rpc = Some(rpc);
+        self
+    }
+
+    /// CONSENSUS SECURITY: set the policy profile used to classify our own
+    /// policy-challenge transactions, so the challenger's verdict is derived from
+    /// the SAME comparator/engine a recipient uses to re-derive it. Should be the
+    /// node's configured profile (the one served by its `/verify/policy` endpoint).
+    pub fn with_policy(mut self, policy: PolicyProfile) -> Self {
+        self.policy = policy;
         self
     }
 
@@ -1426,16 +1450,49 @@ impl VerificationTask {
             }
         };
         let expected_tier = if dirty { "non-T0" } else { "T0" };
+
+        // CONSENSUS SECURITY: derive OUR OWN ground-truth classification of the
+        // exact tx we are about to send, using OUR policy engine. The verdict is
+        // then `our classification == the target's signed classification`, via the
+        // SAME comparator a recipient runs — so the challenger's recorded verdict
+        // and a recipient's re-derived verdict agree on a homogeneous fleet. The
+        // clean/dirty split only controls which tx we build (positive vs negative
+        // control); the engine, not a "non-T0" wildcard, decides the ground truth.
+        let our_tx: bitcoin::Transaction = match hex::decode(&test_tx_hex)
+            .ok()
+            .and_then(|b| bitcoin::consensus::deserialize(&b).ok())
+        {
+            Some(tx) => tx,
+            None => {
+                // We just built this tx; failing to round-trip it is a local bug,
+                // not a peer fault. Skip rather than broadcast a bogus verdict.
+                warn!(
+                    peer = %peer_id_hex[..8],
+                    "Failed to deserialize own policy-challenge tx, skipping"
+                );
+                return Ok(());
+            }
+        };
+        let our_decision = ghost_policy::PolicyEngine::new(self.policy.clone()).evaluate(&our_tx);
+        let our_tier = our_decision.tier().to_string();
+        let our_accepted = our_decision.is_accepted();
+
         debug!(
             dirty,
             tx_hex_len = test_tx_hex.len(),
             expected_tier,
-            "Built policy challenge transaction"
+            our_tier = %our_tier,
+            our_accepted,
+            "Built policy challenge transaction (own classification derived)"
         );
 
+        // CONSENSUS SECURITY: broadcast the tx_hex we used so recipients can BIND
+        // the target's signed classification to it (txid recompute must match the
+        // signed `tx_txid`). tx_type/expected_tier remain for diagnostics.
         let challenge_data = serde_json::json!({
             "tx_type": if dirty { "dirty" } else { "T0" },
             "expected_tier": expected_tier,
+            "tx_hex": test_tx_hex,
         })
         .to_string();
 
@@ -1444,19 +1501,17 @@ impl VerificationTask {
             .verify_policy(&peer.http_address, &test_tx_hex)
             .await;
 
-        let (passed, tier, response_data) = match result {
-            Ok(resp) => {
+        // `target_signed_response` is the TARGET's own signed `PolicyResponse`
+        // JSON; it is threaded into the broadcast so recipients can re-derive the
+        // verdict against their own policy engine instead of trusting our `passed`.
+        let (passed, tier, response_data, target_signed_response) = match result {
+            Ok((resp, signed_raw)) => {
+                // Same comparator the recipient uses — zero divergence. The
+                // target's signed classification is checked against OUR engine's
+                // classification of the SAME tx.
+                let (passed, _detail) =
+                    crate::challenge::validate_policy_response(&resp, &our_tier, our_accepted);
                 let tier = resp.classification.as_ref().map(|c| c.tier.clone());
-                let passed = if dirty {
-                    // GHOST-01 negative control: a real filtering node classifies
-                    // the data-carrier tx as non-T0 AND does not accept it.
-                    let non_t0 = tier.as_ref().map(|t| t != "T0").unwrap_or(false);
-                    resp.success && non_t0 && !resp.accepted
-                } else {
-                    // MED-VER-2: clean tx must classify EXACTLY T0 (not T0 OR T1).
-                    let tier_ok = tier.as_ref().map(|t| t == "T0").unwrap_or(false);
-                    resp.success && tier_ok
-                };
 
                 (
                     passed,
@@ -1470,11 +1525,12 @@ impl VerificationTask {
                         })
                         .to_string(),
                     ),
+                    signed_raw,
                 )
             }
             Err(e) => {
                 warn!(error = %e, peer = %peer_id_hex[..8], "Policy verification failed");
-                (false, None, Some(format!("{{\"error\":\"{}\"}}", e)))
+                (false, None, Some(format!("{{\"error\":\"{}\"}}", e)), None)
             }
         };
 
@@ -1522,7 +1578,7 @@ impl VerificationTask {
             challenge_data,
             response_data,
             timestamp,
-            None,
+            target_signed_response,
         )
         .await;
 

--- a/tests/integration_tests/adversarial.rs
+++ b/tests/integration_tests/adversarial.rs
@@ -73,6 +73,7 @@ fn make_verification_envelope(
         passed,
         challenge_data,
         response_data: None,
+        target_signed_response: None,
         timestamp,
         signature: [0u8; 64],
     };
@@ -226,6 +227,7 @@ async fn test_933_forged_verification_result_wrong_signature() {
         passed: true,
         challenge_data: r#"{"block_height":100,"expected_hash":"abc"}"#.to_string(),
         response_data: Some(r#"{"hash":"abc"}"#.to_string()),
+        target_signed_response: None,
         timestamp: now,
         signature: [0u8; 64],
     };


### PR DESCRIPTION
Closes a node-reward **griefing** hole in capability verification.

## The hole
5-4-3-2-1 node-reward shares (coinbase) are paid on peer-VERIFIED capabilities. The recipient authenticated the challenger but stored its `passed` **verbatim**. Because qualification needs a 95% pass rate, a colluding minority that is merely **>5%** of a targets challengers can sign `passed=false` against an honest node, drag it under the gate, and **steal its reward share**. Comparing to the challenger-reported `response_data` does NOT help — the challenger is the adversary and that data is not in the signed tuple.

## The fix (this PR: the two chain-grounded capabilities)
The recipient **re-derives** the verdict from its OWN ground truth + the **targets** signed response, and overrides `passed`.

- **Archive (+5)**: verify the response is signed by the *target*, take block height/hash/merkle from **inside the signed payload** (never `challenge_data` — else a height-swap reforges the grief), check against the recipients own `get_block_hash`/`get_block_header`, run the shared comparator.
- **Policy (+2)**: the target stamps the classified txs `txid` inside its signed `PolicyResponse`; the recipient reconstructs the tx from the broadcast `tx_hex`, **requires `compute_txid()` == the signed txid** (blocks the tx-swap reforge), then re-classifies via its own `PolicyEngine` and compares.
- **Cannot judge** (no/forged/stale target sig, unparseable, RPC error, height>tip, node behind, txid mismatch) → **store nothing** — never a false FAIL.

## Architecture
`ResultReVerifier` trait in `ghost-consensus` (handler holds `Option<Arc<dyn>>`, default None preserves the no-dep/test path); `ChainReVerifier` impl in `ghost-pool` (the crate with rpc+verification+policy); one shared comparator per capability in `ghost-verification` so challenger and verifier compute identically. Message gains `target_signed_response` (+ Policy `tx_txid`), both `#[serde(default)]` → backward-compatible fleet deploy. `signing_data()` unchanged.

## Tests
Per capability: griefing (`passed=false` but correct → Pass), fraud (`passed=true` but wrong → Fail), swap-reforge (→ Unverifiable), every cant-judge path (→ Unverifiable, handler stores nothing), and no-regression. Full workspace `cargo check --all-targets` clean; `ghost-consensus`/`ghost-verification`/`ghost-pool` test suites green (0 failures).

## Follow-up (not in this PR)
Stratum (+3) and GhostPay (+4) are liveness self-attestations with no chain ground truth — they need **independent challenger probes + outlier-resistant (majority) aggregation** in `qualification.rs`, a distinct and more invasive change. Tracked as the next increment. Until then those two retain current behaviour (a smaller, documented residual).