### PR TITLE
feat: auto-populate the website node list from the live mesh

### DIFF
--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -3398,6 +3398,36 @@ async fn main() -> Result<()> {
             .collect()
     });
 
+    // Live mesh node list for the public /api/v1/pool/mesh-nodes endpoint.
+    // Maps every connected peer to MeshNodeInfo using only already-gossiped,
+    // public fields (capabilities, hashrate, miner count). 120s freshness:
+    // wide enough to tolerate a few missed ~10s health pings, narrow enough
+    // that a genuinely gone node ages out. Self is added by the handler from
+    // local state, so this returns peers only. No network calls.
+    let mesh_for_node_list = Arc::clone(&mesh);
+    verification_state = verification_state.with_mesh_nodes(move || {
+        use ghost_verification::MeshNodeInfo;
+        mesh_for_node_list
+            .peers()
+            .get_connected_peers(120)
+            .into_iter()
+            .map(|p| MeshNodeInfo {
+                node_id: p.node_id_hex(),
+                address: p.public_address.clone(),
+                elder: p.is_elder,
+                cap_archive: p.capabilities.archive_mode,
+                cap_ghost_pay: p.capabilities.ghost_pay,
+                cap_public_mining: p.capabilities.public_mining,
+                cap_reaper: p.capabilities.reaper,
+                cap_elder: p.capabilities.elder_status,
+                hashrate_th: p.local_hashrate_th,
+                miner_count: p.miner_count,
+                // get_connected_peers already filtered to Connected + fresh.
+                healthy: true,
+            })
+            .collect()
+    });
+
     // Mesh-wide deduplicated active miner count. Unions local active miner_id
     // hashes with the most-recent set from each connected peer.
     //

--- a/crates/ghost-verification/src/routes.rs
+++ b/crates/ghost-verification/src/routes.rs
@@ -39,7 +39,7 @@ use ghost_common::constants::{SV1_STRATUM_PORT, SV2_STRATUM_PORT};
 
 use crate::auth::{verify_internal_auth, InternalAuth};
 use crate::challenge::*;
-use crate::server::{ShareBatch, ShareNotification, VerificationState};
+use crate::server::{MeshNodeInfo, ShareBatch, ShareNotification, VerificationState};
 use crate::websocket::{ws_handler, WsAuthQuery};
 
 /// M-STOR-3: Check if a path is in the allowed list
@@ -226,6 +226,11 @@ pub fn create_router(state: Arc<VerificationState>) -> Router {
             "/api/v1/pool/recent_shares",
             get(api_pool_recent_shares_handler),
         )
+        // Live mesh node list: this node + every connected peer, with the
+        // already-public gossiped capability/hashrate/miner fields. Lets the
+        // website render the node list from one node instead of a hard-coded
+        // VM set, so new nodes appear automatically.
+        .route("/api/v1/pool/mesh-nodes", get(api_pool_mesh_nodes_handler))
         // Read-only decentralised-coordinator election view. Returns
         // `{enabled:false}` unless the operator turns on
         // `[coordinator] wraith_election_enabled`.
