### PR TITLE
ghost-pool: register dynamically-joining peers (fix new-node mesh onboarding)

### DIFF
--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -4962,10 +4962,12 @@ async fn main() -> Result<()> {
                                         let ip = addr.ip();
                                         let routable = if conn_is_mainnet {
                                             match ip {
-                                                std::net::IpAddr::V4(v4) => !(v4.is_loopback()
-                                                    || v4.is_private()
-                                                    || v4.is_link_local()
-                                                    || v4.is_unspecified()),
+                                                std::net::IpAddr::V4(v4) => {
+                                                    !(v4.is_loopback()
+                                                        || v4.is_private()
+                                                        || v4.is_link_local()
+                                                        || v4.is_unspecified())
+                                                }
                                                 std::net::IpAddr::V6(v6) => {
                                                     !(v6.is_loopback() || v6.is_unspecified())
                                                 }

--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -4856,6 +4856,19 @@ async fn main() -> Result<()> {
         // DoS attacks that exhaust file descriptors or memory.
         let noise_connection_limit = Arc::new(Semaphore::new(100));
         let mut noise_shutdown = shutdown_tx.subscribe();
+        // MESH REGISTRATION FIX: an inbound Noise connection (a node dialling us)
+        // must trigger a reverse SUB-dial back to that node. Health pings are
+        // ZMQ PUB/SUB broadcasts, so the ONLY way we register a peer is by
+        // subscribing to its PUB sockets — which the SUB loop only does for peers
+        // already in the PeerManager. A dynamically-joining node dials us over
+        // Noise (so its verifications arrive, but are rejected as "unknown
+        // challenger"); without dialling back we never receive its health pings
+        // and never learn it. Only the static seed list got this today, so
+        // non-seed nodes could never join. Captured into the listener task below.
+        let noise_is_mainnet = is_mainnet_round;
+        let noise_disc_port = config.network.p2p.discovery;
+        let reverse_subscribed: Arc<std::sync::Mutex<std::collections::HashSet<std::net::IpAddr>>> =
+            Arc::new(std::sync::Mutex::new(std::collections::HashSet::new()));
 
         tokio::spawn(async move {
             use tokio::net::TcpListener;
@@ -4899,6 +4912,9 @@ async fn main() -> Result<()> {
                     Ok((stream, addr)) => {
                         let pool = Arc::clone(&noise_pool_clone);
                         let mesh = Arc::clone(&mesh_for_noise);
+                        let conn_is_mainnet = noise_is_mainnet;
+                        let conn_disc_port = noise_disc_port;
+                        let conn_rev_sub = Arc::clone(&reverse_subscribed);
 
                         tokio::spawn(async move {
                             // M-17: Hold permit for connection lifetime - released when dropped
@@ -4930,6 +4946,56 @@ async fn main() -> Result<()> {
                                         peer_key = %hex::encode(&conn.peer_key[..8]),
                                         "Accepted Noise connection"
                                     );
+
+                                    // MESH REGISTRATION FIX: reverse-subscribe to this
+                                    // inbound peer so we receive its PUB/SUB health pings
+                                    // (the only path that registers it in the PeerManager).
+                                    // connect_peer mints a placeholder peer; the SUB loop
+                                    // dials its 8555-8562 PUBs; the real node_id then arrives
+                                    // via the first PoW-gated, signed health ping and retires
+                                    // the placeholder. No new trust is granted — counting a
+                                    // peer still requires that valid health ping. Skip
+                                    // private/reserved source IPs on mainnet (SSRF guard) and
+                                    // dial back only once per host (the addr.ip() is the real
+                                    // TCP source of a completed handshake).
+                                    {
+                                        let ip = addr.ip();
+                                        let routable = if conn_is_mainnet {
+                                            match ip {
+                                                std::net::IpAddr::V4(v4) => !(v4.is_loopback()
+                                                    || v4.is_private()
+                                                    || v4.is_link_local()
+                                                    || v4.is_unspecified()),
+                                                std::net::IpAddr::V6(v6) => {
+                                                    !(v6.is_loopback() || v6.is_unspecified())
+                                                }
+                                            }
+                                        } else {
+                                            true
+                                        };
+                                        let first_time = routable
+                                            && conn_rev_sub
+                                                .lock()
+                                                .map(|mut s| s.insert(ip))
+                                                .unwrap_or(false);
+                                        if first_time {
+                                            let mesh_cb = Arc::clone(&mesh);
+                                            let addr_str = format!("{}:{}", ip, conn_disc_port);
+                                            tokio::spawn(async move {
+                                                match mesh_cb.connect_peer(&addr_str).await {
+                                                    Ok(()) => tracing::info!(
+                                                        peer = %addr_str,
+                                                        "Reverse-subscribed to inbound peer (mesh registration)"
+                                                    ),
+                                                    Err(e) => tracing::debug!(
+                                                        peer = %addr_str,
+                                                        error = %e,
+                                                        "Reverse-subscribe connect_peer failed"
+                                                    ),
+                                                }
+                                            });
+                                        }
+                                    }
 
                                     // Handle incoming messages from this connection
                                     // Messages are received, validated, and dispatched to handlers


### PR DESCRIPTION
Fixes the third and most severe fresh-install bug: a new node joins, syncs, runs, and verifies peers — but the seeds **never register it**, so it is invisible to the mesh forever (peer_count stuck at the seed count, its verification results rejected as `unknown challenger`, absent from `mesh-nodes` and the `nodes` table). Only the static seed list ever onboarded a node.

## Root cause
Two transport planes with opposite connect directions:
- **Noise TCP (8563):** the joining node dials the seed → its verifications arrive (but are rejected, unknown peer).
- **ZMQ PUB/SUB (8555–8562):** the *subscriber* dials the publisher. **Health pings are the only thing that registers a peer** (`health_handler.rs:851 upsert_peer`), and they are PUB/SUB broadcasts — so to receive a peers health pings a node must SUB-dial that peers PUB sockets, which the SUB loop only does for peers **already in the PeerManager**. A fresh node is never in it → never dialled back → never registered. Catch-22; the 4 seeds only work because each lists the others in static config.

## Fix
On accepting an inbound Noise connection, reverse-subscribe to that peer via `connect_peer(host:discovery_port)` — the exact primitive the static seed bootstrap uses. It mints a placeholder peer so the SUB loop dials the peers PUBs; the real `node_id` then arrives on the first **PoW-gated, signed** health ping and retires the placeholder. **No new trust** — counting a peer still requires that valid health ping. SSRF-guarded (skip private/reserved source IPs on mainnet) and deduped per host.

## Verified live
Deployed to a canary seed, then rolled all 4: **`peer_count` went 3 → 5 on every seed**, both new nodes (94.237.102.192, 5.22.219.246) now appear in `mesh-nodes` and the `nodes` table, and `unknown challenger` rejections stopped. This is the last of the three compounding bugs (with #113 zk-production release + #114 param self-heal) that made a `curl|bash` mainnet install non-functional.