### PR TITLE
Opt-in node auto-update (default OFF, GPG-verified)

### DIFF
--- a/dashboard/src/app/(dashboard)/system/page.tsx
+++ b/dashboard/src/app/(dashboard)/system/page.tsx
@@ -18,6 +18,8 @@ import {
   useUpdateStatus,
   useStartUpdate,
   useRollbackUpdate,
+  useAutoUpdate,
+  useSetAutoUpdate,
   // Storage & Pruning
   useFullConfig,
   useNodeStatus,
@@ -158,6 +160,11 @@ export default function SystemPage() {
   const startUpdate = useStartUpdate();
   const rollback = useRollbackUpdate();
 
+  // -- Auto-update opt-in (default OFF) --
+  const { data: autoUpdate } = useAutoUpdate();
+  const setAutoUpdateMut = useSetAutoUpdate();
+  const autoUpdateEnabled = autoUpdate?.enabled ?? false;
+
   const [confirmDialogOpen, setConfirmDialogOpen] = useState(false);
   const [rollbackDialogOpen, setRollbackDialogOpen] = useState(false);
 
@@ -254,6 +261,23 @@ export default function SystemPage() {
     } catch (err) {
       setIsUpdating(false);
       toastError("Update Failed", err instanceof Error ? err.message : "Unknown error");
+    }
+  };
+
+  const handleAutoUpdateToggle = async (next: boolean) => {
+    try {
+      const result = await setAutoUpdateMut.mutateAsync(next);
+      success(
+        result.enabled ? "Automatic Updates On" : "Automatic Updates Off",
+        result.enabled
+          ? "Signed releases will be verified and applied automatically (checked every 6h)."
+          : "This node will no longer update itself.",
+      );
+    } catch (err) {
+      toastError(
+        "Toggle Failed",
+        err instanceof Error ? err.message : "Could not change the auto-update setting",
+      );
     }
   };
 
@@ -559,6 +583,42 @@ export default function SystemPage() {
               >
                 Check for Updates
               </Button>
+
+              {/* Automatic Updates (opt-in, default OFF) */}
+              <div className="pt-4 border-t border-gray-800">
+                <div className="flex items-center justify-between">
+                  <div className="pr-4">
+                    <div className="flex items-center gap-2">
+                      <span className="text-sm font-medium text-gray-300">Automatic updates</span>
+                      <Badge variant={autoUpdateEnabled ? "success" : "default"}>
+                        {autoUpdateEnabled ? "On" : "Off"}
+                      </Badge>
+                    </div>
+                    <p className="text-xs text-gray-500 mt-0.5">
+                      When on, newer <strong>signed</strong> releases are applied automatically —
+                      the GPG signature and ghostd checksum are verified before any binary is
+                      swapped, and the node rolls back on a failed health check. Checked every 6h.
+                      Off by default.
+                    </p>
+                    {autoUpdate?.last_status?.result && (
+                      <p className="text-xs text-gray-500 mt-1">
+                        Last check: {autoUpdate.last_status.result}
+                        {autoUpdate.last_status.last_run
+                          ? ` · ${formatDate(autoUpdate.last_status.last_run)}`
+                          : ""}
+                        {autoUpdate.installed_version ? ` · installed ${autoUpdate.installed_version}` : ""}
+                        {autoUpdate.latest_version ? ` · latest ${autoUpdate.latest_version}` : ""}
+                      </p>
+                    )}
+                  </div>
+                  <Toggle
+                    enabled={autoUpdateEnabled}
+                    onChange={handleAutoUpdateToggle}
+                    disabled={setAutoUpdateMut.isPending}
+                    label="Toggle automatic updates"
+                  />
+                </div>
+              </div>
 
               {/* Rollback */}
               <div className="pt-4 border-t border-gray-800">

--- a/dashboard/src/app/api/auto-update/route.ts
+++ b/dashboard/src/app/api/auto-update/route.ts
@@ -1,0 +1,135 @@
+import { NextRequest, NextResponse } from "next/server";
+import { readFile } from "fs/promises";
+import { execFile } from "child_process";
+import { promisify } from "util";
+
+// ---------------------------------------------------------------------------
+// Auto-update opt-in (read + toggle)
+// ---------------------------------------------------------------------------
+// The node updater is gated by /etc/ghost/auto-update.conf (AUTO_UPDATE=true|
+// false). The dashboard is NOT root and never writes that file directly.
+//
+//   GET  — reads the (world-readable) opt-in conf, the installed-version marker,
+//          and the updater's last-run status file. Pure reads, no privilege.
+//   POST — flips the opt-in by shelling out to the root-owned, sudoers-scoped
+//          helper `ghost-autoupdate-toggle on|off`. The sudoers rule
+//          (/etc/sudoers.d/ghost-autoupdate) pins the exact argument, so this
+//          route can do nothing else as root.
+//
+// This route is auth-gated by middleware.ts (valid JWT session required) like
+// every other /api path. It must run on the Node.js runtime (fs + child_process).
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const execFileAsync = promisify(execFile);
+
+const CONF_PATH = process.env.GHOST_AUTOUPDATE_CONF ?? "/etc/ghost/auto-update.conf";
+const VERSION_PATH = process.env.GHOST_VERSION_FILE ?? "/etc/ghost/version";
+const STATUS_PATH = process.env.GHOST_AUTOUPDATE_STATUS ?? "/var/lib/ghost/auto-update.status";
+const TOGGLE_BIN = process.env.GHOST_AUTOUPDATE_TOGGLE ?? "/opt/ghost/bin/ghost-autoupdate-toggle";
+
+interface AutoUpdateStatus {
+  last_run?: string;
+  result?: string;
+  message?: string;
+  installed_version?: string;
+  latest_version?: string;
+}
+
+interface AutoUpdateState {
+  enabled: boolean;
+  installed_version: string | null;
+  latest_version: string | null;
+  last_status: AutoUpdateStatus | null;
+}
+
+// AUTO_UPDATE is "on" ONLY when the conf says exactly `true` — mirrors the
+// updater's own gate, so the UI can never imply opted-in when it isn't.
+async function readEnabled(): Promise<boolean> {
+  try {
+    const raw = await readFile(CONF_PATH, "utf8");
+    const m = raw.match(/^[ \t]*AUTO_UPDATE[ \t]*=[ \t]*([A-Za-z]+)/m);
+    return m?.[1] === "true";
+  } catch {
+    return false; // missing/unreadable conf => treated as opted-out
+  }
+}
+
+async function readInstalledVersion(): Promise<string | null> {
+  try {
+    const v = (await readFile(VERSION_PATH, "utf8")).trim();
+    return v || null;
+  } catch {
+    return null;
+  }
+}
+
+async function readStatus(): Promise<AutoUpdateStatus | null> {
+  try {
+    return JSON.parse(await readFile(STATUS_PATH, "utf8")) as AutoUpdateStatus;
+  } catch {
+    return null;
+  }
+}
+
+async function buildState(): Promise<AutoUpdateState> {
+  const [enabled, installed, status] = await Promise.all([
+    readEnabled(),
+    readInstalledVersion(),
+    readStatus(),
+  ]);
+  return {
+    enabled,
+    installed_version: installed,
+    latest_version: status?.latest_version ?? null,
+    last_status: status,
+  };
+}
+
+export async function GET() {
+  try {
+    return NextResponse.json(await buildState());
+  } catch (error) {
+    return NextResponse.json(
+      { error: `Failed to read auto-update state: ${error instanceof Error ? error.message : "unknown"}` },
+      { status: 500 },
+    );
+  }
+}
+
+export async function POST(request: NextRequest) {
+  let body: { enabled?: unknown };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (typeof body.enabled !== "boolean") {
+    return NextResponse.json({ error: "Body must be { enabled: boolean }" }, { status: 400 });
+  }
+
+  // The ONLY two argv values are the fixed literals "on"/"off" — never user
+  // text — so there is nothing to inject through the privileged helper.
+  const arg = body.enabled ? "on" : "off";
+
+  try {
+    await execFileAsync("sudo", ["-n", TOGGLE_BIN, arg], { timeout: 15_000 });
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : "unknown";
+    return NextResponse.json(
+      { error: `Failed to set auto-update (${arg}): ${msg}` },
+      { status: 500 },
+    );
+  }
+
+  // Return the freshly-read state so the client reflects ground truth, not the
+  // value it optimistically sent.
+  try {
+    return NextResponse.json(await buildState());
+  } catch {
+    return NextResponse.json({ enabled: body.enabled });
+  }
+}

--- a/dashboard/src/hooks/queries/useSystemQueries.ts
+++ b/dashboard/src/hooks/queries/useSystemQueries.ts
@@ -6,12 +6,14 @@ import {
   getUpdateStatus,
   rollbackUpdate,
 } from '@/lib/api/system';
+import { getAutoUpdate, setAutoUpdate } from '@/lib/api/autoUpdate';
 
 export const systemKeys = {
   all: ['system'] as const,
   version: () => [...systemKeys.all, 'version'] as const,
   updates: () => [...systemKeys.all, 'updates'] as const,
   updateStatus: () => [...systemKeys.all, 'updateStatus'] as const,
+  autoUpdate: () => [...systemKeys.all, 'autoUpdate'] as const,
 };
 
 export function useSystemVersion() {
@@ -59,6 +61,26 @@ export function useRollbackUpdate() {
     mutationFn: rollbackUpdate,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: systemKeys.all });
+    },
+  });
+}
+
+// Auto-update opt-in: reflects /etc/ghost/auto-update.conf (default OFF).
+export function useAutoUpdate() {
+  return useQuery({
+    queryKey: systemKeys.autoUpdate(),
+    queryFn: getAutoUpdate,
+    staleTime: 30_000,
+  });
+}
+
+export function useSetAutoUpdate() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (enabled: boolean) => setAutoUpdate(enabled),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: systemKeys.autoUpdate() });
     },
   });
 }

