### PR TITLE
bond: exempt coordinator routes from rate-limit + retry resolves (harness finding)

### DIFF
--- a/bins/ghost-pay/src/main.rs
+++ b/bins/ghost-pay/src/main.rs
@@ -1892,12 +1892,24 @@ async fn main() -> Result<()> {
     // LOW-API-1: Security headers for all responses
     let app = public_routes
         .merge(authenticated_routes)
-        .merge(coordinator_routes)
         .merge(localhost_routes)
-        .layer(axum::middleware::from_fn(security_headers_middleware))
+        // H-8: IP rate-limit only the externally-reachable participant/public
+        // surface (incl. the HMAC-authed `/escrow` and the public/localhost
+        // routes). The coordinator bond routes are merged AFTER this layer and
+        // are therefore EXEMPT.
         .layer(GovernorLayer {
             config: governor_conf,
         })
+        // Coordinator bond routes (`/verify`, `/resolve`, snapshot) are
+        // Bearer-token authed and called by the co-located coordinator over
+        // loopback (`127.0.0.1:8800`) — the token is their protection, not an IP
+        // budget. IP rate-limiting them stranded bonds on a busy round: a
+        // back-to-back `/resolve` burst at round completion hit 429 and
+        // `resolve_round_bonds` swallowed the error (no retry), leaving bonds
+        // `escrowed` and sats withheld. Merging them after the GovernorLayer
+        // exempts them; security headers + CORS below still cover them.
+        .merge(coordinator_routes)
+        .layer(axum::middleware::from_fn(security_headers_middleware))
         .layer(
             CorsLayer::new()
                 .allow_origin(AllowOrigin::list(cors_origins))

--- a/bins/wraith-coordinator/src/bond_resolution.rs
+++ b/bins/wraith-coordinator/src/bond_resolution.rs
@@ -75,30 +75,53 @@ pub fn resolve_round_bonds(
     inputs: &[AcceptedInputs],
     resolution: BondResolution,
 ) -> ResolutionSummary {
+    // A failed resolve leaves the bond stranded as `escrowed` (the participant's
+    // sats stay withheld) with no recovery, so retry transient failures (a brief
+    // ghost-pay blip/restart, a rate-limit on the path) with backoff before
+    // giving up. resolve_bond is idempotent — re-resolving an already-resolved
+    // bond returns AlreadyResolved and never double-credits — so retrying after a
+    // lost-response success is safe.
+    const MAX_ATTEMPTS: u32 = 4;
     let mut summary = ResolutionSummary::default();
     for input in inputs {
-        match ledger.resolve_bond(&input.bond_id, resolution.clone()) {
-            Ok(_record) => {
-                info!(
-                    %session_id,
-                    ghost_id = %input.ghost_id,
-                    bond_id = %input.bond_id,
-                    ?resolution,
-                    "bond resolved",
-                );
-                summary.resolved += 1;
+        let mut last_err = None;
+        for attempt in 1..=MAX_ATTEMPTS {
+            match ledger.resolve_bond(&input.bond_id, resolution.clone()) {
+                Ok(_record) => {
+                    info!(
+                        %session_id,
+                        ghost_id = %input.ghost_id,
+                        bond_id = %input.bond_id,
+                        ?resolution,
+                        attempt,
+                        "bond resolved",
+                    );
+                    summary.resolved += 1;
+                    last_err = None;
+                    break;
+                }
+                Err(e) => {
+                    last_err = Some(e);
+                    if attempt < MAX_ATTEMPTS {
+                        // 200ms, 400ms, 800ms backoff (resolve_bond is blocking).
+                        std::thread::sleep(std::time::Duration::from_millis(
+                            200u64 * (1 << (attempt - 1)),
+                        ));
+                    }
+                }
             }
-            Err(e) => {
-                warn!(
-                    %session_id,
-                    ghost_id = %input.ghost_id,
-                    bond_id = %input.bond_id,
-                    ?resolution,
-                    error = %e,
-                    "bond resolution failed",
-                );
-                summary.failed += 1;
-            }
+        }
+        if let Some(e) = last_err {
+            warn!(
+                %session_id,
+                ghost_id = %input.ghost_id,
+                bond_id = %input.bond_id,
+                ?resolution,
+                attempts = MAX_ATTEMPTS,
+                error = %e,
+                "bond resolution failed after retries — bond may remain escrowed",
+            );
+            summary.failed += 1;
         }
     }
     summary


### PR DESCRIPTION
Fixes the one operational risk the end-to-end bond harness (#123) surfaced — bonds could get stranded `escrowed` (participant sats withheld) on a transient resolve failure.

## Root cause
ghost-pay's per-IP rate limiter (burst 10, 1/sec) also fronted the **coordinator-only** bond routes. A busy co-located coordinator firing a back-to-back `/resolve` burst at round completion could hit **429**, and `resolve_round_bonds` swallowed the error (logged `failed`, no retry) → bond stays `escrowed`, sats withheld.

## Fix (two layers)
1. **ghost-pay** — merge the coordinator bond routes (`/verify`, `/resolve`, snapshot) **after** the `GovernorLayer` so they are exempt from IP rate limiting. They are Bearer-token authed and only ever called by the co-located coordinator over loopback (`127.0.0.1:8800`); the token is their protection. Security headers + CORS still cover them (applied after the merge). The participant-facing `/escrow` (HMAC) and public/localhost routes stay rate-limited.
2. **wraith-coordinator** — `resolve_round_bonds` retries transient resolve failures (4 attempts, 200/400/800ms backoff) before giving up, so a brief ghost-pay blip/restart can't strand a bond. Safe because `resolve_bond` is **idempotent** — re-resolving an already-resolved bond returns `AlreadyResolved` and never double-credits, so retrying after a lost-response success cannot double-pay.

## Verified
`ghost-pay` + `wraith-coordinator` build; coordinator tests pass; fmt/doc clean. With this, the bond seam (proven sound by #123) has no known stuck-funds path before mainnet mixing.