### PR TITLE
consensus: de-flake ban_manager test_ban_expiration (fix macOS CI flake)

### DIFF
--- a/crates/ghost-consensus/src/ban_manager.rs
+++ b/crates/ghost-consensus/src/ban_manager.rs
@@ -467,21 +467,33 @@ mod tests {
         let manager = BanManager::new();
         let node_id = [2u8; 32];
 
-        // Ban for short duration (50ms to avoid platform timing flakiness)
+        // Ban for a long duration. The "banned initially" assertion must not
+        // race the expiry — a short ban can elapse between the ban call and the
+        // check on a heavily loaded CI runner (this is what made the test flaky
+        // on macOS), so use a duration that cannot expire before we look.
         manager.ban_for_duration(
             node_id,
             BanReason::RateLimitExceeded,
-            Duration::from_millis(50),
+            Duration::from_secs(3600),
         );
 
-        // Should be banned initially
+        // Should be banned initially.
         assert!(manager.is_banned(&node_id));
 
-        // Wait for expiration (100ms margin for cross-platform reliability)
-        std::thread::sleep(Duration::from_millis(100));
+        // Force the entry's expiry into the past instead of sleeping. This
+        // exercises the real is_banned expiry + eager-eviction path
+        // deterministically, with no wall-clock dependency to flake under load.
+        {
+            let mut banned = manager.banned_nodes.write();
+            banned
+                .get_mut(&node_id)
+                .expect("ban entry present")
+                .expire_at = Instant::now() - Duration::from_secs(1);
+        }
 
-        // Should no longer be banned
+        // Should no longer be banned, and the stale entry is evicted.
         assert!(!manager.is_banned(&node_id));
+        assert_eq!(manager.banned_count(), 0);
     }
 
     #[test]


### PR DESCRIPTION
The macOS CI failure on the recent main builds was `ban_manager::tests::test_ban_expiration` — a **wall-clock race**, not a regression.

The test banned a node for **50ms** then asserted `is_banned` immediately. On a heavily loaded runner, >50ms can elapse between the ban call and the assertion, so the ban has already expired and `is_banned` returns `false` → `assertion failed: manager.is_banned(&node_id)`.

## Fix (deterministic, no wall-clock dependency)
- Ban for a **long** duration so the "banned initially" check cannot race the expiry.
- Then **force `expire_at` into the past** (the test is in-module and `BanEntry.expire_at` is `pub`) instead of `sleep`ing — this exercises the real `is_banned` expiry + eager-eviction path with zero timing flakiness.
- Also assert the stale entry is evicted (`banned_count() == 0`).

Verified locally: passes 3/3 consecutive runs in ~0.08s (the old version slept 100ms each run).