--- a/dashboard/src/lib/api/autoUpdate.ts
+++ b/dashboard/src/lib/api/autoUpdate.ts
@@ -1,0 +1,46 @@
+// Auto-update opt-in API client.
+//
+// Unlike most dashboard endpoints, this does NOT go through the node-API proxy
+// (/api/proxy/...). The opt-in lives in /etc/ghost/auto-update.conf on the host,
+// so it is served by the dashboard's own Node route at /api/auto-update, which
+// reads the conf and flips it via the sudoers-scoped toggle helper.
+import { getApiBase } from "./client";
+
+export interface AutoUpdateStatus {
+  last_run?: string;
+  result?: string;
+  message?: string;
+  installed_version?: string;
+  latest_version?: string;
+}
+
+export interface AutoUpdateState {
+  enabled: boolean;
+  installed_version: string | null;
+  latest_version: string | null;
+  last_status: AutoUpdateStatus | null;
+}
+
+export async function getAutoUpdate(): Promise<AutoUpdateState> {
+  const res = await fetch(`${getApiBase()}/api/auto-update`, {
+    headers: { "Content-Type": "application/json" },
+  });
+  if (!res.ok) {
+    const e = await res.json().catch(() => ({ error: "Unknown error" }));
+    throw new Error(e.error || `Failed to read auto-update state: ${res.status}`);
+  }
+  return res.json();
+}
+
+export async function setAutoUpdate(enabled: boolean): Promise<AutoUpdateState> {
+  const res = await fetch(`${getApiBase()}/api/auto-update`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ enabled }),
+  });
+  if (!res.ok) {
+    const e = await res.json().catch(() => ({ error: "Unknown error" }));
+    throw new Error(e.error || `Failed to set auto-update: ${res.status}`);
+  }
+  return res.json();
+}

