### PR TITLE
wraith-wallet: surface backup/restore, update check, key-rotation, recovery height

### DIFF
--- a/apps/wraith-wallet/daemon/src/main.rs
+++ b/apps/wraith-wallet/daemon/src/main.rs
@@ -2718,6 +2718,7 @@ mod unix {
                                     funding_txid: l.funding_txid,
                                     funding_vout: l.funding_vout,
                                     creation_height: l.creation_height,
+                                    recovery_height: l.recovery_height,
                                 })
                                 .collect();
                             Response::LocksList(LocksListResponse {

--- a/apps/wraith-wallet/gui/src-tauri/src/lib.rs
+++ b/apps/wraith-wallet/gui/src-tauri/src/lib.rs
@@ -110,6 +110,36 @@ async fn wallet_show_mnemonic(
     to_value(&resp)
 }
 
+/// Back up wallet `name`'s encrypted keystore by copying it to
+/// `to_path` (a destination file the user chose). The daemon performs
+/// the copy itself and refuses to overwrite an existing file. The
+/// keystore stays encrypted end-to-end — no plaintext key material
+/// crosses this boundary.
+#[tauri::command]
+async fn wallet_export(name: String, to_path: String) -> Result<serde_json::Value, String> {
+    let resp = call_daemon(Request::WalletExport { name, to_path }).await?;
+    to_value(&resp)
+}
+
+/// Restore a wallet from a previously-exported encrypted keystore at
+/// `from_path`, installing it as wallet `name`. The daemon refuses if
+/// a wallet of that name already exists on disk.
+#[tauri::command]
+async fn wallet_restore(name: String, from_path: String) -> Result<serde_json::Value, String> {
+    let resp = call_daemon(Request::WalletRestore { name, from_path }).await?;
+    to_value(&resp)
+}
+
+/// Ask the daemon to fetch a release manifest (from `manifest_url`, or
+/// the daemon-configured default when `None`) and compare its version
+/// against the running daemon. The daemon only reports — it never
+/// downloads or installs anything.
+#[tauri::command]
+async fn check_for_update(manifest_url: Option<String>) -> Result<serde_json::Value, String> {
+    let resp = call_daemon(Request::CheckForUpdate { manifest_url }).await?;
+    to_value(&resp)
+}
+
 #[tauri::command]
 async fn light_balance() -> Result<serde_json::Value, String> {
     let resp = call_daemon(Request::LightBalance).await?;
@@ -713,6 +743,9 @@ pub fn run() {
             wallet_create,
             wallet_import,
             wallet_show_mnemonic,
+            wallet_export,
+            wallet_restore,
+            check_for_update,
             light_balance,
             light_receive,
             light_history,

--- a/apps/wraith-wallet/gui/src/lib/tauri.ts
+++ b/apps/wraith-wallet/gui/src/lib/tauri.ts
@@ -268,6 +268,59 @@ export async function walletUnlock(
   return unwrap(resp).payload;
 }
 
+export interface WalletBackupResult {
+  name: string;
+  /// Absolute path the daemon wrote / read.
+  path: string;
+  /// Size of the encrypted keystore copied, in bytes.
+  bytes: number;
+}
+
+/// Back up wallet `name`'s encrypted keystore to `to_path`. The daemon
+/// copies the on-disk keystore (still encrypted) and refuses to
+/// overwrite an existing file.
+export async function walletExport(
+  name: string,
+  to_path: string,
+): Promise<WalletBackupResult> {
+  const resp = await invoke("wallet_export", { name, toPath: to_path });
+  return unwrap<WalletBackupResult>(resp).payload;
+}
+
+/// Restore wallet `name` from an exported keystore at `from_path`. The
+/// daemon refuses if a wallet of that name already exists on disk.
+export async function walletRestore(
+  name: string,
+  from_path: string,
+): Promise<WalletBackupResult> {
+  const resp = await invoke("wallet_restore", { name, fromPath: from_path });
+  return unwrap<WalletBackupResult>(resp).payload;
+}
+
+export interface CheckForUpdateResult {
+  current_version: string;
+  /// Version from the fetched manifest, when fetch + parse succeeded.
+  latest_version: string | null;
+  /// True only when the manifest version byte-equals the running one.
+  up_to_date: boolean;
+  /// Where the manifest was fetched from (resolved override or the
+  /// daemon-configured default).
+  manifest_url: string;
+  tarball: string | null;
+  tarball_sha256: string | null;
+}
+
+/// Ask the daemon to fetch a release manifest and compare its version
+/// against the running daemon. Pass `manifest_url` to override the
+/// daemon-configured default. The daemon only reports — it never
+/// downloads or installs.
+export async function checkForUpdate(
+  manifest_url?: string,
+): Promise<CheckForUpdateResult> {
+  const resp = await invoke("check_for_update", { manifestUrl: manifest_url });
+  return unwrap<CheckForUpdateResult>(resp).payload;
+}
+
 export async function walletLock(name: string | null): Promise<unknown> {
   const resp = await invoke("wallet_lock", { name });
   return unwrap(resp).payload;
@@ -626,16 +679,85 @@ export interface LockEntry {
   funding_address: string;
   funding_txid?: string;
   funding_vout?: number;
+  /// Block height the lock was created at.
   creation_height: number;
+  /// Absolute block height the timelock matures at — after this the wallet's
+  /// unilateral recovery branch is spendable (creation_height + recovery_blocks).
+  recovery_height: number;
 }
 
 export interface LocksListResponse {
   locks: LockEntry[];
 }
 
+/// Wire-format lock entry — matches `wraith_wallet_ipc::LockEntry`
+/// exactly. Field names differ from the frontend's `LockEntry`
+/// (`status` vs `state`), so `locksList` adapts. Reading the wire
+/// shape straight through left `state` undefined, which silently
+/// suppressed every per-row action (Confirm / Recover / Rotate),
+/// since those gate on `state`.
+interface WireLockEntry {
+  lock_id: string;
+  status: string;
+  capacity_sats: number;
+  balance_sats: number;
+  denomination: string;
+  timelock_tier: string;
+  funding_address: string;
+  funding_txid: string | null;
+  funding_vout: number | null;
+  creation_height: number;
+  recovery_height: number;
+}
+
+interface WireLocksListResponse {
+  locks: WireLockEntry[];
+  total_locked_sats: number;
+}
+
 export async function locksList(): Promise<LocksListResponse> {
   const resp = await invoke("locks_list");
-  return unwrap<LocksListResponse>(resp).payload;
+  const raw = unwrap<WireLocksListResponse>(resp).payload;
+  const locks: LockEntry[] = (raw.locks ?? []).map((w) => ({
+    lock_id: w.lock_id,
+    capacity_sats: w.capacity_sats,
+    balance_sats: w.balance_sats,
+    denomination: w.denomination,
+    timelock_tier: w.timelock_tier,
+    status: w.status,
+    funding_address: w.funding_address,
+    funding_txid: w.funding_txid ?? undefined,
+    funding_vout: w.funding_vout ?? undefined,
+    creation_height: w.creation_height,
+    recovery_height: w.recovery_height,
+  }));
+  return { locks };
+}
+
+export type LockJumpPriority = "normal" | "high" | "urgent";
+
+export interface LocksJumpedResult {
+  lock_id: string;
+  /// Jump (key-rotation) transaction id, when the operator broadcast
+  /// it. `null` while the rotation is queued.
+  jump_txid: string | null;
+}
+
+/// Rotate a lock's custody key ("jump"): the operator re-derives the
+/// cooperative key to `target_address`, severing any prior key
+/// exposure while keeping the funds inside the lock. `priority`
+/// trades fee for queue position.
+export async function locksJump(
+  lock_id: string,
+  target_address: string,
+  priority: LockJumpPriority = "normal",
+): Promise<LocksJumpedResult> {
+  const resp = await invoke("locks_jump", {
+    lockId: lock_id,
+    targetAddress: target_address,
+    priority,
+  });
+  return unwrap<LocksJumpedResult>(resp).payload;
 }
 
 export interface LocksPreparedResponse {

--- a/apps/wraith-wallet/gui/src/screens/Locks.tsx
+++ b/apps/wraith-wallet/gui/src/screens/Locks.tsx
@@ -4,9 +4,12 @@ import {
   locksPrepare,
   locksConfirm,
   locksRecover,
+  locksJump,
   type LockEntry,
+  type LockJumpPriority,
   type LocksPreparedResponse,
   type LocksRecoveredResult,
+  type LocksJumpedResult,
 } from "../lib/tauri";
 
 interface Tier {
@@ -28,7 +31,8 @@ const TIERS: Tier[] = [
 /// inline-form style of the Mix and Receive screens.
 type RowForm =
   | { kind: "confirm"; lock_id: string }
-  | { kind: "recover"; lock_id: string };
+  | { kind: "recover"; lock_id: string }
+  | { kind: "jump"; lock_id: string };
 
 export function Locks() {
   const [locks, setLocks] = useState<LockEntry[]>([]);
@@ -36,6 +40,7 @@ export function Locks() {
   const [err, setErr] = useState<string | null>(null);
   const [prep, setPrep] = useState<LocksPreparedResponse | null>(null);
   const [recovery, setRecovery] = useState<LocksRecoveredResult | null>(null);
+  const [jumped, setJumped] = useState<LocksJumpedResult | null>(null);
 
   // Expandable forms.
   const [showPrepare, setShowPrepare] = useState(false);
@@ -45,6 +50,8 @@ export function Locks() {
   const [confirmTxid, setConfirmTxid] = useState("");
   const [recoverDest, setRecoverDest] = useState("");
   const [recoverFee, setRecoverFee] = useState("1000");
+  const [jumpDest, setJumpDest] = useState("");
+  const [jumpPriority, setJumpPriority] = useState<LockJumpPriority>("normal");
 
   const refresh = async () => {
     setErr(null);
@@ -102,10 +109,17 @@ export function Locks() {
     setRecoverFee("1000");
   };
 
+  const openJump = (lock_id: string) => {
+    setOpenRow({ kind: "jump", lock_id });
+    setJumpDest("");
+    setJumpPriority("normal");
+  };
+
   const closeRow = () => {
     setOpenRow(null);
     setConfirmTxid("");
     setRecoverDest("");
+    setJumpDest("");
   };
 
   const onConfirmSubmit = async (lock_id: string) => {
@@ -144,6 +158,27 @@ export function Locks() {
     try {
       const result = await locksRecover(lock_id, dest, fee);
       setRecovery(result);
+      closeRow();
+      await refresh();
+    } catch (e) {
+      setErr((e as Error).message ?? String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onJumpSubmit = async (lock_id: string) => {
+    const dest = jumpDest.trim();
+    if (!dest) {
+      setErr("Target address is required.");
+      return;
+    }
+    setBusy(true);
+    setErr(null);
+    setJumped(null);
+    try {
+      const result = await locksJump(lock_id, dest, jumpPriority);
+      setJumped(result);
       closeRow();
       await refresh();
     } catch (e) {
@@ -258,7 +293,7 @@ export function Locks() {
                 <th>ID</th>
                 <th>Capacity</th>
                 <th>State</th>
-                <th>Created height</th>
+                <th>Recovery height</th>
                 <th />
               </tr>
             </thead>
@@ -283,7 +318,7 @@ export function Locks() {
                           {l.status}
                         </span>
                       </td>
-                      <td className="mono muted">{l.creation_height ?? "—"}</td>
+                      <td className="mono muted">{l.recovery_height ?? "—"}</td>
                       <td style={{ textAlign: "right" }}>
                         {l.status === "pending" && (
                           <button
@@ -296,14 +331,25 @@ export function Locks() {
                           </button>
                         )}
                         {l.status === "active" && (
-                          <button
-                            className="danger"
-                            onClick={() => openRecover(l.lock_id)}
-                            disabled={busy}
-                            title="Unilateral exit — sends a recovery tx straight to bitcoind, no operator cooperation. Only works after the timelock has matured."
-                          >
-                            Recover
-                          </button>
+                          <>
+                            <button
+                              className="secondary"
+                              onClick={() => openJump(l.lock_id)}
+                              disabled={busy}
+                              style={{ marginRight: 6 }}
+                              title="Rotate the lock's custody key to a fresh address — keeps funds inside the lock while severing any prior key exposure. Operator cooperation required."
+                            >
+                              Rotate key
+                            </button>
+                            <button
+                              className="danger"
+                              onClick={() => openRecover(l.lock_id)}
+                              disabled={busy}
+                              title="Unilateral exit — sends a recovery tx straight to bitcoind, no operator cooperation. Only works after the timelock has matured."
+                            >
+                              Recover
+                            </button>
+                          </>
                         )}
                       </td>
                     </tr>
@@ -437,6 +483,81 @@ export function Locks() {
                         </td>
                       </tr>
                     )}
+                    {isOpen && openRow.kind === "jump" && (
+                      <tr key={`${l.lock_id}-form`}>
+                        <td colSpan={5}>
+                          <div
+                            style={{
+                              padding: 12,
+                              background: "var(--bg-subtle, rgba(0,0,0,0.04))",
+                              borderRadius: 6,
+                            }}
+                          >
+                            <strong>
+                              Rotate custody key — {l.lock_id.slice(0, 16)}…
+                            </strong>
+                            <p
+                              className="muted"
+                              style={{ margin: "4px 0 8px", fontSize: 13 }}
+                            >
+                              A jump moves the lock's funds to a fresh
+                              cooperative key at the target address, with the
+                              operator's help. Use it to rotate away from a
+                              key you suspect is exposed without touching the
+                              timelock recovery branch — the balance stays
+                              locked throughout. Higher priority pays a larger
+                              fee for a faster queue slot.
+                            </p>
+                            <div className="col">
+                              <label>Target address</label>
+                              <input
+                                className="mono"
+                                value={jumpDest}
+                                onChange={(e) => setJumpDest(e.target.value)}
+                                placeholder="bc1q… / tb1p… / bcrt1…"
+                                disabled={busy}
+                                autoFocus
+                              />
+                            </div>
+                            <div className="col">
+                              <label>Priority</label>
+                              <select
+                                value={jumpPriority}
+                                onChange={(e) =>
+                                  setJumpPriority(
+                                    e.target.value as LockJumpPriority,
+                                  )
+                                }
+                                disabled={busy}
+                              >
+                                <option value="normal">Normal (queued)</option>
+                                <option value="high">High (expedited)</option>
+                                <option value="urgent">
+                                  Urgent (immediate, higher fee)
+                                </option>
+                              </select>
+                            </div>
+                            <div className="row" style={{ marginTop: 8 }}>
+                              <button
+                                className="secondary"
+                                onClick={closeRow}
+                                disabled={busy}
+                                style={{ marginRight: 6 }}
+                              >
+                                Cancel
+                              </button>
+                              <button
+                                className="primary"
+                                onClick={() => onJumpSubmit(l.lock_id)}
+                                disabled={busy}
+                              >
+                                {busy ? "Rotating…" : "Rotate key"}
+                              </button>
+                            </div>
+                          </div>
+                        </td>
+                      </tr>
+                    )}
                   </Fragment>
                 );
               })}
@@ -444,6 +565,26 @@ export function Locks() {
           </table>
         )}
       </div>
+
+      {jumped && (
+        <div className="card" style={{ borderColor: "var(--pass)" }}>
+          <h2>Key rotation requested ✓</h2>
+          <p className="muted" style={{ margin: 0 }}>
+            The operator is rotating this lock's custody key to the new
+            address. The balance stays locked the whole time.
+          </p>
+          <div className="kv">
+            <div className="k">Lock ID</div>
+            <div className="v mono" style={{ fontSize: 12 }}>
+              {jumped.lock_id}
+            </div>
+            <div className="k">Jump txid</div>
+            <div className="v mono" style={{ fontSize: 12 }}>
+              {jumped.jump_txid ?? "queued — not yet broadcast"}
+            </div>
+          </div>
+        </div>
+      )}
 
       {recovery && (
         <div className="card" style={{ borderColor: "var(--pass)" }}>

--- a/apps/wraith-wallet/gui/src/screens/Settings.tsx
+++ b/apps/wraith-wallet/gui/src/screens/Settings.tsx
@@ -2,8 +2,15 @@ import { useEffect, useState } from "react";
 import {
   daemonEnv,
   daemonHealth,
+  walletList,
+  walletExport,
+  walletRestore,
+  checkForUpdate,
   type DaemonEnvResponse,
   type HealthResponse,
+  type WalletEntry,
+  type WalletBackupResult,
+  type CheckForUpdateResult,
 } from "../lib/tauri";
 
 interface SettingsProps {
@@ -30,6 +37,45 @@ export function Settings({ guiKiosk, daemonKiosk, onToggleGuiKiosk }: SettingsPr
   const [health, setHealth] = useState<HealthResponse | null>(null);
   const [err, setErr] = useState<string | null>(null);
 
+  // Keystore backup / restore.
+  const [wallets, setWallets] = useState<WalletEntry[]>([]);
+  const [backupWallet, setBackupWallet] = useState("");
+  const [backupPath, setBackupPath] = useState("");
+  const [restoreName, setRestoreName] = useState("");
+  const [restorePath, setRestorePath] = useState("");
+  const [keystoreBusy, setKeystoreBusy] = useState(false);
+  const [keystoreErr, setKeystoreErr] = useState<string | null>(null);
+  const [exportResult, setExportResult] = useState<WalletBackupResult | null>(
+    null,
+  );
+  const [restoreResult, setRestoreResult] = useState<WalletBackupResult | null>(
+    null,
+  );
+
+  // Update check.
+  const [updateUrl, setUpdateUrl] = useState("");
+  const [updateBusy, setUpdateBusy] = useState(false);
+  const [updateErr, setUpdateErr] = useState<string | null>(null);
+  const [updateResult, setUpdateResult] = useState<CheckForUpdateResult | null>(
+    null,
+  );
+
+  const refreshWallets = async () => {
+    try {
+      const list = await walletList();
+      setWallets(list.wallets);
+      // Default the backup selector to the active wallet, if any.
+      setBackupWallet((cur) => {
+        if (cur && list.wallets.some((w) => w.name === cur)) return cur;
+        const active = list.wallets.find((w) => w.is_active);
+        return active?.name ?? list.wallets[0]?.name ?? "";
+      });
+    } catch {
+      // Wallet management may be unavailable (e.g. kiosk mode); leave
+      // the list empty so the card shows the "no wallets" hint.
+    }
+  };
+
   useEffect(() => {
     let alive = true;
     const tick = async () => {
@@ -45,12 +91,80 @@ export function Settings({ guiKiosk, daemonKiosk, onToggleGuiKiosk }: SettingsPr
       }
     };
     tick();
+    refreshWallets();
     const id = setInterval(tick, 8000);
     return () => {
       alive = false;
       clearInterval(id);
     };
   }, []);
+
+  const onBackup = async () => {
+    const name = backupWallet.trim();
+    const path = backupPath.trim();
+    if (!name) {
+      setKeystoreErr("Pick a wallet to back up.");
+      return;
+    }
+    if (!path) {
+      setKeystoreErr("Enter a destination file path for the backup.");
+      return;
+    }
+    setKeystoreBusy(true);
+    setKeystoreErr(null);
+    setExportResult(null);
+    try {
+      const r = await walletExport(name, path);
+      setExportResult(r);
+      setBackupPath("");
+    } catch (e) {
+      setKeystoreErr((e as Error).message ?? String(e));
+    } finally {
+      setKeystoreBusy(false);
+    }
+  };
+
+  const onRestore = async () => {
+    const name = restoreName.trim();
+    const path = restorePath.trim();
+    if (!name) {
+      setKeystoreErr("Enter a name for the restored wallet.");
+      return;
+    }
+    if (!path) {
+      setKeystoreErr("Enter the path to the keystore file to restore.");
+      return;
+    }
+    setKeystoreBusy(true);
+    setKeystoreErr(null);
+    setRestoreResult(null);
+    try {
+      const r = await walletRestore(name, path);
+      setRestoreResult(r);
+      setRestoreName("");
+      setRestorePath("");
+      await refreshWallets();
+    } catch (e) {
+      setKeystoreErr((e as Error).message ?? String(e));
+    } finally {
+      setKeystoreBusy(false);
+    }
+  };
+
+  const onCheckUpdate = async () => {
+    setUpdateBusy(true);
+    setUpdateErr(null);
+    setUpdateResult(null);
+    try {
+      const url = updateUrl.trim();
+      const r = await checkForUpdate(url.length > 0 ? url : undefined);
+      setUpdateResult(r);
+    } catch (e) {
+      setUpdateErr((e as Error).message ?? String(e));
+    } finally {
+      setUpdateBusy(false);
+    }
+  };
 
   const fmtUptime = (secs: number | undefined): string => {
     if (secs == null) return "—";
@@ -114,6 +228,218 @@ export function Settings({ guiKiosk, daemonKiosk, onToggleGuiKiosk }: SettingsPr
           <div className="k">IPC socket</div>
           <div className="v mono">{env?.socket_path ?? "—"}</div>
         </div>
+      </div>
+
+      <div className="card">
+        <h2>Keystore backup &amp; restore</h2>
+        <p className="muted" style={{ marginTop: 0, fontSize: 13 }}>
+          Wallets are stored as Argon2id + AES-256-GCM encrypted
+          keystores. A backup is a straight copy of that encrypted file —
+          it never leaves the daemon as plaintext, and it still requires
+          the wallet passphrase to unlock after a restore. Keep it
+          somewhere safe; anyone who also learns the passphrase can spend
+          from it.
+        </p>
+
+        {keystoreErr && (
+          <div className="card error-card" style={{ marginBottom: 12 }}>
+            {keystoreErr}
+          </div>
+        )}
+
+        <h3 style={{ marginBottom: 4 }}>Back up</h3>
+        {wallets.length === 0 ? (
+          <p className="muted" style={{ fontSize: 13 }}>
+            No wallets available to back up.
+          </p>
+        ) : (
+          <>
+            <div className="col">
+              <label>Wallet</label>
+              <select
+                value={backupWallet}
+                onChange={(e) => setBackupWallet(e.target.value)}
+                disabled={keystoreBusy}
+              >
+                {wallets.map((w) => (
+                  <option key={w.name} value={w.name}>
+                    {w.name}
+                    {w.is_active ? " (active)" : ""}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="col">
+              <label>Destination file path</label>
+              <input
+                className="mono"
+                value={backupPath}
+                onChange={(e) => setBackupPath(e.target.value)}
+                placeholder="/home/you/backups/wallet.keystore"
+                disabled={keystoreBusy}
+              />
+              <span className="muted" style={{ fontSize: 12 }}>
+                Absolute path the daemon writes to. It refuses to
+                overwrite an existing file.
+              </span>
+            </div>
+            <div className="row" style={{ marginTop: 8 }}>
+              <button
+                className="btn-primary"
+                onClick={onBackup}
+                disabled={keystoreBusy}
+              >
+                {keystoreBusy ? "Working…" : "Back up keystore"}
+              </button>
+            </div>
+            {exportResult && (
+              <div className="kv" style={{ marginTop: 12 }}>
+                <div className="k">Backed up</div>
+                <div className="v mono" style={{ fontSize: 12 }}>
+                  {exportResult.name}
+                </div>
+                <div className="k">Wrote</div>
+                <div className="v mono" style={{ fontSize: 12 }}>
+                  {exportResult.path}
+                </div>
+                <div className="k">Size</div>
+                <div className="v">
+                  {exportResult.bytes.toLocaleString()} bytes
+                </div>
+              </div>
+            )}
+          </>
+        )}
+
+        <h3 style={{ marginTop: 16, marginBottom: 4 }}>Restore</h3>
+        <div className="col">
+          <label>New wallet name</label>
+          <input
+            value={restoreName}
+            onChange={(e) => setRestoreName(e.target.value)}
+            placeholder="restored-wallet"
+            disabled={keystoreBusy}
+          />
+        </div>
+        <div className="col">
+          <label>Keystore file path</label>
+          <input
+            className="mono"
+            value={restorePath}
+            onChange={(e) => setRestorePath(e.target.value)}
+            placeholder="/home/you/backups/wallet.keystore"
+            disabled={keystoreBusy}
+          />
+          <span className="muted" style={{ fontSize: 12 }}>
+            The daemon refuses to overwrite a wallet that already exists
+            under this name. Unlock it afterwards with its original
+            passphrase.
+          </span>
+        </div>
+        <div className="row" style={{ marginTop: 8 }}>
+          <button
+            className="btn-primary"
+            onClick={onRestore}
+            disabled={keystoreBusy}
+          >
+            {keystoreBusy ? "Working…" : "Restore keystore"}
+          </button>
+        </div>
+        {restoreResult && (
+          <div className="kv" style={{ marginTop: 12 }}>
+            <div className="k">Restored</div>
+            <div className="v mono" style={{ fontSize: 12 }}>
+              {restoreResult.name}
+            </div>
+            <div className="k">Installed at</div>
+            <div className="v mono" style={{ fontSize: 12 }}>
+              {restoreResult.path}
+            </div>
+            <div className="k">Size</div>
+            <div className="v">
+              {restoreResult.bytes.toLocaleString()} bytes
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div className="card">
+        <div className="card-header">
+          <h2>Updates</h2>
+          <span className="pill mute">v{health?.version ?? "—"}</span>
+        </div>
+        <p className="muted" style={{ marginTop: 0, fontSize: 13 }}>
+          Asks the daemon to fetch a signed release manifest and compare
+          its version against the running daemon. Nothing is downloaded
+          or installed — this only tells you whether a newer build
+          exists.
+        </p>
+        <div className="col">
+          <label>Manifest URL (optional)</label>
+          <input
+            className="mono"
+            value={updateUrl}
+            onChange={(e) => setUpdateUrl(e.target.value)}
+            placeholder={
+              env?.network
+                ? "leave blank to use the daemon's configured channel"
+                : "https://…/manifest.json"
+            }
+            disabled={updateBusy}
+          />
+          <span className="muted" style={{ fontSize: 12 }}>
+            Leave blank to use the daemon's{" "}
+            <code>WRAITHD_UPDATE_MANIFEST_URL</code> default. The daemon
+            errors if neither is set.
+          </span>
+        </div>
+        <div className="row" style={{ marginTop: 8 }}>
+          <button
+            className="btn-primary"
+            onClick={onCheckUpdate}
+            disabled={updateBusy}
+          >
+            {updateBusy ? "Checking…" : "Check for updates"}
+          </button>
+        </div>
+        {updateErr && (
+          <div className="card error-card" style={{ marginTop: 12 }}>
+            {updateErr}
+          </div>
+        )}
+        {updateResult && (
+          <div style={{ marginTop: 12 }}>
+            <div className="row" style={{ marginBottom: 8 }}>
+              <span
+                className={`pill ${updateResult.up_to_date ? "pass" : "warn"}`}
+              >
+                {updateResult.up_to_date
+                  ? "up to date"
+                  : "update available"}
+              </span>
+            </div>
+            <div className="kv">
+              <div className="k">Current</div>
+              <div className="v mono">{updateResult.current_version}</div>
+              <div className="k">Latest</div>
+              <div className="v mono">
+                {updateResult.latest_version ?? "—"}
+              </div>
+              <div className="k">Manifest</div>
+              <div className="v mono" style={{ fontSize: 12 }}>
+                {updateResult.manifest_url}
+              </div>
+              {updateResult.tarball && (
+                <>
+                  <div className="k">Tarball</div>
+                  <div className="v mono" style={{ fontSize: 12 }}>
+                    {updateResult.tarball}
+                  </div>
+                </>
+              )}
+            </div>
+          </div>
+        )}
       </div>
 
       <div className="card">

--- a/apps/wraith-wallet/ipc/src/lib.rs
+++ b/apps/wraith-wallet/ipc/src/lib.rs
@@ -968,6 +968,12 @@ pub struct LockEntry {
     pub funding_txid: Option<String>,
     pub funding_vout: Option<u32>,
     pub creation_height: u32,
+    /// Absolute block height at which the lock's timelock matures and
+    /// the wallet's unilateral recovery branch becomes spendable
+    /// (`creation_height + recovery_blocks` per the lock's
+    /// `timelock_tier`). Sourced from the operator-reported
+    /// `recovery_height` on the GSP lock record.
+    pub recovery_height: u32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
Wires several daemon-implemented-but-GUI-unreachable capabilities into the Wraith wallet GUI:

- **Keystore backup / restore** — `wallet_export`/`wallet_restore` Tauri commands + wrappers + a Settings card (daemon does the encrypted file IO, refuses to overwrite).
- **Update check** — `check_for_update` + an Updates card (current/latest version + manifest).
- **Lock key-rotation** — `locksJump` wrapper + a "Rotate key" action on active locks (rotates the cooperative custody key without touching the timelock branch).
- **True recovery height** — `GhostLockInfo.recovery_height` carried through the IPC `LockEntry` + daemon mapping; the Locks "Recovery height" column now shows the real maturation height.

Reconciled with the merged Locks `status` fix (#108): the GUI `LockEntry` uses the wire `status` field throughout, and the Rotate-key action gates on `status === "active"`. Daemon builds, wallet tests pass (0 failures), GUI typecheck clean, doc gate clean.