### PR TITLE
installer: bump to v1.10.8

### DIFF
--- a/scripts/install-node.sh
+++ b/scripts/install-node.sh
@@ -13,7 +13,7 @@
 set -euo pipefail
 
 # ─────────────────────────── network constants ───────────────────────────────
-GHOST_VERSION="v1.10.6"
+GHOST_VERSION="v1.10.8"
 # Signed release artefacts (GPG: defenwycke release key).
 GPG_KEY_FP="777FE81F8CC077FD3D08055E852C2B3190F5B928"
 RELEASE_BASE="https://github.com/bitcoin-ghost/ghost/releases/download/${GHOST_VERSION}"


### PR DESCRIPTION
New installs get the MPC param-corruption hardening (#135 — fixes the fresh-node onboarding crash-loop where a non-elder clobbered the pinned trusted setup) plus the unpaid-ledger prune fix (#133). ghostd hash unchanged.