--- a/scripts/ghost-auto-update.sh
+++ b/scripts/ghost-auto-update.sh
@@ -1,0 +1,411 @@
+#!/usr/bin/env bash
+#
+# Bitcoin Ghost — opt-in node auto-update.
+#
+# Runs as root from `ghost-auto-update.timer` (every 6h, randomised). It is a
+# strict no-op unless the operator has opted in via /etc/ghost/auto-update.conf
+# (AUTO_UPDATE=true). When opted in, it resolves the latest published release,
+# and — ONLY if it is newer than what is installed — downloads the release
+# tarball + ghostd, verifies the detached GPG signature against the pinned
+# release key AND the ghostd SHA256 against the freshly-fetched install.sh,
+# backs up the current binaries, swaps them with a stop→verify-inactive→swap→
+# start sequence, health-checks, and rolls back on any failure.
+#
+# SUPPLY-CHAIN-CRITICAL: a binary is NEVER written unless BOTH the GPG signature
+# and the ghostd checksum verify. The verification logic mirrors the first-run
+# installer (scripts/install-node.sh) exactly.
+#
+# This file is the canonical source. scripts/install-node.sh installs a verbatim
+# copy at /opt/ghost/bin/ghost-auto-update.sh.
+#
+set -euo pipefail
+
+# ─────────────────────────── pinned trust anchors ────────────────────────────
+# Defaults are the production values. Every one is overridable via the
+# environment SOLELY so the abort/accept paths can be exercised hermetically in
+# tests (file:// URLs, a throwaway signing key, temp dirs). Production runs use
+# the pinned defaults untouched.
+GPG_KEY_FP="${GHOST_GPG_KEY_FP:-777FE81F8CC077FD3D08055E852C2B3190F5B928}"
+RELEASE_KEY_URL="${GHOST_RELEASE_KEY_URL:-https://get.bitcoinghost.org/ghost-release-key.asc}"
+INSTALL_SH_URL="${GHOST_INSTALL_SH_URL:-https://get.bitcoinghost.org/install.sh}"
+GHOSTD_URL="${GHOSTD_URL:-https://get.bitcoinghost.org/bin/ghostd}"
+# Release tarball base. When GHOST_RELEASE_BASE is set it is used verbatim;
+# otherwise it is constructed per-version from the GitHub releases download URL.
+RELEASE_BASE_OVERRIDE="${GHOST_RELEASE_BASE:-}"
+
+# ───────────────────────────── managed paths ─────────────────────────────────
+CONF_FILE="${GHOST_AUTOUPDATE_CONF:-/etc/ghost/auto-update.conf}"
+VERSION_FILE="${GHOST_VERSION_FILE:-/etc/ghost/version}"
+STATUS_FILE="${GHOST_AUTOUPDATE_STATUS:-/var/lib/ghost/auto-update.status}"
+BIN_DIR="${GHOST_BIN_DIR:-/opt/ghost/bin}"
+BITCOIN_CONF="${GHOST_BITCOIN_CONF:-/etc/bitcoin/bitcoin.conf}"
+SYSTEMCTL="${GHOST_SYSTEMCTL:-systemctl}"
+
+# ──────────────────────────────── options ────────────────────────────────────
+DRY_RUN="${GHOST_AUTOUPDATE_DRYRUN:-false}"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run) DRY_RUN="true"; shift;;
+    -h|--help)
+      echo "Usage: ghost-auto-update.sh [--dry-run]"; exit 0;;
+    *) echo "Unknown option: $1" >&2; exit 2;;
+  esac
+done
+
+TAG="ghost-auto-update"
+# Log to stderr (captured by the systemd journal for the .service) AND to syslog.
+log()  { echo "[$TAG] $*" >&2; logger -t "$TAG" -- "$*" 2>/dev/null || true; }
+warn() { echo "[$TAG] WARNING: $*" >&2; logger -t "$TAG" -p user.warning -- "$*" 2>/dev/null || true; }
+err()  { echo "[$TAG] ERROR: $*" >&2; logger -t "$TAG" -p user.err -- "$*" 2>/dev/null || true; }
+
+# write_status RESULT MESSAGE [LATEST]
+# Records the outcome of this run as JSON for the dashboard to surface. Always
+# best-effort — a missing directory or read-only fs never affects the update.
+write_status() {
+  local result="$1" message="$2" latest="${3:-}"
+  local installed; installed="$(read_installed_version || true)"
+  local dir; dir="$(dirname "$STATUS_FILE")"
+  mkdir -p "$dir" 2>/dev/null || true
+  cat > "$STATUS_FILE" 2>/dev/null <<EOF || true
+{
+  "last_run": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "result": "${result}",
+  "message": "${message//\"/\'}",
+  "installed_version": "${installed}",
+  "latest_version": "${latest}"
+}
+EOF
+  chmod 644 "$STATUS_FILE" 2>/dev/null || true
+}
+
+# ─────────────────────────────── helpers ─────────────────────────────────────
+
+# Normalise a version string for comparison: strip a leading 'v'.
+normver() { local v="$1"; echo "${v#v}"; }
+
+# Installed version: prefer the file we write on update, fall back to parsing
+# `ghost-pool --version` (clap prints "ghost-pool <semver>").
+read_installed_version() {
+  if [[ -r "$VERSION_FILE" ]]; then
+    local v; v="$(tr -d '[:space:]' < "$VERSION_FILE")"
+    [[ -n "$v" ]] && { echo "$v"; return 0; }
+  fi
+  if [[ -x "$BIN_DIR/ghost-pool" ]]; then
+    local out; out="$("$BIN_DIR/ghost-pool" --version 2>/dev/null || true)"
+    local v; v="$(echo "$out" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
+    [[ -n "$v" ]] && { echo "v$v"; return 0; }
+  fi
+  return 1
+}
+
+# Is $2 strictly newer than $1? (sort -V semantics, leading 'v' ignored)
+is_newer() {
+  local cur new; cur="$(normver "$1")"; new="$(normver "$2")"
+  [[ "$cur" == "$new" ]] && return 1
+  local top; top="$(printf '%s\n%s\n' "$cur" "$new" | sort -V | tail -1)"
+  [[ "$top" == "$new" ]]
+}
+
+# Run a systemctl verb unless we are in dry-run.
+svc() {
+  if [[ "$DRY_RUN" == "true" ]]; then
+    log "DRY-RUN: would run: $SYSTEMCTL $*"
+    return 0
+  fi
+  $SYSTEMCTL "$@"
+}
+
+# Stop a unit and block until it is no longer "active" (avoids the swap racing a
+# still-running process to "Job canceled"). Best-effort up to ~60s.
+stop_and_wait() {
+  local unit="$1"
+  $SYSTEMCTL list-unit-files "$unit" >/dev/null 2>&1 || \
+    [[ -f "/etc/systemd/system/$unit" ]] || { return 0; }
+  svc stop "$unit" || true
+  [[ "$DRY_RUN" == "true" ]] && return 0
+  for _ in $(seq 1 60); do
+    if [[ "$($SYSTEMCTL is-active "$unit" 2>/dev/null || true)" != "active" ]]; then
+      return 0
+    fi
+    sleep 1
+  done
+  warn "$unit did not go inactive within 60s"
+  return 1
+}
+
+unit_present() {
+  local unit="$1"
+  [[ -f "/etc/systemd/system/$unit" ]] && return 0
+  $SYSTEMCTL list-unit-files "$unit" >/dev/null 2>&1
+}
+
+# ─────────────────────────── health checks ───────────────────────────────────
+
+health_ghostd() {
+  local user pass port resp
+  user="$(grep -m1 '^rpcuser=' "$BITCOIN_CONF" 2>/dev/null | cut -d= -f2- || true)"
+  pass="$(grep -m1 '^rpcpassword=' "$BITCOIN_CONF" 2>/dev/null | cut -d= -f2- || true)"
+  port="$(grep -m1 '^rpcport=' "$BITCOIN_CONF" 2>/dev/null | cut -d= -f2- || true)"
+  port="${port:-8332}"
+  [[ -n "$user" && -n "$pass" ]] || { warn "ghostd RPC creds not found in $BITCOIN_CONF"; return 1; }
+  for _ in $(seq 1 30); do
+    resp="$(curl -s --max-time 8 --user "$user:$pass" \
+      --data '{"jsonrpc":"1.0","method":"getblockchaininfo","params":[]}' \
+      "http://127.0.0.1:${port}/" 2>/dev/null || true)"
+    if echo "$resp" | grep -q '"blocks"'; then
+      log "health: ghostd RPC up"
+      return 0
+    fi
+    sleep 2
+  done
+  err "health: ghostd RPC did not respond"
+  return 1
+}
+
+health_ghost_pool() {
+  local resp pc
+  for _ in $(seq 1 30); do
+    resp="$(curl -fsS --max-time 8 "http://127.0.0.1:8080/health?unsigned=true" 2>/dev/null || true)"
+    pc="$(echo "$resp" | grep -oE '"peer_count"[[:space:]]*:[[:space:]]*[0-9]+' | grep -oE '[0-9]+' | head -1 || true)"
+    if [[ -n "$pc" && "$pc" -gt 0 ]]; then
+      log "health: ghost-pool /health peer_count=$pc"
+      return 0
+    fi
+    sleep 2
+  done
+  err "health: ghost-pool /health peer_count not > 0 (last='${pc:-none}')"
+  return 1
+}
+
+health_ghost_pay() {
+  # Only meaningful when ghost-pay is installed. Bond ledger serves TLS with an
+  # identity-derived cert, so -k (we are localhost, integrity is the binary swap
+  # we just verified, not the transport).
+  unit_present ghost-pay.service || { log "health: ghost-pay not installed — skipped"; return 0; }
+  local code
+  for _ in $(seq 1 30); do
+    code="$(curl -k -s -o /dev/null -w '%{http_code}' --max-time 8 "https://127.0.0.1:8800/health" 2>/dev/null || true)"
+    if [[ "$code" == "200" ]]; then
+      log "health: ghost-pay /health=200"
+      return 0
+    fi
+    sleep 2
+  done
+  err "health: ghost-pay /health != 200 (last='${code:-none}')"
+  return 1
+}
+
+run_health_checks() {
+  # GHOST_HEALTHCHECK_OVERRIDE lets an operator substitute a custom post-update
+  # probe (and is the seam the test harness uses to drive the swap/rollback
+  # paths offline). Unset in production → the real ghostd/pool/pay probes run.
+  if [[ -n "${GHOST_HEALTHCHECK_OVERRIDE:-}" ]]; then
+    log "health: running override probe"
+    bash -c "$GHOST_HEALTHCHECK_OVERRIDE"
+    return $?
+  fi
+  health_ghostd && health_ghost_pool && health_ghost_pay
+}
+
+# ──────────────────────────────── main ───────────────────────────────────────
+
+main() {
+  # 1. Opt-in gate. Anything other than exactly AUTO_UPDATE=true is a no-op.
+  local optin=""
+  if [[ -r "$CONF_FILE" ]]; then
+    optin="$(grep -m1 -oE '^[[:space:]]*AUTO_UPDATE[[:space:]]*=[[:space:]]*[A-Za-z]+' "$CONF_FILE" 2>/dev/null \
+      | grep -oE '[A-Za-z]+$' || true)"
+  fi
+  if [[ "$optin" != "true" ]]; then
+    log "auto-update disabled (AUTO_UPDATE='${optin:-unset}') — no-op"
+    write_status "disabled" "auto-update opt-in is off"
+    exit 0
+  fi
+  log "auto-update enabled${DRY_RUN:+ }$([[ "$DRY_RUN" == "true" ]] && echo '(dry-run)')"
+
+  # 2. Resolve installed + latest versions.
+  local installed latest install_sh ghostd_sha
+  installed="$(read_installed_version || true)"
+  [[ -n "$installed" ]] || { err "could not determine installed version"; write_status "error" "installed version unknown"; exit 1; }
+
+  install_sh="$(curl -fsSL --max-time 30 "$INSTALL_SH_URL" 2>/dev/null || true)"
+  [[ -n "$install_sh" ]] || { err "could not fetch install.sh from $INSTALL_SH_URL"; write_status "error" "install.sh unreachable"; exit 1; }
+  latest="$(echo "$install_sh" | grep -m1 -oE 'GHOST_VERSION="?v?[0-9]+\.[0-9]+\.[0-9]+"?' | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
+  [[ "$latest" == v* ]] || latest="v${latest}"
+  ghostd_sha="$(echo "$install_sh" | grep -m1 -oE 'GHOSTD_SHA256="?[0-9a-fA-F]{64}"?' | grep -oE '[0-9a-fA-F]{64}' | head -1 || true)"
+  [[ -n "$latest" && "$latest" != "v" ]] || { err "could not parse latest version from install.sh"; write_status "error" "version parse failed"; exit 1; }
+  [[ -n "$ghostd_sha" ]] || { err "could not parse GHOSTD_SHA256 from install.sh"; write_status "error" "ghostd sha parse failed"; exit 1; }
+
+  log "installed=$installed latest=$latest"
+  if ! is_newer "$installed" "$latest"; then
+    log "already up to date ($installed) — no-op"
+    write_status "up-to-date" "installed $installed is current" "$latest"
+    exit 0
+  fi
+  log "newer version available: $installed -> $latest"
+
+  # 3. Download artefacts to an isolated temp dir.
+  local tarball release_base tmp gnupg
+  tarball="bitcoin-ghost-${latest}-x86_64-unknown-linux-gnu.tar.gz"
+  if [[ -n "$RELEASE_BASE_OVERRIDE" ]]; then
+    release_base="$RELEASE_BASE_OVERRIDE"
+  else
+    release_base="https://github.com/bitcoin-ghost/ghost/releases/download/${latest}"
+  fi
+  tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+  gnupg="$tmp/gnupg"; mkdir -m700 "$gnupg"
+  export GNUPGHOME="$gnupg"
+
+  log "downloading $tarball + signature + ghostd"
+  curl -fsSL --max-time 600 "${release_base}/${tarball}"            -o "$tmp/$tarball"          || { err "download tarball failed"; write_status "error" "tarball download failed" "$latest"; exit 1; }
+  curl -fsSL --max-time 60  "${release_base}/SHA256SUMS.txt"        -o "$tmp/SHA256SUMS.txt"    || { err "download SHA256SUMS.txt failed"; write_status "error" "checksums download failed" "$latest"; exit 1; }
+  curl -fsSL --max-time 60  "${release_base}/SHA256SUMS.txt.asc"    -o "$tmp/SHA256SUMS.txt.asc" || { err "download signature failed"; write_status "error" "signature download failed" "$latest"; exit 1; }
+  curl -fsSL --max-time 600 "$GHOSTD_URL"                           -o "$tmp/ghostd"           || { err "download ghostd failed"; write_status "error" "ghostd download failed" "$latest"; exit 1; }
+
+  # ══════════════════════════════════════════════════════════════════════════
+  # 4. MANDATORY VERIFICATION GATE — no binary is touched unless this passes.
+  #    (a) detached GPG signature over SHA256SUMS.txt is VALID *and* the signer
+  #        is EXACTLY the pinned release-key fingerprint;
+  #    (b) the release tarball's SHA256 matches SHA256SUMS.txt;
+  #    (c) ghostd's SHA256 matches the value in the freshly-fetched install.sh.
+  #    ANY failure → loud abort, binaries untouched, non-zero exit.
+  # ══════════════════════════════════════════════════════════════════════════
+  curl -fsSL --max-time 60 "$RELEASE_KEY_URL" 2>/dev/null | gpg --quiet --import 2>/dev/null || true
+  # Trust the pinned key so gpg suppresses the cosmetic WoT warning.
+  echo "${GPG_KEY_FP}:6:" | gpg --quiet --import-ownertrust 2>/dev/null || true
+
+  # Require VALIDSIG to be EXACTLY our pinned key. This is stronger than "Good
+  # signature from <name>" (which ANY imported key satisfies).
+  if gpg --status-fd=1 --verify "$tmp/SHA256SUMS.txt.asc" "$tmp/SHA256SUMS.txt" 2>/dev/null \
+       | grep -q "VALIDSIG ${GPG_KEY_FP}"; then
+    log "VERIFY ok: release signature valid (key ${GPG_KEY_FP})"
+  else
+    err "VERIFY FAILED: release signature is NOT a valid signature from ${GPG_KEY_FP} — ABORTING, no binary touched."
+    write_status "verify-failed" "GPG signature verification failed for $latest" "$latest"
+    exit 1
+  fi
+
+  if ( cd "$tmp" && grep " ${tarball}\$" SHA256SUMS.txt | sha256sum -c - >/dev/null 2>&1 ); then
+    log "VERIFY ok: tarball checksum matches SHA256SUMS.txt"
+  else
+    err "VERIFY FAILED: tarball SHA256 mismatch — ABORTING, no binary touched."
+    write_status "verify-failed" "tarball checksum mismatch for $latest" "$latest"
+    exit 1
+  fi
+
+  if ( cd "$tmp" && echo "${ghostd_sha}  ghostd" | sha256sum -c - >/dev/null 2>&1 ); then
+    log "VERIFY ok: ghostd checksum matches install.sh (${ghostd_sha})"
+  else
+    err "VERIFY FAILED: ghostd SHA256 mismatch against install.sh — ABORTING, no binary touched."
+    write_status "verify-failed" "ghostd checksum mismatch for $latest" "$latest"
+    exit 1
+  fi
+
+  # 5. Unpack the verified tarball and locate the binaries it carries.
+  tar -xzf "$tmp/$tarball" -C "$tmp"
+  local new_pool new_pay new_cli
+  new_pool="$(find "$tmp" -name ghost-pool -type f | head -1 || true)"
+  new_pay="$(find "$tmp" -name ghost-pay -type f | head -1 || true)"
+  new_cli="$(find "$tmp" -name ghost-cli -type f | head -1 || true)"
+  [[ -n "$new_pool" ]] || { err "verified tarball did not contain ghost-pool"; write_status "error" "tarball missing ghost-pool" "$latest"; exit 1; }
+
+  # Build the swap plan: (dest <- src), only for binaries currently installed
+  # (so we never introduce ghost-pay onto a node that opted out of it).
+  local -a SWAP_DEST=() SWAP_SRC=()
+  SWAP_DEST+=("$BIN_DIR/ghostd");     SWAP_SRC+=("$tmp/ghostd")
+  SWAP_DEST+=("$BIN_DIR/ghost-pool"); SWAP_SRC+=("$new_pool")
+  if [[ -x "$BIN_DIR/ghost-pay" && -n "$new_pay" ]]; then
+    SWAP_DEST+=("$BIN_DIR/ghost-pay"); SWAP_SRC+=("$new_pay")
+  fi
+  if [[ -x "$BIN_DIR/ghost-cli" && -n "$new_cli" ]]; then
+    SWAP_DEST+=("$BIN_DIR/ghost-cli"); SWAP_SRC+=("$new_cli")
+  fi
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    log "DRY-RUN: verification PASSED for $latest. Would back up + swap:"
+    local k
+    for k in "${!SWAP_DEST[@]}"; do log "DRY-RUN:   ${SWAP_DEST[$k]} <- ${SWAP_SRC[$k]}"; done
+    log "DRY-RUN: would then restart services + health-check, rolling back on failure."
+    write_status "dry-run" "verification passed; swap skipped (dry-run) for $latest" "$latest"
+    exit 0
+  fi
+
+  # 6. Back up the current binaries (for rollback).
+  local ts; ts="$(date +%Y%m%d-%H%M%S)"
+  local -a BACKUP_DEST=() BACKUP_OF=()
+  local k
+  for k in "${!SWAP_DEST[@]}"; do
+    local dest="${SWAP_DEST[$k]}"
+    if [[ -e "$dest" ]]; then
+      cp -p "$dest" "${dest}.bak.${ts}"
+      BACKUP_DEST+=("${dest}.bak.${ts}"); BACKUP_OF+=("$dest")
+      log "backed up $dest -> ${dest}.bak.${ts}"
+    fi
+  done
+
+  # rollback: restore every backup taken this run, restart, log.
+  rollback() {
+    err "rolling back to pre-update binaries"
+    stop_and_wait ghost-pay.service || true
+    stop_and_wait ghost-pool.service || true
+    stop_and_wait ghostd.service || true
+    local j
+    for j in "${!BACKUP_DEST[@]}"; do
+      cp -p "${BACKUP_DEST[$j]}" "${BACKUP_OF[$j]}" && log "restored ${BACKUP_OF[$j]}"
+    done
+    $SYSTEMCTL start ghostd.service || true
+    sleep 3
+    $SYSTEMCTL start ghost-pool.service || true
+    unit_present ghost-pay.service && { $SYSTEMCTL start ghost-pay.service || true; }
+    return 0  # never let the rollback's last status trip `set -e` in the caller
+  }
+
+  # 7. Stop services (reverse dependency order), verify inactive.
+  stop_and_wait ghost-pay.service || true
+  stop_and_wait ghost-pool.service || { err "ghost-pool would not stop — rolling back"; rollback; write_status "rolled-back" "ghost-pool failed to stop" "$latest"; exit 1; }
+  stop_and_wait ghostd.service    || { err "ghostd would not stop — rolling back"; rollback; write_status "rolled-back" "ghostd failed to stop" "$latest"; exit 1; }
+
+  # 8. Swap the verified binaries into place atomically (install = temp+rename).
+  # Owned root:root in production (the unit runs as root); a non-root manual run
+  # installs as the caller. If any swap fails, roll the whole set back.
+  local -a OWNER_ARGS=()
+  [[ "$(id -u)" -eq 0 ]] && OWNER_ARGS=(-o root -g root)
+  for k in "${!SWAP_DEST[@]}"; do
+    if install -m755 "${OWNER_ARGS[@]}" "${SWAP_SRC[$k]}" "${SWAP_DEST[$k]}"; then
+      log "swapped ${SWAP_DEST[$k]}"
+    else
+      err "failed to install ${SWAP_DEST[$k]} — rolling back"
+      rollback
+      write_status "rolled-back" "binary swap failed for ${SWAP_DEST[$k]}" "$latest"
+      exit 1
+    fi
+  done
+
+  # 9. Start services (dependency order).
+  $SYSTEMCTL start ghostd.service || { err "ghostd failed to start — rolling back"; rollback; write_status "rolled-back" "ghostd failed to start" "$latest"; exit 1; }
+  sleep 3
+  $SYSTEMCTL start ghost-pool.service || { err "ghost-pool failed to start — rolling back"; rollback; write_status "rolled-back" "ghost-pool failed to start" "$latest"; exit 1; }
+  if unit_present ghost-pay.service; then
+    $SYSTEMCTL start ghost-pay.service || { err "ghost-pay failed to start — rolling back"; rollback; write_status "rolled-back" "ghost-pay failed to start" "$latest"; exit 1; }
+  fi
+
+  # 10. Health-check; roll back on any failure.
+  if run_health_checks; then
+    echo "$latest" > "$VERSION_FILE"; chmod 644 "$VERSION_FILE" 2>/dev/null || true
+    log "UPDATE COMPLETE: now running $latest (backups: *.bak.${ts})"
+    write_status "updated" "updated $installed -> $latest" "$latest"
+    exit 0
+  else
+    err "health checks FAILED after swap — rolling back"
+    rollback
+    if run_health_checks; then
+      log "rollback healthy — back on $installed"
+    else
+      err "rollback health checks ALSO failing — manual intervention required"
+    fi
+    write_status "rolled-back" "health check failed after update to $latest" "$latest"
+    exit 1
+  fi
+}
+
+main "$@"

