### PR TITLE
web: document the three mining modes on nodes.html

### DIFF
--- a/ghost-web/miners.html
+++ b/ghost-web/miners.html
@@ -261,6 +261,16 @@
       <a href="/pool.html#your-miner">lookup on the pool page</a> — no login.
     </p>
 
+    <p class="qsg-foot" style="margin-top:12px">
+      The settings above point at the <strong>public pool</strong> — open to
+      anyone, no permission needed. Some operators instead run a
+      <strong>private pool</strong> you join with a password they give you, or
+      mine <strong>solo</strong> on their own node. Those are choices the
+      <em>node operator</em> makes — see the three
+      <a href="/nodes.html#mining-modes">mining modes</a> if you want to run
+      your own node and decide how its hashpower is used.
+    </p>
+
     <script>
       (function () {
         var POOL = 'pool.bitcoinghost.org';

--- a/ghost-web/nodes.html
+++ b/ghost-web/nodes.html
@@ -204,7 +204,7 @@
 </section>
 
 <!-- ───────── Mining modes ───────── -->
-<section class="block node-modes-section">
+<section class="block node-modes-section" id="mining-modes">
   <div class="container">
     <div class="section-label">mining modes</div>
     <h2 class="section-title">Solo, private pool, or public pool.</h2>

--- a/ghost-web/nodes.html
+++ b/ghost-web/nodes.html
@@ -203,6 +203,50 @@
   </div>
 </section>
 
+<!-- ───────── Mining modes ───────── -->
+<section class="block node-modes-section">
+  <div class="container">
+    <div class="section-label">mining modes</div>
+    <h2 class="section-title">Solo, private pool, or public pool.</h2>
+    <p class="section-lead">
+      Every node decides how its hashpower is used and who may point miners
+      at it. Pick one of three modes — switch any time from the node
+      dashboard. No account, no sign-up, no KYC.
+    </p>
+
+    <ul class="feature-list node-core-pink cap-bulleted">
+      <li>
+        <svg class="gh-bullet" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 10h.01"/><path d="M15 10h.01"/><path d="M12 2a8 8 0 0 0-8 8v12l3-3 2.5 2.5L12 19l2.5 2.5L17 19l3 3V10a8 8 0 0 0-8-8z"/></svg>
+        <div>
+          <div class="fl-name">Private Solo</div>
+          <div class="fl-desc">Your miners only — Stratum ports stay closed to outsiders and the node isn't published in DNS. You keep <strong>99% of the block subsidy plus every transaction fee</strong>, paid straight to your own address. The remaining 1% of the subsidy is the protocol fee, split between the treasury and the node pool. No reward sharing.</div>
+        </div>
+      </li>
+      <li>
+        <svg class="gh-bullet" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 10h.01"/><path d="M15 10h.01"/><path d="M12 2a8 8 0 0 0-8 8v12l3-3 2.5 2.5L12 19l2.5 2.5L17 19l3 3V10a8 8 0 0 0-8-8z"/></svg>
+        <div>
+          <div class="fl-name">Private Pool</div>
+          <div class="fl-desc">Run a pool for a group you choose. Miners connect with a password and rewards are pool-aggregated and shared across connected hashers — but the node stays out of DNS, so the public can't find it. Good for a farm, a club, or friends pooling together.</div>
+        </div>
+      </li>
+      <li>
+        <svg class="gh-bullet" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 10h.01"/><path d="M15 10h.01"/><path d="M12 2a8 8 0 0 0-8 8v12l3-3 2.5 2.5L12 19l2.5 2.5L17 19l3 3V10a8 8 0 0 0-8-8z"/></svg>
+        <div>
+          <div class="fl-name">Public Pool <span class="fl-badge">+3</span></div>
+          <div class="fl-desc">Published in DNS so anyone can point an ASIC at your node. Rewards are pool-aggregated and shared, and accepting external miners earns the public-mining capability (+3 shares). This is the default mode.</div>
+        </div>
+      </li>
+    </ul>
+
+    <p class="section-lead" style="margin-top:1.5rem">
+      Set it at install with <code>--mining-mode solo|pool|public</code>, or
+      change it later in the node dashboard under <strong>Mining</strong>.
+      Your block-explorer coinbase tag reflects the mode
+      (<code>- G H O S T - PublicPool</code>).
+    </p>
+  </div>
+</section>
+
 <!-- ───────── The gate ───────── -->
 <section class="block node-gate-section">
   <div class="container">

--- a/ghost-web/nodes.html
+++ b/ghost-web/nodes.html
@@ -241,8 +241,14 @@
     <p class="section-lead" style="margin-top:1.5rem">
       Set it at install with <code>--mining-mode solo|pool|public</code>, or
       change it later in the node dashboard under <strong>Mining</strong>.
-      Your block-explorer coinbase tag reflects the mode
-      (<code>- G H O S T - PublicPool</code>).
+    </p>
+    <p class="section-lead" style="margin-top:1rem">
+      <strong>Name your pool.</strong> Every block you find carries a tag in
+      its coinbase, visible on any block explorer. By default it reflects the
+      mode (<code>- G H O S T - PublicPool</code>), but you can set a custom
+      name — <code>- G H O S T - YourPool</code> — from the node dashboard's
+      Pool Setup (ASCII, up to 30 characters). It's how your pool gets
+      recognised on-chain.
     </p>
   </div>
 </section>


### PR DESCRIPTION
Adds a "Mining modes" section to the Run a node page explaining the three modes (Private Solo / Private Pool / Public Pool) — reward split, password/DNS differences, the +3 public-mining capability — and how to set it (`--mining-mode` flag or the node dashboard → Mining). Economics verified against `payout.rs` (99% subsidy + all tx fees to the solo operator; 1% split treasury/node-pool). Already deployed live to bitcoinghost.org/nodes.html.