### PR TITLE
release: build ghost-pool with zk-production (fix mainnet install crash-loop)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,14 @@ jobs:
       # release artifacts here.
       - name: Build
         run: |
+          # CRITICAL: ghost-pool MUST be built with --features zk-production so the
+          # released binary can run on mainnet. Without it, is_production_mode() is
+          # false and ghost-pool aborts at startup ("MAINNET SECURITY: ZK consensus
+          # on mainnet requires trusted setup parameters"), so every curl|bash
+          # install crash-loops. zk-production is a compile-time flag with no
+          # build-time artefacts (params are loaded at runtime), so this is safe.
           cargo build --release --target ${{ matrix.target }} \
+            --features ghost-pool/zk-production \
             -p ghost-pool -p ghost-cli -p ghost-pay -p ghost-gsp-bin \
             -p translator_sv2 -p pool_sv2 -p jd_client_sv2 -p jd_server_sv2
 


### PR DESCRIPTION
The release workflow built `ghost-pool` **without** `--features zk-production`, so the published binary has `is_production_mode() == false`. On mainnet, ghost-pool aborts at startup — *"MAINNET SECURITY: ZK consensus on mainnet requires trusted setup parameters"* (`main.rs:1667`) — so **every `curl|bash` install crash-loops and never starts a working node**. This was found when node 6 (a stock install) crash-looped 1,527 times; node 5 only worked because it was hand-provisioned.

Fix: add `--features ghost-pool/zk-production` to the release build. The feature is a compile-time flag with no build-time artefacts (trusted-setup params are loaded at runtime), so nothing else about the build changes. Validated the package-qualified feature syntax resolves cleanly across the multi-package build command.

This is one of two parts — the companion fix makes ghost-pool **self-heal by fetching the params from a seed before the hard check** (separate PR), so a fresh node with the correct binary but no params recovers instead of crashing.