--- a/scripts/ghost-autoupdate-toggle.sh
+++ b/scripts/ghost-autoupdate-toggle.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# ghost-autoupdate-toggle — flip the node auto-update opt-in.
+#
+# This is the ONLY privileged operation the node dashboard performs. The
+# dashboard service user (ghost) may run it via a tightly-scoped sudoers rule
+# (/etc/sudoers.d/ghost-autoupdate) that pins the exact argument to `on` or
+# `off` — nothing else. The script takes NO free-form input: it writes a fixed
+# AUTO_UPDATE=true|false to /etc/ghost/auto-update.conf and enables/disables the
+# timer to match. There is no path by which the dashboard can run an arbitrary
+# command or smuggle other state through this helper.
+#
+# Installed root-owned 0755 at /opt/ghost/bin/ghost-autoupdate-toggle.
+#
+set -euo pipefail
+
+CONF="${GHOST_AUTOUPDATE_CONF:-/etc/ghost/auto-update.conf}"
+SYSTEMCTL="${GHOST_SYSTEMCTL:-systemctl}"
+
+case "${1:-}" in
+  on)  val="true" ;;
+  off) val="false" ;;
+  *) echo "usage: ghost-autoupdate-toggle on|off" >&2; exit 2 ;;
+esac
+
+umask 022
+mkdir -p "$(dirname "$CONF")"
+tmp="$(mktemp "${CONF}.XXXXXX")"
+cat > "$tmp" <<EOF
+# Bitcoin Ghost node auto-update opt-in.
+# Managed by the installer and the node dashboard (ghost-autoupdate-toggle).
+# When AUTO_UPDATE is anything other than exactly 'true', the updater is a no-op.
+AUTO_UPDATE=${val}
+EOF
+chmod 644 "$tmp"
+mv -f "$tmp" "$CONF"
+
+# Keep the timer state in lockstep with the opt-in. Best-effort: the conf flag
+# is the authoritative gate, so a systemd hiccup here can never cause an update.
+if [[ "$val" == "true" ]]; then
+  "$SYSTEMCTL" enable --now ghost-auto-update.timer >/dev/null 2>&1 || true
+else
+  "$SYSTEMCTL" disable --now ghost-auto-update.timer >/dev/null 2>&1 || true
+fi
+
+echo "auto-update set to ${val}"

--- a/scripts/ghost-autoupdate.sudoers
+++ b/scripts/ghost-autoupdate.sudoers
@@ -1,0 +1,13 @@
+# Bitcoin Ghost — node-dashboard auto-update toggle.
+#
+# Grants the dashboard service user (ghost) permission to flip the auto-update
+# opt-in, and NOTHING else. The command is pinned with its exact argument, so
+# `ghost` can run only:
+#     sudo /opt/ghost/bin/ghost-autoupdate-toggle on
+#     sudo /opt/ghost/bin/ghost-autoupdate-toggle off
+# Any other argument (or other command) is rejected by sudo. The toggle binary
+# is root-owned 0755, so the dashboard user cannot rewrite what runs as root.
+#
+# Installed 0440 at /etc/sudoers.d/ghost-autoupdate; validated with `visudo -cf`.
+Defaults!/opt/ghost/bin/ghost-autoupdate-toggle !requiretty
+ghost ALL=(root) NOPASSWD: /opt/ghost/bin/ghost-autoupdate-toggle on, /opt/ghost/bin/ghost-autoupdate-toggle off

