### PR TITLE
dashboard: fix audited bugs (3 dead pages, fail-open auth, dead code, swallowed errors)

### DIFF
--- a/dashboard/src/app/(dashboard)/capacity/page.tsx
+++ b/dashboard/src/app/(dashboard)/capacity/page.tsx
@@ -6,6 +6,7 @@ import { Card } from "@/components/ui/Card";
 import { Badge } from "@/components/ui/Badge";
 import { SkeletonCard } from "@/components/ui/Skeleton";
 import { SectionErrorBoundary } from "@/components/ui/SectionErrorBoundary";
+import { fetchApi } from "@/lib/api/client";
 
 /**
  * Capacity & load-balancer view.
@@ -30,9 +31,10 @@ interface PoolNodesResponse {
 }
 
 async function fetchPoolNodes(): Promise<PoolNodesResponse> {
-  const res = await fetch("/api/internal/pool-nodes", { credentials: "include" });
-  if (!res.ok) throw new Error(`pool-nodes HTTP ${res.status}`);
-  return res.json();
+  // Route through the proxy (fetchApi) so the HMAC-signed internal request
+  // reaches ghost-pool; a bare fetch hits the Next server and always 404s,
+  // which previously left this page rendering only an error card.
+  return fetchApi<PoolNodesResponse>("/api/internal/pool-nodes");
 }
 
 function utilPct(n: PoolNode): number {

--- a/dashboard/src/app/(dashboard)/mempool/page.tsx
+++ b/dashboard/src/app/(dashboard)/mempool/page.tsx
@@ -6,6 +6,7 @@ import { Card } from "@/components/ui/Card";
 import { Badge } from "@/components/ui/Badge";
 import { CopyButton } from "@/components/ui/CopyButton";
 import { SkeletonCard } from "@/components/ui/Skeleton";
+import { fetchApi } from "@/lib/api/client";
 
 /**
  * Per-node mempool view.
@@ -35,9 +36,10 @@ interface MempoolStatus {
 }
 
 async function fetchMempoolStatus(): Promise<MempoolStatus> {
-  const res = await fetch("/api/v1/system/mempool", { credentials: "include" });
-  if (!res.ok) throw new Error(`mempool status HTTP ${res.status}`);
-  return res.json();
+  // Route through the proxy (fetchApi) so the HMAC-signed internal request
+  // reaches ghost-pool; a bare fetch hits the Next server and always 404s,
+  // which previously made every node falsely report "not installed".
+  return fetchApi<MempoolStatus>("/api/v1/system/mempool");
 }
 
 export default function MempoolPage() {

--- a/dashboard/src/app/(dashboard)/reaper/page.tsx
+++ b/dashboard/src/app/(dashboard)/reaper/page.tsx
@@ -6,6 +6,7 @@ import { PageHeader } from "@/components/ui/PageHeader";
 import { StatCard } from "@/components/ui/StatCard";
 import { SectionErrorBoundary } from "@/components/ui/SectionErrorBoundary";
 import { useConfig } from "@/hooks/queries/useConfigQueries";
+import { fetchApi } from "@/lib/api/client";
 
 interface ReaperStats {
   txs_evaluated: number;
@@ -29,11 +30,17 @@ interface ReaperStats {
 }
 
 async function fetchReaperStats(): Promise<ReaperStats | null> {
-  const res = await fetch("/api/v1/reaper/status", { credentials: "include" });
-  if (!res.ok) return null;
-  const data = await res.json();
-  // Endpoint returns null when ghost-pool hasn't wired the callback yet.
-  return data && typeof data === "object" && "txs_evaluated" in data ? data : null;
+  try {
+    // Route through the proxy (fetchApi) so the HMAC-signed internal request
+    // reaches ghost-pool; a bare fetch hits the Next server and always 404s.
+    const data = await fetchApi<unknown>("/api/v1/reaper/status");
+    // Endpoint returns null when ghost-pool hasn't wired the callback yet.
+    return data && typeof data === "object" && "txs_evaluated" in data
+      ? (data as ReaperStats)
+      : null;
+  } catch {
+    return null;
+  }
 }
 
 const DETECTION_VECTORS = [
@@ -58,6 +65,11 @@ const DETECTION_VECTORS = [
     desc: "Detects invalid or non-functional public keys used as data carriers in multisig outputs.",
   },
   {
+    key: "fake_pubkey_curve_point" as const,
+    name: "Fake Pubkey Curve Points",
+    desc: "Flags fake pubkeys that are not valid secp256k1 curve points, a tell-tale sign the value carries embedded data rather than a real key.",
+  },
+  {
     key: "oversized_op_return" as const,
     name: "Oversized OP_RETURN",
     desc: "Flags OP_RETURN outputs exceeding standard relay limits, used for embedding large data payloads.",
@@ -76,6 +88,11 @@ const DETECTION_VECTORS = [
     key: "excess_witness_data" as const,
     name: "Excess Witness Data",
     desc: "Catches witness items far exceeding what the script actually consumes during execution.",
+  },
+  {
+    key: "excess_stack_items" as const,
+    name: "Excess Stack Items",
+    desc: "Flags witnesses that leave surplus elements on the stack after script execution, a vector for stuffing extra data into the witness.",
   },
   {
     key: "legacy_scriptsig_data" as const,

--- a/dashboard/src/app/(dashboard)/swarm/page.tsx
+++ b/dashboard/src/app/(dashboard)/swarm/page.tsx
@@ -18,7 +18,6 @@ import {
   useRemoveSwarmNode,
   useUpdateSwarmNode,
   useRefreshSwarmNode,
-  useConfigureSwarmNode,
   useNodeInfo,
 } from "@/hooks/queries";
 import { setNickname } from "@/lib/api/node";
@@ -64,14 +63,12 @@ export default function SwarmPage() {
   const removeNode = useRemoveSwarmNode();
   const updateNode = useUpdateSwarmNode();
   const refreshNode = useRefreshSwarmNode();
-  const configureNode = useConfigureSwarmNode();
   const queryClient = useQueryClient();
   const { success, error } = useToast();
 
   const [viewMode, setViewMode] = useState<ViewMode>("list");
   const [addDialogOpen, setAddDialogOpen] = useState(false);
   const [editDialogOpen, setEditDialogOpen] = useState(false);
-  const [configDialogOpen, setConfigDialogOpen] = useState(false);
   const [updateDialogOpen, setUpdateDialogOpen] = useState(false);
   const [selectedNode, setSelectedNode] = useState<SwarmNode | null>(null);
   const [newNodeName, setNewNodeName] = useState("");
@@ -114,6 +111,22 @@ export default function SwarmPage() {
   // Refresh all nodes - calls API directly for reliability
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [restartingNode, setRestartingNode] = useState<string | null>(null);
+  // Nodes whose last refresh failed — surfaced as a per-node "stale" marker so
+  // best-effort refresh failures aren't silently swallowed.
+  const [staleNodeIds, setStaleNodeIds] = useState<Set<string>>(new Set());
+
+  const markNodeStale = (nodeId: string, stale: boolean) => {
+    setStaleNodeIds((prev) => {
+      if (prev.has(nodeId) === stale) return prev;
+      const next = new Set(prev);
+      if (stale) {
+        next.add(nodeId);
+      } else {
+        next.delete(nodeId);
+      }
+      return next;
+    });
+  };
 
   const handleRestartNode = async (node: SwarmNode) => {
     if (restartingNode) return;
@@ -170,8 +183,9 @@ export default function SwarmPage() {
       let syncResult = { discovered_peers: 0, removed_stale: 0, total_peers: 0 };
       try {
         syncResult = await syncSwarm();
-      } catch {
-        // Sync failed, continue with refresh anyway
+      } catch (err) {
+        // Sync failed, continue with refresh anyway — but log it.
+        console.error("Swarm sync failed; continuing with refresh", err);
       }
 
       // Refresh all remote nodes in parallel via direct API calls
@@ -179,8 +193,11 @@ export default function SwarmPage() {
         await Promise.all(remoteNodes.map(async (node) => {
           try {
             await refreshSwarmNode(node.node_id);
-          } catch {
-            // Ignore individual failures
+            markNodeStale(node.node_id, false);
+          } catch (err) {
+            // Mark the node stale and log — don't swallow silently.
+            console.error(`Swarm refresh failed for ${node.name} (${node.node_id})`, err);
+            markNodeStale(node.node_id, true);
           }
         }));
       }
@@ -217,8 +234,10 @@ export default function SwarmPage() {
       await Promise.all(remoteNodes.map(async (node) => {
         try {
           await refreshSwarmNode(node.node_id);
-        } catch {
-          // Ignore failures
+          markNodeStale(node.node_id, false);
+        } catch (err) {
+          console.error(`Swarm auto-refresh failed for ${node.name} (${node.node_id})`, err);
+          markNodeStale(node.node_id, true);
         }
       }));
       // Refetch swarm data
@@ -228,11 +247,6 @@ export default function SwarmPage() {
     const interval = setInterval(doRefresh, 30000);
     return () => clearInterval(interval);
   }, [nodes.length, queryClient]); // Re-setup when node count changes
-
-  const handleConfigureClick = (node: SwarmNode) => {
-    setSelectedNode(node);
-    setConfigDialogOpen(true);
-  };
 
   const handleEditClick = (node: SwarmNode) => {
     setSelectedNode(node);
@@ -276,9 +290,6 @@ export default function SwarmPage() {
       error("Failed to Update", err instanceof Error ? err.message : "Unknown error");
     }
   };
-
-  // Suppress unused variable warnings for hooks used only for side effects
-  void configureNode;
 
   return (
     <div className="space-y-6">
@@ -419,6 +430,11 @@ export default function SwarmPage() {
                     <Badge variant={node.online ? "success" : "error"} className="text-xs">
                       {node.online ? "Online" : "Offline"}
                     </Badge>
+                    {staleNodeIds.has(node.node_id) && (
+                      <Badge variant="warning" className="text-xs">
+                        Stale
+                      </Badge>
+                    )}
                     {node.watchdog_health && (
                       <Badge
                         variant={node.watchdog_health === "healthy" ? "success" : node.watchdog_health === "degraded" ? "warning" : "error"}
@@ -496,6 +512,9 @@ export default function SwarmPage() {
                         <Badge variant={node.online ? "success" : "error"}>
                           {node.online ? "Online" : "Offline"}
                         </Badge>
+                        {staleNodeIds.has(node.node_id) && (
+                          <Badge variant="warning">Stale</Badge>
+                        )}
                         {node.watchdog_health && (
                           <Badge
                             variant={node.watchdog_health === "healthy" ? "success" : node.watchdog_health === "degraded" ? "warning" : "error"}
@@ -690,61 +709,6 @@ export default function SwarmPage() {
               disabled={!newNodeName.trim() || !newNodeAddress.trim()}
             >
               Add Node
-            </Button>
-          </div>
-        </div>
-      </Dialog>
-
-      {/* Configure Node Dialog */}
-      <Dialog
-        isOpen={configDialogOpen}
-        onClose={() => setConfigDialogOpen(false)}
-        title={`Configure ${selectedNode?.name ?? "Node"}`}
-      >
-        <div className="space-y-4">
-          <p className="text-gray-400 text-sm">
-            Remote node configuration is available for nodes that support it. Configuration changes
-            require the node to restart.
-          </p>
-
-          <div className="p-4 bg-gray-800/50 rounded-lg">
-            <h4 className="text-sm font-medium text-gray-300 mb-3">Current Status</h4>
-            {selectedNode && (
-              <div className="grid grid-cols-2 gap-2 text-sm">
-                <div>
-                  <span className="text-gray-400">Node:</span>{" "}
-                  <span>{selectedNode.name}</span>
-                </div>
-                <div>
-                  <span className="text-gray-400">Status:</span>{" "}
-                  <Badge variant={selectedNode.online ? "success" : "error"}>
-                    {selectedNode.online ? "Online" : "Offline"}
-                  </Badge>
-                </div>
-                <div>
-                  <span className="text-gray-400">Shares:</span>{" "}
-                  <span>
-                    {selectedNode.shares ?? 0}/{selectedNode.max_shares ?? 0}
-                  </span>
-                </div>
-                <div>
-                  <span className="text-gray-400">Uptime:</span>{" "}
-                  <span>{formatUptime(selectedNode.uptime_percent ?? 0)}</span>
-                </div>
-              </div>
-            )}
-          </div>
-
-          <div className="p-4 bg-orange-900/20 border border-orange-800 rounded-lg">
-            <p className="text-orange-300 text-sm">
-              For detailed node configuration, access the node&apos;s dashboard directly on that machine.
-              Configuration changes are synced automatically via the swarm protocol.
-            </p>
-          </div>
-
-          <div className="flex justify-end pt-4 border-t border-gray-800">
-            <Button variant="ghost" onClick={() => setConfigDialogOpen(false)}>
-              Close
             </Button>
           </div>
         </div>

