### PR TITLE
fix: stop maintenance prune wiping active miners' unpaid ledger; 1-year dark window

### DIFF
--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -4717,7 +4717,6 @@ async fn main() -> Result<()> {
                     match db_for_maintenance.run_maintenance(config) {
                         Ok(result) => {
                             tracing::info!(
-                                shares = result.shares_deleted,
                                 rounds = result.rounds_deleted,
                                 pings = result.pings_deleted,
                                 votes = result.votes_deleted,

--- a/crates/ghost-storage/src/database.rs
+++ b/crates/ghost-storage/src/database.rs
@@ -844,14 +844,27 @@ impl Database {
         Ok(())
     }
 
-    /// Prune old shares from the database
+    /// Prune old, fully-settled rounds from the database.
     ///
-    /// Deletes shares older than the specified number of rounds.
-    /// Returns the number of shares deleted.
+    /// A `rounds` row is deleted ONLY when all three hold:
+    ///   1. it is past the retention window (`round_id < MAX - keep_rounds`),
+    ///   2. its `payout_status` is terminal (`confirmed`/`orphaned`/`failed`),
+    ///   3. it has **zero remaining shares** referencing it.
     ///
-    /// 4.17 SECURITY: Wrapped in transaction for atomicity
-    pub fn prune_old_shares(&self, keep_rounds: u64) -> GhostResult<usize> {
-        // 4.17: Use transaction method for atomic prune
+    /// This function NEVER deletes from the `shares` table. Share-row lifecycle
+    /// is owned solely by [`Database::delete_old_shares`] (Path A), which keeps
+    /// an active or recently-dark miner's unpaid ledger intact. Because an
+    /// unpaid share pins its round via the `NOT EXISTS` guard, a round is only
+    /// reclaimed once `delete_old_shares` has legitimately removed its last
+    /// share (after payout, or after the miner has been dark for over a year).
+    ///
+    /// Note: `shares.round_id` has NO foreign key / `ON DELETE CASCADE` to
+    /// `rounds` (see the `shares` schema in migrations.rs), so deleting a round
+    /// can never cascade into a live unpaid share. The `NOT EXISTS` guard is a
+    /// belt-and-braces invariant that keeps round cleanup honest regardless.
+    ///
+    /// 4.17 SECURITY: Wrapped in transaction for atomicity.
+    pub fn prune_old_rounds(&self, keep_rounds: u64) -> GhostResult<usize> {
         self.transaction(|tx| {
             // Find the minimum round ID to keep
             let current_round: Option<u64> = tx
@@ -864,66 +877,26 @@ impl Database {
 
             let min_round_to_keep = current.saturating_sub(keep_rounds);
 
+            // Delete only terminal-status rounds past the window that have NO
+            // remaining shares. Shares are NOT touched here — an unpaid share
+            // keeps its round alive until Path A prunes that share.
             let deleted = tx
                 .execute(
-                    "DELETE FROM shares WHERE round_id < ?1",
+                    "DELETE FROM rounds
+                     WHERE round_id < ?1
+                       AND payout_status IN ('confirmed', 'orphaned', 'failed')
+                       AND NOT EXISTS (
+                           SELECT 1 FROM shares s WHERE s.round_id = rounds.round_id
+                       )",
                     [min_round_to_keep],
                 )
                 .map_err(|e| GhostError::Database(e.to_string()))?;
 
             if deleted > 0 {
-                info!(deleted, min_round = min_round_to_keep, "Pruned old shares");
-            }
-
-            Ok(deleted)
-        })
-    }
-
-    /// Prune old rounds from the database
-    ///
-    /// Deletes rounds older than the specified number and their associated data.
-    /// Only deletes rounds that are confirmed or orphaned.
-    /// Returns the number of rounds deleted.
-    ///
-    /// 4.17 SECURITY: Wrapped in transaction for atomicity and cascade deletion
-    pub fn prune_old_rounds(&self, keep_rounds: u64) -> GhostResult<usize> {
-        // 4.17: Use transaction method for atomic prune with cascade
-        self.transaction(|tx| {
-            // Find the minimum round ID to keep
-            let current_round: Option<u64> = tx
-                .query_row(
-                    "SELECT MAX(round_id) FROM rounds",
-                    [],
-                    |row| row.get(0),
-                )
-                .map_err(|e| GhostError::Database(e.to_string()))?;
-
-            let Some(current) = current_round else {
-                return Ok(0);
-            };
-
-            let min_round_to_keep = current.saturating_sub(keep_rounds);
-
-            // 4.17: Delete shares first (child records) before rounds (parent)
-            let shares_deleted = tx.execute(
-                "DELETE FROM shares WHERE round_id < ?1",
-                [min_round_to_keep],
-            )
-            .map_err(|e| GhostError::Database(e.to_string()))?;
-
-            // Only delete confirmed or orphaned rounds
-            let deleted = tx.execute(
-                "DELETE FROM rounds WHERE round_id < ?1 AND payout_status IN ('confirmed', 'orphaned', 'failed')",
-                [min_round_to_keep],
-            )
-            .map_err(|e| GhostError::Database(e.to_string()))?;
-
-            if deleted > 0 {
                 info!(
                     rounds_deleted = deleted,
-                    shares_deleted = shares_deleted,
                     min_round = min_round_to_keep,
-                    "Pruned old rounds and associated shares"
+                    "Pruned old empty rounds"
                 );
             }
 
@@ -1099,7 +1072,10 @@ impl Database {
     pub fn run_maintenance(&self, config: MaintenanceConfig) -> GhostResult<MaintenanceResult> {
         info!("Running database maintenance");
 
-        let shares_deleted = self.prune_old_shares(config.keep_rounds)?;
+        // NOTE: `shares` rows are NOT pruned here. The share-row lifecycle is
+        // owned solely by `delete_old_shares` (Path A, run by the dedicated
+        // share-pruning task), which protects active and recently-dark miners'
+        // unpaid ledgers. `prune_old_rounds` only removes already-empty rounds.
         let rounds_deleted = self.prune_old_rounds(config.keep_rounds)?;
         let pings_deleted = self.prune_old_health_pings(config.keep_health_ping_days)?;
         let votes_deleted = self.prune_old_votes(config.keep_rounds)?;
@@ -1119,8 +1095,7 @@ impl Database {
         self.checkpoint()?;
 
         // Optimize if significant data was deleted
-        let total_deleted = shares_deleted
-            + rounds_deleted
+        let total_deleted = rounds_deleted
             + pings_deleted
             + votes_deleted
             + uptime_deleted
@@ -1135,7 +1110,6 @@ impl Database {
         let stats = self.stats()?;
 
         info!(
-            shares_deleted,
             rounds_deleted,
             pings_deleted,
             votes_deleted,
@@ -1149,7 +1123,6 @@ impl Database {
         );
 
         Ok(MaintenanceResult {
-            shares_deleted,
             rounds_deleted,
             pings_deleted,
             votes_deleted,
@@ -1228,7 +1201,6 @@ impl Default for MaintenanceConfig {
 /// Result of database maintenance
 #[derive(Debug, Clone)]
 pub struct MaintenanceResult {
-    pub shares_deleted: usize,
     pub rounds_deleted: usize,
     pub pings_deleted: usize,
     pub votes_deleted: usize,

--- a/crates/ghost-storage/src/queries.rs
+++ b/crates/ghost-storage/src/queries.rs
@@ -1261,7 +1261,17 @@ impl Database {
         })
     }
 
-    /// Delete shares older than `retention_secs` seconds
+    /// Delete shares older than `retention_secs` seconds.
+    ///
+    /// This is the SINGLE authority for the `shares` row lifecycle. It does
+    /// two distinct things:
+    ///   1. PAID shares (`paid_in_proposal_hash IS NOT NULL`) older than
+    ///      `retention_secs` are pruned — a short audit tail, no ledger value.
+    ///   2. UNPAID shares (`paid_in_proposal_hash IS NULL`) are NEVER pruned
+    ///      by age. They are only reclaimed once their miner has been dark
+    ///      (no `last_seen` update) for over **one year**. An actively-mining
+    ///      miner therefore accumulates their unpaid ledger indefinitely and
+    ///      it carries forward across every block, exactly as promised.
     ///
     /// Uses the existing `idx_shares_timestamp` index for efficient deletion.
     /// Returns the number of deleted rows.
@@ -1279,10 +1289,11 @@ impl Database {
             .as_secs() as i64;
         let paid_cutoff = now_s - retention_secs;
         // Inactive-miner cutoff: unpaid shares belonging to miners whose
-        // last_seen is older than 7 days are dropped into the node pool
-        // (via disappearance) so they don't sit on the ledger forever.
-        // Active miners keep every unpaid share regardless of age.
-        const INACTIVE_SECS: i64 = 7 * 24 * 3600;
+        // last_seen is older than ONE YEAR are reclaimed into the node pool
+        // (via disappearance) so a permanently-abandoned miner's ledger does
+        // not pin rows forever. Active miners — and even miners dark for up
+        // to a year — keep every unpaid share regardless of age.
+        const INACTIVE_SECS: i64 = 365 * 24 * 3600;
         let inactive_cutoff = now_s - INACTIVE_SECS;
 
         self.with_connection(|conn| {
@@ -1298,7 +1309,7 @@ impl Database {
                 .map_err(|e| GhostError::Database(e.to_string()))?;
 
             // 2. Unpaid shares: drop only if the miner has been dark for
-            //    7+ days. Active miners keep their full unpaid ledger.
+            //    1+ year. Active miners keep their full unpaid ledger.
             let unpaid_deleted = conn
                 .execute(
                     "DELETE FROM shares
@@ -10212,9 +10223,9 @@ mod tests {
             .as_secs() as i64;
 
         // Insert old share (48 hours ago) belonging to a miner that has
-        // been dark for >7 days. delete_old_shares only prunes unpaid
-        // shares of inactive miners, so the miner row is required for
-        // the inactive-cutoff JOIN to match.
+        // been dark for >1 year. delete_old_shares only prunes unpaid
+        // shares of inactive miners (last_seen older than 1 year), so the
+        // miner row is required for the inactive-cutoff JOIN to match.
         let old_share = ShareRecord {
             id: None,
             round_id: 1,
@@ -10229,8 +10240,8 @@ mod tests {
         db.upsert_miner(&MinerRecord {
             miner_id: "miner_old".to_string(),
             payout_address: String::new(),
-            first_seen: now_s - (10 * 24 * 3600),
-            last_seen: now_s - (8 * 24 * 3600),
+            first_seen: now_s - (400 * 24 * 3600),
+            last_seen: now_s - (400 * 24 * 3600),
             connected_node: None,
             total_shares: 1,
             total_work: 1000.0,
@@ -10287,6 +10298,264 @@ mod tests {
             deleted, 0,
             "Recent share should survive minimum retention guard"
         );
+    }
+
+    // =========================================================================
+    // SHARE-LIFECYCLE / PAYOUT-LEDGER PROTECTION TESTS
+    //
+    // These guard the miners' earned-but-unpaid balances against the two
+    // hourly prune paths. `delete_old_shares` (Path A) is the SINGLE authority
+    // for share-row deletion; `run_maintenance`/`prune_old_rounds` (Path B)
+    // must never touch a still-needed share.
+    // =========================================================================
+
+    fn ledger_now_s() -> i64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64
+    }
+
+    fn ledger_miner(id: &str, last_seen: i64) -> MinerRecord {
+        MinerRecord {
+            miner_id: id.to_string(),
+            payout_address: id.split('.').next().unwrap_or(id).to_string(),
+            first_seen: last_seen - 24 * 3600,
+            last_seen,
+            connected_node: None,
+            total_shares: 1,
+            total_work: 1500.0,
+            blocks_won: 0,
+            total_payouts_sats: 0,
+            avg_hashrate_ths: 0.0,
+        }
+    }
+
+    fn ledger_round(round_id: u64, status: PayoutStatus, start_time: i64) -> RoundRecord {
+        RoundRecord {
+            round_id,
+            block_height: 800_000 + round_id,
+            block_hash: Some(format!("blockhash{round_id}")),
+            start_time,
+            end_time: Some(start_time + 600),
+            total_shares: 0,
+            total_work: 0.0,
+            winning_miner: None,
+            found_by_node: None,
+            payout_status: status,
+            subsidy_sats: Some(625_000_000),
+            tx_fees_sats: Some(1_000_000),
+        }
+    }
+
+    fn ledger_share(round_id: u64, miner_id: &str, hash: &str, timestamp: i64) -> ShareRecord {
+        ShareRecord {
+            id: None,
+            round_id,
+            miner_id: miner_id.to_string(),
+            difficulty: 1500.0,
+            work: 1500.0,
+            share_hash: hash.to_string(),
+            timestamp,
+            received_by: "node1".to_string(),
+            valid: true,
+        }
+    }
+
+    /// THE CORE REGRESSION TEST.
+    ///
+    /// An actively-mining miner has an UNPAID share with an OLD `round_id`
+    /// (far inside the `keep_rounds` prune window) and an OLD timestamp. Both
+    /// hourly prune paths run. The share — and the miner's unpaid ledger — must
+    /// survive untouched.
+    ///
+    /// Pre-fix this FAILS: `run_maintenance` → `prune_old_shares` did
+    /// `DELETE FROM shares WHERE round_id < (MAX-keep_rounds)` with no
+    /// paid/last_seen check and wiped the share.
+    #[test]
+    fn test_active_miner_unpaid_share_survives_both_prune_paths() {
+        let db = Database::in_memory().unwrap();
+        let now_s = ledger_now_s();
+        let miner = "bc1qactive.worker";
+
+        // Actively-mining miner: last_seen == now.
+        db.upsert_miner(&ledger_miner(miner, now_s)).unwrap();
+
+        // Historic confirmed round, deep in the prune window.
+        db.create_round(&ledger_round(
+            1,
+            PayoutStatus::Confirmed,
+            now_s - 30 * 24 * 3600,
+        ))
+        .unwrap();
+        // A current round far ahead so MAX(round_id) - keep_rounds(1000) leaves
+        // round 1 well inside the window the buggy code would have deleted.
+        db.create_round(&ledger_round(2_000, PayoutStatus::Active, now_s))
+            .unwrap();
+
+        // UNPAID share: old round_id, old timestamp, active miner.
+        db.insert_share(&ledger_share(
+            1,
+            miner,
+            "active_old_unpaid",
+            now_s - 30 * 24 * 3600,
+        ))
+        .unwrap();
+
+        let (count_before, work_before) = db.get_miner_unpaid_stats(miner).unwrap();
+        assert_eq!(count_before, 1);
+
+        // Run BOTH hourly paths, exactly as the pool does.
+        db.run_maintenance(crate::database::MaintenanceConfig::default())
+            .unwrap();
+        db.delete_old_shares(24 * 3600).unwrap();
+
+        // The active miner's old unpaid share MUST still exist.
+        let shares = db.get_shares_by_round(1).unwrap();
+        assert_eq!(
+            shares.len(),
+            1,
+            "active miner's old unpaid share was wiped by a prune path"
+        );
+
+        let (count_after, work_after) = db.get_miner_unpaid_stats(miner).unwrap();
+        assert_eq!(count_after, 1, "unpaid-ledger count changed");
+        assert!(
+            (work_after - work_before).abs() < 1e-9,
+            "unpaid-ledger work changed: {work_before} -> {work_after}"
+        );
+    }
+
+    /// A miner dark for 30 days (< 1 year) keeps its unpaid share. Pre-fix this
+    /// FAILS: `delete_old_shares` dropped unpaid shares after only 7 days dark.
+    #[test]
+    fn test_dark_miner_under_one_year_unpaid_share_kept() {
+        let db = Database::in_memory().unwrap();
+        let now_s = ledger_now_s();
+        let miner = "bc1qdark30d.worker";
+
+        db.upsert_miner(&ledger_miner(miner, now_s - 30 * 24 * 3600))
+            .unwrap();
+        db.insert_share(&ledger_share(
+            1,
+            miner,
+            "dark30d_unpaid",
+            now_s - 30 * 24 * 3600,
+        ))
+        .unwrap();
+
+        db.run_maintenance(crate::database::MaintenanceConfig::default())
+            .unwrap();
+        let deleted = db.delete_old_shares(24 * 3600).unwrap();
+
+        assert_eq!(
+            deleted, 0,
+            "share of a 30-day-dark miner must not be pruned"
+        );
+        assert_eq!(db.get_shares_by_round(1).unwrap().len(), 1);
+        let (count, _) = db.get_miner_unpaid_stats(miner).unwrap();
+        assert_eq!(count, 1);
+    }
+
+    /// A miner dark for 400 days (> 1 year) has its abandoned unpaid share
+    /// reclaimed by `delete_old_shares`.
+    #[test]
+    fn test_dark_miner_over_one_year_unpaid_share_reclaimed() {
+        let db = Database::in_memory().unwrap();
+        let now_s = ledger_now_s();
+        let miner = "bc1qdark400d.worker";
+
+        db.upsert_miner(&ledger_miner(miner, now_s - 400 * 24 * 3600))
+            .unwrap();
+        db.insert_share(&ledger_share(
+            1,
+            miner,
+            "dark400d_unpaid",
+            now_s - 400 * 24 * 3600,
+        ))
+        .unwrap();
+
+        let deleted = db.delete_old_shares(24 * 3600).unwrap();
+        assert_eq!(
+            deleted, 1,
+            "share of a >1-year-dark miner must be reclaimed"
+        );
+        assert!(db.get_shares_by_round(1).unwrap().is_empty());
+    }
+
+    /// A PAID share older than the retention window is pruned (harmless audit
+    /// tail), regardless of the miner being active.
+    #[test]
+    fn test_paid_share_pruned_after_retention() {
+        let db = Database::in_memory().unwrap();
+        let now_s = ledger_now_s();
+        let miner = "bc1qpaid.worker";
+
+        // Active miner — proves the prune keys off PAID status, not last_seen.
+        db.upsert_miner(&ledger_miner(miner, now_s)).unwrap();
+        db.insert_share(&ledger_share(1, miner, "paid_old", now_s - 48 * 3600))
+            .unwrap();
+
+        // Commit it to a payout proposal => paid_in_proposal_hash set.
+        let marked = db
+            .mark_miners_paid(&[7u8; 32], &[miner.to_string()], now_s)
+            .unwrap();
+        assert_eq!(marked, 1);
+        // It is now off the unpaid ledger.
+        let (unpaid, _) = db.get_miner_unpaid_stats(miner).unwrap();
+        assert_eq!(unpaid, 0);
+
+        let deleted = db.delete_old_shares(24 * 3600).unwrap();
+        assert_eq!(deleted, 1, "paid share older than 24h must be pruned");
+        assert!(db.get_shares_by_round(1).unwrap().is_empty());
+    }
+
+    /// `prune_old_rounds` must never orphan a share: a past-window confirmed
+    /// round with a remaining share is NOT deleted; once Path A legitimately
+    /// removes the share, a later round prune deletes the now-empty round.
+    #[test]
+    fn test_prune_old_rounds_never_orphans_share() {
+        let db = Database::in_memory().unwrap();
+        let now_s = ledger_now_s();
+        let miner = "bc1qpinned.worker";
+
+        // Current round far ahead so MAX(round_id) - 1000 puts round 1 in window.
+        db.create_round(&ledger_round(2_000, PayoutStatus::Active, now_s))
+            .unwrap();
+        // Past-window, terminal-status (confirmed) round...
+        db.create_round(&ledger_round(
+            1,
+            PayoutStatus::Confirmed,
+            now_s - 30 * 24 * 3600,
+        ))
+        .unwrap();
+        // ...pinned by a remaining share.
+        db.insert_share(&ledger_share(1, miner, "pinning_share", now_s - 48 * 3600))
+            .unwrap();
+
+        // First prune: the share pins round 1 => it must survive.
+        db.prune_old_rounds(1000).unwrap();
+        assert!(
+            db.get_round(1).unwrap().is_some(),
+            "round with a remaining share was orphaned"
+        );
+        assert_eq!(db.get_shares_by_round(1).unwrap().len(), 1);
+
+        // Legitimately remove the share via Path A (mark paid, then age out).
+        db.mark_miners_paid(&[9u8; 32], &[miner.to_string()], now_s)
+            .unwrap();
+        assert_eq!(db.delete_old_shares(24 * 3600).unwrap(), 1);
+        assert!(db.get_shares_by_round(1).unwrap().is_empty());
+
+        // Now the round is empty + confirmed + past-window => it is pruned.
+        let deleted = db.prune_old_rounds(1000).unwrap();
+        assert!(deleted >= 1, "empty terminal round should now be prunable");
+        assert!(
+            db.get_round(1).unwrap().is_none(),
+            "empty terminal round was not pruned"
+        );
+        // The far-ahead active round is untouched.
+        assert!(db.get_round(2_000).unwrap().is_some());
     }
 
     // =========================================================================

--- a/ghost-web/pool.html
+++ b/ghost-web/pool.html
@@ -245,8 +245,9 @@
       When a block is found the top 200 miners by unpaid work (filtered to
       those above the 546-sat dust threshold) get included in the coinbase,
       proportional to their share. Everyone else keeps their ledger intact
-      and carries it forward to compete for the next block. Unpaid shares
-      expire only if a miner goes dark for 7 days.
+      and carries it forward to compete for the next block. Your unpaid
+      work never expires while you keep mining — it is only reclaimed if a
+      miner goes completely dark for over a year.
     </p>
 
     <div class="payout-summary">
@@ -283,8 +284,8 @@
       Ledger model — your unpaid work carries forward across blocks until
       you're included in a coinbase. Miners below the <code>546</code>-sat
       dust line are skipped for that block and their ledger stays intact.
-      Unpaid shares for miners who haven't submitted anything in 7 days
-      are dropped into the node reward pool.
+      Unpaid shares are only reclaimed into the node reward pool if a miner
+      has been dark for over a year.
     </div>
   </div>
 </section>

--- a/tests/integration_tests/storage.rs
+++ b/tests/integration_tests/storage.rs
@@ -316,54 +316,12 @@ fn test_558_share_work_sum() {
     assert!((total - 5500.0).abs() < 0.001);
 }
 
-#[test]
-fn test_559_prune_old_shares() {
-    let db = Database::in_memory().unwrap();
-
-    // Create multiple rounds
-    for round_id in 1..=10u64 {
-        let round = RoundRecord {
-            round_id,
-            block_height: 800000 + round_id,
-            block_hash: None,
-            start_time: 1700000000 + round_id as i64 * 1000,
-            end_time: Some(1700000000 + round_id as i64 * 1000 + 600),
-            total_shares: 1,
-            total_work: 1000.0,
-            winning_miner: None,
-            found_by_node: None,
-            payout_status: PayoutStatus::Confirmed,
-            subsidy_sats: Some(625_000_000),
-            tx_fees_sats: Some(1_000_000),
-        };
-        db.create_round(&round).unwrap();
-
-        let share = ShareRecord {
-            id: None,
-            round_id,
-            miner_id: "miner1".to_string(),
-            difficulty: 1000.0,
-            work: 1000.0,
-            share_hash: format!("hash{}", round_id),
-            timestamp: 1700000000 + round_id as i64 * 1000,
-            received_by: "node1".to_string(),
-            valid: true,
-        };
-        db.insert_share(&share).unwrap();
-    }
-
-    // Prune shares older than 5 rounds from current (round 10)
-    let deleted = db.prune_old_shares(5).unwrap();
-    assert!(deleted > 0);
-
-    // Shares from rounds 1-4 should be deleted
-    let old_shares = db.get_shares_by_round(1).unwrap();
-    assert!(old_shares.is_empty());
-
-    // Shares from round 10 should remain
-    let new_shares = db.get_shares_by_round(10).unwrap();
-    assert_eq!(new_shares.len(), 1);
-}
+// NOTE: the former `test_559_prune_old_shares` was removed along with the
+// `Database::prune_old_shares` function. That round-count-based bulk share
+// delete unconditionally wiped unpaid shares of active miners (the payout-
+// correctness bug). Share-row lifecycle is now owned solely by
+// `delete_old_shares` (Path A); see the dedicated protection tests in
+// `crates/ghost-storage/src/queries.rs` and `database.rs`.
 
 #[test]
 fn test_560_get_round_miners() {


### PR DESCRIPTION
Payout-correctness fix. Two hourly prune paths contradicted each other:

- **Path A** (`delete_old_shares`) correctly protected unpaid shares — only reclaiming them when a miner was dark.
- **Path B** (`run_maintenance` → `prune_old_shares`/`prune_old_rounds`, `keep_rounds=1000`) did `DELETE FROM shares WHERE round_id < MAX-1000` with **no paid/last_seen check**. Since `round_id` advances once per network block, ~1000 rounds ≈ ~7 days — so an **actively-mining** miners earned-but-unpaid ledger was silently wiped after ~7 days whenever the pool went that long without finding a block. Path B overrode Path A.

## Fix
- **`delete_old_shares` is now the single share-row authority.** `prune_old_shares` removed entirely (+ its `run_maintenance` call + `MaintenanceResult.shares_deleted` + the main.rs log field).
- **`prune_old_rounds` no longer touches `shares`**; it deletes a round row only when it is past the window, `payout_status IN (confirmed,orphaned,failed)`, **and has zero remaining shares** (`NOT EXISTS`). An unpaid share now pins its round until the share is legitimately pruned. (FK finding: `shares.round_id` has no FK/cascade to `rounds`, so deleting a round cannot cascade a share — the `NOT EXISTS` is belt-and-braces.)
- **Dark-miner window 7 days → 1 year** (`INACTIVE_SECS = 365*24*3600`): an active miners unpaid ledger never expires; shares are only reclaimed into the node pool after a miner is dark >1 year. Paid-share 24h audit prune unchanged.
- `pool.html` copy updated to match (1 year, not 7 days).

## Tests (ghost-storage, 126 pass)
- `test_active_miner_unpaid_share_survives_both_prune_paths` — old unpaid share of a recently-seen miner survives `run_maintenance` + `delete_old_shares` (**proven to fail on pre-fix code**).
- `..._dark_miner_under_one_year_unpaid_share_kept` (30-day-dark kept), `..._over_one_year_unpaid_share_reclaimed` (400-day-dark reclaimed), `test_paid_share_pruned_after_retention`, `test_prune_old_rounds_never_orphans_share`.