--- a/scripts/install-node.sh
+++ b/scripts/install-node.sh
@@ -48,6 +48,10 @@ WRAITH=""
 # --no-tor pins it off. TOR_MODE only matters when TOR is "true".
 TOR="false"
 TOR_MODE="hybrid"
+# Automatic updates. OFF by default — a node NEVER self-upgrades unless the
+# operator explicitly opts in (here, or later via the dashboard toggle). The
+# updater verifies the GPG release signature before applying anything.
+AUTO_UPDATE="false"
 
 usage() {
   cat <<EOF
@@ -80,6 +84,11 @@ Options:
   --tor-only                  Route over Tor ONLY: no clearnet (onlynet=onion),
                                 close 8333 (implies --tor)
   --no-tor                    Never use Tor                   (default)
+  --auto-update               Automatically apply newer SIGNED releases (off by
+                                default). Verifies the GPG signature + ghostd
+                                checksum before swapping any binary; health-checks
+                                and rolls back on failure. Checked every 6h.
+  --no-auto-update            Never auto-update                (default)
   --non-interactive           Never prompt; use flags/defaults only (for scripts)
   -h, --help                  This help.
 
@@ -108,6 +117,8 @@ while [[ $# -gt 0 ]]; do
     --tor)            TOR="true"; shift; CONFIG_FLAGS=$((CONFIG_FLAGS+1));;
     --tor-only)       TOR="true"; TOR_MODE="tor-only"; shift; CONFIG_FLAGS=$((CONFIG_FLAGS+1));;
     --no-tor)         TOR="false"; shift; CONFIG_FLAGS=$((CONFIG_FLAGS+1));;
+    --auto-update)    AUTO_UPDATE="true"; shift; CONFIG_FLAGS=$((CONFIG_FLAGS+1));;
+    --no-auto-update) AUTO_UPDATE="false"; shift; CONFIG_FLAGS=$((CONFIG_FLAGS+1));;
     --non-interactive) NON_INTERACTIVE="true"; shift;;
     -h|--help)        usage; exit 0;;
     *) echo "Unknown option: $1" >&2; usage; exit 1;;
