### PR TITLE
release: v1.10.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-ghost-tests"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "bitcoin",
  "chrono",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin_core_sv2"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "async-channel 1.9.0",
  "bitcoin-capnp-types",
@@ -3083,7 +3083,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-accounting"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "bitcoin",
  "ghost-common",
@@ -3097,7 +3097,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-buds"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "bitcoin",
  "ghost-common",
@@ -3111,7 +3111,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-cli"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3129,7 +3129,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-common"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -3162,7 +3162,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-consensus"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3193,7 +3193,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-glyph"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "hex",
  "serde",
@@ -3204,7 +3204,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-gsp"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3266,7 +3266,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-gsp-proto"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "bitcoin",
  "chrono",
@@ -3283,7 +3283,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-keys"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "bech32",
  "bitcoin",
@@ -3305,7 +3305,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-locks"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "bitcoin",
  "getrandom 0.2.17",
@@ -3348,7 +3348,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-pay"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3396,7 +3396,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-policy"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "bitcoin",
  "ghost-buds",
@@ -3409,7 +3409,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-pool"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "anyhow",
  "async-channel 2.5.0",
@@ -3464,7 +3464,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-reaper"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "bitcoin",
  "hex",
@@ -3476,7 +3476,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-reconciliation"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "async-trait",
  "bitcoin",
@@ -3502,7 +3502,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-registry"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -3537,7 +3537,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-setup"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "clap",
  "dirs 5.0.1",
@@ -3548,7 +3548,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-storage"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "base64 0.22.1",
  "chacha20poly1305",
@@ -3569,7 +3569,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-tap-core"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3611,7 +3611,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-tap-desktop"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "dirs 6.0.0",
  "getrandom 0.2.17",
@@ -3637,7 +3637,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-tap-integration"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "ghost-gsp-proto",
  "ghost-tap-core",
@@ -3651,7 +3651,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-template"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "bitcoin",
  "ghost-buds",
@@ -3667,7 +3667,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-verification"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "axum 0.7.9",
  "bitcoin",
@@ -4639,7 +4639,7 @@ dependencies = [
 
 [[package]]
 name = "jd_client_sv2"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "async-channel 1.9.0",
  "bitcoin_core_sv2",
@@ -4655,7 +4655,7 @@ dependencies = [
 
 [[package]]
 name = "jd_server_sv2"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -6156,7 +6156,7 @@ dependencies = [
 
 [[package]]
 name = "pool_sv2"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "async-channel 1.9.0",
  "bitcoin_core_sv2",
@@ -7880,7 +7880,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stratum-apps"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "async-channel 1.9.0",
  "axum 0.8.9",
@@ -9093,7 +9093,7 @@ dependencies = [
 
 [[package]]
 name = "translator_sv2"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "async-channel 1.9.0",
  "clap",
@@ -10424,7 +10424,7 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "wraith-coordinator"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -10461,7 +10461,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-protocol"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "bitcoin",
  "getrandom 0.2.17",
@@ -10482,7 +10482,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-cli"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "clap",
  "clap_complete",
@@ -10495,7 +10495,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-core"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -10532,7 +10532,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-daemon"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "axum 0.7.9",
  "base64 0.22.1",
@@ -10557,7 +10557,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-gui"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "serde",
  "serde_json",
@@ -10571,7 +10571,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-ipc"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "libc",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ exclude = []
 # Use scripts/build-all-wallets.sh to build all wallet types.
 
 [workspace.package]
-version = "1.10.6"
+version = "1.10.7"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Bitcoin Ghost Team"]


### PR DESCRIPTION
Workspace version bump 1.10.6 → 1.10.7, capturing all PRs merged since the last release:

- **#133** — unpaid-ledger prune fix (active miners no longer lose unpaid shares; 1-year dark window)
- **#132** — installer 3-way mining-mode + custom pool-name parity (+ fixes a broken solo-install path)
- **#130** — opt-in auto-update (default off, GPG-verified)
- **#128** — Tor installer support
- **#127** — bond-ledger identity-pinned HTTPS (mixing canary fix)
- **#126** — ghostd `/Ghost/` user-agent + version auto-tracking
- **#129/#131** — installer ghostd-hash sync + mining-modes docs

Tagging `v1.10.7` after merge triggers the signed release build.