### PR TITLE
dashboard: first-run onboarding wizard

### DIFF
--- a/dashboard/src/app/(dashboard)/layout.tsx
+++ b/dashboard/src/app/(dashboard)/layout.tsx
@@ -2,6 +2,7 @@
 
 import { ReactNode, useEffect } from 'react';
 import { Sidebar } from '@/components/layout/Sidebar';
+import { OnboardingGate } from '@/components/layout/OnboardingGate';
 import { useRealtimeSync } from '@/hooks/useRealtimeSync';
 import { useUIStore } from '@/stores';
 
@@ -34,6 +35,7 @@ export default function DashboardLayout({ children }: { children: ReactNode }) {
     <div className="flex min-h-screen">
       <RealtimeBridge />
       <TooltipShortcut />
+      <OnboardingGate />
       <Sidebar />
       <main className="flex-1 overflow-auto md:ml-0 ml-0">
         <div className="p-4 md:p-6 pt-14 md:pt-6">

--- a/dashboard/src/app/(dashboard)/settings/layout.tsx
+++ b/dashboard/src/app/(dashboard)/settings/layout.tsx
@@ -7,6 +7,15 @@ import { PageHeader } from "@/components/ui/PageHeader";
 
 const NAV_ITEMS = [
   {
+    href: "/settings/onboarding",
+    label: "Onboarding",
+    icon: (
+      <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+      </svg>
+    ),
+  },
+  {
     href: "/settings/general",
     label: "General",
     icon: (

--- a/dashboard/src/app/(dashboard)/settings/onboarding/page.tsx
+++ b/dashboard/src/app/(dashboard)/settings/onboarding/page.tsx
@@ -1,0 +1,427 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Card, CardHeader } from "@/components/ui/Card";
+import { Button } from "@/components/ui/Button";
+import { Badge } from "@/components/ui/Badge";
+import { StepIndicator } from "@/components/ui/Wizard";
+import { useToast } from "@/components/ui/Toast";
+import { ToggleRow, StatusRow } from "../shared";
+import { MempoolProfileDialog, DEFAULT_MEMPOOL_PROFILE } from "../MempoolProfileDialog";
+import ReaperWizard from "../wizards/ReaperWizard";
+import {
+  useNodeStatus,
+  useHealth,
+  useShares,
+  useConfig,
+  useGhostPayStatus,
+  useSetArchiveMode,
+  useSetPublicMining,
+  useSetReaper,
+  useMempoolProfiles,
+  useActivateMempoolProfile,
+  useSaveMempoolProfile,
+  type CustomMempoolProfile,
+} from "@/hooks/queries";
+import { useOnboarding } from "@/hooks/useOnboarding";
+
+// Preset mempool profiles, mirroring the Policy settings page. Selecting one
+// goes through the real `activateMempoolProfile` endpoint.
+const MEMPOOL_PRESETS = [
+  { name: "standard", desc: "Bitcoin Core defaults — balanced acceptance" },
+  { name: "strict", desc: "Higher fees, reject low-value transactions" },
+  { name: "clean", desc: "Filter inscriptions, ordinals, and BRC-20" },
+  { name: "structured", desc: "Optimized for transaction batching" },
+  { name: "app_friendly", desc: "Accept more experimental tx types" },
+  { name: "ghost", desc: "Full Ghost protocol support (requires Ghost Mode)" },
+];
+
+const STEPS = [
+  { id: "welcome", title: "Welcome" },
+  { id: "capabilities", title: "Capabilities" },
+  { id: "policy", title: "Policy" },
+  { id: "finish", title: "Finish" },
+];
+
+function StatItem({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="flex items-center justify-between p-3 bg-gray-800/50 rounded-lg">
+      <span className="text-sm text-gray-400">{label}</span>
+      <span className="text-sm text-gray-100 font-medium">{value}</span>
+    </div>
+  );
+}
+
+export default function OnboardingPage() {
+  const router = useRouter();
+  const { success, error } = useToast();
+  const { complete } = useOnboarding();
+
+  const [step, setStep] = useState(0);
+
+  // Reads — current node state, used to pre-fill every step.
+  const { data: status } = useNodeStatus();
+  const { data: health } = useHealth();
+  const { data: shares } = useShares();
+  const { data: config } = useConfig();
+  const { data: ghostPay } = useGhostPayStatus();
+
+  // Writes — the SAME hooks the Capabilities/Policy settings pages use.
+  const setArchiveMode = useSetArchiveMode();
+  const setPublicMining = useSetPublicMining();
+  const setReaper = useSetReaper();
+  const { data: mempoolProfilesData } = useMempoolProfiles();
+  const activateMempoolProfile = useActivateMempoolProfile();
+  const saveMempoolProfile = useSaveMempoolProfile();
+
+  // Composed wizard / dialog state.
+  const [reaperWizardOpen, setReaperWizardOpen] = useState(false);
+  const [mempoolDialogOpen, setMempoolDialogOpen] = useState(false);
+  const [editingMempool, setEditingMempool] = useState<CustomMempoolProfile | null>(null);
+
+  const activeMempoolProfile = String(config?.mempool_profile ?? "standard");
+  const ghostPayRunning = Boolean(ghostPay?.l2_height);
+  const budsEnabled = status?.ghost_pay ?? false;
+
+  const handleArchiveToggle = async (enabled: boolean) => {
+    try {
+      await setArchiveMode.mutateAsync(enabled);
+      success("Saved", `Archive Mode ${enabled ? "enabled" : "disabled"}`);
+    } catch (err) {
+      error("Failed", err instanceof Error ? err.message : "Unknown error");
+    }
+  };
+
+  const handlePublicMiningToggle = async (enabled: boolean) => {
+    try {
+      await setPublicMining.mutateAsync(enabled);
+      success("Saved", `Public Mining ${enabled ? "enabled" : "disabled"}`);
+    } catch (err) {
+      error("Failed", err instanceof Error ? err.message : "Unknown error");
+    }
+  };
+
+  const handleReaperToggle = async (enabled: boolean) => {
+    try {
+      await setReaper.mutateAsync(enabled);
+      success("Saved", `Ghost Reaper ${enabled ? "enabled" : "disabled"}`);
+    } catch (err) {
+      error("Failed", err instanceof Error ? err.message : "Unknown error");
+    }
+  };
+
+  const handleActivatePreset = async (name: string) => {
+    try {
+      await activateMempoolProfile.mutateAsync(name);
+      success("Profile Applied", `Mempool profile "${name}" is now active`);
+    } catch (err) {
+      error("Failed", err instanceof Error ? err.message : "Unknown error");
+    }
+  };
+
+  const handleMempoolSave = async () => {
+    if (!editingMempool || !editingMempool.name.trim()) {
+      error("Invalid Name", "Profile name is required");
+      return;
+    }
+    try {
+      await saveMempoolProfile.mutateAsync(editingMempool);
+      success("Profile Saved", `Custom mempool profile "${editingMempool.name}" saved`);
+      setMempoolDialogOpen(false);
+      setEditingMempool(null);
+    } catch (err) {
+      error("Save Failed", err instanceof Error ? err.message : "Unknown error");
+    }
+  };
+
+  const finish = () => {
+    complete();
+    success("Setup Complete", "Your node is configured. You can re-run setup from Settings → Onboarding.");
+    router.push("/");
+  };
+
+  const skip = () => {
+    router.push("/");
+  };
+
+  const reaperEnabled = config?.reaper ?? false;
+  const archiveEnabled = status?.archive_mode ?? false;
+  const publicMiningEnabled = status?.public_mining ?? false;
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader
+          title="Node Setup"
+          subtitle="Review and confirm your node's capabilities and policy. Everything is pre-filled with your node's current values — adjust what you like, or accept the sane defaults."
+        />
+        <div className="py-2">
+          <StepIndicator steps={STEPS} currentStep={step} />
+        </div>
+      </Card>
+
+      {/* Step 1: Welcome / status */}
+      {step === 0 && (
+        <Card>
+          <CardHeader title="Welcome" subtitle="A quick look at your node's current status." />
+          <div className="space-y-3">
+            <StatItem label="Node version" value={status?.version ?? "—"} />
+            <StatItem
+              label="Sync status"
+              value={
+                status?.is_synced ? (
+                  <Badge variant="success">Synced</Badge>
+                ) : (
+                  <Badge variant="warning">Syncing</Badge>
+                )
+              }
+            />
+            <StatItem label="Block height" value={status?.block_height?.toLocaleString() ?? status?.sync_height?.toLocaleString() ?? "—"} />
+            <StatItem label="Peers" value={status?.peer_count ?? "—"} />
+            <StatItem
+              label="Health"
+              value={
+                health?.healthy ?? status?.online ? (
+                  <Badge variant="success">Healthy</Badge>
+                ) : (
+                  <Badge variant="warning">Unknown</Badge>
+                )
+              }
+            />
+            <StatItem
+              label="Elder status"
+              value={
+                shares?.elder ? (
+                  <Badge variant="success">Elder #{shares.elder_slot ?? "?"}</Badge>
+                ) : (
+                  <Badge variant="default">Not Elder</Badge>
+                )
+              }
+            />
+            <StatItem
+              label="Reward shares"
+              value={`${shares?.total ?? 0} / ${shares?.max_shares ?? 15}`}
+            />
+          </div>
+        </Card>
+      )}
+
+      {/* Step 2: Capabilities */}
+      {step === 1 && (
+        <Card>
+          <CardHeader
+            title="Capabilities"
+            subtitle="Capabilities earn shares in the node reward pool (5-4-3-2-1). Toggles are pre-set to your node's current values and save immediately."
+          />
+          <div className="space-y-3">
+            <ToggleRow
+              label="Archive Mode"
+              description="Store full blockchain history. Archive +5 shares."
+              enabled={archiveEnabled}
+              onChange={handleArchiveToggle}
+              disabled={setArchiveMode.isPending}
+              badge={archiveEnabled ? <Badge variant="success">+5 Shares</Badge> : null}
+            />
+            <StatusRow
+              label="Ghost Pay"
+              description={`L2 payment network participation — requires ghost-pay-node${ghostPay?.l2_height ? ` (L2 height: ${ghostPay.l2_height})` : ""}. Ghost Pay +4 shares.`}
+              badge={
+                ghostPayRunning ? (
+                  <Badge variant="success">+4 Shares</Badge>
+                ) : (
+                  <Badge variant="warning">Not Running</Badge>
+                )
+              }
+            />
+            <ToggleRow
+              label="Public Mining"
+              description="Accept connections from public miners. Public Mining +3 shares."
+              enabled={publicMiningEnabled}
+              onChange={handlePublicMiningToggle}
+              disabled={setPublicMining.isPending}
+              badge={publicMiningEnabled ? <Badge variant="success">+3 Shares</Badge> : null}
+            />
+            <ToggleRow
+              label="Bitcoin Pure (Ghost Reaper)"
+              description="Reject non-financial data (inscriptions, drop-stuffing, dust-flood) from your mempool and blocks. Bitcoin Pure +2 shares."
+              enabled={reaperEnabled}
+              onChange={handleReaperToggle}
+              disabled={setReaper.isPending}
+              badge={reaperEnabled ? <Badge variant="success">+2 Shares</Badge> : null}
+            />
+            <StatusRow
+              label="Elder Status"
+              description={
+                shares?.elder
+                  ? `MPC contributor — Elder slot #${shares.elder_slot ?? "?"}`
+                  : "Contribute to the MPC ceremony to earn Elder status. Elder +1 share."
+              }
+              badge={
+                shares?.elder ? (
+                  <Badge variant="success">+1 Share</Badge>
+                ) : (
+                  <Badge variant="default">Not Elder</Badge>
+                )
+              }
+            />
+          </div>
+        </Card>
+      )}
+
+      {/* Step 3: Policy */}
+      {step === 2 && (
+        <div className="space-y-6">
+          <Card>
+            <CardHeader
+              title="Mempool Policy"
+              subtitle="Choose which transactions your node accepts. The default profile is a sane starting point — tune later from Settings → Policy."
+            />
+            <div className="space-y-4">
+              <div className="p-3 bg-gray-800/50 rounded-lg flex justify-between items-center">
+                <div>
+                  <div className="text-gray-100">Current Profile</div>
+                  <div className="text-sm text-gray-400">{activeMempoolProfile}</div>
+                </div>
+                <Badge variant="info">{activeMempoolProfile}</Badge>
+              </div>
+
+              {reaperEnabled && (
+                <div className="p-3 bg-yellow-900/30 border border-yellow-700/50 rounded-lg">
+                  <div className="text-yellow-400 font-medium">Locked by Reaper Mode</div>
+                  <div className="text-sm text-yellow-500/80">
+                    Disable Bitcoin Pure (Reaper) in the previous step to change profiles.
+                  </div>
+                </div>
+              )}
+
+              <div
+                className={`grid grid-cols-1 md:grid-cols-2 gap-2 ${
+                  reaperEnabled ? "opacity-50 pointer-events-none" : ""
+                }`}
+              >
+                {MEMPOOL_PRESETS.map((p) => (
+                  <button
+                    key={p.name}
+                    onClick={() => handleActivatePreset(p.name)}
+                    disabled={reaperEnabled || activateMempoolProfile.isPending}
+                    className={`p-3 rounded-lg border transition-colors text-left ${
+                      activeMempoolProfile === p.name
+                        ? "bg-orange-900/30 border-orange-600 text-orange-300"
+                        : "bg-gray-800/50 border-gray-700 text-gray-300 hover:border-gray-500"
+                    }`}
+                  >
+                    <div className="font-medium capitalize">{p.name.replace(/_/g, " ")}</div>
+                    <div className="text-xs text-gray-500 mt-1">{p.desc}</div>
+                  </button>
+                ))}
+              </div>
+
+              <Button
+                variant="secondary"
+                className="w-full"
+                disabled={reaperEnabled}
+                onClick={() => {
+                  setEditingMempool({ name: "", ...DEFAULT_MEMPOOL_PROFILE });
+                  setMempoolDialogOpen(true);
+                }}
+              >
+                Create Custom Mempool Profile
+              </Button>
+            </div>
+          </Card>
+
+          <Card>
+            <CardHeader
+              title="Reaper Detectors"
+              subtitle="Fine-tune which transaction patterns Ghost Reaper rejects. Opens the same detector wizard used in Settings → Wizards."
+            />
+            <div className="space-y-3">
+              <StatusRow
+                label="Ghost Reaper"
+                description="Per-vector detector and threshold configuration."
+                badge={
+                  reaperEnabled ? (
+                    <Badge variant="success">Enabled</Badge>
+                  ) : (
+                    <Badge variant="default">Disabled</Badge>
+                  )
+                }
+              />
+              <Button variant="secondary" className="w-full" onClick={() => setReaperWizardOpen(true)}>
+                Configure Detectors
+              </Button>
+            </div>
+          </Card>
+        </div>
+      )}
+
+      {/* Step 4: Finish */}
+      {step === 3 && (
+        <Card>
+          <CardHeader title="All Set" subtitle="Here's your node's configuration. Finishing marks setup complete." />
+          <div className="space-y-3">
+            <StatItem
+              label="Archive Mode"
+              value={<Badge variant={archiveEnabled ? "success" : "default"}>{archiveEnabled ? "On" : "Off"}</Badge>}
+            />
+            <StatItem
+              label="Ghost Pay"
+              value={<Badge variant={ghostPayRunning ? "success" : "default"}>{ghostPayRunning ? "Running" : "Not Running"}</Badge>}
+            />
+            <StatItem
+              label="Public Mining"
+              value={<Badge variant={publicMiningEnabled ? "success" : "default"}>{publicMiningEnabled ? "On" : "Off"}</Badge>}
+            />
+            <StatItem
+              label="Bitcoin Pure (Reaper)"
+              value={<Badge variant={reaperEnabled ? "success" : "default"}>{reaperEnabled ? "On" : "Off"}</Badge>}
+            />
+            <StatItem label="Mempool Profile" value={<Badge variant="info">{activeMempoolProfile}</Badge>} />
+            <StatItem label="Reward shares" value={`${shares?.total ?? 0} / ${shares?.max_shares ?? 15}`} />
+          </div>
+        </Card>
+      )}
+
+      {/* Navigation */}
+      <div className="flex items-center justify-between">
+        <div>
+          {step > 0 && (
+            <Button variant="ghost" onClick={() => setStep((s) => Math.max(0, s - 1))}>
+              Back
+            </Button>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          <Button variant="ghost" onClick={skip}>
+            Skip for now
+          </Button>
+          {step < STEPS.length - 1 ? (
+            <Button variant="primary" onClick={() => setStep((s) => Math.min(STEPS.length - 1, s + 1))}>
+              Next
+            </Button>
+          ) : (
+            <Button variant="primary" onClick={finish}>
+              Done
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {/* Composed real wizards / dialogs */}
+      <ReaperWizard isOpen={reaperWizardOpen} onClose={() => setReaperWizardOpen(false)} />
+      <MempoolProfileDialog
+        isOpen={mempoolDialogOpen}
+        onClose={() => {
+          setMempoolDialogOpen(false);
+          setEditingMempool(null);
+        }}
+        profile={editingMempool}
+        onProfileChange={setEditingMempool}
+        onSave={handleMempoolSave}
+        saving={saveMempoolProfile.isPending}
+        budsEnabled={budsEnabled}
+      />
+    </div>
+  );
+}

--- a/dashboard/src/components/layout/OnboardingGate.tsx
+++ b/dashboard/src/components/layout/OnboardingGate.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { useEffect } from 'react';
+import { usePathname, useRouter } from 'next/navigation';
+import {
+  ONBOARDING_PATH,
+  hasSeenOnboardingThisSession,
+  isOnboarded,
+  markOnboardingSeen,
+} from '@/hooks/useOnboarding';
+
+/**
+ * First-run redirect. On the first dashboard load of a browser that has not yet
+ * completed onboarding, send the operator to the onboarding flow exactly once
+ * per session. After that (e.g. they hit "Skip for now"), they are not trapped:
+ * the per-session `seen` marker stops further auto-redirects until they reopen
+ * the dashboard in a fresh session, and completing the flow sets the persistent
+ * flag so it never fires again.
+ *
+ * Renders nothing.
+ */
+export function OnboardingGate() {
+  const router = useRouter();
+  const pathname = usePathname();
+
+  useEffect(() => {
+    if (pathname === ONBOARDING_PATH) return;
+    if (isOnboarded()) return;
+    if (hasSeenOnboardingThisSession()) return;
+
+    markOnboardingSeen();
+    router.replace(ONBOARDING_PATH);
+  }, [pathname, router]);
+
+  return null;
+}

--- a/dashboard/src/hooks/useOnboarding.ts
+++ b/dashboard/src/hooks/useOnboarding.ts
@@ -1,0 +1,87 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+// ---------------------------------------------------------------------------
+// First-run onboarding completion flag
+// ---------------------------------------------------------------------------
+// The ghost-node API exposes only specific, typed config endpoints (archive
+// mode, public mining, reaper, mempool/template profiles, payout address …).
+// There is NO generic node-side key/value or dashboard-preferences endpoint we
+// could persist an `onboarding_complete` marker to without inventing a new
+// backend route — which is out of scope for a frontend change and would not be
+// a "real" reused endpoint.
+//
+// So the completion flag lives in localStorage under `ghost_dashboard_onboarded`.
+// LIMITATION: this is per-browser. An operator who opens the dashboard from a
+// fresh browser / cleared storage will be re-offered onboarding. The flow is
+// idempotent (it only confirms the node's already-applied config), so re-running
+// it is harmless. The "Onboarding" entry under Settings re-opens it any time.
+// ---------------------------------------------------------------------------
+
+export const ONBOARDED_KEY = 'ghost_dashboard_onboarded';
+// Per-tab marker so a "skip for now" doesn't re-trap the operator on every
+// navigation within the same session (a fresh session re-offers it until done).
+export const ONBOARD_SEEN_KEY = 'ghost_dashboard_onboard_seen';
+export const ONBOARDING_PATH = '/settings/onboarding';
+
+function readFlag(storage: 'local' | 'session', key: string): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    const store = storage === 'local' ? window.localStorage : window.sessionStorage;
+    return store.getItem(key) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+export function isOnboarded(): boolean {
+  return readFlag('local', ONBOARDED_KEY);
+}
+
+export function hasSeenOnboardingThisSession(): boolean {
+  return readFlag('session', ONBOARD_SEEN_KEY);
+}
+
+export function markOnboardingSeen(): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.sessionStorage.setItem(ONBOARD_SEEN_KEY, 'true');
+  } catch {
+    /* storage unavailable — fall through, gate simply re-checks next mount */
+  }
+}
+
+export function setOnboarded(value: boolean): void {
+  if (typeof window === 'undefined') return;
+  try {
+    if (value) window.localStorage.setItem(ONBOARDED_KEY, 'true');
+    else window.localStorage.removeItem(ONBOARDED_KEY);
+  } catch {
+    /* storage unavailable */
+  }
+}
+
+/**
+ * React hook exposing the completion flag. `onboarded` is `null` until the
+ * client has read localStorage (avoids an SSR/first-paint flash).
+ */
+export function useOnboarding() {
+  const [onboarded, setOnboardedState] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    setOnboardedState(isOnboarded());
+  }, []);
+
+  const complete = useCallback(() => {
+    setOnboarded(true);
+    setOnboardedState(true);
+  }, []);
+
+  const reset = useCallback(() => {
+    setOnboarded(false);
+    setOnboardedState(false);
+  }, []);
+
+  return { onboarded, complete, reset };
+}


### PR DESCRIPTION
Adds a guided first-run setup flow to the node dashboard so operators review and confirm their node config on first login.

- New `/settings/onboarding` route + an "Onboarding" entry in the settings sub-nav (re-runnable any time).
- `OnboardingGate` redirects to the flow once per session until completed; completion persisted in `localStorage` (`ghost_dashboard_onboarded`) since the node API exposes no generic preferences key.
- Capabilities step reuses `useSetArchiveMode`/`useSetPublicMining`/`useSetReaper`; policy step reuses `activateMempoolProfile`, `MempoolProfileDialog`, `ReaperWizard`. **No new config path** — everything writes back through existing endpoints.
- Pre-filled from the nodes current config; behind the existing JWT auth like every other route (no localhost/XFF bypass).

Cherry-picked cleanly onto current main (no conflicts with #109/#110/#111). All reused hooks/components verified against current main — no drift. `npm run build` passes (TypeScript clean, route in the manifest).