--- a/dashboard/src/middleware.ts
+++ b/dashboard/src/middleware.ts
@@ -50,10 +50,14 @@ export async function middleware(request: NextRequest) {
     return addSecurityHeaders(NextResponse.next());
   }
 
-  // Remote access — password-gated dashboard
+  // Remote access — password-gated dashboard.
+  // Fail CLOSED: if no DASHBOARD_PASSWORD is configured we cannot authenticate a
+  // remote caller, so deny rather than serve unauthenticated. Localhost is
+  // handled above and is unaffected; remote access only works once the operator
+  // sets a password.
   const dashboardPassword = process.env.DASHBOARD_PASSWORD;
   if (!dashboardPassword) {
-    return addSecurityHeaders(NextResponse.next());
+    return redirectToLogin(request, pathname);
   }
 
   const token = request.cookies.get("ghost-session")?.value;


### PR DESCRIPTION
A fresh audit of the node dashboard. The prior "dust-flood control" and "stub wizards" blockers are now resolved (dust-flood is wired; no fake-success wizards found). Remaining autonomously-fixable issues fixed here:

- **3 pages permanently 404 (BLOCKER)** — `reaper`, `mempool`, `capacity` pages called bare `fetch("/api/v1/...")` instead of the proxy helper `fetchApi()` (which rewrites to `/api/proxy/...` + HMAC-signs). They hit the Next server directly → always 404: reaper showed "—" for every counter (incl. dust-flood), mempool falsely told every operator "not installed", capacity rendered only an error. Now routed through `fetchApi`, error contracts preserved.
- **Auth fail-OPEN (MAJOR)** — `middleware.ts` served REMOTE requests with no auth when `DASHBOARD_PASSWORD` was unset. Now fails CLOSED (redirect to login); localhost behaviour unchanged.
- **Dead Swarm "Configure Node" dialog** — removed (unreachable; the shared hook definition is left intact for other callers).
- **Swallowed swarm refresh errors** — three empty `catch {}` now `console.error` + a per-node "Stale" badge.
- **2 missing reaper counters** — `fake_pubkey_curve_point` + `excess_stack_items` now render.

`npm run build` green (integrated type-check clean). Left as needs-decision: the `isLocalhost`/XFF trusted-proxy model, login rate-limiting, cookie-secure-over-HTTP, the MempoolPolicyWizard custom step, and a dashboard GlyphWizard (new backend).