### PR TITLE
consensus: concurrent per-peer broadcast (fix stale-share gossip backpressure)

### DIFF
--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -3822,8 +3822,11 @@ async fn main() -> Result<()> {
 
     // Share broadcast relay: sync callback → async Noise broadcast
     // Follows the MPC relay pattern (main.rs:1107-1134)
+    // Buffer cushion for share-relay bursts. The real throughput fix is the
+    // concurrent per-peer fan-out in MeshNetwork::broadcast; this just absorbs
+    // short bursts so try_send doesn't drop proofs under load.
     let (share_broadcast_tx, mut share_broadcast_rx) =
-        tokio::sync::mpsc::channel::<ghost_common::types::ShareProof>(256);
+        tokio::sync::mpsc::channel::<ghost_common::types::ShareProof>(1024);
     let mesh_for_shares_relay = Arc::clone(&mesh);
     tokio::spawn(async move {
         while let Some(proof) = share_broadcast_rx.recv().await {

--- a/crates/ghost-consensus/src/mesh.rs
+++ b/crates/ghost-consensus/src/mesh.rs
@@ -1595,25 +1595,37 @@ impl MeshNetwork {
         }
 
         // Sensitive messages use point-to-point Noise to each known peer.
-        let peers = self.peers.get_connected_peers(60);
-        let mut sent = 0;
+        // Fan the sends out CONCURRENTLY rather than awaiting each peer in turn:
+        // a sequential loop made one slow or unreachable peer stall the entire
+        // broadcast, and as the mesh grew (3 -> 5+ peers) that backed up the
+        // share-relay queue until proofs aged past the freshness cap and were
+        // dropped as stale. Concurrent fan-out bounds each broadcast to the
+        // slowest single peer instead of the sum, and each peer has its own Noise
+        // connection so the sends don't contend.
+        let self_id = self.identity.node_id();
+        let targets: Vec<_> = self
+            .peers
+            .get_connected_peers(60)
+            .into_iter()
+            .filter(|peer| peer.node_id != self_id)
+            .collect();
 
-        for peer in peers {
-            if peer.node_id == self.identity.node_id() {
-                continue; // Don't send to ourselves
-            }
-
-            match self.send_to_peer(&peer, &envelope).await {
-                Ok(_) => sent += 1,
+        let envelope_ref = &envelope;
+        let results = futures::future::join_all(targets.into_iter().map(|peer| async move {
+            match self.send_to_peer(&peer, envelope_ref).await {
+                Ok(_) => true,
                 Err(e) => {
                     warn!(
                         peer = %peer.node_id_short(),
                         error = %e,
                         "Failed to send to peer"
                     );
+                    false
                 }
             }
-        }
+        }))
+        .await;
+        let sent = results.into_iter().filter(|&ok| ok).count();
 
         debug!(
             msg_type = ?envelope.msg_type,


### PR DESCRIPTION
Fixes gossip backpressure surfaced during the cluster-enforcement verification (not gate-related): the seeds were dropping ~2500 cross-node shares / 3h as stale, with frequent `Share broadcast channel full` and `Failed to send to peer`.

## Root cause
`MeshNetwork::broadcast` sent Noise (sensitive) messages — including signed `ShareProof`s — to peers in a **sequential `await` loop**, so each broadcast cost the **sum** of all per-peer send times and a single slow/unreachable peer stalled the entire broadcast. As the mesh grew 3→5+ peers, the share-relay consumer fell behind, the 256-deep relay channel backed up, and proofs aged past the 600s freshness cap (`MAX_SHARE_AGE_SECS`) and were dropped — impairing cross-node share propagation (payout-fairness relevant).

## Fix
- **Concurrent fan-out** of the per-peer sends via `futures::join_all` — each broadcast is now bounded by the *slowest single peer* rather than the sum, and one bad peer no longer stalls the rest. Each peer has its own Noise connection (`send_encrypted` → `get_connection(noise_addr)`), so the concurrent sends are independent.
- Bumped the share-relay channel 256 → 1024 as burst insurance.

## Verified
`ghost-pool` builds with `--features zk-production`; 247 ghost-consensus tests pass; clippy clean on the changed code; `RUSTDOCFLAGS=-D warnings cargo doc` clean. Will canary-deploy + confirm the stale-share rejection rate drops before rolling the fleet.