@@ -2358,6 +2363,102 @@ async fn api_pool_recent_shares_handler(
         "now_ts": now_s,
         "since_ts": since_ts,
         "shares": shares,
+    }))
+}
+
+/// Shape one connected peer (`MeshNodeInfo`) into the public mesh-node JSON
+/// object. Self is shaped inline by the handler from local state, so this
+/// helper always renders a peer (`is_self = false`). Pulled out as a free
+/// function so the JSON contract is unit-testable without a live server.
+fn mesh_node_to_json(node: &MeshNodeInfo) -> serde_json::Value {
+    serde_json::json!({
+        "node_id": node.node_id,
+        "address": node.address,
+        "elder": node.elder,
+        "capabilities": {
+            "archive": node.cap_archive,
+            "ghost_pay": node.cap_ghost_pay,
+            "public_mining": node.cap_public_mining,
+            "reaper": node.cap_reaper,
+            "elder": node.cap_elder,
+        },
+        "hashrate_th": node.hashrate_th,
+        "miner_count": node.miner_count,
+        "healthy": node.healthy,
+        "is_self": false,
+    })
+}
+
+/// Live mesh node list = this node (self) + every connected peer.
+///
+/// PUBLIC, no auth (same exposure level as `recent_shares`): every field
+/// returned is already gossiped openly in health pings. The website polls
+/// this on one bootstrap node and renders the whole mesh, so newly-joined
+/// nodes appear automatically without a hard-coded VM list or a per-node
+/// nginx proxy block.
+///
+/// Self is built from this node's local state (the same sources
+/// `/api/v1/mining/status` uses); peers come from the in-memory
+/// `PeerManager` via the `mesh_nodes` callback (no network calls). Results
+/// are deduplicated by `node_id` with self always included exactly once;
+/// a missing field on any one peer degrades to a default (`0`/`false`)
+/// rather than failing the whole response.
+async fn api_pool_mesh_nodes_handler(
+    State(state): State<Arc<VerificationState>>,
+) -> impl IntoResponse {
+    let health = state.get_health().await;
+
+    // Self address: the operator-configured public host (+ HTTP port when a
+    // bare host was configured). Falls back to an empty string — never fails.
+    let self_address = {
+        let config = state.dashboard_config.read();
+        match config.stratum_host.clone() {
+            Some(host) if host.contains(':') => host,
+            Some(host) => {
+                let port = config.http_port.unwrap_or(8080);
+                format!("{host}:{port}")
+            }
+            None => String::new(),
+        }
+    };
+
+    let self_caps = &health.capabilities;
+    let self_node = serde_json::json!({
+        "node_id": health.node_id,
+        "address": self_address,
+        "elder": self_caps.elder_status,
+        "capabilities": {
+            "archive": self_caps.archive_mode,
+            "ghost_pay": self_caps.ghost_pay,
+            "public_mining": self_caps.public_mining,
+            "reaper": self_caps.reaper,
+            "elder": self_caps.elder_status,
+        },
+        // This node's own realized hashrate (same windowed value it gossips);
+        // 0.0 on deploys without the local-hashrate provider wired.
+        "hashrate_th": state.local_hashrate().unwrap_or(0.0),
+        "miner_count": health.miner_count,
+        // Self is serving this request, so it is healthy by definition.
+        "healthy": true,
+        "is_self": true,
+    });
+
+    let mut nodes = vec![self_node];
+    // Dedup by node_id; self is already in, so skip any peer that re-reports
+    // this node's id (e.g. a same-host placeholder).
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    seen.insert(health.node_id.clone());
+
+    for peer in state.mesh_nodes() {
+        if seen.insert(peer.node_id.clone()) {
+            nodes.push(mesh_node_to_json(&peer));
+        }
+    }
+
+    let total = nodes.len();
+    Json(serde_json::json!({
+        "nodes": nodes,
+        "total": total,
     }))
 }
 
@@ -7513,5 +7614,65 @@ mod tests {
     fn test_safe_proc_path_traversal() {
         let allowed = vec!["/proc/meminfo".to_string(), "/proc/cpuinfo".to_string()];
         assert!(!is_safe_proc_path("/proc/../etc/passwd", &allowed));
+    }
+
+    #[test]
+    fn test_mesh_node_to_json_shape() {
+        let node = MeshNodeInfo {
+            node_id: "deadbeef".to_string(),
+            address: "1.2.3.4:8080".to_string(),
+            elder: true,
+            cap_archive: true,
+            cap_ghost_pay: false,
+            cap_public_mining: true,
+            cap_reaper: false,
+            cap_elder: true,
+            hashrate_th: 12.5,
+            miner_count: 3,
+            healthy: true,
+        };
+
+        let v = mesh_node_to_json(&node);
+        assert_eq!(v["node_id"], "deadbeef");
+        assert_eq!(v["address"], "1.2.3.4:8080");
+        assert_eq!(v["elder"], true);
+        assert_eq!(v["hashrate_th"], 12.5);
+        assert_eq!(v["miner_count"], 3);
+        assert_eq!(v["healthy"], true);
+        // Peers are never self.
+        assert_eq!(v["is_self"], false);
+        // Capabilities are nested exactly as the website expects.
+        assert_eq!(v["capabilities"]["archive"], true);
+        assert_eq!(v["capabilities"]["ghost_pay"], false);
+        assert_eq!(v["capabilities"]["public_mining"], true);
+        assert_eq!(v["capabilities"]["reaper"], false);
+        assert_eq!(v["capabilities"]["elder"], true);
+    }
+
+    #[test]
+    fn test_mesh_node_to_json_defaults_for_bare_peer() {
+        // A peer that has only just been discovered (no gossiped metrics yet)
+        // must still serialize to a complete object with safe defaults rather
+        // than dropping fields or failing.
+        let node = MeshNodeInfo {
+            node_id: "00ff".to_string(),
+            address: String::new(),
+            elder: false,
+            cap_archive: false,
+            cap_ghost_pay: false,
+            cap_public_mining: false,
+            cap_reaper: false,
+            cap_elder: false,
+            hashrate_th: 0.0,
+            miner_count: 0,
+            healthy: false,
+        };
+
+        let v = mesh_node_to_json(&node);
+        assert_eq!(v["address"], "");
+        assert_eq!(v["hashrate_th"], 0.0);
+        assert_eq!(v["miner_count"], 0);
+        assert_eq!(v["healthy"], false);
+        assert!(v["capabilities"].is_object());
     }
 }

