### PR TITLE
release: v1.10.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-ghost-tests"
-version = "1.10.4"
+version = "1.10.5"
 dependencies = [
  "bitcoin",
  "chrono",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin_core_sv2"
-version = "1.10.4"
+version = "1.10.5"
 dependencies = [
  "async-channel 1.9.0",
  "bitcoin-capnp-types",
@@ -3083,7 +3083,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-accounting"
-version = "1.10.4"
+version = "1.10.5"
 dependencies = [
  "bitcoin",
  "ghost-common",
@@ -3097,7 +3097,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-buds"
-version = "1.10.4"
+version = "1.10.5"
 dependencies = [
  "bitcoin",
  "ghost-common",
@@ -3111,7 +3111,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-cli"
-version = "1.10.4"
+version = "1.10.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3129,7 +3129,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-common"
-version = "1.10.4"
+version = "1.10.5"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -3162,7 +3162,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-consensus"
-version = "1.10.4"
+version = "1.10.5"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3193,7 +3193,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-glyph"
-version = "1.10.4"
+version = "1.10.5"
 dependencies = [
  "hex",
  "serde",
@@ -3204,7 +3204,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-gsp"
-version = "1.10.4"
+version = "1.10.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3266,7 +3266,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-gsp-proto"
-version = "1.10.4"
+version = "1.10.5"
 dependencies = [
  "bitcoin",
  "chrono",
@@ -3283,7 +3283,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-keys"
-version = "1.10.4"
+version = "1.10.5"
 dependencies = [
  "bech32",
  "bitcoin",
@@ -3305,7 +3305,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-locks"
-version = "1.10.4"
+version = "1.10.5"
 dependencies = [
  "bitcoin",
  "getrandom 0.2.17",
@@ -3348,7 +3348,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-pay"
-version = "1.10.4"
+version = "1.10.5"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3396,7 +3396,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-policy"
-version = "1.10.4"
+version = "1.10.5"
 dependencies = [
  "bitcoin",
  "ghost-buds",
@@ -3409,7 +3409,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-pool"
-version = "1.10.4"
+version = "1.10.5"
 dependencies = [
  "anyhow",
  "async-channel 2.5.0",
@@ -3464,7 +3464,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-reaper"
-version = "1.10.4"
+version = "1.10.5"
 dependencies = [
  "bitcoin",
  "hex",
@@ -3476,7 +3476,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-reconciliation"
-version = "1.10.4"
+version = "1.10.5"
 dependencies = [
  "async-trait",
  "bitcoin",
@@ -3502,7 +3502,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-registry"
-version = "1.10.4"
+version = "1.10.5"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -3537,7 +3537,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-setup"
-version = "1.10.4"
+version = "1.10.5"
 dependencies = [
  "clap",
  "dirs 5.0.1",
@@ -3548,7 +3548,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-storage"
-version = "1.10.4"
+version = "1.10.5"
 dependencies = [
  "base64 0.22.1",
  "chacha20poly1305",
@@ -3569,7 +3569,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-tap-core"
-version = "1.10.4"
+version = "1.10.5"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3611,7 +3611,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-tap-desktop"
-version = "1.10.4"
+version = "1.10.5"
 dependencies = [
  "dirs 6.0.0",
  "getrandom 0.2.17",
@@ -3637,7 +3637,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-tap-integration"
-version = "1.10.4"
+version = "1.10.5"
 dependencies = [
  "ghost-gsp-proto",
  "ghost-tap-core",
@@ -3651,7 +3651,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-template"
-version = "1.10.4"
+version = "1.10.5"
 dependencies = [
  "bitcoin",
  "ghost-buds",
@@ -3667,7 +3667,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-verification"
-version = "1.10.4"
+version = "1.10.5"
 dependencies = [
  "axum 0.7.9",
  "bitcoin",
@@ -4639,7 +4639,7 @@ dependencies = [
 
 [[package]]
 name = "jd_client_sv2"
-version = "1.10.4"
+version = "1.10.5"
 dependencies = [
  "async-channel 1.9.0",
  "bitcoin_core_sv2",
@@ -4655,7 +4655,7 @@ dependencies = [
 
 [[package]]
 name = "jd_server_sv2"
-version = "1.10.4"
+version = "1.10.5"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -6156,7 +6156,7 @@ dependencies = [
 
 [[package]]
 name = "pool_sv2"
-version = "1.10.4"
+version = "1.10.5"
 dependencies = [
  "async-channel 1.9.0",
  "bitcoin_core_sv2",
@@ -7880,7 +7880,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stratum-apps"
-version = "1.10.4"
+version = "1.10.5"
 dependencies = [
  "async-channel 1.9.0",
  "axum 0.8.9",
@@ -9093,7 +9093,7 @@ dependencies = [
 
 [[package]]
 name = "translator_sv2"
-version = "1.10.4"
+version = "1.10.5"
 dependencies = [
  "async-channel 1.9.0",
  "clap",
@@ -10424,7 +10424,7 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "wraith-coordinator"
-version = "1.10.4"
+version = "1.10.5"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -10455,7 +10455,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-protocol"
-version = "1.10.4"
+version = "1.10.5"
 dependencies = [
  "bitcoin",
  "getrandom 0.2.17",
@@ -10476,7 +10476,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-cli"
-version = "1.10.4"
+version = "1.10.5"
 dependencies = [
  "clap",
  "clap_complete",
@@ -10489,7 +10489,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-core"
-version = "1.10.4"
+version = "1.10.5"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -10526,7 +10526,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-daemon"
-version = "1.10.4"
+version = "1.10.5"
 dependencies = [
  "axum 0.7.9",
  "base64 0.22.1",
@@ -10551,7 +10551,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-gui"
-version = "1.10.4"
+version = "1.10.5"
 dependencies = [
  "serde",
  "serde_json",
@@ -10565,7 +10565,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-ipc"
-version = "1.10.4"
+version = "1.10.5"
 dependencies = [
  "libc",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ exclude = []
 # Use scripts/build-all-wallets.sh to build all wallet types.
 
 [workspace.package]
-version = "1.10.4"
+version = "1.10.5"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Bitcoin Ghost Team"]

--- a/scripts/install-node.sh
+++ b/scripts/install-node.sh
@@ -13,7 +13,7 @@
 set -euo pipefail
 
 # ─────────────────────────── network constants ───────────────────────────────
-GHOST_VERSION="v1.10.3"
+GHOST_VERSION="v1.10.5"
 # Signed release artefacts (GPG: defenwycke release key).
 GPG_KEY_FP="777FE81F8CC077FD3D08055E852C2B3190F5B928"
 RELEASE_BASE="https://github.com/bitcoin-ghost/ghost/releases/download/${GHOST_VERSION}"


### PR DESCRIPTION
Cuts **v1.10.5** — the first release that actually works for a fresh `curl|bash` mainnet install.

Bumps `[workspace.package].version` 1.10.4 → 1.10.5 and the installer `GHOST_VERSION` → v1.10.5.

Carries the three onboarding fixes merged today:
- **#113** release builds ghost-pool with `--features zk-production` (so the binary runs on mainnet instead of crash-looping on the security gate).
- **#114** param self-heal — a fresh node fetches the MPC trusted-setup params from seeds (hash-verified) before the hard check, instead of crash-looping.
- **#115** inbound-peer mesh registration — a joining node is now dialled back + subscribed, so the seeds register it (it stops being an invisible "unknown challenger").

Tagging `v1.10.5` after merge triggers the release pipeline (multi-target build + GPG-signed `SHA256SUMS`).