### PR TITLE
wraith-wallet: fix runtime bugs (false-success payments, dead Locks buttons, swallowed errors)

### DIFF
--- a/apps/wraith-wallet/daemon/src/main.rs
+++ b/apps/wraith-wallet/daemon/src/main.rs
@@ -2707,7 +2707,9 @@ mod unix {
                                 .into_iter()
                                 .map(|l| LockEntry {
                                     lock_id: l.lock_id,
-                                    status: format!("{:?}", l.status).to_lowercase(),
+                                    // Canonical lowercase via Display ("pending"/"active"/"in_use");
+                                    // Debug formatting would render multi-word variants wrong (e.g. "inuse").
+                                    status: l.status.to_string(),
                                     capacity_sats: l.capacity_sats,
                                     balance_sats: l.balance_sats,
                                     denomination: l.denomination,

--- a/apps/wraith-wallet/gui/src/lib/tauri.ts
+++ b/apps/wraith-wallet/gui/src/lib/tauri.ts
@@ -257,19 +257,25 @@ export async function walletShowMnemonic(
   return unwrap<{ name: string; mnemonic: string }>(resp).payload;
 }
 
+// These three unwrap() so a daemon Response::Error (e.g. wrong passphrase) THROWS
+// rather than resolving as { result: "error" } — otherwise the caller's success
+// path runs and the failure is silently swallowed (no error shown to the user).
 export async function walletUnlock(
   name: string,
   passphrase: string,
 ): Promise<unknown> {
-  return await invoke("wallet_unlock", { name, passphrase });
+  const resp = await invoke("wallet_unlock", { name, passphrase });
+  return unwrap(resp).payload;
 }
 
 export async function walletLock(name: string | null): Promise<unknown> {
-  return await invoke("wallet_lock", { name });
+  const resp = await invoke("wallet_lock", { name });
+  return unwrap(resp).payload;
 }
 
 export async function walletSelect(name: string): Promise<unknown> {
-  return await invoke("wallet_select", { name });
+  const resp = await invoke("wallet_select", { name });
+  return unwrap(resp).payload;
 }
 
 export async function walletGhostId(): Promise<{
@@ -402,13 +408,18 @@ export async function lightSend(
   memo?: string,
   shroud_max_ms?: number,
 ): Promise<unknown> {
-  return await invoke("light_send", {
+  const resp = await invoke("light_send", {
     recipient,
     amountSats: amount_sats,
     mode,
     memo,
     shroudMaxMs: shroud_max_ms,
   });
+  // Must unwrap: the daemon serializes a rejected payment as
+  // { result: "error", message }, which `invoke` RESOLVES. Without unwrap the
+  // caller's success branch runs and the UI falsely reports "Sent". unwrap()
+  // throws on result:"error" so Send.tsx's catch surfaces the real failure.
+  return unwrap(resp).payload;
 }
 
 export interface LightUtxoEntry {
@@ -577,7 +588,8 @@ export async function wraithMixRun(
 // ----- GSP ---------------------------------------------------------------
 
 export async function gspAuth(): Promise<unknown> {
-  return await invoke("gsp_auth");
+  const resp = await invoke("gsp_auth");
+  return unwrap(resp).payload;
 }
 
 export interface GspSessionStatus {
@@ -599,14 +611,22 @@ export async function gspSessionStatus(): Promise<GspSessionStatus> {
 
 // ----- Locks -------------------------------------------------------------
 
+// Must match the wire `LockEntry` in ipc/src/lib.rs exactly. The fields are read
+// from an `unknown` cast, so a name mismatch is invisible to tsc but breaks at
+// runtime — previously `state`/`created_at`/`recovery_height` (none of which exist
+// on the wire) left the State pill blank and the Confirm/Recover buttons (gated on
+// `state`) permanently unreachable.
 export interface LockEntry {
   lock_id: string;
+  status: string;
   capacity_sats: number;
-  state: string;
-  created_at: number;
-  funding_address?: string;
+  balance_sats: number;
+  denomination: string;
+  timelock_tier: string;
+  funding_address: string;
   funding_txid?: string;
-  recovery_height?: number;
+  funding_vout?: number;
+  creation_height: number;
 }
 
 export interface LocksListResponse {
@@ -635,7 +655,8 @@ export async function locksConfirm(
   lock_id: string,
   funding_txid: string,
 ): Promise<unknown> {
-  return await invoke("locks_confirm", { lockId: lock_id, fundingTxid: funding_txid });
+  const resp = await invoke("locks_confirm", { lockId: lock_id, fundingTxid: funding_txid });
+  return unwrap(resp).payload;
 }
 
 export interface LocksRecoveredResult {

--- a/apps/wraith-wallet/gui/src/screens/Locks.tsx
+++ b/apps/wraith-wallet/gui/src/screens/Locks.tsx
@@ -258,7 +258,7 @@ export function Locks() {
                 <th>ID</th>
                 <th>Capacity</th>
                 <th>State</th>
-                <th>Recovery height</th>
+                <th>Created height</th>
                 <th />
               </tr>
             </thead>
@@ -273,19 +273,19 @@ export function Locks() {
                       <td>
                         <span
                           className={`pill ${
-                            l.state === "active"
+                            l.status === "active"
                               ? "pass"
-                              : l.state === "pending"
+                              : l.status === "pending"
                                 ? "warn"
                                 : "mute"
                           }`}
                         >
-                          {l.state}
+                          {l.status}
                         </span>
                       </td>
-                      <td className="mono muted">{l.recovery_height ?? "—"}</td>
+                      <td className="mono muted">{l.creation_height ?? "—"}</td>
                       <td style={{ textAlign: "right" }}>
-                        {l.state === "pending" && (
+                        {l.status === "pending" && (
                           <button
                             className="secondary"
                             onClick={() => openConfirm(l.lock_id)}
@@ -295,7 +295,7 @@ export function Locks() {
                             Confirm funding
                           </button>
                         )}
-                        {l.state === "active" && (
+                        {l.status === "active" && (
                           <button
                             className="danger"
                             onClick={() => openRecover(l.lock_id)}
@@ -380,8 +380,9 @@ export function Locks() {
                             >
                               Builds, signs, and broadcasts a recovery tx
                               with the wallet's recovery secret. Only works
-                              after the timelock has matured (recovery
-                              height {l.recovery_height ?? "—"}). The
+                              after the timelock (tier {l.timelock_tier})
+                              matures — lock created at height{" "}
+                              {l.creation_height ?? "—"}. The
                               operator is bypassed entirely — this is the
                               wallet's safety net for an unresponsive Ghost
                               Pay node.


### PR DESCRIPTION
A fresh end-to-end audit of the Wraith wallet found screens that compile cleanly but break at runtime (the GUI reads daemon responses from an `unknown` cast, so contract mismatches are invisible to `tsc`). Fixes:

- **False "Sent" on failed payments** — `lightSend` returned the raw `invoke` result without `unwrap()`, so a daemon `Response::Error` RESOLVED and the success branch ran. Now unwraps → the failure throws and `Send.tsx` surfaces it.
- **Dead Locks Confirm/Recover buttons** — the GUI `LockEntry` used `state`/`created_at`/`recovery_height`; the wire sends `status`/`creation_height`. `l.state` was always `undefined`, so the status pill was blank and the buttons (gated on it) never rendered. Interface now matches `ipc/src/lib.rs`; height column relabelled.
- **Swallowed errors** — `walletUnlock` (wrong passphrase), `walletLock`, `walletSelect`, `gspAuth`, `locksConfirm` now `unwrap()` so the existing catch blocks render the error.
- **Lock status** — `Display` (canonical `"pending"`/`"active"`/`"in_use"`) instead of `Debug`.

GUI typecheck clean; daemon builds; wallet tests pass. Out of scope (separate decisions): Mix bond escrow (no-op stub), CLI-only capabilities (keystore backup/restore, update check, lock key-rotation).