--- a/crates/ghost-verification/src/server.rs
+++ b/crates/ghost-verification/src/server.rs
@@ -866,6 +866,45 @@ pub struct PoolPeerInfo {
     pub max_capacity: u32,
 }
 
+/// One mesh node as surfaced by the public `/api/v1/pool/mesh-nodes`
+/// endpoint. Carries only the gossiped, already-public fields a peer
+/// advertises in its health pings, so the website can render the live
+/// node list (self + every connected peer) without hard-coding the
+/// original VM set. Filled by a callback in `bins/ghost-pool` from each
+/// `Peer` returned by `PeerManager::get_connected_peers`, keeping the
+/// `ghost-consensus` peer type out of this crate's public surface.
+///
+/// `elder` is the peer's elder *status* (registration order), while the
+/// `cap_elder` capability mirrors the same bit as advertised in the
+/// node's capability set; both are surfaced so the frontend can show the
+/// elder badge consistently with the other capability flags.
+#[derive(Debug, Clone)]
+pub struct MeshNodeInfo {
+    /// Node ID (hex).
+    pub node_id: String,
+    /// Public address (`host:port`) the peer advertises. May be empty if
+    /// the peer has not published one yet.
+    pub address: String,
+    /// Whether this node is an elder (registration order).
+    pub elder: bool,
+    /// Archive-mode capability.
+    pub cap_archive: bool,
+    /// Ghost Pay (L2) capability.
+    pub cap_ghost_pay: bool,
+    /// Public-mining capability.
+    pub cap_public_mining: bool,
+    /// Reaper strict-mode capability.
+    pub cap_reaper: bool,
+    /// Elder-status capability bit (mirrors `elder`).
+    pub cap_elder: bool,
+    /// The node's own realized hashrate (TH/s) over its trailing window.
+    pub hashrate_th: f64,
+    /// Miners currently connected to this node.
+    pub miner_count: u32,
+    /// Whether the node is considered healthy/reachable on the mesh.
+    pub healthy: bool,
+}
+
 pub struct VerificationState {
     /// Node ID (hex)
     pub node_id: String,
@@ -962,6 +1001,13 @@ pub struct VerificationState {
     /// momentarily unreachable. None on older deploys without the provider —
     /// callers fall back to the node-local DB record only.
     get_mesh_best_records: Option<Box<dyn Fn() -> Vec<WindowBestRecord> + Send + Sync>>,
+    /// Live mesh node list: every connected peer (NOT self) from
+    /// `PeerManager::get_connected_peers`, mapped to `MeshNodeInfo`. Backs the
+    /// public `/api/v1/pool/mesh-nodes` endpoint so the website renders the
+    /// whole mesh from one node instead of a hard-coded VM list. The handler
+    /// prepends this node (self) from local state. None on deploys without the
+    /// provider wired — the endpoint then returns just self.
+    get_mesh_nodes: Option<Box<dyn Fn() -> Vec<MeshNodeInfo> + Send + Sync>>,
     /// Signal to trigger graceful restart (set by config update API)
     /// When true, main.rs will initiate shutdown and exit with code 100
     pub restart_signal: Arc<AtomicBool>,
@@ -1135,6 +1181,7 @@ impl VerificationState {
             get_mesh_total_hashrate: None,
             get_local_hashrate: None,
             get_mesh_best_records: None,
+            get_mesh_nodes: None,
             // VF-C2: Default to requiring internal auth for security
             require_internal_auth: true,
             restart_signal: Arc::new(AtomicBool::new(false)),
@@ -1673,6 +1720,26 @@ impl VerificationState {
     /// one winner per window), or None if no callback has been wired up.
     pub fn mesh_best_records(&self) -> Option<Vec<WindowBestRecord>> {
         self.get_mesh_best_records.as_ref().map(|f| f())
+    }
+
+    /// Set the live mesh-node-list callback (connected peers, not self).
+    pub fn with_mesh_nodes(
+        mut self,
+        f: impl Fn() -> Vec<MeshNodeInfo> + Send + Sync + 'static,
+    ) -> Self {
+        self.get_mesh_nodes = Some(Box::new(f));
+        self
+    }
+
+    /// Returns the connected peers as `MeshNodeInfo` (self excluded), or an
+    /// empty vec if no callback has been wired up. The `mesh-nodes` handler
+    /// prepends this node from local state, so an empty result still yields a
+    /// one-element (self-only) response rather than a failure.
+    pub fn mesh_nodes(&self) -> Vec<MeshNodeInfo> {
+        self.get_mesh_nodes
+            .as_ref()
+            .map(|f| f())
+            .unwrap_or_default()
     }
 
     /// Set archive handler

--- a/ghost-web/index.html
+++ b/ghost-web/index.html
@@ -545,7 +545,32 @@
       return out;
     }
 
+    // Bootstrap seeds = the original four load-balancer proxies. New mesh
+    // nodes have NO per-node proxy, so we always enter through one of these
+    // seeds; the /api/v1/pool/mesh-nodes endpoint then returns the WHOLE mesh
+    // (self + every connected peer) from that single node, so nodes 5, 6, …
+    // appear automatically without a hard-coded list.
     var VMS = ['vm1', 'vm2', 'vm3', 'vm4'];
+
+    // Try each seed in order; the first that answers returns the live mesh
+    // node list. Returns null if every seed is unreachable so the caller can
+    // fall back gracefully.
+    async function fetchMeshNodes() {
+      for (var i = 0; i < VMS.length; i++) {
+        try {
+          var ctl = new AbortController();
+          var t = setTimeout(function () { ctl.abort(); }, 5000);
+          var r = await fetch('/api/pool/' + VMS[i] + '/api/v1/pool/mesh-nodes', { signal: ctl.signal });
+          clearTimeout(t);
+          if (r.ok) {
+            var d = await r.json();
+            if (d && Array.isArray(d.nodes) && d.nodes.length) return d.nodes;
+          }
+        } catch (e) { /* try the next seed */ }
+      }
+      return null;
+    }
+
     // Always render with a unit suffix so a 0-hashrate moment looks
     // "loaded but quiet" rather than "broken / not populated".
     function formatHashrate(ths) {
@@ -558,6 +583,9 @@
     }
     async function refresh() {
       try {
+        // Kick off the whole-mesh node fetch in parallel with the per-seed
+        // status polls so the headline metrics aren't gated on it.
+        var meshNodesPromise = fetchMeshNodes();
         var results = await Promise.all(VMS.map(function (vm) {
           var ctl = new AbortController();
           var t = setTimeout(function () { ctl.abort(); }, 5000);
@@ -606,9 +634,18 @@
         var heightEl = document.getElementById('live-height');
         if (hashEl)   hashEl.innerHTML = formatHashrate(hashSmoothed != null ? hashSmoothed : hash);
         if (minersEl) minersEl.textContent = Math.round(minersSmoothed != null ? minersSmoothed : rawMiners).toString();
-        if (nodesEl)  nodesEl.innerHTML = online + '<span class="unit"> / 4</span>';
+        // Active nodes: the live mesh count (self + connected peers) from one
+        // seed, so new nodes show up automatically. Falls back to "online / 4"
+        // — the count of reachable seeds — when the mesh endpoint is briefly
+        // unavailable, so the tile never blanks or breaks.
+        var meshNodes = await meshNodesPromise;
+        var meshCount = (meshNodes && meshNodes.length) ? meshNodes.length : null;
+        if (nodesEl) {
+          if (meshCount != null) nodesEl.textContent = String(meshCount);
+          else nodesEl.innerHTML = online + '<span class="unit"> / ' + VMS.length + '</span>';
+        }
         if (heightEl) heightEl.textContent = height ? height.toLocaleString() : '—';
-        console.debug('[index] refresh ok · ' + online + '/4 nodes · ' + hash.toFixed(2) + ' TH/s · ' + rawMiners + ' miners');
+        console.debug('[index] refresh ok · ' + online + '/' + VMS.length + ' seeds · ' + (meshCount != null ? meshCount + ' mesh nodes · ' : '') + hash.toFixed(2) + ' TH/s · ' + rawMiners + ' miners');
       } catch (err) {
         // Don't let a transient error stop the 30s polling cadence — log
         // and let the next tick try again.

--- a/ghost-web/pool.html
+++ b/ghost-web/pool.html
@@ -236,6 +236,20 @@
   </div>
 </section>
 
+<section class="block nodes-section">
+  <div class="container">
+    <div class="section-label">network</div>
+    <h2 class="section-title">Nodes on the mesh.</h2>
+    <p class="section-lead">
+      Every node currently gossiping on the pool mesh — this node plus every
+      connected peer, with its verified capabilities, own hashrate and miner
+      count. The list populates live from the mesh, so new nodes appear
+      automatically as they join.
+    </p>
+    <div class="node-grid" id="node-grid"></div>
+  </div>
+</section>
+
 <section class="block payout-section">
   <div class="container">
     <div class="section-label">next block payout</div>
@@ -708,6 +722,102 @@
     getHashrate: function () { return lastStats.hashrate; },
     getMiners:   function () { return lastStats.miners; }
   };
+
+  // ───────── Mesh node list ─────────
+  // The node list populates from the live mesh, not a hard-coded VM set.
+  // POOL_NODES (the four load-balancer proxies) are only BOOTSTRAP SEEDS here:
+  // a newly-joined node has no per-node proxy, so we enter through one seed and
+  // the /api/v1/pool/mesh-nodes endpoint returns the WHOLE mesh (self + every
+  // connected peer) from there. The aggregate sections above keep fanning out
+  // to the seeds because their figures are mesh-aggregated/gossiped and already
+  // reflect new nodes from any one seed.
+  function escHtml(s) {
+    return String(s == null ? '' : s).replace(/[&<>"']/g, function (c) {
+      return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c];
+    });
+  }
+
+  async function fetchMeshNodes() {
+    for (var i = 0; i < POOL_NODES.length; i++) {
+      try {
+        var ctl = new AbortController();
+        var t = setTimeout(function () { ctl.abort(); }, 5000);
+        var r = await fetch('/api/pool/' + POOL_NODES[i].id + '/api/v1/pool/mesh-nodes', { signal: ctl.signal });
+        clearTimeout(t);
+        if (r.ok) {
+          var d = await r.json();
+          if (d && Array.isArray(d.nodes) && d.nodes.length) return d.nodes;
+        }
+      } catch (e) { /* try the next seed */ }
+    }
+    return null;
+  }
+
+  function nodeCapBadges(caps) {
+    caps = caps || {};
+    var defs = [
+      ['elder', 'elder'],
+      ['archive', 'archive'],
+      ['ghost_pay', 'ghost pay'],
+      ['public_mining', 'public'],
+      ['reaper', 'reaper'],
+    ];
+    return defs.map(function (d) {
+      var on = !!caps[d[0]];
+      return '<span class="cap' + (on ? '' : ' off') + '">' + escHtml(d[1]) + '</span>';
+    }).join('');
+  }
+
+  function renderMeshNodes(nodes) {
+    var grid = document.getElementById('node-grid');
+    if (!grid) return;
+    if (!nodes || !nodes.length) {
+      grid.innerHTML = '<p class="section-lead" style="grid-column:1/-1">Mesh node list unavailable — retrying…</p>';
+      return;
+    }
+    // Self first, then elders, then by hashrate. Stable, readable ordering.
+    var sorted = nodes.slice().sort(function (a, b) {
+      if (!!a.is_self !== !!b.is_self) return a.is_self ? -1 : 1;
+      if (!!a.elder !== !!b.elder) return a.elder ? -1 : 1;
+      return (b.hashrate_th || 0) - (a.hashrate_th || 0);
+    });
+    grid.innerHTML = sorted.map(function (n) {
+      var id = String(n.node_id || '');
+      var shortId = id ? id.slice(0, 8) : '????????';
+      var name = n.is_self ? 'this node' : ('node ' + shortId);
+      var healthy = n.healthy !== false;
+      var hr = formatHashrate(typeof n.hashrate_th === 'number' ? n.hashrate_th : 0);
+      var miners = (typeof n.miner_count === 'number') ? n.miner_count : 0;
+      var addr = n.address ? escHtml(n.address) : '—';
+      var elderStar = n.elder ? ' <span style="color:var(--accent);font-size:12px" title="elder">★</span>' : '';
+      return '' +
+        '<div class="node-card">' +
+          '<div class="head">' +
+            '<span class="name">' + escHtml(name) + elderStar + '</span>' +
+            '<span class="status ' + (healthy ? 'online' : 'offline') + '">' + (healthy ? 'online' : 'offline') + '</span>' +
+          '</div>' +
+          '<div class="row"><span class="k">hashrate</span><span class="v">' + hr + '</span></div>' +
+          '<div class="row"><span class="k">miners</span><span class="v">' + miners + '</span></div>' +
+          '<div class="row"><span class="k">node id</span><span class="v" style="word-break:break-all">' + escHtml(shortId) + '</span></div>' +
+          '<div class="row"><span class="k">address</span><span class="v" style="word-break:break-all">' + addr + '</span></div>' +
+          '<div class="caps">' + nodeCapBadges(n.capabilities) + '</div>' +
+        '</div>';
+    }).join('');
+  }
+
+  async function refreshMeshNodes() {
+    try {
+      var nodes = await fetchMeshNodes();
+      // Only overwrite the grid when we have data; a transient failure keeps
+      // the last good list rather than blanking it. Show the placeholder only
+      // on the very first load when nothing has rendered yet.
+      var grid = document.getElementById('node-grid');
+      if (nodes && nodes.length) renderMeshNodes(nodes);
+      else if (grid && !grid.children.length) renderMeshNodes(null);
+    } catch (e) { /* keep last good render */ }
+  }
+  refreshMeshNodes();
+  setInterval(refreshMeshNodes, 30000);
 
   // ───────── Difficulty helpers (shared by Records + Leaderboards) ─────────
   // Bitcoin "difficulty 1" target. Dividing it by a share's hash-as-int


### PR DESCRIPTION
The website node list was hardcoded to the 4 original VMs and could not show new nodes (5, 6, …) that join the mesh. This makes it populate automatically.

## Backend
New PUBLIC (no-auth, like `recent_shares`) endpoint **`GET /api/v1/pool/mesh-nodes`** on the ghost-verification axum router. Returns every mesh node — self + each connected peer from `PeerManager::get_connected_peers(120)` — as `{node_id, address, elder, capabilities, hashrate_th, miner_count, healthy, is_self}`. No network calls; it surfaces the per-peer data each node already holds from health-ping gossip. Deduped by `node_id`, self included once.

## Frontend
- `pool.html` gains a live "Nodes on the mesh" grid that fetches `mesh-nodes` (bootstrap-fallback across the 4 seed proxies — whichever responds returns the whole mesh) and renders one card per node, **HTML-escaped** (peer data is gossiped, so untrusted). Self first, then elders, then by hashrate. New nodes appear within one 30s poll, forever, with no config edits.
- `index.html` "active nodes" tile now shows the live mesh count instead of a hardcoded `/ 4`.
- All aggregate sections (hashrate, leaderboard, records, quasar) are unchanged — they are mesh-aggregated/gossiped and already reflect new nodes via any seed.

No nginx changes: the existing per-VM proxies remain only as bootstrap entry points.

## Tests
`mesh_node_to_json` shape + bare-peer defaults unit tests; ghost-pool + ghost-verification suites, clippy, and the rustdoc `-D warnings` doc gate all green. Frontend scripts pass `node --check`.