@@ -213,6 +224,12 @@ run_wizard() {
     fi
   fi
 
+  # Automatic updates. Off by default — explicit opt-in only. Every applied
+  # update verifies the GPG release signature before swapping any binary.
+  echo
+  echo "Maintenance:"
+  AUTO_UPDATE="$(prompt_yes_no "  Enable automatic updates? (verifies GPG signature before applying)" N)"
+
   # Nickname.
   echo
   local nn
@@ -230,6 +247,7 @@ run_wizard() {
   echo "  Ghost Pay      : $GHOST_PAY"
   echo "  Wraith mixing  : $WRAITH"
   echo "  Tor            : $([[ "$TOR" == "true" ]] && echo "$TOR_MODE" || echo "off")"
+  echo "  Auto-update    : $AUTO_UPDATE"
   echo "  Nickname       : $NICKNAME"
   echo
   local proceed
@@ -728,6 +746,574 @@ EOF
 systemctl daemon-reload >/dev/null 2>&1
 systemctl enable --now ghost-mining-firewall.path >/dev/null 2>&1
 /opt/ghost/bin/reconcile-mining-firewall.sh >/dev/null 2>&1 || true   # apply initial state
+
+# ────────────────────── 10b. auto-update (opt-in) ────────────────────────────
+# Always install the updater, its toggle, the sudoers scope, and the systemd
+# units — but the timer is enabled (and the conf says true) ONLY when the
+# operator opted in. With AUTO_UPDATE=false the node NEVER self-upgrades; the
+# pieces just sit dormant so the dashboard toggle can flip it on later.
+log "Installing auto-update (opt-in: ${AUTO_UPDATE})"
+
+# The verifying updater (canonical source: scripts/ghost-auto-update.sh). It is
+# a strict no-op unless /etc/ghost/auto-update.conf opts in, and it GPG-verifies
+# every release before swapping a binary.
+cat > /opt/ghost/bin/ghost-auto-update.sh <<'GHOST_AUTOUPDATE_SH_EOF'
+#!/usr/bin/env bash
+#
+# Bitcoin Ghost — opt-in node auto-update.
+#
+# Runs as root from `ghost-auto-update.timer` (every 6h, randomised). It is a
+# strict no-op unless the operator has opted in via /etc/ghost/auto-update.conf
+# (AUTO_UPDATE=true). When opted in, it resolves the latest published release,
+# and — ONLY if it is newer than what is installed — downloads the release
+# tarball + ghostd, verifies the detached GPG signature against the pinned
+# release key AND the ghostd SHA256 against the freshly-fetched install.sh,
+# backs up the current binaries, swaps them with a stop→verify-inactive→swap→
+# start sequence, health-checks, and rolls back on any failure.
+#
+# SUPPLY-CHAIN-CRITICAL: a binary is NEVER written unless BOTH the GPG signature
+# and the ghostd checksum verify. The verification logic mirrors the first-run
+# installer (scripts/install-node.sh) exactly.
+#
+# This file is the canonical source. scripts/install-node.sh installs a verbatim
+# copy at /opt/ghost/bin/ghost-auto-update.sh.
+#
+set -euo pipefail
+
+# ─────────────────────────── pinned trust anchors ────────────────────────────
+# Defaults are the production values. Every one is overridable via the
+# environment SOLELY so the abort/accept paths can be exercised hermetically in
+# tests (file:// URLs, a throwaway signing key, temp dirs). Production runs use
+# the pinned defaults untouched.
+GPG_KEY_FP="${GHOST_GPG_KEY_FP:-777FE81F8CC077FD3D08055E852C2B3190F5B928}"
+RELEASE_KEY_URL="${GHOST_RELEASE_KEY_URL:-https://get.bitcoinghost.org/ghost-release-key.asc}"
+INSTALL_SH_URL="${GHOST_INSTALL_SH_URL:-https://get.bitcoinghost.org/install.sh}"
+GHOSTD_URL="${GHOSTD_URL:-https://get.bitcoinghost.org/bin/ghostd}"
+# Release tarball base. When GHOST_RELEASE_BASE is set it is used verbatim;
+# otherwise it is constructed per-version from the GitHub releases download URL.
+RELEASE_BASE_OVERRIDE="${GHOST_RELEASE_BASE:-}"
+
+# ───────────────────────────── managed paths ─────────────────────────────────
+CONF_FILE="${GHOST_AUTOUPDATE_CONF:-/etc/ghost/auto-update.conf}"
+VERSION_FILE="${GHOST_VERSION_FILE:-/etc/ghost/version}"
+STATUS_FILE="${GHOST_AUTOUPDATE_STATUS:-/var/lib/ghost/auto-update.status}"
+BIN_DIR="${GHOST_BIN_DIR:-/opt/ghost/bin}"
+BITCOIN_CONF="${GHOST_BITCOIN_CONF:-/etc/bitcoin/bitcoin.conf}"
+SYSTEMCTL="${GHOST_SYSTEMCTL:-systemctl}"
+
+# ──────────────────────────────── options ────────────────────────────────────
+DRY_RUN="${GHOST_AUTOUPDATE_DRYRUN:-false}"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run) DRY_RUN="true"; shift;;
+    -h|--help)
+      echo "Usage: ghost-auto-update.sh [--dry-run]"; exit 0;;
+    *) echo "Unknown option: $1" >&2; exit 2;;
+  esac
+done
+
+TAG="ghost-auto-update"
+# Log to stderr (captured by the systemd journal for the .service) AND to syslog.
+log()  { echo "[$TAG] $*" >&2; logger -t "$TAG" -- "$*" 2>/dev/null || true; }
+warn() { echo "[$TAG] WARNING: $*" >&2; logger -t "$TAG" -p user.warning -- "$*" 2>/dev/null || true; }
+err()  { echo "[$TAG] ERROR: $*" >&2; logger -t "$TAG" -p user.err -- "$*" 2>/dev/null || true; }
+
+# write_status RESULT MESSAGE [LATEST]
+# Records the outcome of this run as JSON for the dashboard to surface. Always
+# best-effort — a missing directory or read-only fs never affects the update.
+write_status() {
+  local result="$1" message="$2" latest="${3:-}"
+  local installed; installed="$(read_installed_version || true)"
+  local dir; dir="$(dirname "$STATUS_FILE")"
+  mkdir -p "$dir" 2>/dev/null || true
+  cat > "$STATUS_FILE" 2>/dev/null <<EOF || true
+{
+  "last_run": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "result": "${result}",
+  "message": "${message//\"/\'}",
+  "installed_version": "${installed}",
+  "latest_version": "${latest}"
+}
+EOF
+  chmod 644 "$STATUS_FILE" 2>/dev/null || true
+}
+
+# ─────────────────────────────── helpers ─────────────────────────────────────
+
+# Normalise a version string for comparison: strip a leading 'v'.
+normver() { local v="$1"; echo "${v#v}"; }
+
+# Installed version: prefer the file we write on update, fall back to parsing
+# `ghost-pool --version` (clap prints "ghost-pool <semver>").
+read_installed_version() {
+  if [[ -r "$VERSION_FILE" ]]; then
+    local v; v="$(tr -d '[:space:]' < "$VERSION_FILE")"
+    [[ -n "$v" ]] && { echo "$v"; return 0; }
+  fi
+  if [[ -x "$BIN_DIR/ghost-pool" ]]; then
+    local out; out="$("$BIN_DIR/ghost-pool" --version 2>/dev/null || true)"
+    local v; v="$(echo "$out" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
+    [[ -n "$v" ]] && { echo "v$v"; return 0; }
+  fi
+  return 1
+}
+
+# Is $2 strictly newer than $1? (sort -V semantics, leading 'v' ignored)
+is_newer() {
+  local cur new; cur="$(normver "$1")"; new="$(normver "$2")"
+  [[ "$cur" == "$new" ]] && return 1
+  local top; top="$(printf '%s\n%s\n' "$cur" "$new" | sort -V | tail -1)"
+  [[ "$top" == "$new" ]]
+}
+
+# Run a systemctl verb unless we are in dry-run.
+svc() {
+  if [[ "$DRY_RUN" == "true" ]]; then
+    log "DRY-RUN: would run: $SYSTEMCTL $*"
+    return 0
+  fi
+  $SYSTEMCTL "$@"
+}
+
+# Stop a unit and block until it is no longer "active" (avoids the swap racing a
+# still-running process to "Job canceled"). Best-effort up to ~60s.
+stop_and_wait() {
+  local unit="$1"
+  $SYSTEMCTL list-unit-files "$unit" >/dev/null 2>&1 || \
+    [[ -f "/etc/systemd/system/$unit" ]] || { return 0; }
+  svc stop "$unit" || true
+  [[ "$DRY_RUN" == "true" ]] && return 0
+  for _ in $(seq 1 60); do
+    if [[ "$($SYSTEMCTL is-active "$unit" 2>/dev/null || true)" != "active" ]]; then
+      return 0
+    fi
+    sleep 1
+  done
+  warn "$unit did not go inactive within 60s"
+  return 1
+}
+
+unit_present() {
+  local unit="$1"
+  [[ -f "/etc/systemd/system/$unit" ]] && return 0
+  $SYSTEMCTL list-unit-files "$unit" >/dev/null 2>&1
+}
+
+# ─────────────────────────── health checks ───────────────────────────────────
+
+health_ghostd() {
+  local user pass port resp
+  user="$(grep -m1 '^rpcuser=' "$BITCOIN_CONF" 2>/dev/null | cut -d= -f2- || true)"
+  pass="$(grep -m1 '^rpcpassword=' "$BITCOIN_CONF" 2>/dev/null | cut -d= -f2- || true)"
+  port="$(grep -m1 '^rpcport=' "$BITCOIN_CONF" 2>/dev/null | cut -d= -f2- || true)"
+  port="${port:-8332}"
+  [[ -n "$user" && -n "$pass" ]] || { warn "ghostd RPC creds not found in $BITCOIN_CONF"; return 1; }
+  for _ in $(seq 1 30); do
+    resp="$(curl -s --max-time 8 --user "$user:$pass" \
+      --data '{"jsonrpc":"1.0","method":"getblockchaininfo","params":[]}' \
+      "http://127.0.0.1:${port}/" 2>/dev/null || true)"
+    if echo "$resp" | grep -q '"blocks"'; then
+      log "health: ghostd RPC up"
+      return 0
+    fi
+    sleep 2
+  done
+  err "health: ghostd RPC did not respond"
+  return 1
+}
+
+health_ghost_pool() {
+  local resp pc
+  for _ in $(seq 1 30); do
+    resp="$(curl -fsS --max-time 8 "http://127.0.0.1:8080/health?unsigned=true" 2>/dev/null || true)"
+    pc="$(echo "$resp" | grep -oE '"peer_count"[[:space:]]*:[[:space:]]*[0-9]+' | grep -oE '[0-9]+' | head -1 || true)"
+    if [[ -n "$pc" && "$pc" -gt 0 ]]; then
+      log "health: ghost-pool /health peer_count=$pc"
+      return 0
+    fi
+    sleep 2
+  done
+  err "health: ghost-pool /health peer_count not > 0 (last='${pc:-none}')"
+  return 1
+}
+
+health_ghost_pay() {
+  # Only meaningful when ghost-pay is installed. Bond ledger serves TLS with an
+  # identity-derived cert, so -k (we are localhost, integrity is the binary swap
+  # we just verified, not the transport).
+  unit_present ghost-pay.service || { log "health: ghost-pay not installed — skipped"; return 0; }
+  local code
+  for _ in $(seq 1 30); do
+    code="$(curl -k -s -o /dev/null -w '%{http_code}' --max-time 8 "https://127.0.0.1:8800/health" 2>/dev/null || true)"
+    if [[ "$code" == "200" ]]; then
+      log "health: ghost-pay /health=200"
+      return 0
+    fi
+    sleep 2
+  done
+  err "health: ghost-pay /health != 200 (last='${code:-none}')"
+  return 1
+}
+
+run_health_checks() {
+  # GHOST_HEALTHCHECK_OVERRIDE lets an operator substitute a custom post-update
+  # probe (and is the seam the test harness uses to drive the swap/rollback
+  # paths offline). Unset in production → the real ghostd/pool/pay probes run.
+  if [[ -n "${GHOST_HEALTHCHECK_OVERRIDE:-}" ]]; then
+    log "health: running override probe"
+    bash -c "$GHOST_HEALTHCHECK_OVERRIDE"
+    return $?
+  fi
+  health_ghostd && health_ghost_pool && health_ghost_pay
+}
+
+# ──────────────────────────────── main ───────────────────────────────────────
+
+main() {
+  # 1. Opt-in gate. Anything other than exactly AUTO_UPDATE=true is a no-op.
+  local optin=""
+  if [[ -r "$CONF_FILE" ]]; then
+    optin="$(grep -m1 -oE '^[[:space:]]*AUTO_UPDATE[[:space:]]*=[[:space:]]*[A-Za-z]+' "$CONF_FILE" 2>/dev/null \
+      | grep -oE '[A-Za-z]+$' || true)"
+  fi
+  if [[ "$optin" != "true" ]]; then
+    log "auto-update disabled (AUTO_UPDATE='${optin:-unset}') — no-op"
+    write_status "disabled" "auto-update opt-in is off"
+    exit 0
+  fi
+  log "auto-update enabled${DRY_RUN:+ }$([[ "$DRY_RUN" == "true" ]] && echo '(dry-run)')"
+
+  # 2. Resolve installed + latest versions.
+  local installed latest install_sh ghostd_sha
+  installed="$(read_installed_version || true)"
+  [[ -n "$installed" ]] || { err "could not determine installed version"; write_status "error" "installed version unknown"; exit 1; }
+
+  install_sh="$(curl -fsSL --max-time 30 "$INSTALL_SH_URL" 2>/dev/null || true)"
+  [[ -n "$install_sh" ]] || { err "could not fetch install.sh from $INSTALL_SH_URL"; write_status "error" "install.sh unreachable"; exit 1; }
+  latest="$(echo "$install_sh" | grep -m1 -oE 'GHOST_VERSION="?v?[0-9]+\.[0-9]+\.[0-9]+"?' | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
+  [[ "$latest" == v* ]] || latest="v${latest}"
+  ghostd_sha="$(echo "$install_sh" | grep -m1 -oE 'GHOSTD_SHA256="?[0-9a-fA-F]{64}"?' | grep -oE '[0-9a-fA-F]{64}' | head -1 || true)"
+  [[ -n "$latest" && "$latest" != "v" ]] || { err "could not parse latest version from install.sh"; write_status "error" "version parse failed"; exit 1; }
+  [[ -n "$ghostd_sha" ]] || { err "could not parse GHOSTD_SHA256 from install.sh"; write_status "error" "ghostd sha parse failed"; exit 1; }
+
+  log "installed=$installed latest=$latest"
+  if ! is_newer "$installed" "$latest"; then
+    log "already up to date ($installed) — no-op"
+    write_status "up-to-date" "installed $installed is current" "$latest"
+    exit 0
+  fi
+  log "newer version available: $installed -> $latest"
+
+  # 3. Download artefacts to an isolated temp dir.
+  local tarball release_base tmp gnupg
+  tarball="bitcoin-ghost-${latest}-x86_64-unknown-linux-gnu.tar.gz"
+  if [[ -n "$RELEASE_BASE_OVERRIDE" ]]; then
+    release_base="$RELEASE_BASE_OVERRIDE"
+  else
+    release_base="https://github.com/bitcoin-ghost/ghost/releases/download/${latest}"
+  fi
+  tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+  gnupg="$tmp/gnupg"; mkdir -m700 "$gnupg"
+  export GNUPGHOME="$gnupg"
+
+  log "downloading $tarball + signature + ghostd"
+  curl -fsSL --max-time 600 "${release_base}/${tarball}"            -o "$tmp/$tarball"          || { err "download tarball failed"; write_status "error" "tarball download failed" "$latest"; exit 1; }
+  curl -fsSL --max-time 60  "${release_base}/SHA256SUMS.txt"        -o "$tmp/SHA256SUMS.txt"    || { err "download SHA256SUMS.txt failed"; write_status "error" "checksums download failed" "$latest"; exit 1; }
+  curl -fsSL --max-time 60  "${release_base}/SHA256SUMS.txt.asc"    -o "$tmp/SHA256SUMS.txt.asc" || { err "download signature failed"; write_status "error" "signature download failed" "$latest"; exit 1; }
+  curl -fsSL --max-time 600 "$GHOSTD_URL"                           -o "$tmp/ghostd"           || { err "download ghostd failed"; write_status "error" "ghostd download failed" "$latest"; exit 1; }
+
+  # ══════════════════════════════════════════════════════════════════════════
+  # 4. MANDATORY VERIFICATION GATE — no binary is touched unless this passes.
+  #    (a) detached GPG signature over SHA256SUMS.txt is VALID *and* the signer
+  #        is EXACTLY the pinned release-key fingerprint;
+  #    (b) the release tarball's SHA256 matches SHA256SUMS.txt;
+  #    (c) ghostd's SHA256 matches the value in the freshly-fetched install.sh.
+  #    ANY failure → loud abort, binaries untouched, non-zero exit.
+  # ══════════════════════════════════════════════════════════════════════════
+  curl -fsSL --max-time 60 "$RELEASE_KEY_URL" 2>/dev/null | gpg --quiet --import 2>/dev/null || true
+  # Trust the pinned key so gpg suppresses the cosmetic WoT warning.
+  echo "${GPG_KEY_FP}:6:" | gpg --quiet --import-ownertrust 2>/dev/null || true
+
+  # Require VALIDSIG to be EXACTLY our pinned key. This is stronger than "Good
+  # signature from <name>" (which ANY imported key satisfies).
+  if gpg --status-fd=1 --verify "$tmp/SHA256SUMS.txt.asc" "$tmp/SHA256SUMS.txt" 2>/dev/null \
+       | grep -q "VALIDSIG ${GPG_KEY_FP}"; then
+    log "VERIFY ok: release signature valid (key ${GPG_KEY_FP})"
+  else
+    err "VERIFY FAILED: release signature is NOT a valid signature from ${GPG_KEY_FP} — ABORTING, no binary touched."
+    write_status "verify-failed" "GPG signature verification failed for $latest" "$latest"
+    exit 1
+  fi
+
+  if ( cd "$tmp" && grep " ${tarball}\$" SHA256SUMS.txt | sha256sum -c - >/dev/null 2>&1 ); then
+    log "VERIFY ok: tarball checksum matches SHA256SUMS.txt"
+  else
+    err "VERIFY FAILED: tarball SHA256 mismatch — ABORTING, no binary touched."
+    write_status "verify-failed" "tarball checksum mismatch for $latest" "$latest"
+    exit 1
+  fi
+
+  if ( cd "$tmp" && echo "${ghostd_sha}  ghostd" | sha256sum -c - >/dev/null 2>&1 ); then
+    log "VERIFY ok: ghostd checksum matches install.sh (${ghostd_sha})"
+  else
+    err "VERIFY FAILED: ghostd SHA256 mismatch against install.sh — ABORTING, no binary touched."
+    write_status "verify-failed" "ghostd checksum mismatch for $latest" "$latest"
+    exit 1
+  fi
+
+  # 5. Unpack the verified tarball and locate the binaries it carries.
+  tar -xzf "$tmp/$tarball" -C "$tmp"
+  local new_pool new_pay new_cli
+  new_pool="$(find "$tmp" -name ghost-pool -type f | head -1 || true)"
+  new_pay="$(find "$tmp" -name ghost-pay -type f | head -1 || true)"
+  new_cli="$(find "$tmp" -name ghost-cli -type f | head -1 || true)"
+  [[ -n "$new_pool" ]] || { err "verified tarball did not contain ghost-pool"; write_status "error" "tarball missing ghost-pool" "$latest"; exit 1; }
+
+  # Build the swap plan: (dest <- src), only for binaries currently installed
+  # (so we never introduce ghost-pay onto a node that opted out of it).
+  local -a SWAP_DEST=() SWAP_SRC=()
+  SWAP_DEST+=("$BIN_DIR/ghostd");     SWAP_SRC+=("$tmp/ghostd")
+  SWAP_DEST+=("$BIN_DIR/ghost-pool"); SWAP_SRC+=("$new_pool")
+  if [[ -x "$BIN_DIR/ghost-pay" && -n "$new_pay" ]]; then
+    SWAP_DEST+=("$BIN_DIR/ghost-pay"); SWAP_SRC+=("$new_pay")
+  fi
+  if [[ -x "$BIN_DIR/ghost-cli" && -n "$new_cli" ]]; then
+    SWAP_DEST+=("$BIN_DIR/ghost-cli"); SWAP_SRC+=("$new_cli")
+  fi
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    log "DRY-RUN: verification PASSED for $latest. Would back up + swap:"
+    local k
+    for k in "${!SWAP_DEST[@]}"; do log "DRY-RUN:   ${SWAP_DEST[$k]} <- ${SWAP_SRC[$k]}"; done
+    log "DRY-RUN: would then restart services + health-check, rolling back on failure."
+    write_status "dry-run" "verification passed; swap skipped (dry-run) for $latest" "$latest"
+    exit 0
+  fi
+
+  # 6. Back up the current binaries (for rollback).
+  local ts; ts="$(date +%Y%m%d-%H%M%S)"
+  local -a BACKUP_DEST=() BACKUP_OF=()
+  local k
+  for k in "${!SWAP_DEST[@]}"; do
+    local dest="${SWAP_DEST[$k]}"
+    if [[ -e "$dest" ]]; then
+      cp -p "$dest" "${dest}.bak.${ts}"
+      BACKUP_DEST+=("${dest}.bak.${ts}"); BACKUP_OF+=("$dest")
+      log "backed up $dest -> ${dest}.bak.${ts}"
+    fi
+  done
+
+  # rollback: restore every backup taken this run, restart, log.
+  rollback() {
+    err "rolling back to pre-update binaries"
+    stop_and_wait ghost-pay.service || true
+    stop_and_wait ghost-pool.service || true
+    stop_and_wait ghostd.service || true
+    local j
+    for j in "${!BACKUP_DEST[@]}"; do
+      cp -p "${BACKUP_DEST[$j]}" "${BACKUP_OF[$j]}" && log "restored ${BACKUP_OF[$j]}"
+    done
+    $SYSTEMCTL start ghostd.service || true
+    sleep 3
+    $SYSTEMCTL start ghost-pool.service || true
+    unit_present ghost-pay.service && { $SYSTEMCTL start ghost-pay.service || true; }
+    return 0  # never let the rollback's last status trip `set -e` in the caller
+  }
+
+  # 7. Stop services (reverse dependency order), verify inactive.
+  stop_and_wait ghost-pay.service || true
+  stop_and_wait ghost-pool.service || { err "ghost-pool would not stop — rolling back"; rollback; write_status "rolled-back" "ghost-pool failed to stop" "$latest"; exit 1; }
+  stop_and_wait ghostd.service    || { err "ghostd would not stop — rolling back"; rollback; write_status "rolled-back" "ghostd failed to stop" "$latest"; exit 1; }
+
+  # 8. Swap the verified binaries into place atomically (install = temp+rename).
+  # Owned root:root in production (the unit runs as root); a non-root manual run
+  # installs as the caller. If any swap fails, roll the whole set back.
+  local -a OWNER_ARGS=()
+  [[ "$(id -u)" -eq 0 ]] && OWNER_ARGS=(-o root -g root)
+  for k in "${!SWAP_DEST[@]}"; do
+    if install -m755 "${OWNER_ARGS[@]}" "${SWAP_SRC[$k]}" "${SWAP_DEST[$k]}"; then
+      log "swapped ${SWAP_DEST[$k]}"
+    else
+      err "failed to install ${SWAP_DEST[$k]} — rolling back"
+      rollback
+      write_status "rolled-back" "binary swap failed for ${SWAP_DEST[$k]}" "$latest"
+      exit 1
+    fi
+  done
+
+  # 9. Start services (dependency order).
+  $SYSTEMCTL start ghostd.service || { err "ghostd failed to start — rolling back"; rollback; write_status "rolled-back" "ghostd failed to start" "$latest"; exit 1; }
+  sleep 3
+  $SYSTEMCTL start ghost-pool.service || { err "ghost-pool failed to start — rolling back"; rollback; write_status "rolled-back" "ghost-pool failed to start" "$latest"; exit 1; }
+  if unit_present ghost-pay.service; then
+    $SYSTEMCTL start ghost-pay.service || { err "ghost-pay failed to start — rolling back"; rollback; write_status "rolled-back" "ghost-pay failed to start" "$latest"; exit 1; }
+  fi
+
+  # 10. Health-check; roll back on any failure.
+  if run_health_checks; then
+    echo "$latest" > "$VERSION_FILE"; chmod 644 "$VERSION_FILE" 2>/dev/null || true
+    log "UPDATE COMPLETE: now running $latest (backups: *.bak.${ts})"
+    write_status "updated" "updated $installed -> $latest" "$latest"
+    exit 0
+  else
+    err "health checks FAILED after swap — rolling back"
+    rollback
+    if run_health_checks; then
+      log "rollback healthy — back on $installed"
+    else
+      err "rollback health checks ALSO failing — manual intervention required"
+    fi
+    write_status "rolled-back" "health check failed after update to $latest" "$latest"
+    exit 1
+  fi
+}
+
+main "$@"
+GHOST_AUTOUPDATE_SH_EOF
+chmod 755 /opt/ghost/bin/ghost-auto-update.sh
+chown root:root /opt/ghost/bin/ghost-auto-update.sh
+
+# The privileged toggle the dashboard may sudo (scoped to on|off only).
+cat > /opt/ghost/bin/ghost-autoupdate-toggle <<'GHOST_AUTOUPDATE_TOGGLE_EOF'
+#!/usr/bin/env bash
+#
+# ghost-autoupdate-toggle — flip the node auto-update opt-in.
+#
+# This is the ONLY privileged operation the node dashboard performs. The
+# dashboard service user (ghost) may run it via a tightly-scoped sudoers rule
+# (/etc/sudoers.d/ghost-autoupdate) that pins the exact argument to `on` or
+# `off` — nothing else. The script takes NO free-form input: it writes a fixed
+# AUTO_UPDATE=true|false to /etc/ghost/auto-update.conf and enables/disables the
+# timer to match. There is no path by which the dashboard can run an arbitrary
+# command or smuggle other state through this helper.
+#
+# Installed root-owned 0755 at /opt/ghost/bin/ghost-autoupdate-toggle.
+#
+set -euo pipefail
+
+CONF="${GHOST_AUTOUPDATE_CONF:-/etc/ghost/auto-update.conf}"
+SYSTEMCTL="${GHOST_SYSTEMCTL:-systemctl}"
+
+case "${1:-}" in
+  on)  val="true" ;;
+  off) val="false" ;;
+  *) echo "usage: ghost-autoupdate-toggle on|off" >&2; exit 2 ;;
+esac
+
+umask 022
+mkdir -p "$(dirname "$CONF")"
+tmp="$(mktemp "${CONF}.XXXXXX")"
+cat > "$tmp" <<EOF
+# Bitcoin Ghost node auto-update opt-in.
+# Managed by the installer and the node dashboard (ghost-autoupdate-toggle).
+# When AUTO_UPDATE is anything other than exactly 'true', the updater is a no-op.
+AUTO_UPDATE=${val}
+EOF
+chmod 644 "$tmp"
+mv -f "$tmp" "$CONF"
+
+# Keep the timer state in lockstep with the opt-in. Best-effort: the conf flag
+# is the authoritative gate, so a systemd hiccup here can never cause an update.
+if [[ "$val" == "true" ]]; then
+  "$SYSTEMCTL" enable --now ghost-auto-update.timer >/dev/null 2>&1 || true
+else
+  "$SYSTEMCTL" disable --now ghost-auto-update.timer >/dev/null 2>&1 || true
+fi
+
+echo "auto-update set to ${val}"
+GHOST_AUTOUPDATE_TOGGLE_EOF
+chmod 755 /opt/ghost/bin/ghost-autoupdate-toggle
+chown root:root /opt/ghost/bin/ghost-autoupdate-toggle
+
+# Sudoers scope: the dashboard user (ghost) may run ONLY the toggle, on|off.
+cat > /etc/sudoers.d/ghost-autoupdate <<'GHOST_AUTOUPDATE_SUDOERS_EOF'
+# Bitcoin Ghost — node-dashboard auto-update toggle.
+#
+# Grants the dashboard service user (ghost) permission to flip the auto-update
+# opt-in, and NOTHING else. The command is pinned with its exact argument, so
+# `ghost` can run only:
+#     sudo /opt/ghost/bin/ghost-autoupdate-toggle on
+#     sudo /opt/ghost/bin/ghost-autoupdate-toggle off
+# Any other argument (or other command) is rejected by sudo. The toggle binary
+# is root-owned 0755, so the dashboard user cannot rewrite what runs as root.
+#
+# Installed 0440 at /etc/sudoers.d/ghost-autoupdate; validated with `visudo -cf`.
+Defaults!/opt/ghost/bin/ghost-autoupdate-toggle !requiretty
+ghost ALL=(root) NOPASSWD: /opt/ghost/bin/ghost-autoupdate-toggle on, /opt/ghost/bin/ghost-autoupdate-toggle off
+GHOST_AUTOUPDATE_SUDOERS_EOF
+chmod 440 /etc/sudoers.d/ghost-autoupdate
+chown root:root /etc/sudoers.d/ghost-autoupdate
+# Refuse to ship a malformed sudoers file (would otherwise break ALL sudo).
+# Non-fatal: on failure we remove it (sudo stays safe) and continue — the node
+# installs fine; only the dashboard toggle would be unavailable until fixed.
+if ! visudo -cf /etc/sudoers.d/ghost-autoupdate >/dev/null 2>&1; then
+  rm -f /etc/sudoers.d/ghost-autoupdate
+  log "WARNING: generated sudoers file failed validation — removed it (dashboard auto-update toggle disabled)"
+fi
+
+# systemd units (service + 6h randomised timer).
+cat > /etc/systemd/system/ghost-auto-update.service <<'GHOST_AUTOUPDATE_SERVICE_EOF'
+[Unit]
+Description=Bitcoin Ghost opt-in node auto-update (verifies GPG signature before applying)
+Documentation=https://get.bitcoinghost.org
+# Only meaningful once the node is up; never block boot on it.
+After=network-online.target ghostd.service ghost-pool.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+# The script itself is a no-op unless /etc/ghost/auto-update.conf opts in.
+ExecStart=/opt/ghost/bin/ghost-auto-update.sh
+# Verification, binary swap, and systemctl control all require root.
+User=root
+# Never tie the result of a periodic check to a "failed" unit dashboard.
+SuccessExitStatus=0
+GHOST_AUTOUPDATE_SERVICE_EOF
+cat > /etc/systemd/system/ghost-auto-update.timer <<'GHOST_AUTOUPDATE_TIMER_EOF'
+[Unit]
+Description=Bitcoin Ghost opt-in node auto-update (every 6h, randomised)
+Documentation=https://get.bitcoinghost.org
+
+[Timer]
+# First check shortly after boot, then every 6 hours.
+OnBootSec=15min
+OnUnitActiveSec=6h
+# Spread fleet load / avoid a thundering herd on the release host.
+RandomizedDelaySec=1h
+# Catch up a missed window (e.g. the node was off) on next boot.
+Persistent=true
+Unit=ghost-auto-update.service
+
+[Install]
+WantedBy=timers.target
+GHOST_AUTOUPDATE_TIMER_EOF
+
+# Opt-in config (world-readable so the dashboard can show the current state;
+# only root, or the scoped toggle via sudo, can write it).
+cat > /etc/ghost/auto-update.conf <<EOF
+# Bitcoin Ghost node auto-update opt-in.
+# Managed by the installer and the node dashboard (ghost-autoupdate-toggle).
+# When AUTO_UPDATE is anything other than exactly 'true', the updater is a no-op.
+AUTO_UPDATE=${AUTO_UPDATE}
+EOF
+chmod 644 /etc/ghost/auto-update.conf
+chown root:root /etc/ghost/auto-update.conf
+
+# Baseline installed-version marker the updater compares against.
+echo "${GHOST_VERSION}" > /etc/ghost/version
+chmod 644 /etc/ghost/version
+chown root:root /etc/ghost/version
+
+systemctl daemon-reload >/dev/null 2>&1 || true
+# Enable + start the timer ONLY when opted in. Default path: timer stays
+# installed-but-inactive, so the node can never self-upgrade.
+if [[ "$AUTO_UPDATE" == "true" ]]; then
+  systemctl enable --now ghost-auto-update.timer >/dev/null 2>&1 || true
+  log "auto-update ENABLED — checking for signed releases every 6h"
+else
+  systemctl disable --now ghost-auto-update.timer >/dev/null 2>&1 || true
+  log "auto-update disabled (default) — node will not self-upgrade"
+fi
 
 # ─────────────────────────────── 11. start ───────────────────────────────────
 log "Starting services"

