### PR TITLE
bond: identity-pinned HTTPS for the coordinator↔ghost-pay seam (canary fix)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10441,6 +10441,7 @@ dependencies = [
  "hyper",
  "reqwest 0.12.28",
  "rusqlite",
+ "rustls",
  "scrypt",
  "secp256k1 0.29.1",
  "serde",

--- a/bins/ghost-pay/src/main.rs
+++ b/bins/ghost-pay/src/main.rs
@@ -9396,6 +9396,64 @@ mod wraith_bond_tests {
         format!("http://{addr}")
     }
 
+    /// Like `spawn_server`, but serves the bond router over HTTPS with an
+    /// **identity-derived** TLS cert (cert pubkey == node_id from `secret`),
+    /// exactly as a production node does via `--identity-key`. Returns the
+    /// `https://` base URL and the served node_id so the test can pin the real
+    /// `GhostPayBondLedger` client against it. Mirrors the production TLS
+    /// accept loop in `main`.
+    async fn spawn_server_tls(state: Arc<AppState>, secret: [u8; 32]) -> (String, [u8; 32]) {
+        use ghost_common::signer::{LocalSigner, Signer};
+
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+        let node_id = LocalSigner::from_bytes(&secret).public_key();
+        let tls = ghost_common::tls::build_server_config_with_identity(
+            &ghost_common::config::TlsConfig::default(),
+            &secret,
+            None,
+        )
+        .expect("identity TLS config");
+
+        let app = bond_router(state);
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let acceptor = tokio_rustls::TlsAcceptor::from(tls);
+
+        tokio::spawn(async move {
+            let mut make_service =
+                app.into_make_service_with_connect_info::<std::net::SocketAddr>();
+            loop {
+                let (tcp, remote) = match listener.accept().await {
+                    Ok(v) => v,
+                    Err(_) => continue,
+                };
+                let acceptor = acceptor.clone();
+                let tower_service = {
+                    use tower::Service;
+                    match make_service.call(remote).await {
+                        Ok(s) => s,
+                        Err(_) => continue,
+                    }
+                };
+                tokio::spawn(async move {
+                    let tls_stream = match acceptor.accept(tcp).await {
+                        Ok(s) => s,
+                        Err(_) => return,
+                    };
+                    let io = hyper_util::rt::TokioIo::new(tls_stream);
+                    let svc = hyper_util::service::TowerToHyperService::new(tower_service);
+                    let _ = hyper_util::server::conn::auto::Builder::new(
+                        hyper_util::rt::TokioExecutor::new(),
+                    )
+                    .serve_connection(io, svc)
+                    .await;
+                });
+            }
+        });
+
+        (format!("https://{addr}"), node_id)
+    }
+
     fn seed_balance(db: &Database, gid: &str, amount: i64) {
         db.with_connection(|conn| {
             let mut pid = [0u8; 16];
@@ -9775,11 +9833,34 @@ mod wraith_bond_tests {
             EscrowOutcome::BondId(id) => id,
             _ => panic!("created"),
         };
-        let base = spawn_server(state).await;
+        // Serve the bond router over real HTTPS with an identity cert, exactly
+        // as a production node does, and pin the client to its node_id.
+        let server_secret = [7u8; 32];
+        let (base, node_id) = spawn_server_tls(state, server_secret).await;
+
+        // NEGATIVE pinning check: a client pinned to a DIFFERENT node_id must
+        // fail the TLS handshake — proving the pin actually rejects wrong certs
+        // rather than accepting any cert.
+        {
+            let base_wrong = base.clone();
+            let wrong = tokio::task::spawn_blocking(move || {
+                let wrong_node_id = ghost_common::signer::Signer::public_key(
+                    &ghost_common::signer::LocalSigner::from_bytes(&[8u8; 32]),
+                );
+                let ledger = GhostPayBondLedger::new(base_wrong, "rtok", wrong_node_id).unwrap();
+                ledger.verify_bond("alice", "s1", 500)
+            })
+            .await
+            .unwrap();
+            assert!(
+                matches!(wrong, Err(wraith_protocol::BondError::LedgerUnreachable(_))),
+                "wrong-node_id pin must fail the handshake (LedgerUnreachable); got {wrong:?}"
+            );
+        }
 
         // GhostPayBondLedger is blocking (ureq) — drive it off the runtime.
         let result = tokio::task::spawn_blocking(move || {
-            let ledger = GhostPayBondLedger::new(base, "rtok").unwrap();
+            let ledger = GhostPayBondLedger::new(base, "rtok", node_id).unwrap();
 
             // verify happy path returns the same bond id.
             let verified = ledger.verify_bond("alice", "s1", 500).unwrap();

--- a/bins/ghost-pool/src/coordinator_supervisor.rs
+++ b/bins/ghost-pool/src/coordinator_supervisor.rs
@@ -43,6 +43,11 @@ pub struct CoordinatorRoleConfig {
     pub listen: SocketAddr,
     pub bond_ledger_url: Option<String>,
     pub bond_ledger_token: Option<String>,
+    /// This node's own `node_id` (Ed25519 pubkey). The co-located ghost-pay
+    /// derives its identity TLS cert from the SAME `node.key`, so the bond
+    /// ledger client pins the server cert's pubkey to exactly this value —
+    /// rejecting any other certificate on the loopback bond seam.
+    pub node_id: [u8; 32],
     pub fee_address: Option<String>,
     /// ghostd RPC the broadcaster pushes merged round txs to (reused from
     /// `[bitcoin]`).
@@ -128,23 +133,26 @@ impl CoordinatorSupervisor {
     async fn start(&self) {
         // Production bond ledger. On mainnet its presence was already enforced
         // in `maybe_new`; off mainnet a node may run without one (test nets).
-        let bond_ledger: Option<Arc<dyn BondLedger>> =
-            match (&self.cfg.bond_ledger_url, &self.cfg.bond_ledger_token) {
-                (Some(url), Some(token)) => match GhostPayBondLedger::new(url, token) {
-                    Ok(l) => Some(Arc::new(l)),
-                    Err(e) => {
-                        error!(error = %e, "coordinator: bond ledger init failed; not activating");
-                        return;
-                    }
-                },
-                (Some(_), None) => {
-                    error!(
-                    "coordinator: bond_ledger_url set without bond_ledger_token; not activating"
-                );
+        let bond_ledger: Option<Arc<dyn BondLedger>> = match (
+            &self.cfg.bond_ledger_url,
+            &self.cfg.bond_ledger_token,
+        ) {
+            (Some(url), Some(token)) => match GhostPayBondLedger::new(url, token, self.cfg.node_id)
+            {
+                Ok(l) => Some(Arc::new(l)),
+                Err(e) => {
+                    error!(error = %e, "coordinator: bond ledger init failed; not activating");
                     return;
                 }
-                _ => None,
-            };
+            },
+            (Some(_), None) => {
+                error!(
+                    "coordinator: bond_ledger_url set without bond_ledger_token; not activating"
+                );
+                return;
+            }
+            _ => None,
+        };
 
         let broadcaster: Option<Arc<dyn Broadcaster>> = match GhostdBroadcaster::new(
             self.cfg.ghostd_rpc_url.clone(),
@@ -223,6 +231,7 @@ mod tests {
             listen: "0.0.0.0:9100".parse().unwrap(),
             bond_ledger_url: bond_ledger_url.map(String::from),
             bond_ledger_token: bond_ledger_url.map(|_| "tok".to_string()),
+            node_id: [0u8; 32],
             fee_address: None,
             ghostd_rpc_url: "http://127.0.0.1:8332".to_string(),
             ghostd_rpc_user: "u".to_string(),

--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -3671,6 +3671,10 @@ async fn main() -> Result<()> {
             listen,
             bond_ledger_url: config.coordinator.bond_ledger_url.clone(),
             bond_ledger_token: config.coordinator.bond_ledger_token.clone(),
+            // The co-located ghost-pay serves its bond endpoints with an
+            // identity cert derived from this SAME node identity, so the bond
+            // ledger client pins against our own node_id.
+            node_id: identity.node_id(),
             fee_address: config.coordinator.coordinator_fee_address.clone(),
             ghostd_rpc_url: format!(
                 "http://{}:{}",

--- a/bins/wraith-coordinator/Cargo.toml
+++ b/bins/wraith-coordinator/Cargo.toml
@@ -39,6 +39,10 @@ path = "src/main.rs"
 [dependencies]
 # Workspace crates
 wraith-protocol = { workspace = true }
+# Identity-pinning TLS: the bond ledger client pins ghost-pay's Ed25519
+# identity cert against the co-located node_id via
+# `ghost_common::tls::IdentityPinningVerifier`.
+ghost-common = { workspace = true }
 
 # Bitcoin (just needed for Network enum + re-exports)
 bitcoin = { workspace = true }
@@ -56,6 +60,11 @@ hyper = { workspace = true }
 # ureq is pure-sync (no tokio entanglement) and exactly fits the
 # "occasional sync HTTP call from inside an async handler" use case.
 ureq = { version = "2.10", features = ["json", "tls"] }
+# rustls ClientConfig wiring for the bond ledger's identity-pinned TLS. ureq
+# 2.12 links the same rustls 0.23 as `ghost-common`, so the
+# `Arc<rustls::ClientConfig>` we build with `IdentityPinningVerifier` is
+# accepted directly by `AgentBuilder::tls_config`.
+rustls = { workspace = true }
 reqwest = { workspace = true }
 base64 = { workspace = true }
 
@@ -100,7 +109,6 @@ secp256k1 = { workspace = true }
 # assertions; `scrypt` re-derives the same DB key ghost-pay derives from
 # `GHOST_PAY_PASSWORD`; `tempfile` provides the throwaway data dir.
 ghost-storage = { workspace = true }
-ghost-common = { workspace = true }
 rusqlite = { workspace = true }
 scrypt = { workspace = true }
 tempfile = "3.10"

--- a/bins/wraith-coordinator/src/bond_ledger_http.rs
+++ b/bins/wraith-coordinator/src/bond_ledger_http.rs
@@ -51,8 +51,10 @@
 //!   on-chain / L2 escrow accounting; this client just observes
 //!   the result.
 
+use std::sync::Arc;
 use std::time::Duration;
 
+use ghost_common::tls::{IdentityPinningVerifier, PubkeyAllowList};
 use serde::{Deserialize, Serialize};
 use tracing::debug;
 
@@ -60,9 +62,21 @@ use wraith_protocol::{BondError, BondId, BondLedger, BondRecord, BondResolution}
 
 /// Ghost-pay HTTP-backed BondLedger.
 ///
-/// HTTP transport is `ureq` — pure-sync with no internal tokio
+/// Transport is HTTPS over `ureq` — pure-sync with no internal tokio
 /// runtime. `reqwest::blocking` would panic on Drop inside the
 /// surrounding axum/tokio runtime.
+///
+/// ## Identity-pinned TLS
+///
+/// ghost-pay serves its bond endpoints with a self-signed,
+/// **identity-derived** certificate whose Ed25519 public key IS the node's
+/// `node_id` (see `ghost_common::tls::build_server_config_with_identity`).
+/// There is no CA and no DNS name to validate against. So this client pins:
+/// the TLS server certificate is accepted iff its Ed25519 pubkey equals the
+/// one `node_id` the coordinator was told to expect (the co-located
+/// ghost-pay derives its cert from the SAME `node.key`, so cert pubkey ==
+/// node_id). Any other certificate — a MITM, a different node, a CA-issued
+/// cert — is rejected at the handshake. `base_url` MUST be `https://`.
 pub struct GhostPayBondLedger {
     base_url: String,
     /// Bearer auth token; sent as `Authorization: Bearer <token>` on
@@ -73,15 +87,53 @@ pub struct GhostPayBondLedger {
 }
 
 impl GhostPayBondLedger {
-    /// Construct from a base URL + bearer token. URL is normalised
-    /// to lose any trailing slash so subsequent path concatenation
-    /// is unambiguous.
-    pub fn new(base_url: impl Into<String>, bearer_token: &str) -> Result<Self, BondError> {
+    /// Construct from a base URL + bearer token, pinning the TLS server
+    /// certificate to `expected_node_id`.
+    ///
+    /// `base_url` is normalised to lose any trailing slash so subsequent path
+    /// concatenation is unambiguous, and MUST use the `https://` scheme — the
+    /// bond seam carries fund-bearing escrow state and is never spoken in the
+    /// clear. The `ureq` agent is configured with a rustls `ClientConfig`
+    /// whose certificate verifier ([`IdentityPinningVerifier`]) accepts ONLY a
+    /// server cert whose Ed25519 public key equals `expected_node_id`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BondError::Other`] if `base_url` is not `https://`.
+    pub fn new(
+        base_url: impl Into<String>,
+        bearer_token: &str,
+        expected_node_id: [u8; 32],
+    ) -> Result<Self, BondError> {
+        let base_url = base_url.into().trim_end_matches('/').to_string();
+        if !base_url.starts_with("https://") {
+            return Err(BondError::Other(format!(
+                "bond ledger base_url must use https:// (identity-pinned TLS); got `{base_url}`"
+            )));
+        }
+
+        // Install the process-wide rustls crypto provider on first use so the
+        // constructor is self-sufficient (idempotent: a second install returns
+        // Err which we deliberately ignore).
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
+        // Pin to EXACTLY the co-located ghost-pay's node_id. ghost-pay derives
+        // its identity cert from the same `node.key`, so the presented cert's
+        // Ed25519 pubkey must equal `expected_node_id`; anything else (MITM,
+        // wrong node, CA cert) fails the handshake.
+        let allow: PubkeyAllowList = Arc::new(move |k: &[u8; 32]| *k == expected_node_id);
+        let verifier = Arc::new(IdentityPinningVerifier::new(allow));
+        let tls_config = rustls::ClientConfig::builder()
+            .dangerous()
+            .with_custom_certificate_verifier(verifier)
+            .with_no_client_auth();
+
         let agent = ureq::AgentBuilder::new()
             .timeout(Duration::from_secs(15))
+            .tls_config(Arc::new(tls_config))
             .build();
         Ok(Self {
-            base_url: base_url.into().trim_end_matches('/').to_string(),
+            base_url,
             auth_header: format!("Bearer {bearer_token}"),
             agent,
         })
@@ -255,43 +307,86 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::{BufRead, BufReader, Write};
-    use std::net::{TcpListener, TcpStream};
+    use std::io::{BufRead, BufReader, Read, Write};
+    use std::net::TcpListener;
     use std::thread::JoinHandle;
 
-    /// Tiny one-shot HTTP/1.1 server. Same pattern as the broadcaster
-    /// tests — drops complexity for unblockedness.
-    fn one_shot(reply_status: u16, reply_body: serde_json::Value) -> (String, JoinHandle<String>) {
-        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-        let port = listener.local_addr().unwrap().port();
-        let url = format!("http://127.0.0.1:{port}");
-        let handle = std::thread::spawn(move || {
-            let (mut stream, _) = listener.accept().unwrap();
-            let body = read_request(&stream);
-            let body_str = reply_body.to_string();
-            let resp = format!(
-                "HTTP/1.1 {} OK\r\n\
-                 Content-Type: application/json\r\n\
-                 Content-Length: {}\r\n\
-                 \r\n\
-                 {}",
-                reply_status,
-                body_str.len(),
-                body_str
-            );
-            stream.write_all(resp.as_bytes()).unwrap();
-            body
-        });
-        (url, handle)
+    use ghost_common::config::TlsConfig;
+    use ghost_common::signer::{LocalSigner, Signer};
+    use ghost_common::tls::build_server_config_with_identity;
+
+    /// The `node_id` (Ed25519 pubkey) ghost-pay advertises for a given 32-byte
+    /// identity seed — the value an honest client must pin against.
+    fn node_id_for(secret: &[u8; 32]) -> [u8; 32] {
+        LocalSigner::from_bytes(secret).public_key()
     }
 
-    fn read_request(stream: &TcpStream) -> String {
+    /// One-shot HTTPS/1.1 server serving an **identity-derived** TLS cert
+    /// (cert pubkey == node_id from `secret`) that answers exactly one request
+    /// with `(reply_status, reply_body)`. Returns the `https://` base URL, the
+    /// served node_id, and a join handle yielding the request line + body the
+    /// client sent. The client below completes a real rustls handshake and
+    /// pins on the cert pubkey — this is the production trust path, not a mock.
+    ///
+    /// All socket IO is failure-tolerant so the negative pinning test (where
+    /// the client aborts the handshake) never panics the server thread.
+    fn one_shot_tls(
+        secret: [u8; 32],
+        reply_status: u16,
+        reply_body: serde_json::Value,
+    ) -> (String, [u8; 32], JoinHandle<String>) {
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+        let server_config = build_server_config_with_identity(&TlsConfig::default(), &secret, None)
+            .expect("server identity TLS config");
+        let node_id = node_id_for(&secret);
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let url = format!("https://127.0.0.1:{port}");
+
+        let handle = std::thread::spawn(move || {
+            let (mut tcp, _) = listener.accept().unwrap();
+            let mut conn = rustls::ServerConnection::new(server_config).unwrap();
+            let body_str = reply_body.to_string();
+            let request = {
+                let mut tls = rustls::Stream::new(&mut conn, &mut tcp);
+                let request = read_request(&mut tls);
+                let resp = format!(
+                    "HTTP/1.1 {} OK\r\n\
+                     Content-Type: application/json\r\n\
+                     Connection: close\r\n\
+                     Content-Length: {}\r\n\
+                     \r\n\
+                     {}",
+                    reply_status,
+                    body_str.len(),
+                    body_str
+                );
+                let _ = tls.write_all(resp.as_bytes());
+                let _ = tls.flush();
+                request
+            };
+            // Cleanly close the TLS session so the client reads to EOF.
+            conn.send_close_notify();
+            let _ = conn.complete_io(&mut tcp);
+            request
+        });
+        (url, node_id, handle)
+    }
+
+    /// Read one HTTP/1.1 request (request line, then a Content-Length body)
+    /// from any `Read`, returning `"<METHOD PATH> <body>"`. Tolerant of IO
+    /// errors (a rejected handshake just yields what was read so far).
+    fn read_request<R: Read>(stream: R) -> String {
         let mut reader = BufReader::new(stream);
         let mut content_length: usize = 0;
         let mut method_path = String::new();
         loop {
             let mut line = String::new();
-            reader.read_line(&mut line).unwrap();
+            match reader.read_line(&mut line) {
+                Ok(0) | Err(_) => break,
+                Ok(_) => {}
+            }
             if line == "\r\n" {
                 break;
             }
@@ -307,14 +402,30 @@ mod tests {
             return method_path;
         }
         let mut body = vec![0u8; content_length];
-        std::io::Read::read_exact(&mut reader, &mut body).unwrap();
-        format!("{method_path} {}", String::from_utf8(body).unwrap())
+        if reader.read_exact(&mut body).is_err() {
+            return method_path;
+        }
+        format!("{method_path} {}", String::from_utf8_lossy(&body))
+    }
+
+    #[test]
+    fn new_rejects_non_https_base_url() {
+        // `GhostPayBondLedger` isn't `Debug`, so match rather than `unwrap_err`.
+        match GhostPayBondLedger::new("http://127.0.0.1:8800", "tok", [0u8; 32]) {
+            Ok(_) => panic!("http:// base_url must be rejected"),
+            Err(BondError::Other(m)) => assert!(m.contains("https"), "msg: {m}"),
+            Err(other) => panic!("expected Other(https...); got {other:?}"),
+        }
     }
 
     #[test]
     fn verify_bond_returns_bond_id_on_success() {
-        let (url, server) = one_shot(200, serde_json::json!({ "bond_id": "ghost-pay-bond-abc" }));
-        let ledger = GhostPayBondLedger::new(url, "tok").unwrap();
+        let (url, node_id, server) = one_shot_tls(
+            [1u8; 32],
+            200,
+            serde_json::json!({ "bond_id": "ghost-pay-bond-abc" }),
+        );
+        let ledger = GhostPayBondLedger::new(url, "tok", node_id).unwrap();
         let id = ledger
             .verify_bond("wallet-x", "session-y", 500)
             .expect("verify ok");
@@ -327,12 +438,13 @@ mod tests {
     }
 
     #[test]
-    fn verify_bond_maps_404_not_bonded_to_NotBonded() {
-        let (url, server) = one_shot(
+    fn verify_bond_maps_404_to_not_bonded() {
+        let (url, node_id, server) = one_shot_tls(
+            [2u8; 32],
             404,
             serde_json::json!({ "error": "not_bonded", "detail": "" }),
         );
-        let ledger = GhostPayBondLedger::new(url, "tok").unwrap();
+        let ledger = GhostPayBondLedger::new(url, "tok", node_id).unwrap();
         let err = ledger.verify_bond("wx", "sy", 500).unwrap_err();
         match err {
             BondError::NotBonded {
@@ -349,11 +461,12 @@ mod tests {
 
     #[test]
     fn verify_bond_maps_409_amount_mismatch() {
-        let (url, server) = one_shot(
+        let (url, node_id, server) = one_shot_tls(
+            [3u8; 32],
             409,
             serde_json::json!({ "error": "amount_mismatch", "detail": "actual=499" }),
         );
-        let ledger = GhostPayBondLedger::new(url, "tok").unwrap();
+        let ledger = GhostPayBondLedger::new(url, "tok", node_id).unwrap();
         let err = ledger.verify_bond("wx", "sy", 500).unwrap_err();
         match err {
             BondError::AmountMismatch { expected_sats, .. } => {
@@ -365,13 +478,44 @@ mod tests {
     }
 
     #[test]
-    fn verify_bond_maps_transport_error_to_LedgerUnreachable() {
-        // 127.0.0.1:1 — reserved-low, refuses immediately.
-        let ledger = GhostPayBondLedger::new("http://127.0.0.1:1", "tok").unwrap();
+    fn verify_bond_maps_transport_error_to_unreachable() {
+        // 127.0.0.1:1 — reserved-low, refuses immediately. The `https` scheme
+        // satisfies the constructor; the connection itself fails at transport.
+        let ledger = GhostPayBondLedger::new("https://127.0.0.1:1", "tok", [0u8; 32]).unwrap();
         let err = ledger.verify_bond("a", "b", 1).unwrap_err();
         match err {
             BondError::LedgerUnreachable(_) => {}
             other => panic!("expected LedgerUnreachable; got {other:?}"),
         }
+    }
+
+    /// NEGATIVE pinning test — the whole point of the fix. The server presents
+    /// an identity cert for node_id A, but the client pins node_id B. The
+    /// rustls handshake MUST reject the cert, so the call fails at transport
+    /// and never reads the (would-be successful) 200 body. A pinning impl that
+    /// accepted any cert would turn this into an `Ok` and fail the test.
+    #[test]
+    fn verify_bond_rejects_wrong_pinned_node_id() {
+        let (url, served_node_id, server) = one_shot_tls(
+            [4u8; 32],
+            200,
+            serde_json::json!({ "bond_id": "must-never-be-read" }),
+        );
+        // Client pins a DIFFERENT node_id (seed [5u8; 32]) than the server serves.
+        let wrong_node_id = node_id_for(&[5u8; 32]);
+        assert_ne!(served_node_id, wrong_node_id, "test setup: ids must differ");
+
+        let ledger = GhostPayBondLedger::new(url, "tok", wrong_node_id).unwrap();
+        let err = ledger
+            .verify_bond("wallet-x", "session-y", 500)
+            .expect_err("pinning a wrong node_id must NOT succeed");
+        match err {
+            BondError::LedgerUnreachable(_) => {}
+            other => panic!(
+                "wrong pinned node_id MUST fail the TLS handshake \
+                 (LedgerUnreachable); got {other:?}"
+            ),
+        }
+        let _ = server.join();
     }
 }

--- a/bins/wraith-coordinator/src/main.rs
+++ b/bins/wraith-coordinator/src/main.rs
@@ -122,10 +122,12 @@ struct Cli {
     #[arg(long, env = "WRAITH_COORDINATOR_FILL_WINDOW_SECS")]
     fill_window_secs: Option<u64>,
 
-    /// Production ghost-pay BondLedger HTTP endpoint, e.g.
-    /// `http://127.0.0.1:8800/`. Calls the `/api/v1/wraith/bond/*`
+    /// Production ghost-pay BondLedger HTTPS endpoint, e.g.
+    /// `https://127.0.0.1:8800/`. Calls the `/api/v1/wraith/bond/*`
     /// endpoint set defined in `bond_ledger_http.rs`. Auth via the
-    /// matching --bond-ledger-token (HTTP Bearer).
+    /// matching --bond-ledger-token (HTTP Bearer). MUST be `https://`:
+    /// the client pins ghost-pay's identity cert (see
+    /// --bond-ledger-node-id).
     #[arg(long, env = "WRAITH_COORDINATOR_BOND_LEDGER_URL")]
     bond_ledger_url: Option<String>,
 
@@ -134,6 +136,14 @@ struct Cli {
     /// boot. Required when --bond-ledger-url is set.
     #[arg(long, env = "WRAITH_COORDINATOR_BOND_LEDGER_TOKEN")]
     bond_ledger_token: Option<String>,
+
+    /// The ghost-pay node's `node_id` (64-hex Ed25519 pubkey) to pin its
+    /// TLS identity cert against. ghost-pay derives its bond-endpoint cert
+    /// from its `node.key`, so the cert's pubkey IS this node_id; the
+    /// client accepts that cert and no other (no CA, no DNS). Required when
+    /// --bond-ledger-url is set.
+    #[arg(long, env = "WRAITH_COORDINATOR_BOND_LEDGER_NODE_ID")]
+    bond_ledger_node_id: Option<String>,
 
     /// Use an in-memory StubBroadcaster instead of a real backend.
     /// Refused on mainnet — a stub broadcaster doesn't actually push
@@ -226,9 +236,16 @@ async fn main() -> Result<()> {
             .bond_ledger_token
             .as_deref()
             .ok_or_else(|| anyhow::anyhow!("--bond-ledger-url requires --bond-ledger-token"))?;
-        let ledger = GhostPayBondLedger::new(url, token)
+        let node_id_hex = cli.bond_ledger_node_id.as_deref().ok_or_else(|| {
+            anyhow::anyhow!(
+                "--bond-ledger-url requires --bond-ledger-node-id (the ghost-pay \
+                 node_id to pin its identity TLS cert against)"
+            )
+        })?;
+        let node_id = parse_node_id(node_id_hex)?;
+        let ledger = GhostPayBondLedger::new(url, token, node_id)
             .map_err(|e| anyhow::anyhow!("ghost-pay bond ledger: {e}"))?;
-        info!(endpoint = %url, "using GhostPayBondLedger");
+        info!(endpoint = %url, "using GhostPayBondLedger (identity-pinned TLS)");
         Some(Arc::new(ledger))
     } else {
         None
@@ -375,6 +392,20 @@ fn init_logging() {
     let filter = tracing_subscriber::EnvFilter::try_from_default_env()
         .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
     tracing_subscriber::fmt().with_env_filter(filter).init();
+}
+
+/// Parse a 64-hex Ed25519 `node_id` (the value the bond ledger client pins
+/// ghost-pay's identity TLS cert against) into raw bytes.
+fn parse_node_id(s: &str) -> Result<[u8; 32]> {
+    let bytes = hex::decode(s.trim())
+        .with_context(|| format!("--bond-ledger-node-id must be 64-hex; got `{s}`"))?;
+    let arr: [u8; 32] = bytes.as_slice().try_into().map_err(|_| {
+        anyhow::anyhow!(
+            "--bond-ledger-node-id must decode to exactly 32 bytes (got {})",
+            bytes.len()
+        )
+    })?;
+    Ok(arr)
 }
 
 fn parse_network(s: &str) -> Result<bitcoin::Network> {

--- a/bins/wraith-coordinator/tests/bond_e2e.rs
+++ b/bins/wraith-coordinator/tests/bond_e2e.rs
@@ -6,8 +6,10 @@
 //! coordinator using the **real** `GhostPayBondLedger` HTTP client. Every
 //! load-bearing component on the bond path is the production article:
 //!
-//!   - the real `ghost-pay` server (subprocess, ephemeral port, plain
-//!     HTTP, non-mainnet `signet`),
+//!   - the real `ghost-pay` server (subprocess, ephemeral port, non-mainnet
+//!     `signet`) serving **real HTTPS** with an identity-derived cert (cert
+//!     pubkey == node_id, from a `--identity-key` node.key), against which the
+//!     coordinator client pins — the exact production trust path,
 //!   - the real participant HMAC auth on `/escrow`
 //!     (`X-Ghost-Signature` + `X-Ghost-Timestamp`),
 //!   - the real coordinator Bearer auth on `/verify` + `/resolve` +
@@ -48,6 +50,8 @@ use hmac::{Hmac, Mac};
 use sha2::Sha256;
 use tower::ServiceExt;
 
+use ghost_common::signer::{LocalSigner, Signer};
+use ghost_common::tls::{IdentityPinningVerifier, PubkeyAllowList};
 use ghost_storage::Database;
 use wraith_coordinator::bond_ledger_http::GhostPayBondLedger;
 use wraith_coordinator::broadcaster::{Broadcaster, StubBroadcaster};
@@ -73,6 +77,12 @@ const DB_PASSWORD: &str = "e2e-ghost-pay-db-password-0123456789abcdef";
 
 /// Per-participant signet change/fee destination (valid bech32 checksum).
 const TEST_FEE_ADDRESS: &str = "tb1q0xcqpzrky6eff2g52qdye53xkk9jxkvraulyla";
+
+/// 32-byte Ed25519 identity seed written to the ghost-pay `node.key` and
+/// handed to ghost-pay via `--identity-key`. ghost-pay derives its bond-endpoint
+/// TLS cert from this seed (cert pubkey == node_id), and the coordinator client
+/// pins against that node_id.
+const NODE_IDENTITY_SEED: [u8; 32] = [0x5a; 32];
 
 /// Five distinct valid signet P2WPKH mix-output addresses (keys `[i;32]`).
 const FIVE_SIGNET_ADDRS: [&str; 5] = [
@@ -179,9 +189,36 @@ fn free_port() -> u16 {
     l.local_addr().unwrap().port()
 }
 
+/// The `node_id` (Ed25519 pubkey) ghost-pay advertises for a 32-byte seed.
+fn node_id_for(secret: &[u8; 32]) -> [u8; 32] {
+    LocalSigner::from_bytes(secret).public_key()
+}
+
+/// Build a `ureq` agent that pins ghost-pay's identity TLS cert against
+/// `node_id` — the same pinning the production `GhostPayBondLedger` uses, so
+/// the participant HMAC `/escrow` calls and health polls in this test ride the
+/// real HTTPS path too.
+fn pinned_agent(node_id: [u8; 32]) -> ureq::Agent {
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+    let allow: PubkeyAllowList = Arc::new(move |k: &[u8; 32]| *k == node_id);
+    let verifier = Arc::new(IdentityPinningVerifier::new(allow));
+    let tls = rustls::ClientConfig::builder()
+        .dangerous()
+        .with_custom_certificate_verifier(verifier)
+        .with_no_client_auth();
+    ureq::AgentBuilder::new()
+        .timeout(Duration::from_secs(15))
+        .tls_config(Arc::new(tls))
+        .build()
+}
+
 struct GhostPay {
     child: Child,
     base_url: String,
+    /// node_id ghost-pay serves its identity cert for (== `node_id_for(seed)`).
+    node_id: [u8; 32],
+    /// Pinned HTTPS agent for the test's own participant/health calls.
+    agent: ureq::Agent,
     /// A long-lived handle on the same encrypted DB the server uses, opened
     /// before spawn (so migrations don't race) and kept for read-back
     /// ground-truth assertions over `wraith_bonds`.
@@ -205,6 +242,12 @@ impl GhostPay {
             seed_l2_balance(&db, ghost_id, *sats);
         }
 
+        // Write the node.key (32-byte Ed25519 seed) ghost-pay derives its
+        // identity TLS cert from, and compute the node_id we pin against.
+        let key_path = data_dir.path().join("node.key");
+        std::fs::write(&key_path, NODE_IDENTITY_SEED).expect("write node.key");
+        let node_id = node_id_for(&NODE_IDENTITY_SEED);
+
         let port = free_port();
         let bin = ghost_pay_binary();
         let child = Command::new(bin)
@@ -214,6 +257,10 @@ impl GhostPay {
             .arg(format!("127.0.0.1:{port}"))
             .arg("--data-dir")
             .arg(data_dir.path())
+            // Serve the bond endpoints over HTTPS with the identity-derived
+            // cert (cert pubkey == node_id) — the production trust path.
+            .arg("--identity-key")
+            .arg(&key_path)
             .arg("--api-secret")
             .arg(API_SECRET)
             .arg("--bond-ledger-token")
@@ -234,10 +281,12 @@ impl GhostPay {
             .spawn()
             .expect("spawn ghost-pay");
 
-        let base_url = format!("http://127.0.0.1:{port}");
+        let base_url = format!("https://127.0.0.1:{port}");
         let gp = GhostPay {
             child,
             base_url,
+            node_id,
+            agent: pinned_agent(node_id),
             db,
             _data_dir: data_dir,
         };
@@ -257,10 +306,11 @@ impl GhostPay {
         let url = format!("{}/health", self.base_url);
         let deadline = Instant::now() + Duration::from_secs(45);
         loop {
-            match ureq::get(&url).timeout(Duration::from_secs(2)).call() {
-                // Any HTTP status (incl. 503) means the listener is up.
+            match self.agent.get(&url).timeout(Duration::from_secs(2)).call() {
+                // Any HTTP status (incl. 503) means the TLS listener is up and
+                // the pinned handshake succeeded.
                 Ok(_) | Err(ureq::Error::Status(_, _)) => break,
-                // Transport error (connection refused) — still binding.
+                // Transport error (connection refused / TLS not ready) — still binding.
                 Err(_) => {}
             }
             if Instant::now() >= deadline {
@@ -275,7 +325,7 @@ impl GhostPay {
     /// Build a fresh real `GhostPayBondLedger` pointed at this server with
     /// the matching Bearer token.
     fn ledger(&self) -> GhostPayBondLedger {
-        GhostPayBondLedger::new(&self.base_url, BOND_TOKEN).expect("ledger")
+        GhostPayBondLedger::new(&self.base_url, BOND_TOKEN, self.node_id).expect("ledger")
     }
 }
 
@@ -353,6 +403,7 @@ enum EscrowResult {
 /// real `require_api_auth` middleware verifies.
 fn escrow_bond(
     pacer: &Pacer,
+    agent: &ureq::Agent,
     base_url: &str,
     ghost_id: &str,
     session_id: &str,
@@ -375,7 +426,8 @@ fn escrow_bond(
     mac.update(body.as_bytes());
     let sig = hex::encode(mac.finalize().into_bytes());
 
-    let resp = ureq::post(&format!("{base_url}/api/v1/wraith/bond/escrow"))
+    let resp = agent
+        .post(&format!("{base_url}/api/v1/wraith/bond/escrow"))
         .set("content-type", "application/json")
         .set("X-Ghost-Signature", &sig)
         .set("X-Ghost-Timestamp", &ts.to_string())
@@ -395,8 +447,14 @@ fn escrow_bond(
     }
 }
 
-fn escrow_ok(pacer: &Pacer, base: &str, ghost_id: &str, session_id: &str) -> String {
-    match escrow_bond(pacer, base, ghost_id, session_id, BOND_SATS) {
+fn escrow_ok(
+    pacer: &Pacer,
+    agent: &ureq::Agent,
+    base: &str,
+    ghost_id: &str,
+    session_id: &str,
+) -> String {
+    match escrow_bond(pacer, agent, base, ghost_id, session_id, BOND_SATS) {
         EscrowResult::Ok(id) => id,
         EscrowResult::Err(code, err) => panic!("escrow {ghost_id} failed: {code} {err}"),
     }
@@ -729,6 +787,35 @@ async fn bond_e2e_real_ghostpay_full_lifecycle() {
     let gp = GhostPay::spawn(&seeds);
     let pacer: Pacer = Arc::new(Mutex::new(RateMirror::new()));
     let base = gp.base_url.clone();
+    // Pinned HTTPS agent for the participant `/escrow` + health calls — same
+    // identity pin the coordinator's bond ledger client uses.
+    let agent = gp.agent.clone();
+
+    // ======================================================================
+    // PHASE 0 — NEGATIVE PIN: a bond ledger client pinned to the WRONG node_id
+    //           must FAIL the TLS handshake against the real ghost-pay server.
+    //           This proves the pin actually rejects a non-matching cert — a
+    //           pinning impl that accepted any cert would let `verify_bond`
+    //           succeed here, which is worse than the original bug.
+    // ======================================================================
+    {
+        let wrong_node_id = node_id_for(&[0xa5; 32]);
+        assert_ne!(
+            wrong_node_id, gp.node_id,
+            "test setup: wrong node_id must differ from the served one"
+        );
+        // Same https base_url + valid Bearer token — ONLY the pinned node_id
+        // is wrong, isolating the TLS pin as the cause of failure.
+        let wrong_ledger =
+            GhostPayBondLedger::new(&base, BOND_TOKEN, wrong_node_id).expect("ledger ctor");
+        let err = wrong_ledger
+            .verify_bond("h0", "any-session", BOND_SATS)
+            .expect_err("wrong-node_id pin MUST NOT verify a bond");
+        assert!(
+            matches!(err, wraith_protocol::BondError::LedgerUnreachable(_)),
+            "wrong pin must fail at the TLS handshake (LedgerUnreachable); got {err:?}"
+        );
+    }
 
     // ======================================================================
     // PHASE 1 — HAPPY PATH: escrow → join → verify → mix → resolve(refund)
@@ -743,7 +830,7 @@ async fn bond_e2e_real_ghostpay_full_lifecycle() {
         // 1b. Each escrows a real 500-sat bond via ghost-pay /escrow (HMAC).
         let mut bond_ids = Vec::new();
         for g in &happy {
-            let id = escrow_ok(&pacer, &base, g, &session_id);
+            let id = escrow_ok(&pacer, &agent, &base, g, &session_id);
             assert!(id.starts_with("gpbond-"), "real bond id: {id}");
             bond_ids.push(id);
         }
@@ -893,13 +980,13 @@ async fn bond_e2e_real_ghostpay_full_lifecycle() {
     {
         // `ds` was seeded with exactly one bond's worth (500). First escrow
         // (session ds-A) succeeds and consumes the whole spendable balance.
-        let id_a = escrow_ok(&pacer, &base, "ds", "ds-A");
+        let id_a = escrow_ok(&pacer, &agent, &base, "ds", "ds-A");
         assert!(id_a.starts_with("gpbond-"));
         assert_eq!(held_bonds(&gp.db, "ds"), 500, "first escrow held");
 
         // Second escrow (different session ds-B) must be refused: spendable
         // is now 0 because the live bond is netted out by spendable_l2_balance.
-        match escrow_bond(&pacer, &base, "ds", "ds-B", BOND_SATS) {
+        match escrow_bond(&pacer, &agent, &base, "ds", "ds-B", BOND_SATS) {
             EscrowResult::Err(code, err) => {
                 assert_eq!(code, 402, "double-spend escrow rejected");
                 assert_eq!(err, "insufficient_balance");
@@ -923,7 +1010,7 @@ async fn bond_e2e_real_ghostpay_full_lifecycle() {
 
         let mut bond_ids = std::collections::HashMap::new();
         for g in &slash {
-            bond_ids.insert(*g, escrow_ok(&pacer, &base, g, &session_id));
+            bond_ids.insert(*g, escrow_ok(&pacer, &agent, &base, g, &session_id));
         }
 
         force_locked(&state, &session_id);

--- a/scripts/install-node.sh
+++ b/scripts/install-node.sh
@@ -411,7 +411,10 @@ EOF
 # in-process coordinator when this node wins a seat; `coordinator_port` is the
 # listen port (0.0.0.0:<port>); `bond_ledger_url`/`bond_ledger_token` point at
 # the local ghost-pay bond ledger (the token MUST equal ghost-pay's
-# GHOST_PAY_BOND_LEDGER_TOKEN). `wraith_election_enabled` + `coordinator_enabled`
+# GHOST_PAY_BOND_LEDGER_TOKEN). The URL is `https://` — ghost-pay serves its
+# bond endpoints with an identity-derived TLS cert and the coordinator pins it
+# against this node's own node_id (cert pubkey == node_id), so plain HTTP would
+# be rejected. `wraith_election_enabled` + `coordinator_enabled`
 # + `advertised_endpoint` make this node electable and let it compute the
 # per-epoch draw, so a single enabled node is enough and many are safe.
 if [[ "$WRAITH" == "true" ]]; then
@@ -423,7 +426,7 @@ coordinator_enabled = true
 advertised_endpoint = "${PUBIP}:9100"
 coordinator_port = 9100
 coordinator_role_enabled = true
-bond_ledger_url = "http://127.0.0.1:8800"
+bond_ledger_url = "https://127.0.0.1:8800"
 bond_ledger_token = "${BOND_LEDGER_TOKEN}"
 EOF
 fi

--- a/scripts/install-node.sh
+++ b/scripts/install-node.sh
@@ -549,7 +549,7 @@ Type=simple
 User=ghost
 Group=ghost
 WorkingDirectory=/var/lib/ghost
-ExecStart=/opt/ghost/bin/ghost-pay --api-listen 0.0.0.0:8800 --data-dir /home/ghost/.ghost/ghost-pay --bitcoin-rpc http://127.0.0.1:8332 --network mainnet --treasury-address bc1qgxg5ywk835c9fp6arz6d6x50xpk6y0ualt900k --node-payout-address ${PAYOUT_ADDRESS}
+ExecStart=/opt/ghost/bin/ghost-pay --api-listen 0.0.0.0:8800 --data-dir /home/ghost/.ghost/ghost-pay --bitcoin-rpc http://127.0.0.1:8332 --network mainnet --treasury-address bc1qgxg5ywk835c9fp6arz6d6x50xpk6y0ualt900k --node-payout-address ${PAYOUT_ADDRESS} --identity-key /home/ghost/.ghost/node.key
 Environment=RUST_LOG=info
 Environment=BITCOIN_RPC_USER=ghostrpc_mainnet
 Environment=BITCOIN_RPC_PASSWORD=${RPCPW}

--- a/scripts/ops/health-check.sh
+++ b/scripts/ops/health-check.sh
@@ -84,9 +84,10 @@ check_node() {
         echo "pool_ok=0" >> "$out"
     fi
 
-    # 2. ghost-pay reachable
-    if curl -sf --connect-timeout 3 "http://$ip:$GHOST_PAY_PORT/health" >/dev/null 2>&1 \
-       || curl -sf --connect-timeout 3 "http://$ip:$GHOST_PAY_PORT/api/v1/l2/state" >/dev/null 2>&1; then
+    # 2. ghost-pay reachable (ghost-pay serves HTTPS with an identity-derived
+    #    self-signed cert, so probe https with -k)
+    if curl -skf --connect-timeout 3 "https://$ip:$GHOST_PAY_PORT/health" >/dev/null 2>&1 \
+       || curl -skf --connect-timeout 3 "https://$ip:$GHOST_PAY_PORT/api/v1/l2/state" >/dev/null 2>&1; then
         echo "pay_ok=1" >> "$out"
     else
         echo "pay_ok=0" >> "$out"


### PR DESCRIPTION
Fixes the blocker the mixing canary surfaced: ghost-pay serves HTTPS (self-signed identity cert, pubkey == node_id) but `GhostPayBondLedger` used a plain ureq/HTTP client + the installer set `http://` → the coordinator could not reach its bond ledger, so mixing would fail on mainnet. The bonded-mix harness missed it because it ran ghost-pay in plain-HTTP test mode.

## Fix
- **`GhostPayBondLedger`** now speaks **identity-pinned HTTPS**: kept ureq (`AgentBuilder::tls_config(Arc<rustls::ClientConfig>)`; ureq 2.12.1 shares the same rustls 0.23 as ghost-common), reusing the proven `IdentityPinningVerifier` from `ghost-verification::with_pinning`. It pins the server certs Ed25519 pubkey == the nodes `node_id`, and rejects `http://` URLs.
- **node_id flow:** ghost-pool passes `identity.node_id()` → `CoordinatorRoleConfig.node_id` → `coordinator_supervisor` → `GhostPayBondLedger::new`. Standalone coordinator binary gains a required `--bond-ledger-node-id`.
- **Harness updated to real HTTPS** (ghost-pay spawned with `--identity-key`), so the seam is now covered.
- **Installer** `bond_ledger_url` → `https://`, and ghost-pay `ExecStart` gains `--identity-key /home/ghost/.ghost/node.key` (without it a fresh-install ghost-pay served plain HTTP). Ops health-check probes ghost-pay over `https -k`.

## Verified
Positive: full bonded-mix `bond_e2e` over real HTTPS with pinning passes (escrow→verify→mix→refund, slash/abort, gates). **Negative (the point):** three tests prove pinning a *wrong* node_id fails the call with `LedgerUnreachable` (aborted TLS handshake) — never a silent accept. `cargo test -p wraith-coordinator` 14+58+2 green; builds/clippy/fmt/doc clean.