### PR TITLE
dashboard: SSH-tunnel-only auth, working custom mempool wizard, GlyphWizard

### DIFF
--- a/dashboard/src/app/(dashboard)/glyph/page.tsx
+++ b/dashboard/src/app/(dashboard)/glyph/page.tsx
@@ -1,0 +1,375 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { PageHeader } from "@/components/ui/PageHeader";
+import { Card, CardHeader } from "@/components/ui/Card";
+import { Button } from "@/components/ui/Button";
+import { Badge } from "@/components/ui/Badge";
+import { useToast } from "@/components/ui/Toast";
+import {
+  checkGlyphAvailability,
+  claimGlyph,
+  getGhostId,
+  getGlyph,
+  GLYPH_GRID,
+  GLYPH_PIXELS,
+  type GlyphInfo,
+} from "@/lib/api/ghostpay";
+
+/// The 26-colour Ghost Glyph palette. Index -> [r, g, b]. Copied byte-for-byte
+/// from crates/ghost-glyph/src/palette.rs — palette indices are what the bitmap
+/// (and its uniqueness hash) are built from, so this must never drift.
+const PALETTE: [number, number, number][] = [
+  [0, 0, 0],
+  [255, 255, 255],
+  [28, 28, 36],
+  [48, 48, 64],
+  [80, 80, 104],
+  [128, 128, 160],
+  [192, 192, 212],
+  [24, 32, 80],
+  [40, 60, 140],
+  [64, 100, 200],
+  [120, 160, 230],
+  [16, 48, 32],
+  [32, 100, 64],
+  [80, 200, 120],
+  [160, 240, 180],
+  [80, 16, 16],
+  [160, 40, 24],
+  [220, 80, 40],
+  [255, 160, 80],
+  [48, 16, 80],
+  [100, 40, 160],
+  [160, 80, 220],
+  [200, 160, 255],
+  [255, 220, 60],
+  [0, 200, 200],
+  [255, 100, 160],
+];
+
+function rgb(idx: number): string {
+  const c = PALETTE[idx] ?? PALETTE[0];
+  return `rgb(${c[0]}, ${c[1]}, ${c[2]})`;
+}
+
+function blankPixels(): number[] {
+  return new Array<number>(GLYPH_PIXELS).fill(0);
+}
+
+function shortHash(h: string | null | undefined): string {
+  if (!h) return "—";
+  return h.length > 20 ? `${h.slice(0, 10)}…${h.slice(-8)}` : h;
+}
+
+export default function GlyphPage() {
+  const toast = useToast();
+
+  const [ghostId, setGhostId] = useState<string | null>(null);
+  const [pixels, setPixels] = useState<number[]>(blankPixels);
+  const [selected, setSelected] = useState<number>(1); // white by default
+  const [info, setInfo] = useState<GlyphInfo | null>(null);
+  const [designed, setDesigned] = useState(false);
+
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const [avail, setAvail] = useState<boolean | null>(null);
+  const [painting, setPainting] = useState(false);
+
+  // Load the node's ghost_id, then its existing glyph (if any). getGlyph
+  // resolves to null on a 404 — the expected "not yet designed" path.
+  useEffect(() => {
+    let alive = true;
+    setLoading(true);
+    setErr(null);
+    (async () => {
+      try {
+        const id = await getGhostId();
+        if (!alive) return;
+        const gid = id.ghost_id?.trim() || null;
+        setGhostId(gid);
+        if (!gid) {
+          setErr("The node did not return a Ghost ID. Ghost Pay may be disabled on this node.");
+          return;
+        }
+        const g = await getGlyph(gid);
+        if (!alive) return;
+        if (g && Array.isArray(g.pixels) && g.pixels.length === GLYPH_PIXELS) {
+          setInfo(g);
+          setPixels(g.pixels.slice());
+          setDesigned(true);
+        } else {
+          setInfo(null);
+          setPixels(blankPixels());
+          setDesigned(false);
+        }
+      } catch (e) {
+        if (!alive) return;
+        setErr(e instanceof Error ? e.message : String(e));
+      } finally {
+        if (alive) setLoading(false);
+      }
+    })();
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  const paint = (i: number) => {
+    setPixels((prev) => {
+      if (prev[i] === selected) return prev;
+      const next = prev.slice();
+      next[i] = selected;
+      return next;
+    });
+    // Editing invalidates any prior availability result.
+    setAvail(null);
+  };
+
+  const onClear = () => {
+    setPixels(blankPixels());
+    setAvail(null);
+  };
+
+  const onCheck = async () => {
+    setErr(null);
+    setAvail(null);
+    setBusy(true);
+    try {
+      const available = await checkGlyphAvailability(pixels);
+      setAvail(available);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onClaim = async () => {
+    setErr(null);
+    if (!ghostId) {
+      setErr("Ghost ID not loaded yet — try again in a moment.");
+      return;
+    }
+    setBusy(true);
+    try {
+      const r = await claimGlyph(ghostId, pixels);
+      setInfo((prev) => ({
+        ghost_id: ghostId,
+        pixels: pixels.slice(),
+        bitmap_hash: r.bitmap_hash,
+        commitment: r.commitment,
+        funding_txid: prev?.funding_txid ?? null,
+        registered_at: prev?.registered_at ?? null,
+        status: r.status,
+      }));
+      setDesigned(true);
+      toast.success(
+        "Glyph claimed",
+        `Status ${r.status}. Pending until the funding lock confirms (see Locks).`,
+      );
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const statusLabel = useMemo(() => {
+    const s = info?.status ?? (designed ? "pending" : "none");
+    if (s === "registered") return "registered";
+    if (s === "pending") return "pending";
+    return "not yet designed";
+  }, [info, designed]);
+
+  const statusVariant = statusLabel === "registered" ? "success" : statusLabel === "pending" ? "warning" : "default";
+
+  return (
+    <div>
+      <PageHeader
+        eyebrow="identity · visual"
+        title="Ghost Glyph"
+        subtitle="A 16×16, 26-colour mark bound to your node's Ghost ID. Design one, check that it's unclaimed, then claim it — it locks in once its funding lock confirms."
+      />
+
+      {err && (
+        <div
+          className="mb-6 p-4 rounded"
+          style={{ background: "rgba(220, 38, 38, 0.1)", border: "1px solid rgba(220, 38, 38, 0.4)", color: "#fca5a5" }}
+        >
+          {err}
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        {/* Editor */}
+        <div className="lg:col-span-2">
+          <Card>
+            <CardHeader
+              title="Pixel editor"
+              action={<Badge variant={statusVariant}>{statusLabel}</Badge>}
+            />
+            <p style={{ color: "var(--dim)", fontSize: "13px", margin: "0 0 12px" }}>
+              Click — or click and drag — to paint with the selected colour.
+            </p>
+
+            <div
+              style={{
+                display: "grid",
+                gridTemplateColumns: `repeat(${GLYPH_GRID}, 1fr)`,
+                gap: 1,
+                width: "100%",
+                maxWidth: 384,
+                aspectRatio: "1 / 1",
+                background: "var(--rule)",
+                border: "1px solid var(--rule)",
+                userSelect: "none",
+              }}
+              onMouseLeave={() => setPainting(false)}
+            >
+              {pixels.map((p, i) => (
+                <button
+                  key={i}
+                  type="button"
+                  aria-label={`pixel ${i}`}
+                  onMouseDown={() => {
+                    if (loading || busy) return;
+                    setPainting(true);
+                    paint(i);
+                  }}
+                  onMouseEnter={() => {
+                    if (painting && !loading && !busy) paint(i);
+                  }}
+                  onMouseUp={() => setPainting(false)}
+                  disabled={loading || busy}
+                  style={{
+                    background: rgb(p),
+                    border: 0,
+                    padding: 0,
+                    margin: 0,
+                    cursor: loading || busy ? "default" : "pointer",
+                    aspectRatio: "1 / 1",
+                  }}
+                />
+              ))}
+            </div>
+
+            <div style={{ marginTop: 16 }}>
+              <label style={{ color: "var(--dim)", fontSize: "13px" }}>Palette</label>
+              <div
+                style={{
+                  display: "grid",
+                  gridTemplateColumns: "repeat(13, 1fr)",
+                  gap: 4,
+                  maxWidth: 384,
+                  marginTop: 6,
+                }}
+              >
+                {PALETTE.map((_, idx) => (
+                  <button
+                    key={idx}
+                    type="button"
+                    title={`colour ${idx}`}
+                    aria-label={`palette colour ${idx}`}
+                    onClick={() => setSelected(idx)}
+                    disabled={busy}
+                    style={{
+                      background: rgb(idx),
+                      aspectRatio: "1 / 1",
+                      border: selected === idx ? "2px solid var(--accent)" : "1px solid var(--rule)",
+                      borderRadius: 3,
+                      padding: 0,
+                      cursor: busy ? "default" : "pointer",
+                    }}
+                  />
+                ))}
+              </div>
+              <p style={{ color: "var(--dim)", fontSize: "12px", margin: "8px 0 0" }}>
+                Selected: colour {selected}
+              </p>
+            </div>
+
+            <div className="flex flex-wrap gap-2" style={{ marginTop: 16 }}>
+              <Button variant="outline" onClick={onClear} disabled={busy || loading}>
+                Clear
+              </Button>
+              <Button variant="default" onClick={onCheck} loading={busy} disabled={loading}>
+                Check availability
+              </Button>
+              <Button variant="primary" onClick={onClaim} loading={busy} disabled={loading || !ghostId}>
+                Claim glyph
+              </Button>
+            </div>
+
+            {avail !== null && (
+              <div style={{ marginTop: 12 }}>
+                <Badge variant={avail ? "success" : "error"}>
+                  {avail ? "available — unclaimed" : "taken — pick another design"}
+                </Badge>
+              </div>
+            )}
+          </Card>
+        </div>
+
+        {/* Preview + details */}
+        <div className="flex flex-col gap-6">
+          <Card>
+            <CardHeader title="Preview" />
+            <div
+              style={{
+                display: "grid",
+                gridTemplateColumns: `repeat(${GLYPH_GRID}, 1fr)`,
+                width: "100%",
+                maxWidth: 256,
+                aspectRatio: "1 / 1",
+                imageRendering: "pixelated",
+                border: "1px solid var(--rule)",
+              }}
+            >
+              {pixels.map((p, i) => (
+                <div key={i} style={{ background: rgb(p), aspectRatio: "1 / 1" }} />
+              ))}
+            </div>
+          </Card>
+
+          <Card>
+            <CardHeader title="Details" />
+            <dl style={{ display: "grid", gridTemplateColumns: "auto 1fr", gap: "8px 16px", fontSize: 13 }}>
+              <dt style={{ color: "var(--dim)" }}>Ghost ID</dt>
+              <dd className="font-mono" style={{ wordBreak: "break-all", color: "var(--fg)" }}>
+                {ghostId ?? (loading ? "loading…" : "—")}
+              </dd>
+              <dt style={{ color: "var(--dim)" }}>Status</dt>
+              <dd style={{ color: "var(--fg)" }}>{statusLabel}</dd>
+              <dt style={{ color: "var(--dim)" }}>Bitmap hash</dt>
+              <dd className="font-mono" title={info?.bitmap_hash ?? ""} style={{ color: "var(--fg)" }}>
+                {shortHash(info?.bitmap_hash)}
+              </dd>
+              <dt style={{ color: "var(--dim)" }}>Commitment</dt>
+              <dd className="font-mono" title={info?.commitment ?? ""} style={{ color: "var(--fg)" }}>
+                {shortHash(info?.commitment)}
+              </dd>
+              {info?.funding_txid && (
+                <>
+                  <dt style={{ color: "var(--dim)" }}>Funding txid</dt>
+                  <dd className="font-mono" style={{ wordBreak: "break-all", color: "var(--fg)" }}>
+                    {info.funding_txid}
+                  </dd>
+                </>
+              )}
+              {info?.registered_at != null && (
+                <>
+                  <dt style={{ color: "var(--dim)" }}>Registered</dt>
+                  <dd style={{ color: "var(--fg)" }}>
+                    {new Date(info.registered_at * 1000).toLocaleString()}
+                  </dd>
+                </>
+              )}
+            </dl>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/app/(dashboard)/settings/wizards/MempoolPolicyWizard.tsx
+++ b/dashboard/src/app/(dashboard)/settings/wizards/MempoolPolicyWizard.tsx
@@ -7,12 +7,20 @@ import { Input } from '@/components/ui/Input';
 import { Toggle } from '@/components/ui/Toggle';
 import { Badge } from '@/components/ui/Badge';
 import { useToast } from '@/components/ui/Toast';
-import { useSetMempoolProfile, useSetTemplateProfile } from '@/hooks/queries';
+import {
+  useSetMempoolProfile,
+  useSetTemplateProfile,
+  useSaveMempoolProfile,
+  useActivateMempoolProfile,
+} from '@/hooks/queries';
+import { DEFAULT_MEMPOOL_PROFILE } from '../MempoolProfileDialog';
 import type { MempoolProfile, TemplateProfile } from '@/types/api';
+import type { CustomMempoolProfile } from '@/lib/api/config';
 
 interface MempoolPolicyData {
   mempool_profile: string;
   template_profile: string;
+  profile_name: string;
   min_relay_tx_fee: number;
   max_mempool_size: number;
   mempool_expiry: number;
@@ -66,6 +74,8 @@ const TEMPLATE_PROFILES = [
 export default function MempoolPolicyWizard({ isOpen, onClose }: MempoolPolicyWizardProps) {
   const setMempoolProfile = useSetMempoolProfile();
   const setTemplateProfile = useSetTemplateProfile();
+  const saveMempoolProfile = useSaveMempoolProfile();
+  const activateMempoolProfile = useActivateMempoolProfile();
   const toast = useToast();
 
   const steps = useMemo<WizardStep<MempoolPolicyData>[]>(() => {
@@ -85,9 +95,15 @@ export default function MempoolPolicyWizard({ isOpen, onClose }: MempoolPolicyWi
         description: 'Configure core mempool parameters',
         validate: (data) => {
           if (data.mempool_profile !== 'custom') return null;
-          if (data.min_relay_tx_fee <= 0) return 'Minimum relay fee must be greater than 0';
-          if (data.max_mempool_size < 5) return 'Mempool size must be at least 5 MB';
-          if (data.mempool_expiry < 1) return 'Mempool expiry must be at least 1 hour';
+          if (!data.profile_name.trim()) return 'Please name this custom profile';
+          if (!Number.isFinite(data.min_relay_tx_fee) || data.min_relay_tx_fee <= 0)
+            return 'Minimum relay fee must be greater than 0';
+          if (!Number.isFinite(data.max_mempool_size) || data.max_mempool_size < 5)
+            return 'Mempool size must be at least 5 MB';
+          if (data.max_mempool_size > 10000) return 'Mempool size must be at most 10000 MB';
+          if (!Number.isFinite(data.mempool_expiry) || data.mempool_expiry < 1)
+            return 'Mempool expiry must be at least 1 hour';
+          if (data.mempool_expiry > 8760) return 'Mempool expiry must be at most 8760 hours (1 year)';
           return null;
         },
       },
@@ -110,25 +126,46 @@ export default function MempoolPolicyWizard({ isOpen, onClose }: MempoolPolicyWi
         title: 'Confirm',
         description: 'Review and apply your mempool policy',
         onSubmit: async (data) => {
-          const profile = data.mempool_profile === 'custom' ? 'ghost' : data.mempool_profile;
-          await setMempoolProfile.mutateAsync(profile as MempoolProfile);
+          if (data.mempool_profile === 'custom') {
+            // Build a real custom profile from the collected fields (defaults
+            // fill in everything the wizard doesn't surface), persist it, then
+            // activate it — mirroring MempoolProfileDialog's save+activate flow.
+            const customProfile: CustomMempoolProfile = {
+              ...DEFAULT_MEMPOOL_PROFILE,
+              name: data.profile_name.trim(),
+              min_relay_tx_fee: data.min_relay_tx_fee,
+              max_mempool_size: data.max_mempool_size,
+              mempool_expiry: data.mempool_expiry,
+              datacarrier: data.datacarrier,
+              filter_inscriptions: data.filter_inscriptions,
+              filter_brc20: data.filter_brc20,
+              filter_runes: data.filter_runes,
+            };
+            await saveMempoolProfile.mutateAsync(customProfile);
+            await activateMempoolProfile.mutateAsync(customProfile.name);
+          } else {
+            await setMempoolProfile.mutateAsync(data.mempool_profile as MempoolProfile);
+          }
           await setTemplateProfile.mutateAsync(data.template_profile as TemplateProfile);
           toast.success(
             'Mempool Policy Updated',
-            `Mempool profile set to ${data.mempool_profile}, template set to ${data.template_profile}`
+            data.mempool_profile === 'custom'
+              ? `Custom profile "${data.profile_name.trim()}" saved and activated, template set to ${data.template_profile}`
+              : `Mempool profile set to ${data.mempool_profile}, template set to ${data.template_profile}`
           );
           onClose();
         },
       },
     ];
     return allSteps;
-  }, [setMempoolProfile, setTemplateProfile, toast, onClose]);
+  }, [setMempoolProfile, setTemplateProfile, saveMempoolProfile, activateMempoolProfile, toast, onClose]);
 
   const wizard = useWizard<MempoolPolicyData>({
     steps,
     initialData: {
       mempool_profile: 'standard',
       template_profile: 'standard',
+      profile_name: 'Custom Policy',
       min_relay_tx_fee: 1,
       max_mempool_size: 300,
       mempool_expiry: 336,
@@ -207,6 +244,15 @@ export default function MempoolPolicyWizard({ isOpen, onClose }: MempoolPolicyWi
           {/* Step 1: Core Settings (custom only) */}
           {wizard.currentStep === 1 && (
             <div className="space-y-4">
+              <div className="p-4 rounded-lg bg-gray-800/50">
+                <Input
+                  label="Profile Name"
+                  type="text"
+                  value={data.profile_name}
+                  onChange={(e) => setData({ profile_name: e.target.value })}
+                  helperText="A label for this custom profile; it is saved and activated on your node"
+                />
+              </div>
               <div className="p-4 rounded-lg bg-gray-800/50">
                 <Input
                   label="Minimum Relay TX Fee (sat/vB)"
@@ -356,6 +402,10 @@ export default function MempoolPolicyWizard({ isOpen, onClose }: MempoolPolicyWi
                 <div className="p-4 rounded-lg bg-gray-800/50">
                   <h4 className="text-gray-100 font-medium mb-3">Custom Settings</h4>
                   <div className="space-y-3">
+                    <div className="flex items-center justify-between">
+                      <span className="text-gray-400">Profile Name</span>
+                      <span className="text-gray-100">{data.profile_name}</span>
+                    </div>
                     <div className="flex items-center justify-between">
                       <span className="text-gray-400">Min Relay Fee</span>
                       <span className="text-gray-100">{data.min_relay_tx_fee} sat/vB</span>

--- a/dashboard/src/app/api/auth/login/route.ts
+++ b/dashboard/src/app/api/auth/login/route.ts
@@ -6,7 +6,83 @@ import {
   timingSafeEqualStr,
 } from "@/lib/jwt";
 
+// ---------------------------------------------------------------------------
+// Per-client login rate limiting (Finding 8)
+// ---------------------------------------------------------------------------
+// In-memory fixed-window limiter: at most MAX_ATTEMPTS within WINDOW_MS per
+// client before further attempts are rejected with 429. An in-memory Map is
+// sufficient for a single-node, SSH-tunnel-only dashboard (one process, no
+// horizontal scaling). A successful login clears the client's counter.
+//
+// We key on the connection IP when the runtime exposes it. We do NOT key on
+// X-Forwarded-For: it is client-spoofable, so trusting it would let an
+// attacker rotate the header to dodge the limit. When no trustworthy IP is
+// available (the tunnel-only norm, where every request originates from
+// 127.0.0.1), all attempts share a single global bucket — which is exactly
+// the throttle we want for a single-operator dashboard.
+// ---------------------------------------------------------------------------
+
+const MAX_ATTEMPTS = 5;
+const WINDOW_MS = 15 * 60 * 1000; // 15 minutes
+
+interface Bucket {
+  count: number;
+  resetAt: number;
+}
+
+const attempts = new Map<string, Bucket>();
+
+function clientKey(request: NextRequest): string {
+  // `ip` is populated by some Next.js runtimes/hosts; it is the connection
+  // address, not a client-supplied header, so it is safe to key on.
+  const ip = (request as unknown as { ip?: string }).ip;
+  return ip && ip.length > 0 ? ip : "global";
+}
+
+/** Returns the bucket after recording one attempt, or null if over the limit. */
+function recordAttempt(key: string): { limited: boolean; retryAfterSecs: number } {
+  const now = Date.now();
+  const existing = attempts.get(key);
+
+  if (!existing || now >= existing.resetAt) {
+    attempts.set(key, { count: 1, resetAt: now + WINDOW_MS });
+    return { limited: false, retryAfterSecs: 0 };
+  }
+
+  if (existing.count >= MAX_ATTEMPTS) {
+    return {
+      limited: true,
+      retryAfterSecs: Math.max(1, Math.ceil((existing.resetAt - now) / 1000)),
+    };
+  }
+
+  existing.count += 1;
+  return { limited: false, retryAfterSecs: 0 };
+}
+
+function clearAttempts(key: string): void {
+  attempts.delete(key);
+}
+
+// Opportunistic cleanup so the Map can't grow unbounded across many keys.
+function sweepExpired(now: number): void {
+  for (const [key, bucket] of attempts) {
+    if (now >= bucket.resetAt) attempts.delete(key);
+  }
+}
+
 export async function POST(request: NextRequest) {
+  const key = clientKey(request);
+  sweepExpired(Date.now());
+
+  const { limited, retryAfterSecs } = recordAttempt(key);
+  if (limited) {
+    return NextResponse.json(
+      { error: "Too many login attempts. Try again later." },
+      { status: 429, headers: { "Retry-After": String(retryAfterSecs) } },
+    );
+  }
+
   const { password } = await request.json();
   const dashboardPassword = process.env.DASHBOARD_PASSWORD;
 
@@ -23,10 +99,18 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "No signing secret configured" }, { status: 500 });
   }
 
+  // Successful auth — reset this client's attempt counter so a legitimate
+  // operator isn't throttled by their own earlier typos.
+  clearAttempts(key);
+
   const ttl = resolveTtlSecs();
   const token = await signSession("operator", secret, ttl);
 
   const response = NextResponse.json({ ok: true, expires_in: ttl });
+  // `secure` is gated on HTTPS. Under the SSH-tunnel-only model the dashboard
+  // is served over localhost HTTP, so the cookie is intentionally allowed on a
+  // non-TLS connection — it never traverses an untrusted network (the SSH
+  // tunnel provides the transport encryption). httpOnly + sameSite still apply.
   response.cookies.set("ghost-session", token, {
     httpOnly: true,
     secure: request.nextUrl.protocol === "https:",

--- a/dashboard/src/components/layout/Sidebar.tsx
+++ b/dashboard/src/components/layout/Sidebar.tsx
@@ -23,6 +23,7 @@ import {
   Banknote,
   HardDrive,
   Cpu,
+  Palette,
   Settings,
   ChevronLeft,
   X,
@@ -93,6 +94,7 @@ const GROUPS: NavGroup[] = [
     label: "identity",
     items: [
       { href: "/elders", label: "Elders & MPC", icon: <Users {...ICON} /> },
+      { href: "/glyph", label: "Glyph", icon: <Palette {...ICON} /> },
     ],
   },
   {

--- a/dashboard/src/lib/api/ghostpay.ts
+++ b/dashboard/src/lib/api/ghostpay.ts
@@ -51,6 +51,91 @@ export async function getGhostId(): Promise<GhostIdResponse> {
   return fetchGhostPay<GhostIdResponse>('/api/v1/keys/ghost-id');
 }
 
+// === Ghost Glyph ===========================================================
+// A glyph is a 16x16 grid of palette indices (0..25), 256 bytes total. The
+// backend keys uniqueness on SHA256("GhostGlyphBitmap/v1" || pixels) — we must
+// compute the IDENTICAL hash here so the availability check matches what the
+// claim will register. Mirrors crates/ghost-glyph/src/glyph.rs.
+
+export const GLYPH_GRID = 16;
+export const GLYPH_PIXELS = GLYPH_GRID * GLYPH_GRID; // 256
+export const GLYPH_PALETTE_SIZE = 26;
+
+const GLYPH_BITMAP_DOMAIN = 'GhostGlyphBitmap/v1';
+
+export interface GlyphInfo {
+  ghost_id: string;
+  pixels: number[];
+  bitmap_hash: string;
+  commitment: string;
+  funding_txid: string | null;
+  registered_at: number | null;
+  status: string; // "pending" | "registered" (backend never returns "none" here)
+}
+
+export interface GlyphClaimResult {
+  commitment: string;
+  bitmap_hash: string;
+  status: string;
+}
+
+export interface GlyphAvailability {
+  available: boolean;
+}
+
+/**
+ * Compute the bitmap uniqueness hash exactly as the Rust backend does:
+ * SHA256(domain-bytes || 256 pixel-bytes), hex-encoded. Uses Web Crypto so it
+ * runs in the browser without a dependency.
+ */
+export async function computeBitmapHash(pixels: number[]): Promise<string> {
+  if (pixels.length !== GLYPH_PIXELS) {
+    throw new Error(`Expected ${GLYPH_PIXELS} pixels, got ${pixels.length}`);
+  }
+  const domain = new TextEncoder().encode(GLYPH_BITMAP_DOMAIN);
+  const buf = new Uint8Array(domain.length + GLYPH_PIXELS);
+  buf.set(domain, 0);
+  for (let i = 0; i < GLYPH_PIXELS; i++) {
+    const v = pixels[i];
+    if (!Number.isInteger(v) || v < 0 || v >= GLYPH_PALETTE_SIZE) {
+      throw new Error(`Invalid pixel value at index ${i}`);
+    }
+    buf[domain.length + i] = v;
+  }
+  const digest = await crypto.subtle.digest('SHA-256', buf);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+/** Fetch the glyph registered to a ghost_id. Returns null when none exists (404). */
+export async function getGlyph(ghostId: string): Promise<GlyphInfo | null> {
+  try {
+    return await fetchGhostPay<GlyphInfo>(`/api/v1/glyph/${encodeURIComponent(ghostId)}`);
+  } catch (e) {
+    // 404 ("Glyph not found") is the expected "not yet designed" path.
+    if (e instanceof Error && /not found/i.test(e.message)) return null;
+    throw e;
+  }
+}
+
+/** Check whether a bitmap design is unclaimed, by its computed bitmap hash. */
+export async function checkGlyphAvailability(pixels: number[]): Promise<boolean> {
+  const hash = await computeBitmapHash(pixels);
+  const r = await fetchGhostPay<GlyphAvailability>(
+    `/api/v1/glyph/check/${encodeURIComponent(hash)}`,
+  );
+  return r.available;
+}
+
+/** Submit a glyph claim for a ghost_id (pending until its lock funds). */
+export async function claimGlyph(ghostId: string, pixels: number[]): Promise<GlyphClaimResult> {
+  return fetchGhostPay<GlyphClaimResult>('/api/v1/glyph/claim', {
+    method: 'POST',
+    body: JSON.stringify({ ghost_id: ghostId, pixels }),
+  });
+}
+
 // Ghost Pay Status
 export async function getGhostPayStatus(): Promise<GhostPayStatus> {
   return fetchApi<GhostPayStatus>('/api/v1/ghostpay/status');

--- a/dashboard/src/middleware.ts
+++ b/dashboard/src/middleware.ts
@@ -2,7 +2,28 @@ import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import { resolveJwtSecret, verifySession } from "@/lib/jwt";
 
-const PUBLIC_PATHS = ["/login", "/api/auth/login", "/api/auth/logout"];
+// ---------------------------------------------------------------------------
+// SSH-tunnel-only access model
+// ---------------------------------------------------------------------------
+// The dashboard is reachable ONLY over an SSH tunnel:
+//
+//     ssh -L 3000:localhost:3000 ghost-vmN
+//
+// There is no remote/LAN access mode. The deployment binds the dashboard to
+// 127.0.0.1, but this middleware does NOT rely on that — it fails closed even
+// if the server is mis-bound to 0.0.0.0. A valid JWT session gates EVERY route
+// (pages, the node API proxy, and the ghost-pay proxy) so the backend can never
+// be reached unauthenticated.
+//
+// We deliberately do NOT consult `X-Forwarded-For` or the `Host` header for any
+// auth decision: both are client-spoofable, and the previous "localhost bypass"
+// they powered let a direct connection to a mis-bound dashboard skip auth
+// entirely. Auth is the JWT cookie and nothing else.
+// ---------------------------------------------------------------------------
+
+// Paths that must remain reachable without a session: the login page, its
+// supporting auth API (login/logout/refresh), and Next.js static assets.
+const PUBLIC_PREFIXES = ["/login", "/api/auth/"];
 
 const SECURITY_HEADERS = {
   "X-Frame-Options": "DENY",
@@ -18,65 +39,53 @@ function addSecurityHeaders(response: NextResponse): NextResponse {
   return response;
 }
 
-export async function middleware(request: NextRequest) {
-  const { pathname } = request.nextUrl;
-
-  // Allow public paths
-  if (PUBLIC_PATHS.some((p) => pathname.startsWith(p))) {
-    return NextResponse.next();
-  }
-
-  // Allow static files and Next.js internals
-  if (
+function isStaticAsset(pathname: string): boolean {
+  return (
     pathname.startsWith("/_next") ||
     pathname.startsWith("/favicon") ||
     pathname.endsWith(".svg") ||
     pathname.endsWith(".ico")
-  ) {
+  );
+}
+
+export async function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  // Public, unauthenticated paths: login flow + Next.js internals/static.
+  if (PUBLIC_PREFIXES.some((p) => pathname.startsWith(p)) || isStaticAsset(pathname)) {
     return NextResponse.next();
   }
 
-  // Check if request is from localhost — skip auth
-  const forwardedFor = request.headers.get("x-forwarded-for");
-  const ip = forwardedFor?.split(",")[0]?.trim() || "";
-  const isLocalhost =
-    ip === "127.0.0.1" ||
-    ip === "::1" ||
-    ip === "localhost" ||
-    ip === "" || // Direct access (no proxy)
-    request.headers.get("host")?.startsWith("localhost");
-
-  if (isLocalhost) {
-    return addSecurityHeaders(NextResponse.next());
-  }
-
-  // Remote access — password-gated dashboard.
-  // Fail CLOSED: if no DASHBOARD_PASSWORD is configured we cannot authenticate a
-  // remote caller, so deny rather than serve unauthenticated. Localhost is
-  // handled above and is unaffected; remote access only works once the operator
-  // sets a password.
-  const dashboardPassword = process.env.DASHBOARD_PASSWORD;
-  if (!dashboardPassword) {
-    return redirectToLogin(request, pathname);
-  }
-
+  // Everything else — pages AND the API proxies — requires a valid session.
   const token = request.cookies.get("ghost-session")?.value;
-  if (!token) {
-    return redirectToLogin(request, pathname);
-  }
+  const secret = token ? await resolveJwtSecret() : null;
+  const payload = secret ? await verifySession(token!, secret) : null;
 
-  const secret = await resolveJwtSecret();
-  if (!secret) {
-    // Server misconfig — fail closed.
-    return redirectToLogin(request, pathname);
-  }
-
-  const payload = await verifySession(token, secret);
   if (!payload) {
-    return redirectToLogin(request, pathname);
+    // Fail closed. A missing password (no resolvable secret) means no one can
+    // authenticate — that is a deliberate locked state, not an open door.
+    return denyAccess(request, pathname);
   }
 
   return addSecurityHeaders(NextResponse.next());
+}
+
+/**
+ * Reject an unauthenticated request. API calls (the node proxy + ghost-pay
+ * proxy) get a 401 JSON body so the client's fetch layer surfaces a real
+ * auth error instead of silently receiving the login HTML. Page navigations
+ * are redirected to the login screen.
+ */
+function denyAccess(request: NextRequest, pathname: string): NextResponse {
+  if (pathname.startsWith("/api/")) {
+    const response = NextResponse.json(
+      { error: "Authentication required" },
+      { status: 401 },
+    );
+    response.cookies.delete("ghost-session");
+    return addSecurityHeaders(response);
+  }
+  return redirectToLogin(request, pathname);
 }
 
 function redirectToLogin(request: NextRequest, pathname: string): NextResponse {
@@ -87,7 +96,7 @@ function redirectToLogin(request: NextRequest, pathname: string): NextResponse {
   const response = NextResponse.redirect(loginUrl);
   // Clear a stale/expired cookie so the next request doesn't retrigger the same path.
   response.cookies.delete("ghost-session");
-  return response;
+  return addSecurityHeaders(response);
 }
 
 export const config = {


### PR DESCRIPTION
Implements three operator-requested dashboard improvements.

## 1. SSH-tunnel-only auth (closes the auth holes)
Decision: the dashboard is SSH-tunnel-only; the password (JWT) gates ALL access.
- **Removed the localhost/`X-Forwarded-For` auth bypass entirely** — the old code treated a *missing* XFF as localhost (`ip === ""`), so a direct hit on a `0.0.0.0`-bound dashboard bypassed auth; XFF is also spoofable. No auth decision now consults XFF or Host.
- **Valid JWT required for everything** except `/login`, `/api/auth/*`, and static assets — so the page routes AND both backend proxies (`/api/proxy`, `/api/ghostpay-proxy`) are gated (the node/ghost-pay APIs can no longer be hit unauthenticated). Fails CLOSED (no token / no secret → deny: 401 JSON for API, redirect for pages). This subsumes the earlier #109 fail-closed fix.
- **Login rate-limiting** — in-memory 5 attempts / 15 min per connection IP, then 429 (keyed on the connection IP, NOT spoofable XFF). Constant-time compare retained.
- Cookie stays HTTP-only/`sameSite` lax; `secure` is HTTPS-gated with a comment that access is SSH-tunnel-only so it never traverses an untrusted network.

## 2. Custom mempool wizard actually persists  [was silently discarding input]
The `MempoolPolicyWizard` "Custom" step now builds a real `CustomMempoolProfile` from the operators fields and calls `saveMempoolProfile` + `activateMempoolProfile` (mirroring the existing dialog) instead of collapsing to the `ghost` preset. Added a profile-name input + numeric validation; real errors surface.

## 3. GlyphWizard / glyph page  [was absent]
New `/glyph` page + nav entry: view the nodes current glyph, design on a 16×16 grid (26-colour palette copied byte-for-byte from `ghost-glyph`), check availability, and claim. Bitmap hash computed client-side via Web Crypto as `SHA256("GhostGlyphBitmap/v1" || pixels)` — identical to `GhostGlyph::compute_bitmap_hash`. Calls ghost-pays existing `/api/v1/glyph/*` routes through the signed `ghostpay-proxy`; node ghost_id from the existing `getGhostId()`. All values React-escaped; graceful message if Ghost Pay is disabled.

`npm run build` green (42 routes). Auth model verified: no XFF/Host in auth logic.