--- a/scripts/systemd/ghost-auto-update.service
+++ b/scripts/systemd/ghost-auto-update.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Bitcoin Ghost opt-in node auto-update (verifies GPG signature before applying)
+Documentation=https://get.bitcoinghost.org
+# Only meaningful once the node is up; never block boot on it.
+After=network-online.target ghostd.service ghost-pool.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+# The script itself is a no-op unless /etc/ghost/auto-update.conf opts in.
+ExecStart=/opt/ghost/bin/ghost-auto-update.sh
+# Verification, binary swap, and systemctl control all require root.
+User=root
+# Never tie the result of a periodic check to a "failed" unit dashboard.
+SuccessExitStatus=0

--- a/scripts/systemd/ghost-auto-update.timer
+++ b/scripts/systemd/ghost-auto-update.timer
@@ -1,0 +1,16 @@
+[Unit]
+Description=Bitcoin Ghost opt-in node auto-update (every 6h, randomised)
+Documentation=https://get.bitcoinghost.org
+
+[Timer]
+# First check shortly after boot, then every 6 hours.
+OnBootSec=15min
+OnUnitActiveSec=6h
+# Spread fleet load / avoid a thundering herd on the release host.
+RandomizedDelaySec=1h
+# Catch up a missed window (e.g. the node was off) on next boot.
+Persistent=true
+Unit=ghost-auto-update.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Adds an **opt-in** node auto-updater. A node never self-upgrades unless the operator explicitly enables it (installer flag/wizard step + dashboard toggle); default OFF everywhere.

