### PR TITLE
web: dedup mesh node list by host (suppress transient restart phantoms)

### DIFF
--- a/ghost-web/index.html
+++ b/ghost-web/index.html
@@ -639,7 +639,18 @@
         // — the count of reachable seeds — when the mesh endpoint is briefly
         // unavailable, so the tile never blanks or breaks.
         var meshNodes = await meshNodesPromise;
-        var meshCount = (meshNodes && meshNodes.length) ? meshNodes.length : null;
+        // Count DISTINCT hosts, not raw entries: during a node restart the mesh
+        // briefly reports stale same-IP session duplicates that age out within
+        // ~2 min, which would otherwise inflate this tile.
+        var meshCount = null;
+        if (meshNodes && meshNodes.length) {
+          var hosts = {};
+          meshNodes.forEach(function (n) {
+            var s = String((n && n.address) || ''); var i = s.lastIndexOf(':');
+            hosts[(i > 0 ? s.slice(0, i) : s) || ('id:' + ((n && n.node_id) || ''))] = 1;
+          });
+          meshCount = Object.keys(hosts).length;
+        }
         if (nodesEl) {
           if (meshCount != null) nodesEl.textContent = String(meshCount);
           else nodesEl.innerHTML = online + '<span class="unit"> / ' + VMS.length + '</span>';

--- a/ghost-web/pool.html
+++ b/ghost-web/pool.html
@@ -775,6 +775,19 @@
       grid.innerHTML = '<p class="section-lead" style="grid-column:1/-1">Mesh node list unavailable — retrying…</p>';
       return;
     }
+    // Collapse transient same-address duplicates. During a node restart the mesh
+    // briefly reports stale session peer-entries (same IP, a different node_id,
+    // hashrate 0) that age out of the freshness window within ~2 min — without
+    // this they'd flash as phantom extra nodes. Dedup by host, keeping the best
+    // entry per IP: prefer self, then non-zero hashrate, then non-zero miners.
+    function hostOf(a) { var s = String(a || ''); var i = s.lastIndexOf(':'); return i > 0 ? s.slice(0, i) : s; }
+    function nodeScore(x) { return (x.is_self ? 100 : 0) + (((x.hashrate_th || 0) > 0) ? 10 : 0) + (((x.miner_count || 0) > 0) ? 1 : 0); }
+    var byHost = {};
+    nodes.forEach(function (n) {
+      var key = hostOf(n.address) || ('id:' + (n.node_id || ''));
+      if (!byHost[key] || nodeScore(n) > nodeScore(byHost[key])) byHost[key] = n;
+    });
+    nodes = Object.keys(byHost).map(function (k) { return byHost[k]; });
     // Self first, then elders, then by hashrate. Stable, readable ordering.
     var sorted = nodes.slice().sort(function (a, b) {
       if (!!a.is_self !== !!b.is_self) return a.is_self ? -1 : 1;


### PR DESCRIPTION
Frontend follow-up to the auto-populating node list (#106).

`/api/v1/pool/mesh-nodes` dedups by `node_id`, but during a node restart the mesh briefly reports stale session peer-entries — same IP, a different `node_id`, hashrate 0 — that age out of the 120s freshness window within ~2 min. Mid-roll they flashed as phantom extra nodes (7 instead of 4) before settling.

This collapses by host on the client: `pool.html` keeps the best entry per IP (prefer self → non-zero hashrate → non-zero miners; phantoms are hashrate-0), and `index.html` counts distinct hosts for the active-nodes tile. Steady state unchanged. Already deployed to the web host; this keeps main in sync. A backend address-dedup at the endpoint remains a follow-up for the next ghost-pool deploy.