### PR TITLE
ghostd: user-agent Ghost + auto-track version from Cargo.toml

### DIFF
--- a/ghost-core/CMakeLists.txt
+++ b/ghost-core/CMakeLists.txt
@@ -27,9 +27,27 @@ get_directory_property(precious_variables CACHE_VARIABLES)
 # Project / Package metadata
 #=============================
 set(CLIENT_NAME "Ghost Core")
-set(CLIENT_VERSION_MAJOR 1)
-set(CLIENT_VERSION_MINOR 0)
-set(CLIENT_VERSION_BUILD 0)
+# Single source of truth: derive the client version from the workspace
+# Cargo.toml so ghostd's reported version auto-tracks releases. A release bump
+# updates Cargo.toml's [workspace.package] version, and the next ghostd build
+# follows it — no manual sync, never stuck at a stale version again.
+file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/../Cargo.toml" _ghost_ws_version_lines
+     REGEX "^version = \"[0-9]+\\.[0-9]+\\.[0-9]+\"")
+if(_ghost_ws_version_lines)
+  list(GET _ghost_ws_version_lines 0 _ghost_ws_version_line)
+endif()
+if(_ghost_ws_version_line MATCHES "version = \"([0-9]+)\\.([0-9]+)\\.([0-9]+)\"")
+  set(CLIENT_VERSION_MAJOR ${CMAKE_MATCH_1})
+  set(CLIENT_VERSION_MINOR ${CMAKE_MATCH_2})
+  set(CLIENT_VERSION_BUILD ${CMAKE_MATCH_3})
+  message(STATUS "Ghost client version (from workspace Cargo.toml): ${CLIENT_VERSION_MAJOR}.${CLIENT_VERSION_MINOR}.${CLIENT_VERSION_BUILD}")
+else()
+  # Fallback for a standalone ghost-core build with no adjacent Cargo.toml.
+  set(CLIENT_VERSION_MAJOR 1)
+  set(CLIENT_VERSION_MINOR 10)
+  set(CLIENT_VERSION_BUILD 6)
+  message(WARNING "Ghost: could not read version from ../Cargo.toml; using fallback ${CLIENT_VERSION_MAJOR}.${CLIENT_VERSION_MINOR}.${CLIENT_VERSION_BUILD}")
+endif()
 set(CLIENT_VERSION_RC 0)
 set(CLIENT_VERSION_IS_RELEASE "true")
 set(COPYRIGHT_YEAR "2025")

--- a/ghost-core/src/clientversion.cpp
+++ b/ghost-core/src/clientversion.cpp
@@ -21,7 +21,7 @@ using util::Join;
  * for both ghostd and ghost-qt, to make it harder for attackers to
  * target servers or GUI users specifically.
  */
-const std::string UA_NAME("GhostCore");
+const std::string UA_NAME("Ghost");
 
 
 #include <bitcoin-build-info.h>


### PR DESCRIPTION
Two small ghost-core changes (network-visible after a ghostd rebuild + redeploy):

1. **P2P user-agent** `/GhostCore:x/` → `/Ghost:x/` (`UA_NAME` in `clientversion.cpp`). Keeps a neutral wire identity (no "Bitcoin" in the user-agent, which would invite "claiming the Bitcoin name" criticism on the network).
2. **Version auto-tracking** — `CMakeLists.txt` previously hardcoded the client version at **1.0.0**, decoupled from the Rust workspace `1.10.6`, so ghostd reported a stale version forever. Now it reads the version from the workspace `Cargo.toml` `[workspace.package]` version (single source of truth), so a release bump auto-updates ghostds reported version on the next build — verified the CMake regex parses `1.10.6`. Falls back to a literal only for a standalone ghost-core build.

After this builds + redeploys, nodes advertise `/Ghost:1.10.6/` and track future bumps automatically.