## Security (the load-bearing part)
No binary is touched unless **all three** pass, exactly mirroring the installer first-run verification: import the release key, `gpg --status-fd=1 --verify SHA256SUMS.txt.asc SHA256SUMS.txt` requiring `VALIDSIG <pinned-fingerprint>` (stronger than "Good signature from <name>"), then `sha256sum -c` the tarball against the signed `SHA256SUMS.txt` and ghostd against `install.sh`. Any failure → abort + `exit 1`, no binary touched. Verified the v1.10.6 release actually carries `SHA256SUMS.txt`/`.asc` and the installer uses the identical scheme.

## Behaviour
- `/etc/ghost/auto-update.conf` (`AUTO_UPDATE=false` default) is the single source of truth; updater is a strict no-op unless `true`.
- On a newer signed release: backup → stop→verify-inactive→swap→start (avoids the `Job canceled` race) → health-check (ghostd RPC, ghost-pool peer_count>0, ghost-pay https). Any failure rolls back to the backups; `/etc/ghost/version` bumps only after a clean health check.
- systemd `ghost-auto-update.timer` (6h, randomised), enabled only when opted in.
- Installer: `--auto-update`/`--no-auto-update` + wizard step; default path unchanged.
- Dashboard: an "Automatic updates" toggle on the System page. The dashboard is NOT root — it flips the opt-in via a sudoers-pinned helper accepting only the literals `on`/`off`.

## Tests
14/14 updater harness (incl. bad-signature + tampered-tarball → abort, binaries untouched), 9/9 swap/rollback (unhealthy → rolls back), shellcheck clean, sudoers `visudo`-validated, dashboard builds. Not deployed — for review.