### PR TITLE
MPC: resume rolling trusted-setup ceremony to 101 (genesis-anchored, autonomous)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3183,6 +3183,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "snow",
+ "tempfile",
  "thiserror 1.0.69",
  "tmq",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3339,6 +3339,7 @@ dependencies = [
  "rand 0.8.6",
  "rusqlite",
  "serde",
+ "serde_json",
  "sha2 0.10.9",
  "tempfile",
  "thiserror 1.0.69",

--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -971,6 +971,84 @@ async fn try_fetch_params_from_seed(
     true
 }
 
+/// Fetch + parse one circuit's parameters from a peer entirely IN MEMORY.
+///
+/// Used by the BFT voter / params-adoption path to obtain a candidate parameter
+/// set for cryptographic verification without touching the on-disk parameter
+/// files (only the post-approval apply persists parameters). When
+/// `expected_hash` is set, the parsed parameters' `hash_parameters()` (the
+/// structured LINEAGE hash) must match or `None` is returned. The heavy
+/// parse/hash runs on a blocking thread so the async runtime is never stalled.
+#[cfg(feature = "mpc-ceremony")]
+async fn fetch_and_parse_params(
+    host: &str,
+    endpoint: &str,
+    expected_hash: Option<[u8; 32]>,
+) -> Option<ghost_mpc::Groth16Params> {
+    let url = format!("http://{}:8080/api/v1/mpc/{}", host, endpoint);
+    let resp = reqwest::Client::new()
+        .get(&url)
+        .timeout(std::time::Duration::from_secs(60))
+        .send()
+        .await
+        .ok()?;
+    if !resp.status().is_success() {
+        return None;
+    }
+    let data = resp.bytes().await.ok()?;
+    if data.len() <= 1000 {
+        return None;
+    }
+    tokio::task::spawn_blocking(move || {
+        let params = ghost_mpc::params::read_parameters_from_bytes(&data).ok()?;
+        if let Some(expected) = expected_hash {
+            let h = ghost_mpc::contribution::hash_parameters(&params).ok()?;
+            if h != expected {
+                tracing::debug!(
+                    expected = %hex::encode(&expected[..8]),
+                    got = %hex::encode(&h[..8]),
+                    "MPC fetch: parsed params hash != expected lineage hash"
+                );
+                return None;
+            }
+        }
+        Some(params)
+    })
+    .await
+    .ok()?
+}
+
+/// Fetch a full candidate parameter bundle (note-spend + payout + unshield) from
+/// the network for one contribution.
+///
+/// The primary note-spend parameters MUST hash-match `expected_note_spend_hash`
+/// (the contribution's claimed lineage head) — only then is a bundle returned.
+/// `payout`/`unshield` ride along best-effort (they share the same toxic waste).
+/// Returns `None` if no seed can supply matching note-spend parameters, which
+/// forces the voter to ABSTAIN rather than approve blind.
+#[cfg(feature = "mpc-ceremony")]
+async fn fetch_ceremony_params_bundle(
+    seeds: &[String],
+    expected_note_spend_hash: [u8; 32],
+) -> Option<ghost_consensus::mpc_handler::FetchedCeremonyParams> {
+    for seed in seeds {
+        let host = seed.split(':').next().unwrap_or(seed);
+        let note_spend =
+            match fetch_and_parse_params(host, "params", Some(expected_note_spend_hash)).await {
+                Some(p) => p,
+                None => continue,
+            };
+        let payout = fetch_and_parse_params(host, "payout-params", None).await;
+        let unshield = fetch_and_parse_params(host, "unshield-params", None).await;
+        return Some(ghost_consensus::mpc_handler::FetchedCeremonyParams {
+            note_spend: std::sync::Arc::new(note_spend),
+            payout: payout.map(std::sync::Arc::new),
+            unshield: unshield.map(std::sync::Arc::new),
+        });
+    }
+    None
+}
+
 /// Startup self-heal: ensure the trusted-setup parameters exist on disk before
 /// the hard `load_trusted_params` check, fetching them from seeds if missing.
 ///
@@ -2744,233 +2822,181 @@ async fn main() -> Result<()> {
         // we need to fetch the actual params binary from the contributor so our
         // local params stay current. Without this, /api/v1/mpc/params serves stale
         // genesis params and new contributors can't build valid hash chains.
-        let params_dir_for_callback = ceremony_manager.params_dir().clone();
         let ceremony_mgr_for_callback = Arc::clone(&ceremony_manager);
         let seed_nodes_for_callback = config.network.seed_nodes.clone();
+        let db_for_callback = Arc::clone(&db);
         type ParamsUpdateFn = dyn Fn(&[u8; 32], &[u8; 32]) + Send + Sync;
         let params_update_callback: Arc<ParamsUpdateFn> = Arc::new(
             move |expected_hash: &[u8; 32], _contributor: &[u8; 32]| {
-                let params_dir = params_dir_for_callback.clone();
                 let ceremony_mgr = Arc::clone(&ceremony_mgr_for_callback);
                 let seeds = seed_nodes_for_callback.clone();
+                let db = Arc::clone(&db_for_callback);
                 let expected = *expected_hash;
                 tokio::spawn(async move {
-                    // Small delay to let the contributing node finish writing
+                    // Small delay to let the contributing node finish writing.
                     tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
-                    // Serialise this callback's param writes against the
-                    // ceremony-task fetch path so the two writers can never
-                    // interleave on the same `note_spend_params_*.bin` files.
+
+                    // Fast path: we already hold these params (e.g. we voted and
+                    // applied through the manager directly). Nothing to adopt.
+                    if ceremony_mgr.current_params_hash() == expected {
+                        return;
+                    }
+
+                    // SECURITY (params_callback trust-gap upgrade): a node adopting
+                    // parameters it did not itself vote on must run the SAME
+                    // cryptographic gate as a voter — never adopt on a bare hash
+                    // match. Recover the full contribution (proof, prev, position)
+                    // from the BFT-approved row that apply_contribution persisted.
+                    let record = match db.get_mpc_contribution_by_new_hash(&expected) {
+                        Ok(Some(r)) => r,
+                        Ok(None) => {
+                            tracing::warn!(
+                                expected = %hex::encode(&expected[..8]),
+                                "MPC params_callback: no approved contribution row for hash — refusing to adopt"
+                            );
+                            return;
+                        }
+                        Err(e) => {
+                            tracing::warn!(error = %e, "MPC params_callback: contribution lookup failed");
+                            return;
+                        }
+                    };
+                    let proof: ghost_mpc::ContributionProof = match serde_json::from_slice(
+                        &record.contribution_proof,
+                    ) {
+                        Ok(p) => p,
+                        Err(e) => {
+                            tracing::warn!(error = %e, "MPC params_callback: malformed stored proof — refusing to adopt");
+                            return;
+                        }
+                    };
+                    let contribution = ghost_mpc::MpcContribution {
+                        position: record.elder_position,
+                        prev_params_hash: record.prev_params_hash,
+                        new_params_hash: record.new_params_hash,
+                        proof,
+                        contributor: record.contributor_node_id.clone(),
+                        timestamp: record.created_at,
+                        commitment_hash: None,
+                    };
+
+                    // Serialise param writes against the other writers (startup
+                    // fetch, BFT apply) on the shared parameter files.
                     let _param_write_guard = param_write_lock().lock().await;
-                    let _ = std::fs::create_dir_all(&params_dir);
-                    // Try each seed node, verify the fetched params hash matches
-                    for seed in &seeds {
-                        let host = seed.split(':').next().unwrap_or(seed);
-                        let url = format!("http://{}:8080/api/v1/mpc/params", host);
-                        match reqwest::Client::new()
-                            .get(&url)
-                            .timeout(std::time::Duration::from_secs(60))
-                            .send()
-                            .await
-                        {
-                            Ok(resp) if resp.status().is_success() => {
-                                match resp.bytes().await {
-                                    Ok(data) if data.len() > 1000 => {
-                                        // Write to temp file, load, verify hash
-                                        let tmp_path = params_dir.join("note_spend_params_tmp.bin");
-                                        if let Err(e) = std::fs::write(&tmp_path, &data) {
-                                            tracing::warn!(error = %e, peer = %host,
-                                                "MPC params_callback: Failed to write temp params");
-                                            continue;
-                                        }
-                                        // Load and verify hash before committing
-                                        match ghost_mpc::params::load_parameters(&tmp_path) {
-                                            Ok(params) => {
-                                                match ghost_mpc::contribution::hash_parameters(
-                                                    &params,
-                                                ) {
-                                                    Ok(hash) if hash == expected => {
-                                                        // Hash matches! Move to current
-                                                        let current = params_dir
-                                                            .join("note_spend_params_current.bin");
-                                                        if let Err(e) =
-                                                            std::fs::rename(&tmp_path, &current)
-                                                        {
-                                                            tracing::warn!(error = %e, "MPC params_callback: Failed to rename params");
-                                                            continue;
-                                                        }
-                                                        // Save updated VK alongside params
-                                                        let vk_path =
-                                                            params_dir.join("note_spend_vk.bin");
-                                                        if let Err(e) =
-                                                            ghost_mpc::params::save_verifying_key(
-                                                                &vk_path, &params.vk,
-                                                            )
-                                                        {
-                                                            tracing::warn!(error = %e, "MPC params_callback: Failed to save VK");
-                                                        }
-                                                        if let Err(e) =
-                                                            ceremony_mgr.load_current_params()
-                                                        {
-                                                            tracing::warn!(error = %e, "MPC params_callback: Failed to reload");
-                                                        } else {
-                                                            tracing::info!(
-                                                                size = data.len(),
-                                                                peer = %host,
-                                                                hash = %hex::encode(&hash[..8]),
-                                                                "MPC params_callback: Verified and updated note_spend params"
-                                                            );
-                                                        }
-                                                        // Also fetch latest payout params from same peer (with VK extraction)
-                                                        let payout_url = format!("http://{}:8080/api/v1/mpc/payout-params", host);
-                                                        if let Ok(payout_resp) =
-                                                            reqwest::Client::new()
-                                                                .get(&payout_url)
-                                                                .timeout(
-                                                                    std::time::Duration::from_secs(
-                                                                        60,
-                                                                    ),
-                                                                )
-                                                                .send()
-                                                                .await
-                                                        {
-                                                            if payout_resp.status().is_success() {
-                                                                if let Ok(payout_data) =
-                                                                    payout_resp.bytes().await
-                                                                {
-                                                                    if payout_data.len() > 1000 {
-                                                                        let payout_current = params_dir.join("payout_params_current.bin");
-                                                                        let payout_write =
-                                                                            std::fs::read_link(
-                                                                                &payout_current,
-                                                                            )
-                                                                            .unwrap_or(
-                                                                                payout_current
-                                                                                    .clone(),
-                                                                            );
-                                                                        if let Err(e) =
-                                                                            std::fs::write(
-                                                                                &payout_write,
-                                                                                &payout_data,
-                                                                            )
-                                                                        {
-                                                                            tracing::warn!(error = %e, "MPC params_callback: Failed to save payout params");
-                                                                        } else {
-                                                                            // Extract and save payout VK
-                                                                            if let Ok(payout_params) = ghost_mpc::params::load_parameters(&payout_write) {
-                                                                                let payout_vk_path = params_dir.join("payout_vk.bin");
-                                                                                if let Err(e) = ghost_mpc::params::save_verifying_key(&payout_vk_path, &payout_params.vk) {
-                                                                                    tracing::warn!(error = %e, "MPC params_callback: Failed to save payout VK");
-                                                                                }
-                                                                            }
-                                                                            tracing::info!(
-                                                                                size = payout_data.len(),
-                                                                                peer = %host,
-                                                                                "MPC params_callback: Updated payout params"
-                                                                            );
-                                                                        }
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                        // Also fetch latest unshield params from same peer (with VK extraction)
-                                                        let unshield_url = format!("http://{}:8080/api/v1/mpc/unshield-params", host);
-                                                        if let Ok(unshield_resp) =
-                                                            reqwest::Client::new()
-                                                                .get(&unshield_url)
-                                                                .timeout(
-                                                                    std::time::Duration::from_secs(
-                                                                        60,
-                                                                    ),
-                                                                )
-                                                                .send()
-                                                                .await
-                                                        {
-                                                            if unshield_resp.status().is_success() {
-                                                                if let Ok(unshield_data) =
-                                                                    unshield_resp.bytes().await
-                                                                {
-                                                                    if unshield_data.len() > 1000 {
-                                                                        let unshield_current = params_dir.join("unshield_params_current.bin");
-                                                                        let unshield_write =
-                                                                            std::fs::read_link(
-                                                                                &unshield_current,
-                                                                            )
-                                                                            .unwrap_or(
-                                                                                unshield_current
-                                                                                    .clone(),
-                                                                            );
-                                                                        if let Err(e) =
-                                                                            std::fs::write(
-                                                                                &unshield_write,
-                                                                                &unshield_data,
-                                                                            )
-                                                                        {
-                                                                            tracing::warn!(error = %e, "MPC params_callback: Failed to save unshield params");
-                                                                        } else {
-                                                                            // Extract and save unshield VK
-                                                                            if let Ok(unshield_params) = ghost_mpc::params::load_parameters(&unshield_write) {
-                                                                                let unshield_vk_path = params_dir.join("unshield_vk.bin");
-                                                                                if let Err(e) = ghost_mpc::params::save_verifying_key(&unshield_vk_path, &unshield_params.vk) {
-                                                                                    tracing::warn!(error = %e, "MPC params_callback: Failed to save unshield VK");
-                                                                                }
-                                                                            }
-                                                                            tracing::info!(
-                                                                                size = unshield_data.len(),
-                                                                                peer = %host,
-                                                                                "MPC params_callback: Updated unshield params"
-                                                                            );
-                                                                        }
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                        return;
-                                                    }
-                                                    Ok(hash) => {
-                                                        tracing::debug!(
-                                                            peer = %host,
-                                                            got = %hex::encode(&hash[..8]),
-                                                            expected = %hex::encode(&expected[..8]),
-                                                            "MPC params_callback: Hash mismatch, trying next peer"
-                                                        );
-                                                        let _ = std::fs::remove_file(&tmp_path);
-                                                    }
-                                                    Err(e) => {
-                                                        tracing::warn!(error = %e, "MPC params_callback: Hash computation failed");
-                                                        let _ = std::fs::remove_file(&tmp_path);
-                                                    }
-                                                }
-                                            }
-                                            Err(e) => {
-                                                tracing::warn!(error = %e, peer = %host,
-                                                    "MPC params_callback: Failed to load params for verification");
-                                                let _ = std::fs::remove_file(&tmp_path);
-                                            }
-                                        }
-                                    }
-                                    _ => continue,
-                                }
+
+                    // Fetch the candidate bundle (note-spend hash MUST match).
+                    let bundle = match fetch_ceremony_params_bundle(&seeds, expected).await {
+                        Some(b) => b,
+                        None => {
+                            tracing::warn!(
+                                expected = %hex::encode(&expected[..8]),
+                                "MPC params_callback: no peer had matching params"
+                            );
+                            return;
+                        }
+                    };
+
+                    // CRYPTO GATE: verify the fetched params are a valid
+                    // transformation of OUR current params (the prev) before
+                    // hot-swapping. Genesis (position 1) / pre-genesis nodes have
+                    // no prev to verify against and adopt the hash-pinned anchor.
+                    if contribution.position >= 2 && ceremony_mgr.has_current_params() {
+                        let mgr = Arc::clone(&ceremony_mgr);
+                        let note_spend = Arc::clone(&bundle.note_spend);
+                        let contribution_for_verify = contribution.clone();
+                        let verified = tokio::task::spawn_blocking(move || {
+                            mgr.verify_contribution(&note_spend, &contribution_for_verify)
+                        })
+                        .await;
+                        match verified {
+                            Ok(Ok(true)) => {}
+                            other => {
+                                tracing::warn!(
+                                    position = contribution.position,
+                                    result = ?other,
+                                    "MPC params_callback: candidate params FAILED verification — refusing to adopt (never adopt on hash match alone)"
+                                );
+                                return;
                             }
-                            _ => continue,
                         }
                     }
-                    tracing::warn!(
-                        expected = %hex::encode(&expected[..8]),
-                        "MPC params_callback: No peer had matching params"
-                    );
+
+                    // Adopt through the manager: disk write + symlink + in-memory
+                    // hot-swap + count/current_params_hash + ossify check.
+                    let note_spend = (*bundle.note_spend).clone();
+                    let payout = bundle.payout.as_ref().map(|p| (**p).clone());
+                    let unshield = bundle.unshield.as_ref().map(|p| (**p).clone());
+                    let mgr = Arc::clone(&ceremony_mgr);
+                    let contribution_for_apply = contribution.clone();
+                    let applied = tokio::task::spawn_blocking(move || {
+                        mgr.apply_contribution_multi(
+                            note_spend,
+                            payout,
+                            unshield,
+                            &contribution_for_apply,
+                        )
+                    })
+                    .await;
+                    match applied {
+                        Ok(Ok(())) => {
+                            // Persist the singleton from the manager's authoritative state.
+                            let s = ceremony_mgr.state();
+                            let db_state = ghost_storage::queries::MpcCeremonyState {
+                                contribution_count: s.contribution_count,
+                                current_params_hash: s.current_params_hash,
+                                is_ossified: s.is_ossified,
+                                ossified_at: s.ossified_at,
+                                block_vk_hash: s.note_spend_vk_hash,
+                                payout_vk_hash: s.payout_vk_hash,
+                                updated_at: s.updated_at,
+                                ceremony_id: s.ceremony_id,
+                            };
+                            if let Err(e) = db.save_mpc_ceremony_state(&db_state) {
+                                tracing::warn!(error = %e, "MPC params_callback: failed to persist ceremony singleton");
+                            }
+                            tracing::info!(
+                                position = contribution.position,
+                                hash = %hex::encode(&expected[..8]),
+                                "MPC params_callback: verified and adopted contribution params"
+                            );
+                        }
+                        Ok(Err(e)) => {
+                            tracing::warn!(error = %e, position = contribution.position, "MPC params_callback: manager apply failed");
+                        }
+                        Err(e) => {
+                            tracing::warn!(error = %e, "MPC params_callback: apply task panicked");
+                        }
+                    }
                 });
             },
         );
+
+        // Stage 1a: the network fetcher the voter uses to obtain a candidate's
+        // parameters before running real cryptographic verification. Fetches the
+        // bundle in memory (no disk writes — verification is read-only).
+        let seed_nodes_for_fetch = config.network.seed_nodes.clone();
+        let params_fetcher: ghost_consensus::mpc_handler::MpcParamsFetchFn =
+            Arc::new(move |expected: [u8; 32]| {
+                let seeds = seed_nodes_for_fetch.clone();
+                Box::pin(async move { fetch_ceremony_params_bundle(&seeds, expected).await })
+            });
 
         let mpc_handler = Arc::new(
             MpcHandler::new(Arc::clone(&identity), Arc::clone(&db))
                 .with_broadcaster(mpc_broadcast)
                 .with_params_callback(params_update_callback)
+                // Stage 1a: wire the authoritative crypto backend + fetcher so the
+                // voter verifies (Schnorr + pairing) before approving.
+                .with_ceremony_manager(Arc::clone(&ceremony_manager))
+                .with_params_fetcher(params_fetcher)
                 .with_state(
                     ceremony_manager.contribution_count(),
                     ceremony_manager.is_ossified(),
                 ),
         );
+        // Install the self-reference so MPC message handling can offload heavy
+        // fetch/verify/apply work off the single-threaded mesh message loop.
+        mpc_handler.init_self_ref();
 
         // Register MPC handler with mesh
         mesh.register_handler(Arc::clone(&mpc_handler)

--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -1049,6 +1049,115 @@ async fn fetch_ceremony_params_bundle(
     None
 }
 
+/// Stage C task 3: fetch a single position's FULL contribution (with the real
+/// `contribution_proof`) AND its retained approve/reject votes from a peer's
+/// `/api/v1/mpc/votes/{position}` endpoint, and persist BOTH locally.
+///
+/// This is what makes catch-up autonomous: the old `/contributors` sync saved
+/// rows with an EMPTY proof and NO votes, so a fresh node could neither re-run
+/// `verify_contribution` nor check the retained BFT quorum. After this call the
+/// local DB holds the real proof (filled via the safe proof-fill upsert in
+/// `save_mpc_contribution`) and every retained vote, so the genesis-anchored
+/// startup verification has the data it needs. Returns `true` if at least the
+/// proof or some votes were persisted from some seed.
+#[cfg(feature = "mpc-ceremony")]
+async fn sync_mpc_proof_and_votes(
+    seeds: &[String],
+    position: u32,
+    db: &ghost_storage::Database,
+) -> bool {
+    for seed in seeds {
+        let host = seed.split(':').next().unwrap_or(seed);
+        let url = format!("http://{}:8080/api/v1/mpc/votes/{}", host, position);
+        let resp = match reqwest::Client::new()
+            .get(&url)
+            .timeout(std::time::Duration::from_secs(15))
+            .send()
+            .await
+        {
+            Ok(r) if r.status().is_success() => r,
+            _ => continue,
+        };
+        let data: serde_json::Value = match resp.json().await {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+
+        let mut persisted = false;
+
+        // 1. Persist the real proof (proof-fill upsert preserves an applied row).
+        if let Some(c) = data.get("contribution") {
+            let proof_hex = c
+                .get("contribution_proof")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let node_id = c.get("node_id").and_then(|v| v.as_str()).unwrap_or("");
+            let prev = c
+                .get("prev_params_hash")
+                .and_then(|v| v.as_str())
+                .and_then(|h| hex::decode(h).ok())
+                .and_then(|b| <[u8; 32]>::try_from(b.as_slice()).ok());
+            let new = c
+                .get("new_params_hash")
+                .and_then(|v| v.as_str())
+                .and_then(|h| hex::decode(h).ok())
+                .and_then(|b| <[u8; 32]>::try_from(b.as_slice()).ok());
+            let created_at = c.get("created_at").and_then(|v| v.as_u64()).unwrap_or(0);
+            let epoch = c.get("epoch").and_then(|v| v.as_u64()).unwrap_or(0);
+
+            if let (false, Ok(proof_bytes), Some(prev), Some(new)) = (
+                proof_hex.is_empty() || node_id.is_empty(),
+                hex::decode(proof_hex),
+                prev,
+                new,
+            ) {
+                let record = ghost_storage::queries::MpcContributionRecord {
+                    elder_position: position,
+                    contributor_node_id: node_id.to_string(),
+                    prev_params_hash: prev,
+                    new_params_hash: new,
+                    contribution_proof: proof_bytes,
+                    epoch,
+                    created_at,
+                };
+                if db.save_mpc_contribution(&record).is_ok() {
+                    persisted = true;
+                }
+            }
+        }
+
+        // 2. Persist every retained vote (save_mpc_vote upserts by (pos, voter)).
+        if let Some(votes) = data.get("votes").and_then(|v| v.as_array()) {
+            for v in votes {
+                let voter = v.get("voter_node_id").and_then(|x| x.as_str());
+                let approve = v.get("approve").and_then(|x| x.as_bool());
+                let sig = v
+                    .get("signature")
+                    .and_then(|x| x.as_str())
+                    .and_then(|h| hex::decode(h).ok());
+                let voted_at = v.get("voted_at").and_then(|x| x.as_u64()).unwrap_or(0);
+                if let (Some(voter), Some(approve), Some(sig)) = (voter, approve, sig) {
+                    let vote = ghost_storage::queries::MpcVerificationVote {
+                        contribution_position: position,
+                        voter_node_id: voter.to_string(),
+                        approve,
+                        signature: sig,
+                        voted_at,
+                    };
+                    if db.save_mpc_vote(&vote).is_ok() {
+                        persisted = true;
+                    }
+                }
+            }
+        }
+
+        if persisted {
+            return true;
+        }
+    }
+    false
+}
+
 /// Startup self-heal: ensure the trusted-setup parameters exist on disk before
 /// the hard `load_trusted_params` check, fetching them from seeds if missing.
 ///
@@ -2246,6 +2355,18 @@ async fn main() -> Result<()> {
     #[allow(unused_assignments, unused_mut)]
     let mut l2_tree_state_fn_opt: Option<ghost_verification::L2TreeStateFn> = None;
 
+    // Stage C: when the ZK startup mode is genesis-anchored ROLLING (the static
+    // current-params pin `ZK_PARAMS_HASH` is absent but `ZK_GENESIS_PARAMS_HASH`
+    // is set), this carries the immutable genesis lineage anchor from the
+    // zk-consensus gate down to the MPC block, which runs the genesis-anchored
+    // lineage + retained-quorum verification (fail-closed). `None` keeps the
+    // legacy static-pin / test behaviour exactly.
+    #[cfg_attr(
+        not(all(feature = "zk-consensus", feature = "mpc-ceremony")),
+        allow(unused_mut, unused_variables, unused_assignments)
+    )]
+    let mut zk_rolling_anchor: Option<[u8; 32]> = None;
+
     #[cfg(feature = "zk-consensus")]
     {
         use ghost_consensus::epoch_manager::{EpochManager, EpochManagerConfig};
@@ -2266,26 +2387,55 @@ async fn main() -> Result<()> {
         }
 
         if is_production {
-            // SELF-HEAL: a fresh production node may have the binary but no MPC
-            // ceremony output on disk yet. Fetch + verify the params from seeds
-            // BEFORE the hard `load_trusted_params` check, otherwise the process
-            // would exit here and the background MPC task that fetches params
-            // would never run — an unrecoverable crash-loop. The fetch path
-            // verifies every blob against the pinned ZK_PARAMS_HASH, so a
-            // malicious seed cannot inject forged trusted-setup parameters.
-            #[cfg(feature = "mpc-ceremony")]
-            if let Ok(zk_params_path) = std::env::var(ghost_zkp::ZK_PARAMS_PATH_ENV) {
-                let params_dir = std::path::PathBuf::from(&zk_params_path);
-                // ALWAYS run the self-heal: it validates present params against
-                // the pinned hash and quarantines + re-fetches a present-but-
-                // corrupt set (the node6 case), in addition to fetching a missing
-                // one. Gating this on `!current.exists()` would let a corrupt-but-
-                // present file slip straight into the hard `load_trusted_params`
-                // check below and crash-loop the node.
-                ensure_mpc_params_present(&config.network.seed_nodes, &params_dir).await?;
+            // Stage C: choose the trusted-setup verification mode explicitly.
+            // StaticPin (`ZK_PARAMS_HASH` set) = the legacy frozen/pinned and
+            // post-ossification path, bit-identical to prior releases.
+            // GenesisAnchoredRolling (`ZK_PARAMS_HASH` absent, `ZK_GENESIS_PARAMS_HASH`
+            // set) = the unpinned rolling path: the static current-params file
+            // check is replaced by the genesis-anchored lineage + retained-quorum
+            // verification run in the MPC block below. Neither set on a production
+            // node → `select_startup_mode` errors and startup aborts (never
+            // unverified).
+            match ghost_zkp::select_startup_mode()? {
+                ghost_zkp::ZkStartupMode::StaticPin => {
+                    // SELF-HEAL: a fresh production node may have the binary but no
+                    // MPC ceremony output on disk yet. Fetch + verify the params
+                    // from seeds BEFORE the hard `load_trusted_params` check,
+                    // otherwise the process would exit here and the background MPC
+                    // task that fetches params would never run — an unrecoverable
+                    // crash-loop. The fetch path verifies every blob against the
+                    // pinned ZK_PARAMS_HASH, so a malicious seed cannot inject
+                    // forged trusted-setup parameters.
+                    #[cfg(feature = "mpc-ceremony")]
+                    if let Ok(zk_params_path) = std::env::var(ghost_zkp::ZK_PARAMS_PATH_ENV) {
+                        let params_dir = std::path::PathBuf::from(&zk_params_path);
+                        // ALWAYS run the self-heal: it validates present params
+                        // against the pinned hash and quarantines + re-fetches a
+                        // present-but-corrupt set (the node6 case), in addition to
+                        // fetching a missing one. Gating this on `!current.exists()`
+                        // would let a corrupt-but-present file slip straight into
+                        // the hard `load_trusted_params` check below and crash-loop
+                        // the node.
+                        ensure_mpc_params_present(&config.network.seed_nodes, &params_dir).await?;
+                    }
+                    ghost_zkp::load_trusted_params()?;
+                    info!(
+                        "ZK consensus using PRODUCTION parameters from MPC ceremony (static pin)"
+                    );
+                }
+                ghost_zkp::ZkStartupMode::GenesisAnchoredRolling { genesis_anchor } => {
+                    // Rolling: do NOT run the static file-hash check (there is no
+                    // current pin to check against). The genesis-anchored lineage
+                    // + retained-quorum verification runs in the MPC block below
+                    // and is FATAL on failure. Hand it the immutable anchor.
+                    zk_rolling_anchor = Some(genesis_anchor);
+                    info!(
+                        anchor = %hex::encode(&genesis_anchor[..8]),
+                        "ZK consensus in ROLLING mode: trusted setup verified by genesis anchor + \
+                         lineage chain + retained BFT quorum (static current-params pin absent)"
+                    );
+                }
             }
-            ghost_zkp::load_trusted_params()?;
-            info!("ZK consensus using PRODUCTION parameters from MPC ceremony");
         } else {
             warn!("ZK consensus using TEST parameters - NOT SECURE FOR MAINNET");
         }
@@ -2787,6 +2937,64 @@ async fn main() -> Result<()> {
             }
         };
 
+        // Stage C task 2 + 5: genesis-anchored startup verification (ROLLING mode).
+        //
+        // When the node is UNPINNED (no static `ZK_PARAMS_HASH`, an immutable
+        // `ZK_GENESIS_PARAMS_HASH` instead — `zk_rolling_anchor` is Some), the
+        // static current-params file check was deliberately skipped at the ZK
+        // gate. Here we validate the evolving setup the rolling way: genesis
+        // anchor → lineage chain 1..N → retained BFT quorum per position →
+        // on-disk head. This is FATAL on failure (same fail-closed posture the
+        // static pin had — a mismatch means lineage/quorum is broken, not merely
+        // "file != static hash"). On success we true-up the singleton (task 5) so
+        // a node that abstained on some position is reconciled to the verified
+        // head + chain length.
+        if let Some(genesis_anchor) = zk_rolling_anchor {
+            // Head lineage hash of the on-disk current params (None if not loaded).
+            let head_lineage: Option<[u8; 32]> = ceremony_manager
+                .note_spend_params()
+                .and_then(|p| ghost_mpc::contribution::hash_parameters(&p).ok());
+
+            let verified_count = db
+                .verify_mpc_genesis_anchored_lineage(&genesis_anchor, head_lineage.as_ref())
+                .map_err(|e| {
+                    anyhow::anyhow!(
+                        "MAINNET SECURITY (rolling): genesis-anchored trusted-setup verification \
+                         FAILED — refusing to start (fail-closed). {e}"
+                    )
+                })?;
+
+            info!(
+                count = verified_count,
+                anchor = %hex::encode(&genesis_anchor[..8]),
+                "MPC: genesis-anchored startup verification PASSED (anchor + lineage + retained \
+                 BFT quorum + on-disk head)"
+            );
+
+            // Task 5: reconcile the singleton to the verified head + length.
+            if let Some(head) = head_lineage {
+                let now = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_secs())
+                    .unwrap_or(0);
+                match db.reconcile_mpc_singleton_to_head(
+                    verified_count,
+                    &head,
+                    &genesis_anchor,
+                    now,
+                ) {
+                    Ok(true) => info!(
+                        count = verified_count,
+                        "MPC: trued-up mpc_ceremony singleton to the verified rolling head"
+                    ),
+                    Ok(false) => {}
+                    Err(e) => {
+                        warn!(error = %e, "MPC: singleton true-up after verification failed")
+                    }
+                }
+            }
+        }
+
         // Create broadcast callback for MPC handler
         // Uses async Noise relay: sync closure queues messages, background task
         // routes them through mesh.broadcast() which uses Noise encryption
@@ -2900,12 +3108,35 @@ async fn main() -> Result<()> {
                     // transformation of OUR current params (the prev) before
                     // hot-swapping. Genesis (position 1) / pre-genesis nodes have
                     // no prev to verify against and adopt the hash-pinned anchor.
+                    //
+                    // Stage C task 4: use the catch-up (no timestamp-skew) verify.
+                    // This path adopts an ALREADY-BFT-APPROVED contribution that
+                    // may be HISTORICAL (a node offline for days, or replaying the
+                    // chain), whose timestamp is far outside the live ±1h window.
+                    // Every cryptographic check (Schnorr bound to ceremony_id, hash
+                    // chain, h/l pairing transform against OUR prev) is identical to
+                    // the live path; only the freshness window — a replay defence
+                    // for LIVE proposals, irrelevant once a contribution is part of
+                    // the approved lineage — is dropped.
                     if contribution.position >= 2 && ceremony_mgr.has_current_params() {
                         let mgr = Arc::clone(&ceremony_mgr);
                         let note_spend = Arc::clone(&bundle.note_spend);
                         let contribution_for_verify = contribution.clone();
+                        let prev_params = match mgr.note_spend_params() {
+                            Some(p) => p,
+                            None => {
+                                tracing::warn!(
+                                    "MPC params_callback: no current params to verify against — refusing to adopt"
+                                );
+                                return;
+                            }
+                        };
                         let verified = tokio::task::spawn_blocking(move || {
-                            mgr.verify_contribution(&note_spend, &contribution_for_verify)
+                            mgr.verify_contribution_catchup(
+                                &prev_params,
+                                &note_spend,
+                                &contribution_for_verify,
+                            )
                         })
                         .await;
                         match verified {
@@ -3304,11 +3535,23 @@ async fn main() -> Result<()> {
                                                     {
                                                         synced_count += 1;
                                                     }
+
+                                                    // Stage C task 3: upgrade the
+                                                    // proof-less placeholder with the
+                                                    // REAL proof + retained votes so
+                                                    // catch-up can re-verify + check
+                                                    // the retained BFT quorum.
+                                                    sync_mpc_proof_and_votes(
+                                                        &seed_nodes_for_mpc,
+                                                        position,
+                                                        &db_for_mpc,
+                                                    )
+                                                    .await;
                                                 }
                                                 if synced_count > 0 {
                                                     info!(
                                                         count = synced_count,
-                                                        "MPC: Synced contributor records from peer"
+                                                        "MPC: Synced contributor records (+ proofs/votes) from peer"
                                                     );
                                                 }
                                                 break;
@@ -3609,6 +3852,16 @@ async fn main() -> Result<()> {
                                             };
 
                                         let _ = db_for_mpc.save_mpc_contribution(&record);
+
+                                        // Stage C task 3: fill the real proof +
+                                        // retained votes for catch-up re-verification
+                                        // and the retained BFT quorum check.
+                                        sync_mpc_proof_and_votes(
+                                            &seed_nodes_for_mpc,
+                                            position,
+                                            &db_for_mpc,
+                                        )
+                                        .await;
                                     }
                                     break;
                                 }

--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -2580,8 +2580,29 @@ async fn main() -> Result<()> {
         use ghost_consensus::MpcHandler;
         use ghost_mpc::CeremonyManager;
 
-        // Load MPC ceremony state from database
+        // Load MPC ceremony state from database (the backfilled singleton)
         let mpc_state = db.get_mpc_ceremony_state()?;
+
+        // Stage A task 2: derive the STABLE ceremony_id.
+        //
+        // ceremony_id binds every Schnorr proof, so it must be identical on
+        // every node and unchanging for the life of the ceremony. The canonical
+        // source is position-1's `prev_params_hash` (the genesis lineage hash);
+        // the persisted `mpc_ceremony.ceremony_id` column is a backfilled cache
+        // of the same value. Prefer the canonical derivation, fall back to the
+        // cached column, then to zero (pre-genesis — genesis init then sets it).
+        //
+        // This deliberately REPLACES the old behaviour of using
+        // `current_params_hash`, which changed every time a contribution was
+        // applied and so could never be a stable ceremony binding.
+        let persisted_ceremony_id = mpc_state
+            .as_ref()
+            .map(|s| s.ceremony_id)
+            .filter(|cid| *cid != [0u8; 32]);
+        let stable_ceremony_id = db
+            .mpc_genesis_ceremony_id()?
+            .or(persisted_ceremony_id)
+            .unwrap_or([0u8; 32]);
 
         // Determine params directory (from config or default)
         let mpc_params_dir =
@@ -2603,8 +2624,8 @@ async fn main() -> Result<()> {
                 note_spend_vk_hash: s.block_vk_hash,
                 payout_vk_hash: s.payout_vk_hash,
                 updated_at: s.updated_at,
-                // Fields added in later versions - derive ceremony_id from params hash
-                ceremony_id: s.current_params_hash, // Use params hash as ceremony ID for continuity
+                // Stable genesis-derived ceremony_id (NOT current_params_hash).
+                ceremony_id: stable_ceremony_id,
                 pending_commitment_count: 0,
             }),
         ) {
@@ -2613,6 +2634,78 @@ async fn main() -> Result<()> {
                 warn!(error = %e, "Failed to initialize MPC ceremony manager, continuing without MPC");
                 // Create a minimal ceremony manager that reports as ossified
                 Arc::new(CeremonyManager::new(mpc_params_dir))
+            }
+        };
+
+        // Stage A task 3: startup lineage cross-check (fail-closed).
+        //
+        // After loading the current parameters, recompute their LINEAGE hash
+        // (`hash_parameters` — structured VK + h + l vectors, NOT the raw-file
+        // pin hash) and require it to equal BOTH:
+        //   * the singleton's `current_params_hash`, and
+        //   * `mpc_contributions[MAX].new_params_hash`.
+        // A mismatch means the on-disk params are corrupt or out of step with
+        // the recorded lineage; this node must NOT enter the rolling /
+        // contribution path (it would poison the lineage). The result gates the
+        // auto-contribute task below. The existing frozen/pinned behaviour is
+        // untouched — pinned nodes still freeze via their own guard, and the
+        // raw-file `ZK_PARAMS_HASH` check (a DIFFERENT digest) still runs.
+        let mpc_lineage_ok: bool = {
+            let count = ceremony_manager.contribution_count();
+            if count == 0 {
+                // Pre-genesis / genesis-forming: nothing applied to cross-check.
+                true
+            } else {
+                match ceremony_manager.note_spend_params() {
+                    None => {
+                        error!(
+                            count,
+                            "MPC lineage cross-check FAILED: ceremony reports contributions but no \
+                             parameters are loaded — refusing to enter rolling (fail-closed)"
+                        );
+                        false
+                    }
+                    Some(params) => match ghost_mpc::contribution::hash_parameters(&params) {
+                        Err(e) => {
+                            error!(error = %e, "MPC lineage cross-check FAILED: could not hash loaded params — refusing rolling");
+                            false
+                        }
+                        Ok(file_lineage) => {
+                            // contributions[MAX].new_params_hash (lineage head)
+                            let contribution_head = db
+                                .get_mpc_contribution(count)
+                                .ok()
+                                .flatten()
+                                .map(|c| c.new_params_hash);
+                            // mpc_ceremony.current_params_hash (loaded into state)
+                            let singleton_head = ceremony_manager.current_params_hash();
+
+                            let ok = ghost_mpc::lineage_head_matches(
+                                &file_lineage,
+                                &singleton_head,
+                                contribution_head.as_ref(),
+                            );
+                            if ok {
+                                info!(
+                                    position = count,
+                                    "MPC lineage cross-check passed: on-disk params match recorded lineage head"
+                                );
+                            } else {
+                                error!(
+                                    position = count,
+                                    on_disk = %hex::encode(&file_lineage[..8]),
+                                    contribution_head = contribution_head
+                                        .map(|h| hex::encode(&h[..8]))
+                                        .unwrap_or_else(|| "<missing>".to_string()),
+                                    singleton_head = %hex::encode(&singleton_head[..8]),
+                                    "MPC lineage cross-check FAILED: on-disk params do not match the \
+                                     recorded lineage head — refusing rolling (fail-closed)"
+                                );
+                            }
+                            ok
+                        }
+                    },
+                }
             }
         };
 
@@ -2950,6 +3043,20 @@ async fn main() -> Result<()> {
                 }
             }
 
+            // Stage A task 3: fail-closed lineage gate. If the startup
+            // cross-check found the on-disk params out of step with the recorded
+            // lineage head, do NOT enter the rolling/contribution path — a
+            // contribution built on top of mismatched params would poison the
+            // lineage. The node keeps serving whatever it loaded; it just won't
+            // fetch or contribute. (Pinned/frozen nodes already returned above.)
+            if !mpc_lineage_ok {
+                error!(
+                    "MPC: startup lineage cross-check failed — refusing to enter the rolling \
+                     ceremony (fail-closed). Investigate on-disk params vs recorded lineage."
+                );
+                return;
+            }
+
             // Retry loop: attempt contribution up to 5 times with random 10-100s intervals.
             // This handles race conditions where multiple nodes try the same position
             // simultaneously — the loser retries at the next position.
@@ -2983,8 +3090,12 @@ async fn main() -> Result<()> {
                 // hash). On test nets (no pinned hash) this is the normal forming
                 // path. Either way the fetch can no longer clobber pinned params.
                 if !ceremony_manager_for_startup.has_current_params() {
-                    // Use DB to determine if this is truly genesis or if we need to fetch
-                    let db_count = db_for_mpc.get_mpc_elder_count().unwrap_or(0) as u32;
+                    // Use DB to determine if this is truly genesis or if we need to fetch.
+                    // Authoritative progression count = mpc_ceremony singleton (falls back to
+                    // COUNT(mpc_contributions) when the singleton is absent, e.g. fresh genesis).
+                    let db_count = db_for_mpc
+                        .mpc_contribution_count_authoritative()
+                        .unwrap_or(0);
 
                     if db_count == 0 && is_genesis_node {
                         // Genesis protection layer 1: Query seed peers for existing contributors
@@ -3225,8 +3336,13 @@ async fn main() -> Result<()> {
                     return;
                 }
 
-                // Determine position from DB (authoritative source, not stale in-memory state)
-                let db_count = db_for_mpc.get_mpc_elder_count().unwrap_or(0) as u32;
+                // Determine position from DB (authoritative source, not stale in-memory state).
+                // Progression count comes from the mpc_ceremony singleton (falls back to
+                // COUNT(mpc_contributions) when absent). Voter-set sizing still uses
+                // get_mpc_elder_count() in the handler — these are deliberately distinct.
+                let db_count = db_for_mpc
+                    .mpc_contribution_count_authoritative()
+                    .unwrap_or(0);
                 let next_position = db_count + 1;
 
                 info!(

--- a/crates/ghost-common/src/constants.rs
+++ b/crates/ghost-common/src/constants.rs
@@ -141,6 +141,26 @@ pub const ELDER_OFFLINE_THRESHOLD_DAYS: u64 = 7;
 /// PROTOCOL CONSTANT — DO NOT MODIFY AFTER MAINNET
 pub const BFT_THRESHOLD_PERCENT: u64 = 67;
 
+/// BFT threshold percentage for MPC ceremony contribution approval (67%).
+///
+/// SINGLE SOURCE OF TRUTH shared by `ghost-mpc` and `ghost-consensus` so the
+/// quorum required to apply a new MPC contribution is computed identically on
+/// every node. A mismatch here is a consensus split: one node would apply a
+/// contribution (advancing the trusted-setup lineage) while another rejects it.
+/// PROTOCOL CONSTANT — DO NOT MODIFY AFTER MAINNET
+pub const MPC_BFT_THRESHOLD_PERCENT: u32 = 67;
+
+/// Minimum number of MPC contributors before BFT supermajority voting applies.
+///
+/// During bootstrap (fewer than this many contributors) the genesis node may
+/// approve alone (threshold = 1). At or above this count the threshold becomes
+/// a `MPC_BFT_THRESHOLD_PERCENT` supermajority: `ceil(count * percent / 100)`.
+/// Set to 4 because with only 3 contributors `ceil(3 * 67 / 100) = 3` would
+/// require unanimity — too fragile, since any single offline node would block
+/// all further contributions.
+/// PROTOCOL CONSTANT — DO NOT MODIFY AFTER MAINNET
+pub const MPC_BFT_BOOTSTRAP_COUNT: u32 = 4;
+
 /// Consensus voting timeout in milliseconds
 pub const CONSENSUS_TIMEOUT_MS: u64 = 5000;
 

--- a/crates/ghost-common/src/lib.rs
+++ b/crates/ghost-common/src/lib.rs
@@ -39,6 +39,7 @@ pub mod identity_rotation;
 pub mod instant;
 pub mod key_rotation;
 pub mod metrics;
+pub mod mpc;
 pub mod rpc;
 pub mod sanitize;
 pub mod serde_hex;

--- a/crates/ghost-common/src/mpc.rs
+++ b/crates/ghost-common/src/mpc.rs
@@ -1,0 +1,161 @@
+//|======================================================================================================================|
+//|                                                                                                                      |
+//|  ▄▄▄▄    ██▓▄▄▄█████▓ ▄████▄   ▒█████   ██▓ ███▄    █      ▄████  ██░ ██  ▒█████    ██████ ▄▄▄█████▓   ▄████████▄    |
+//| ▓█████▄ ▓██▒▓  ██▒ ▓▒▒██▀ ▀█  ▒██▒  ██▒▓██▒ ██ ▀█   █     ██▒ ▀█▒▓██░ ██▒▒██▒  ██▒▒██    ▒ ▓  ██▒ ▓▒   ███▀██▀███    |
+//| ▒██▒ ▄██▒██▒▒ ▓██░ ▒░▒▓█    ▄ ▒██░  ██▒▒██▒▓██  ▀█ ██▒   ▒██░▄▄▄░▒██▀▀██░▒██░  ██▒░ ▓██▄   ▒ ▓██░ ▒░   ██████████░   |
+//| ▒██░█▀  ░██░░ ▓██▓ ░ ▒▓▓▄ ▄██▒▒██   ██░░██░▓██▒  ▐▌██▒   ░▓█  ██▓░▓█ ░██ ▒██   ██░  ▒   ██▒░ ▓██▓ ░    ██████████░░▒ |
+//| ░▓█  ▀█▓░██░  ▒██▒ ░ ▒ ▓███▀ ░░ ████▓▒░░██░▒██░   ▓██░   ░▒▓███▀▒░▓█▒░██▓░ ████▓▒░▒██████▒▒  ▒██▒ ░    ██▀▀██▀▀██░▒  |
+//| ░▒▓███▀▒░▓    ▒ ░░   ░ ░▒ ▒  ░░ ▒░▒░▒░ ░▓  ░ ▒░   ▒ ▒     ░▒   ▒  ▒ ░░▒░▒░ ▒░▒░▒░ ▒ ▒▓▒ ▒ ░  ▒ ░░      ▒ ░░▒░▒ ░░▒░  |
+//|----------------------------------------------------------------------------------------------------------------------|
+//|             < B I T C O I N  G H O S T > < D E F E N W Y C K E > < R E A D  T H E  W H I T E P A P E R >             |
+//|----------------------------------------------------------------------------------------------------------------------|
+//| PROJECT: Bitcoin Ghost                                                                                               |
+//| FILE: mpc.rs                                                                                                         |
+//|======================================================================================================================|
+
+//! Shared MPC ceremony primitives.
+//!
+//! These are the consensus-critical, wire-format building blocks of the rolling
+//! MPC ceremony that must be IDENTICAL on every code path that hashes a
+//! contribution, signs/verifies a vote, or computes the BFT quorum.
+//!
+//! They live in `ghost-common` (the leaf dependency) so that all of the
+//! following observe ONE definition and can never silently diverge:
+//!
+//! * `ghost-consensus` (the live voter/handler) — builds the wire messages.
+//! * `ghost-storage` (the genesis-anchored startup verifier) — re-derives the
+//!   contribution hash + vote signing message from retained DB rows to check the
+//!   retained BFT quorum, WITHOUT keeping every historical parameter blob.
+//! * `ghost-mpc` — re-exports the threshold so the library and the handler agree.
+//!
+//! A change to any of these byte layouts is a hard consensus fork; they are
+//! pinned with explicit `v1` domain separators and round-trip tests.
+
+use crate::constants::{MPC_BFT_BOOTSTRAP_COUNT, MPC_BFT_THRESHOLD_PERCENT};
+use crate::types::NodeId;
+use sha2::{Digest, Sha256};
+
+/// Domain separator for the contribution identity hash.
+const CONTRIBUTION_HASH_DOMAIN: &[u8] = b"MpcContributionHash/v1";
+/// Domain separator for the per-vote signing message.
+const VOTE_SIGNING_DOMAIN: &[u8] = b"MpcVerificationVote/v1";
+
+/// Compute the stable identity hash of a contribution.
+///
+/// This is the value a verification vote references (and signs over). It binds
+/// the contribution to its `contributor`, `position`, and resulting
+/// `new_params_hash` (the lineage hash). It deliberately does NOT include the
+/// proof bytes or prev hash — the vote attests to "I approve THIS new params at
+/// THIS position from THIS contributor"; the prev/lineage link is enforced
+/// separately by the chain-link check.
+///
+/// SECURITY: byte layout is consensus-critical and matches the live wire
+/// message (`MpcContributionMessage::contribution_hash`) exactly.
+pub fn contribution_hash(
+    contributor: &NodeId,
+    elder_position: u32,
+    new_params_hash: &[u8; 32],
+) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(CONTRIBUTION_HASH_DOMAIN);
+    hasher.update(contributor);
+    hasher.update(elder_position.to_le_bytes());
+    hasher.update(new_params_hash);
+    hasher.finalize().into()
+}
+
+/// Compute the message an elder signs when voting on a contribution.
+///
+/// Binds the `contribution_hash` and the approve/reject bit. SECURITY: byte
+/// layout matches the live wire message (`MpcVerificationVoteMessage::
+/// signing_message`) exactly so a retained vote signature verifies identically
+/// whether checked live or re-derived at startup from DB rows.
+pub fn vote_signing_message(contribution_hash: &[u8; 32], approve: bool) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(VOTE_SIGNING_DOMAIN);
+    hasher.update(contribution_hash);
+    hasher.update([approve as u8]);
+    hasher.finalize().into()
+}
+
+/// Compute the BFT threshold (number of approve votes required) for an MPC
+/// contribution given the number of *eligible* contributors at the time it was
+/// voted on.
+///
+/// SINGLE SOURCE OF TRUTH. The live voter (`ghost-consensus`) and the retained
+/// quorum check at startup (`ghost-storage`) MUST use this identical function:
+/// the startup check verifies a contribution under EXACTLY the same rule it was
+/// approved under. If startup demanded a stricter quorum than the live path
+/// applied, a legitimately-approved chain would fail-closed and brick the node;
+/// if it demanded a weaker one, a forged chain could slip in. Both are avoided
+/// by sharing this one definition.
+///
+/// During bootstrap (fewer than `MPC_BFT_BOOTSTRAP_COUNT` contributors) the
+/// threshold is 1; at or above it the threshold is the
+/// `MPC_BFT_THRESHOLD_PERCENT` supermajority `ceil(count * percent / 100)`.
+pub fn mpc_bft_threshold(contributor_count: u32) -> u32 {
+    if contributor_count < MPC_BFT_BOOTSTRAP_COUNT {
+        1
+    } else {
+        contributor_count
+            .saturating_mul(MPC_BFT_THRESHOLD_PERCENT)
+            .div_ceil(100)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_contribution_hash_is_stable_and_layout_pinned() {
+        let contributor = [0x11u8; 32];
+        let new = [0x22u8; 32];
+        let h = contribution_hash(&contributor, 7, &new);
+
+        // Recompute the expected digest independently (the pinned layout).
+        let mut hasher = Sha256::new();
+        hasher.update(b"MpcContributionHash/v1");
+        hasher.update(contributor);
+        hasher.update(7u32.to_le_bytes());
+        hasher.update(new);
+        let expected: [u8; 32] = hasher.finalize().into();
+        assert_eq!(h, expected);
+
+        // Different position / contributor / hash all change the digest.
+        assert_ne!(h, contribution_hash(&contributor, 8, &new));
+        assert_ne!(h, contribution_hash(&[0x33; 32], 7, &new));
+        assert_ne!(h, contribution_hash(&contributor, 7, &[0x44; 32]));
+    }
+
+    #[test]
+    fn test_vote_signing_message_distinguishes_approve_reject() {
+        let ch = [0xAB; 32];
+        let approve = vote_signing_message(&ch, true);
+        let reject = vote_signing_message(&ch, false);
+        assert_ne!(
+            approve, reject,
+            "approve and reject must sign distinct bytes"
+        );
+
+        let mut hasher = Sha256::new();
+        hasher.update(b"MpcVerificationVote/v1");
+        hasher.update(ch);
+        hasher.update([1u8]);
+        let expected: [u8; 32] = hasher.finalize().into();
+        assert_eq!(approve, expected);
+    }
+
+    #[test]
+    fn test_mpc_bft_threshold_matches_documented_rule() {
+        // Bootstrap range (< 4): threshold 1.
+        assert_eq!(mpc_bft_threshold(0), 1);
+        assert_eq!(mpc_bft_threshold(1), 1);
+        assert_eq!(mpc_bft_threshold(3), 1);
+        // Supermajority at/above bootstrap.
+        assert_eq!(mpc_bft_threshold(4), 3); // ceil(268/100)
+        assert_eq!(mpc_bft_threshold(10), 7); // ceil(670/100)
+        assert_eq!(mpc_bft_threshold(100), 67);
+        assert_eq!(mpc_bft_threshold(101), 68); // ceil(6767/100)
+    }
+}

--- a/crates/ghost-consensus/Cargo.toml
+++ b/crates/ghost-consensus/Cargo.toml
@@ -69,3 +69,6 @@ optional = true
 [dependencies.ghost-mpc]
 workspace = true
 optional = true
+
+[dev-dependencies]
+tempfile = "3.10"

--- a/crates/ghost-consensus/src/message.rs
+++ b/crates/ghost-consensus/src/message.rs
@@ -1129,14 +1129,16 @@ impl MpcContributionMessage {
     }
 
     /// Get a hash of this contribution for voting reference
+    ///
+    /// Delegates to the single shared definition in `ghost_common::mpc` so the
+    /// live voter and the genesis-anchored startup verifier (which re-derives
+    /// this from retained DB rows) compute byte-identical hashes.
     pub fn contribution_hash(&self) -> [u8; 32] {
-        use sha2::{Digest, Sha256};
-        let mut hasher = Sha256::new();
-        hasher.update(b"MpcContributionHash/v1");
-        hasher.update(self.candidate);
-        hasher.update(self.elder_position.to_le_bytes());
-        hasher.update(self.new_params_hash);
-        hasher.finalize().into()
+        ghost_common::mpc::contribution_hash(
+            &self.candidate,
+            self.elder_position,
+            &self.new_params_hash,
+        )
     }
 
     /// Verify the candidate's signature
@@ -1182,13 +1184,11 @@ pub struct MpcVerificationVoteMessage {
 
 impl MpcVerificationVoteMessage {
     /// Get the message to be signed
+    ///
+    /// Delegates to `ghost_common::mpc` so a retained vote signature verifies
+    /// identically whether checked live here or re-derived at startup.
     pub fn signing_message(&self) -> [u8; 32] {
-        use sha2::{Digest, Sha256};
-        let mut hasher = Sha256::new();
-        hasher.update(b"MpcVerificationVote/v1");
-        hasher.update(self.contribution_hash);
-        hasher.update([self.approve as u8]);
-        hasher.finalize().into()
+        ghost_common::mpc::vote_signing_message(&self.contribution_hash, self.approve)
     }
 
     /// Verify the voter's signature

--- a/crates/ghost-consensus/src/mpc_handler.rs
+++ b/crates/ghost-consensus/src/mpc_handler.rs
@@ -48,7 +48,7 @@
 use async_trait::async_trait;
 use parking_lot::RwLock;
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 use std::time::Instant;
 use tracing::{debug, error, info, warn};
 
@@ -63,6 +63,71 @@ use crate::message::{
     MessageEnvelope, MessageType, MpcContributionMessage, MpcParametersRequestMessage,
     MpcParametersResponseMessage, MpcVerificationVoteMessage,
 };
+
+#[cfg(feature = "mpc-ceremony")]
+use ghost_mpc::{CeremonyManager, ContributionProof, Groth16Params, MpcContribution, MpcError};
+#[cfg(feature = "mpc-ceremony")]
+use ghost_storage::queries::MpcCeremonyState;
+#[cfg(feature = "mpc-ceremony")]
+use std::future::Future;
+#[cfg(feature = "mpc-ceremony")]
+use std::pin::Pin;
+
+/// A fetched, hash-matched bundle of ceremony parameters for ONE contribution.
+///
+/// Returned by the injected [`MpcParamsFetchFn`]. The fetcher guarantees that
+/// `hash_parameters(note_spend)` equals the requested lineage hash before
+/// handing the bundle back — so the voter never feeds mismatched parameters
+/// into the cryptographic check. `payout`/`unshield` ride along for the apply
+/// step (they share the same toxic waste as `note_spend`).
+#[cfg(feature = "mpc-ceremony")]
+#[derive(Clone)]
+pub struct FetchedCeremonyParams {
+    /// Primary (note-spend) parameters — the lineage chain.
+    pub note_spend: Arc<Groth16Params>,
+    /// Payout circuit parameters (same toxic waste), if the peer served them.
+    pub payout: Option<Arc<Groth16Params>>,
+    /// Unshield circuit parameters (same toxic waste), if the peer served them.
+    pub unshield: Option<Arc<Groth16Params>>,
+}
+
+/// Async callback that fetches a candidate's parameter bundle from the network.
+///
+/// Input: the expected note-spend lineage hash (`hash_parameters`) of the new
+/// parameters. Output: `Some(bundle)` only when a peer supplied parameters whose
+/// `hash_parameters()` matches the request; `None` on any fetch/parse/mismatch.
+///
+/// A `None` result means the voter could not obtain the parameters and MUST
+/// abstain — it must never weaken verification or vote approve blind.
+#[cfg(feature = "mpc-ceremony")]
+pub type MpcParamsFetchFn = Arc<
+    dyn Fn([u8; 32]) -> Pin<Box<dyn Future<Output = Option<FetchedCeremonyParams>> + Send>>
+        + Send
+        + Sync,
+>;
+
+/// A cryptographically-verified parameter bundle held between the approve vote
+/// and the apply step, keyed by `new_params_hash`. Bounded by
+/// `PENDING_CONTRIBUTION_TIMEOUT_SECS` so a never-applied entry is reclaimed.
+#[cfg(feature = "mpc-ceremony")]
+struct CachedParams {
+    inserted_at: Instant,
+    bundle: FetchedCeremonyParams,
+}
+
+/// The outcome of evaluating a contribution: the only way to reach `Approve` is
+/// a successful real cryptographic verification. `Abstain` casts NO vote
+/// (fail-closed for transient/local failures so the 67% threshold is not
+/// dragged toward rejection); `Reject` casts a signed reject vote.
+///
+/// Without the `mpc-ceremony` feature there is no cryptographic backend, so
+/// `Approve` is never constructed (the voter always abstains) — allow that.
+#[cfg_attr(not(feature = "mpc-ceremony"), allow(dead_code))]
+enum VoteDecision {
+    Approve,
+    Reject(String),
+    Abstain,
+}
 
 /// BFT threshold + bootstrap count for MPC contribution approval.
 ///
@@ -196,6 +261,23 @@ pub struct MpcHandler {
     is_ossified: RwLock<bool>,
     /// Current contribution count
     contribution_count: RwLock<u32>,
+    /// Weak self-handle so message processing can offload the heavy
+    /// fetch/verify/apply work to a background task. The mesh message loop is
+    /// single-threaded — running a multi-hundred-megabyte pairing verification
+    /// inline would stall ALL inbound messages (health pings, shares, votes).
+    /// Set once via [`MpcHandler::init_self_ref`] after the handler is `Arc`-wrapped.
+    weak_self: RwLock<Option<Weak<MpcHandler>>>,
+    /// Ceremony manager: the authoritative cryptographic backend. Required to
+    /// run `verify_contribution` (Schnorr + pairing checks) before approving.
+    #[cfg(feature = "mpc-ceremony")]
+    ceremony_manager: Option<Arc<CeremonyManager>>,
+    /// Network fetcher for candidate parameters (see [`MpcParamsFetchFn`]).
+    #[cfg(feature = "mpc-ceremony")]
+    params_fetcher: Option<MpcParamsFetchFn>,
+    /// Verified parameter bundles, keyed by `new_params_hash`, cached between the
+    /// approve vote and the apply step so the (large) params are fetched once.
+    #[cfg(feature = "mpc-ceremony")]
+    verified_params: RwLock<HashMap<[u8; 32], CachedParams>>,
 }
 
 impl MpcHandler {
@@ -210,6 +292,13 @@ impl MpcHandler {
             pending_contributions: RwLock::new(HashMap::new()),
             is_ossified: RwLock::new(false),
             contribution_count: RwLock::new(0),
+            weak_self: RwLock::new(None),
+            #[cfg(feature = "mpc-ceremony")]
+            ceremony_manager: None,
+            #[cfg(feature = "mpc-ceremony")]
+            params_fetcher: None,
+            #[cfg(feature = "mpc-ceremony")]
+            verified_params: RwLock::new(HashMap::new()),
         }
     }
 
@@ -223,6 +312,35 @@ impl MpcHandler {
     pub fn with_params_callback(mut self, callback: ParamsUpdateCallback) -> Self {
         self.params_callback = Some(callback);
         self
+    }
+
+    /// Wire the authoritative cryptographic backend (the ceremony manager).
+    ///
+    /// Without it the handler cannot verify contributions and will ABSTAIN on
+    /// every non-genesis contribution rather than approve unverified.
+    #[cfg(feature = "mpc-ceremony")]
+    pub fn with_ceremony_manager(mut self, manager: Arc<CeremonyManager>) -> Self {
+        self.ceremony_manager = Some(manager);
+        self
+    }
+
+    /// Wire the network parameter fetcher used to obtain candidate parameters
+    /// before cryptographic verification.
+    #[cfg(feature = "mpc-ceremony")]
+    pub fn with_params_fetcher(mut self, fetcher: MpcParamsFetchFn) -> Self {
+        self.params_fetcher = Some(fetcher);
+        self
+    }
+
+    /// Record a weak self-reference so MPC message handling can be offloaded to
+    /// a background task. Call this exactly once after `Arc`-wrapping the handler.
+    pub fn init_self_ref(self: &Arc<Self>) {
+        *self.weak_self.write() = Some(Arc::downgrade(self));
+    }
+
+    /// Upgrade the weak self-reference, if it was installed.
+    fn upgrade_self(&self) -> Option<Arc<MpcHandler>> {
+        self.weak_self.read().as_ref().and_then(Weak::upgrade)
     }
 
     /// Initialize with ceremony state
@@ -254,7 +372,11 @@ impl MpcHandler {
     }
 
     /// Handle an incoming MPC contribution
-    fn handle_contribution(&self, msg: MpcContributionMessage, sender: NodeId) -> GhostResult<()> {
+    async fn handle_contribution(
+        &self,
+        msg: MpcContributionMessage,
+        sender: NodeId,
+    ) -> GhostResult<()> {
         debug!(
             position = msg.elder_position,
             sender = %hex::encode(&sender[..8]),
@@ -316,6 +438,13 @@ impl MpcHandler {
                 c.received_at.elapsed().as_secs() < PENDING_CONTRIBUTION_TIMEOUT_SECS
             });
 
+            // Reclaim any cached verified parameters that aged out without being
+            // applied (rejected / no-quorum). Same lifetime bound as the pending.
+            #[cfg(feature = "mpc-ceremony")]
+            self.verified_params.write().retain(|_, c| {
+                c.inserted_at.elapsed().as_secs() < PENDING_CONTRIBUTION_TIMEOUT_SECS
+            });
+
             pending.insert(
                 contribution_hash,
                 PendingContribution {
@@ -354,13 +483,13 @@ impl MpcHandler {
             info!(
                 "MPC genesis: Auto-approving first contribution (no existing contributors to vote)"
             );
-            self.apply_contribution(&contribution_hash)?;
+            self.apply_contribution(&contribution_hash).await?;
             return Ok(());
         }
 
         // If we're an MPC contributor, verify and vote on new contributions
         if self.is_mpc_contributor() {
-            self.verify_and_vote(&msg)?;
+            self.verify_and_vote(&msg).await?;
         }
 
         Ok(())
@@ -386,59 +515,214 @@ impl MpcHandler {
         self.db.get_mpc_elder_count().unwrap_or(0)
     }
 
-    /// Verify a contribution and cast our vote
-    fn verify_and_vote(&self, msg: &MpcContributionMessage) -> GhostResult<()> {
+    /// Cheap structural + hash-chain pre-check (the FAST REJECT).
+    ///
+    /// Returns `true` only when the proof is present, the hashes are well-formed
+    /// and distinct, AND `prev_params_hash` chains from the recorded previous
+    /// contribution. This is necessary but NOT sufficient — it does NOT prove
+    /// the contribution is a valid cryptographic transformation. Approval
+    /// additionally requires [`MpcHandler::crypto_decide`].
+    fn structural_precheck(&self, msg: &MpcContributionMessage) -> bool {
         // Structural validation: proof exists, hashes are non-zero and different
         let structurally_valid = !msg.contribution_proof.is_empty()
             && msg.prev_params_hash != [0u8; 32]
             && msg.new_params_hash != [0u8; 32]
             && msg.prev_params_hash != msg.new_params_hash;
+        if !structurally_valid {
+            return false;
+        }
 
-        // Hash chain validation: verify prev_params_hash matches the latest contribution
-        // This prevents contributions that don't chain from the current ceremony state
-        let chain_valid = if msg.elder_position == 1 {
-            // Genesis contribution has no predecessor to validate against
-            true
-        } else {
-            // Check that prev_params_hash matches new_params_hash of the previous contribution
-            match self.db.get_mpc_contribution(msg.elder_position - 1) {
-                Ok(Some(prev)) => {
-                    if prev.new_params_hash != msg.prev_params_hash {
-                        warn!(
-                            position = msg.elder_position,
-                            expected = %hex::encode(&prev.new_params_hash[..8]),
-                            got = %hex::encode(&msg.prev_params_hash[..8]),
-                            "MPC contribution prev_params_hash does not chain from previous contribution"
-                        );
-                        false
-                    } else {
-                        true
-                    }
-                }
-                Ok(None) => {
+        // Hash chain validation: verify prev_params_hash matches the latest contribution.
+        if msg.elder_position == 1 {
+            // Genesis contribution has no predecessor to validate against.
+            return true;
+        }
+        match self.db.get_mpc_contribution(msg.elder_position - 1) {
+            Ok(Some(prev)) => {
+                if prev.new_params_hash != msg.prev_params_hash {
                     warn!(
                         position = msg.elder_position,
-                        prev_position = msg.elder_position - 1,
-                        "Cannot verify hash chain: previous contribution not found"
+                        expected = %hex::encode(&prev.new_params_hash[..8]),
+                        got = %hex::encode(&msg.prev_params_hash[..8]),
+                        "MPC contribution prev_params_hash does not chain from previous contribution"
                     );
                     false
+                } else {
+                    true
                 }
-                Err(e) => {
-                    warn!(error = %e, "Failed to look up previous MPC contribution for chain verification");
-                    false
-                }
+            }
+            Ok(None) => {
+                warn!(
+                    position = msg.elder_position,
+                    prev_position = msg.elder_position - 1,
+                    "Cannot verify hash chain: previous contribution not found"
+                );
+                false
+            }
+            Err(e) => {
+                warn!(error = %e, "Failed to look up previous MPC contribution for chain verification");
+                false
+            }
+        }
+    }
+
+    /// Decide how to vote on a contribution.
+    ///
+    /// SECURITY (Stage 1a): the ONLY path to [`VoteDecision::Approve`] is a
+    /// successful cryptographic `verify_contribution` (Schnorr proof + h/l
+    /// pairing checks) against the candidate's fetched parameters. The cheap
+    /// structural/chain check is merely a fast reject. A transient inability to
+    /// fetch/verify yields [`VoteDecision::Abstain`] (fail-closed: cast no vote)
+    /// so a flaky node never approves blind and never drags the 67% threshold
+    /// toward rejection.
+    async fn decide_vote(&self, msg: &MpcContributionMessage) -> VoteDecision {
+        if !self.structural_precheck(msg) {
+            return VoteDecision::Reject("Invalid structure or hash chain".to_string());
+        }
+
+        #[cfg(feature = "mpc-ceremony")]
+        {
+            self.crypto_decide(msg).await
+        }
+        #[cfg(not(feature = "mpc-ceremony"))]
+        {
+            // No cryptographic backend compiled in — cannot authoritatively
+            // verify, so we must NOT approve. Abstain (fail-closed).
+            let _ = msg;
+            VoteDecision::Abstain
+        }
+    }
+
+    /// Authoritative cryptographic decision (Stage 1a). Fetches the candidate's
+    /// new parameters, confirms they hash to the claimed `new_params_hash`, then
+    /// runs the full Schnorr + pairing `verify_contribution` bound to the stable
+    /// `ceremony_id`. Heavy work (param hash + pairing checks) runs on a blocking
+    /// thread so the mesh loop is never stalled.
+    #[cfg(feature = "mpc-ceremony")]
+    async fn crypto_decide(&self, msg: &MpcContributionMessage) -> VoteDecision {
+        let manager = match &self.ceremony_manager {
+            Some(m) => Arc::clone(m),
+            None => {
+                warn!("MPC: no ceremony manager wired — abstaining (cannot verify)");
+                return VoteDecision::Abstain;
+            }
+        };
+        let fetcher = match &self.params_fetcher {
+            Some(f) => Arc::clone(f),
+            None => {
+                warn!("MPC: no params fetcher wired — abstaining (cannot verify)");
+                return VoteDecision::Abstain;
             }
         };
 
-        let valid = structurally_valid && chain_valid;
+        // 1. Fetch the candidate's parameters. None => cannot verify => ABSTAIN.
+        let claimed = msg.new_params_hash;
+        let bundle = match fetcher(claimed).await {
+            Some(b) => b,
+            None => {
+                info!(
+                    position = msg.elder_position,
+                    expected = %hex::encode(&claimed[..8]),
+                    "MPC: could not fetch candidate parameters — abstaining (fail-closed)"
+                );
+                return VoteDecision::Abstain;
+            }
+        };
 
-        // Sign and broadcast vote
+        // 1b. Defence in depth: confirm the fetched bytes hash to the claim.
+        // A mismatch means we hold the wrong params (e.g. fetched from a stale
+        // peer) and cannot judge the contribution — ABSTAIN, do not reject.
+        {
+            let ns = Arc::clone(&bundle.note_spend);
+            let h =
+                tokio::task::spawn_blocking(move || ghost_mpc::contribution::hash_parameters(&ns))
+                    .await;
+            match h {
+                Ok(Ok(hash)) if hash == claimed => {}
+                Ok(Ok(hash)) => {
+                    warn!(
+                        expected = %hex::encode(&claimed[..8]),
+                        got = %hex::encode(&hash[..8]),
+                        "MPC: fetched params hash != claimed new_params_hash — abstaining"
+                    );
+                    return VoteDecision::Abstain;
+                }
+                _ => {
+                    warn!("MPC: failed to hash fetched params — abstaining");
+                    return VoteDecision::Abstain;
+                }
+            }
+        }
+
+        // 2. Reconstruct the contribution. A malformed proof is part of the
+        // signed payload every node sees identically — REJECT (deterministic).
+        let contribution = match reconstruct_contribution(msg) {
+            Some(c) => c,
+            None => {
+                return VoteDecision::Reject("Malformed contribution proof".to_string());
+            }
+        };
+
+        // 3. Run the authoritative verification on a blocking thread.
+        let note_spend = Arc::clone(&bundle.note_spend);
+        let contribution_for_verify = contribution.clone();
+        let manager_for_verify = Arc::clone(&manager);
+        let result = tokio::task::spawn_blocking(move || {
+            manager_for_verify.verify_contribution(&note_spend, &contribution_for_verify)
+        })
+        .await;
+
+        match result {
+            Ok(Ok(true)) => {
+                // 4. Cache the verified bundle for the apply step (fetch once).
+                self.verified_params.write().insert(
+                    claimed,
+                    CachedParams {
+                        inserted_at: Instant::now(),
+                        bundle,
+                    },
+                );
+                VoteDecision::Approve
+            }
+            Ok(Ok(false)) => {
+                VoteDecision::Reject("Contribution failed cryptographic verification".to_string())
+            }
+            Ok(Err(e)) => classify_verify_error(e),
+            Err(join_err) => {
+                warn!(error = %join_err, "MPC: verification task panicked — abstaining");
+                VoteDecision::Abstain
+            }
+        }
+    }
+
+    /// Verify a contribution and cast our vote.
+    async fn verify_and_vote(&self, msg: &MpcContributionMessage) -> GhostResult<()> {
+        match self.decide_vote(msg).await {
+            VoteDecision::Abstain => {
+                info!(
+                    position = msg.elder_position,
+                    "MPC: abstaining on contribution (could not authoritatively verify)"
+                );
+                Ok(())
+            }
+            VoteDecision::Approve => self.cast_vote(msg, true, None).await,
+            VoteDecision::Reject(reason) => self.cast_vote(msg, false, Some(reason)).await,
+        }
+    }
+
+    /// Sign, persist, broadcast our vote, count it locally, and apply on threshold.
+    async fn cast_vote(
+        &self,
+        msg: &MpcContributionMessage,
+        approve: bool,
+        reason: Option<String>,
+    ) -> GhostResult<()> {
         let signing_msg = {
             let mut hasher = sha2::Sha256::new();
             use sha2::Digest;
             hasher.update(b"MpcVerificationVote/v1");
             hasher.update(msg.contribution_hash());
-            hasher.update([valid as u8]);
+            hasher.update([approve as u8]);
             let result: [u8; 32] = hasher.finalize().into();
             result
         };
@@ -448,12 +732,8 @@ impl MpcHandler {
         let vote_msg = MpcVerificationVoteMessage {
             contribution_hash: msg.contribution_hash(),
             voter: self.identity.node_id(),
-            approve: valid,
-            rejection_reason: if valid {
-                None
-            } else {
-                Some("Invalid proof".to_string())
-            },
+            approve,
+            rejection_reason: reason,
             signature,
             timestamp: std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
@@ -465,7 +745,7 @@ impl MpcHandler {
         let db_vote = DbMpcVote {
             contribution_position: msg.elder_position,
             voter_node_id: hex::encode(self.identity.node_id()),
-            approve: valid,
+            approve,
             signature: signature.to_vec(),
             voted_at: vote_msg.timestamp,
         };
@@ -480,31 +760,26 @@ impl MpcHandler {
 
         info!(
             position = msg.elder_position,
-            approve = valid,
+            approve = approve,
             "Cast MPC verification vote"
         );
 
-        // CRITICAL: Also count our own vote locally and check threshold
-        // Without this, our vote only goes to peers but doesn't trigger
-        // the approval threshold on this node
+        // CRITICAL: Also count our own vote locally and check threshold.
         let contribution_hash = msg.contribution_hash();
         let should_apply = {
             let mut pending = self.pending_contributions.write();
             if let Some(contribution) = pending.get_mut(&contribution_hash) {
                 // H-4: Insert our node ID into voters set before incrementing count.
-                // This prevents double-counting if our own vote arrives back via P2P.
                 let our_id = self.identity.node_id();
                 if !contribution.voters.insert(our_id) {
-                    // Already voted (shouldn't happen in normal flow, but guard against it)
                     return Ok(());
                 }
-                if valid {
+                if approve {
                     contribution.approval_count += 1;
                 } else {
                     contribution.rejection_count += 1;
                 }
 
-                // Check if we have BFT threshold
                 let contributor_count = self.mpc_contributor_count();
                 let threshold = bft_threshold(contributor_count);
 
@@ -522,20 +797,19 @@ impl MpcHandler {
             }
         };
 
-        // Apply if threshold reached
         if should_apply {
             info!(
                 position = msg.elder_position,
                 "MPC contribution threshold met, applying"
             );
-            self.apply_contribution(&contribution_hash)?;
+            self.apply_contribution(&contribution_hash).await?;
         }
 
         Ok(())
     }
 
     /// Handle an incoming verification vote
-    fn handle_verification_vote(
+    async fn handle_verification_vote(
         &self,
         msg: MpcVerificationVoteMessage,
         sender: NodeId,
@@ -618,21 +892,29 @@ impl MpcHandler {
 
         // Apply if threshold reached
         if should_apply {
-            self.apply_contribution(&msg.contribution_hash)?;
+            self.apply_contribution(&msg.contribution_hash).await?;
         }
 
         Ok(())
     }
 
-    /// Apply a contribution after BFT approval
-    fn apply_contribution(&self, contribution_hash: &[u8; 32]) -> GhostResult<()> {
+    /// Apply a contribution after BFT approval.
+    ///
+    /// Records the contribution row, then (Stage 1b) drives the canonical
+    /// parameter swap through the ceremony manager and persists the
+    /// `mpc_ceremony` singleton so the on-disk params, in-memory hot-swap, and
+    /// the authoritative count/hash all advance atomically with the recorded
+    /// lineage. `save_mpc_contribution` stays strictly inside this
+    /// post-threshold path — no elder position is ever recorded without BFT
+    /// approval.
+    async fn apply_contribution(&self, contribution_hash: &[u8; 32]) -> GhostResult<()> {
         let contribution = {
             let mut pending = self.pending_contributions.write();
             pending.remove(contribution_hash)
         };
 
         if let Some(contribution) = contribution {
-            let msg = &contribution.message;
+            let msg = contribution.message.clone();
 
             // Save contribution to database
             let record = MpcContributionRecord {
@@ -646,7 +928,7 @@ impl MpcHandler {
             };
             self.db.save_mpc_contribution(&record)?;
 
-            // Update state
+            // Update handler-tracked progression state.
             *self.contribution_count.write() = msg.elder_position;
 
             // Check for ossification
@@ -655,7 +937,16 @@ impl MpcHandler {
                 info!("MPC ceremony OSSIFIED at 101 contributions");
             }
 
-            // Notify callback with contributor's node_id so caller can fetch params
+            // Stage 1b: apply through the ceremony manager (disk write + symlink
+            // + in-memory hot-swap + count/current_params_hash + ossify) using the
+            // parameters we verified during our approve vote, then persist the
+            // singleton. Applies IMMEDIATELY on threshold (rolling design), not at
+            // an epoch boundary.
+            #[cfg(feature = "mpc-ceremony")]
+            self.apply_through_manager(&msg).await;
+
+            // Notify callback so nodes that did not vote (no locally-cached
+            // params) fetch + verify + adopt the new parameters.
             if let Some(callback) = &self.params_callback {
                 callback(&msg.new_params_hash, &msg.candidate);
             }
@@ -668,6 +959,74 @@ impl MpcHandler {
         }
 
         Ok(())
+    }
+
+    /// Stage 1b: drive the parameter swap through the ceremony manager using the
+    /// cached, already-verified parameters, then persist the `mpc_ceremony`
+    /// singleton from the manager's authoritative post-apply state.
+    #[cfg(feature = "mpc-ceremony")]
+    async fn apply_through_manager(&self, msg: &MpcContributionMessage) {
+        let manager = match &self.ceremony_manager {
+            Some(m) => Arc::clone(m),
+            None => return,
+        };
+
+        // The verified bundle must have been cached during our approve vote.
+        // If it is absent (we abstained, or we are a non-voter that reached
+        // threshold via peer votes) we do NOT fabricate state here — the
+        // params_callback path fetches + verifies + adopts asynchronously.
+        let bundle = match self.verified_params.write().remove(&msg.new_params_hash) {
+            Some(c) => c.bundle,
+            None => {
+                debug!(
+                    position = msg.elder_position,
+                    "MPC apply: no locally-cached verified params — deferring adoption to params_callback"
+                );
+                return;
+            }
+        };
+
+        let contribution = match reconstruct_contribution(msg) {
+            Some(c) => c,
+            None => {
+                warn!("MPC apply: could not reconstruct contribution from message");
+                return;
+            }
+        };
+
+        // Clone owned params out of the cached Arcs for the manager (owned API).
+        let note_spend = (*bundle.note_spend).clone();
+        let payout = bundle.payout.as_ref().map(|p| (**p).clone());
+        let unshield = bundle.unshield.as_ref().map(|p| (**p).clone());
+
+        let manager_for_apply = Arc::clone(&manager);
+        let apply_res = tokio::task::spawn_blocking(move || {
+            manager_for_apply.apply_contribution_multi(note_spend, payout, unshield, &contribution)
+        })
+        .await;
+
+        match apply_res {
+            Ok(Ok(())) => {
+                // Persist the singleton from the manager's authoritative state.
+                // On position 101 the manager ossifies internally, so the saved
+                // state carries is_ossified=1 (do NOT rely on a separate
+                // set_ceremony_ossified UPDATE, which no-ops on an absent row).
+                if let Err(e) = persist_singleton(&self.db, &manager) {
+                    warn!(error = %e, "MPC: failed to persist ceremony singleton after apply");
+                } else {
+                    info!(
+                        position = msg.elder_position,
+                        "MPC: applied contribution through ceremony manager and persisted singleton"
+                    );
+                }
+            }
+            Ok(Err(e)) => {
+                warn!(error = %e, position = msg.elder_position, "MPC: ceremony manager apply failed");
+            }
+            Err(e) => {
+                warn!(error = %e, "MPC: ceremony manager apply task panicked");
+            }
+        }
     }
 
     /// Handle parameter request
@@ -714,6 +1073,68 @@ impl MpcHandler {
     }
 }
 
+/// Reconstruct the `ghost-mpc` contribution record from a wire message.
+///
+/// `contribution_proof` is the `serde_json` encoding of [`ContributionProof`]
+/// (see the send path in `ghost-pool`); `timestamp` is seconds (matching what
+/// `verify_contribution`'s skew window expects); `contributor` is the hex of the
+/// candidate node id (informational — not used by the crypto checks).
+#[cfg(feature = "mpc-ceremony")]
+fn reconstruct_contribution(msg: &MpcContributionMessage) -> Option<MpcContribution> {
+    let proof: ContributionProof = serde_json::from_slice(&msg.contribution_proof).ok()?;
+    Some(MpcContribution {
+        position: msg.elder_position,
+        prev_params_hash: msg.prev_params_hash,
+        new_params_hash: msg.new_params_hash,
+        proof,
+        contributor: hex::encode(msg.candidate),
+        timestamp: msg.timestamp,
+        commitment_hash: None,
+    })
+}
+
+/// Map a `verify_contribution` error to a vote decision.
+///
+/// Cryptographic failures (bad proof / hash / chain) are deterministic across
+/// honest nodes — REJECT. Infrastructure / transient errors (no local params,
+/// position desync, ossified) are not proof of forgery and could be local-only,
+/// so they ABSTAIN (fail-closed: never approve, never drag the threshold).
+#[cfg(feature = "mpc-ceremony")]
+fn classify_verify_error(e: MpcError) -> VoteDecision {
+    match e {
+        MpcError::InvalidProof(_)
+        | MpcError::HashMismatch { .. }
+        | MpcError::InvalidChain { .. } => {
+            VoteDecision::Reject(format!("Cryptographic verification failed: {e}"))
+        }
+        _ => {
+            warn!(error = %e, "MPC: non-cryptographic verification error — abstaining");
+            VoteDecision::Abstain
+        }
+    }
+}
+
+/// Persist the `mpc_ceremony` singleton from the manager's authoritative state.
+///
+/// Maps `ghost_mpc::CeremonyState` → `MpcCeremonyState` (note
+/// `note_spend_vk_hash` → `block_vk_hash`). This is the single writer that keeps
+/// the singleton in lock-step with the in-memory hot-swap and on-disk params.
+#[cfg(feature = "mpc-ceremony")]
+fn persist_singleton(db: &Database, manager: &CeremonyManager) -> GhostResult<()> {
+    let s = manager.state();
+    let db_state = MpcCeremonyState {
+        contribution_count: s.contribution_count,
+        current_params_hash: s.current_params_hash,
+        is_ossified: s.is_ossified,
+        ossified_at: s.ossified_at,
+        block_vk_hash: s.note_spend_vk_hash,
+        payout_vk_hash: s.payout_vk_hash,
+        updated_at: s.updated_at,
+        ceremony_id: s.ceremony_id,
+    };
+    db.save_mpc_ceremony_state(&db_state)
+}
+
 #[async_trait]
 impl MessageHandler for MpcHandler {
     async fn handle_message(&self, envelope: Arc<MessageEnvelope>) -> GhostResult<()> {
@@ -751,12 +1172,36 @@ impl MessageHandler for MpcHandler {
                     candidate = %hex::encode(&msg.candidate[..8]),
                     "MpcContribution deserialized"
                 );
-                self.handle_contribution(msg, envelope.sender)?;
+                // Offload to a background task: handling may fetch + run heavy
+                // pairing verification, which must NOT stall the single-threaded
+                // mesh message loop. Falls back to inline when no self-ref is set
+                // (e.g. unit tests that drive methods directly).
+                let sender = envelope.sender;
+                match self.upgrade_self() {
+                    Some(me) => {
+                        tokio::spawn(async move {
+                            if let Err(e) = me.handle_contribution(msg, sender).await {
+                                warn!(error = %e, "MPC contribution handling failed");
+                            }
+                        });
+                    }
+                    None => self.handle_contribution(msg, sender).await?,
+                }
             }
             MessageType::MpcVerificationVote => {
                 let msg: MpcVerificationVoteMessage = serde_json::from_slice(&envelope.payload)
                     .map_err(|e| GhostError::Serialization(e.to_string()))?;
-                self.handle_verification_vote(msg, envelope.sender)?;
+                let sender = envelope.sender;
+                match self.upgrade_self() {
+                    Some(me) => {
+                        tokio::spawn(async move {
+                            if let Err(e) = me.handle_verification_vote(msg, sender).await {
+                                warn!(error = %e, "MPC vote handling failed");
+                            }
+                        });
+                    }
+                    None => self.handle_verification_vote(msg, sender).await?,
+                }
             }
             MessageType::MpcParametersRequest => {
                 let msg: MpcParametersRequestMessage = serde_json::from_slice(&envelope.payload)
@@ -905,6 +1350,267 @@ mod tests {
             remaining_millis,
             (max as u64 - 1) * MPC_MILLIS_PER_TOKEN,
             "refill must cap at max_tokens (then -1 for the consume just made)"
+        );
+    }
+}
+
+/// Stage 1a/1b tests: the BFT voter now runs REAL cryptographic verification
+/// before approving, applies through the ceremony manager, and persists the
+/// `mpc_ceremony` singleton. These exercise the closed vulnerability end-to-end.
+#[cfg(all(test, feature = "mpc-ceremony"))]
+mod ceremony_vote_tests {
+    use super::*;
+    use ghost_mpc::CeremonyManager;
+    use ghost_storage::Database;
+    use tempfile::TempDir;
+
+    /// A genesis-initialised manager (real Groth16 params for all three circuits).
+    fn genesis_manager() -> (Arc<CeremonyManager>, TempDir) {
+        let dir = TempDir::new().unwrap();
+        let mgr = CeremonyManager::new(dir.path().to_path_buf());
+        mgr.ensure_genesis_initialized().unwrap();
+        (Arc::new(mgr), dir)
+    }
+
+    /// Build a signed wire message for a generated contribution. `contribution_proof`
+    /// is the `serde_json` encoding of the proof (matching the production send path);
+    /// `timestamp` is seconds (matching `verify_contribution`'s skew window).
+    fn message_for(
+        contribution: &ghost_mpc::MpcContribution,
+        identity: &NodeIdentity,
+    ) -> MpcContributionMessage {
+        let proof_bytes = serde_json::to_vec(&contribution.proof).unwrap();
+        let mut msg = MpcContributionMessage {
+            candidate: identity.node_id(),
+            elder_position: contribution.position,
+            prev_params_hash: contribution.prev_params_hash,
+            new_params_hash: contribution.new_params_hash,
+            contribution_proof: proof_bytes,
+            signature: [0u8; 64],
+            timestamp: contribution.timestamp,
+        };
+        let sm = msg.signing_message();
+        msg.signature = identity.sign(&sm);
+        msg
+    }
+
+    fn fetcher_returning(params: Arc<Groth16Params>) -> MpcParamsFetchFn {
+        Arc::new(move |_expected| {
+            let p = Arc::clone(&params);
+            Box::pin(async move {
+                Some(FetchedCeremonyParams {
+                    note_spend: p,
+                    payout: None,
+                    unshield: None,
+                })
+            })
+        })
+    }
+
+    fn fetcher_failing() -> MpcParamsFetchFn {
+        Arc::new(move |_expected| Box::pin(async move { Option::<FetchedCeremonyParams>::None }))
+    }
+
+    fn insert_pending(handler: &MpcHandler, msg: &MpcContributionMessage) {
+        handler.pending_contributions.write().insert(
+            msg.contribution_hash(),
+            PendingContribution {
+                message: msg.clone(),
+                received_at: Instant::now(),
+                approval_count: 0,
+                rejection_count: 0,
+                voters: std::collections::HashSet::new(),
+            },
+        );
+    }
+
+    /// (1) A valid contribution is cryptographically verified → approved → at the
+    /// (bootstrap) threshold it applies: a `mpc_contributions` row is written, the
+    /// `mpc_ceremony` singleton is populated with the incremented count + matching
+    /// `current_params_hash`, and the manager hot-swaps the parameters.
+    #[tokio::test]
+    async fn test_valid_contribution_approved_applied_and_persisted() {
+        let identity = Arc::new(NodeIdentity::generate());
+        let db = Arc::new(Database::in_memory().unwrap());
+        let (manager, _dir) = genesis_manager();
+
+        let (new_params, contribution) = manager.generate_contribution("node1").unwrap();
+        let new_params = Arc::new(new_params);
+        let msg = message_for(&contribution, &identity);
+
+        let handler = MpcHandler::new(Arc::clone(&identity), Arc::clone(&db))
+            .with_ceremony_manager(Arc::clone(&manager))
+            .with_params_fetcher(fetcher_returning(Arc::clone(&new_params)))
+            .with_state(0, false);
+        insert_pending(&handler, &msg);
+
+        handler.verify_and_vote(&msg).await.unwrap();
+
+        // mpc_contributions row recorded at position 1.
+        let row = db.get_mpc_contribution(1).unwrap();
+        assert!(
+            row.is_some(),
+            "contribution row must be saved at position 1"
+        );
+        assert_eq!(row.unwrap().new_params_hash, contribution.new_params_hash);
+
+        // Singleton populated, count incremented, hash matches.
+        let singleton = db
+            .get_mpc_ceremony_state()
+            .unwrap()
+            .expect("singleton must be persisted");
+        assert_eq!(singleton.contribution_count, 1);
+        assert_eq!(singleton.current_params_hash, contribution.new_params_hash);
+
+        // Manager hot-swapped in memory.
+        assert_eq!(manager.contribution_count(), 1);
+        assert_eq!(manager.current_params_hash(), contribution.new_params_hash);
+
+        // We cast exactly one approve vote (no reject).
+        let (approvals, rejections) = db.count_mpc_approvals(1).unwrap();
+        assert_eq!(approvals, 1);
+        assert_eq!(rejections, 0);
+    }
+
+    /// (2) A forged contribution — valid structure + valid hash-chain link but a
+    /// TAMPERED Schnorr proof — is REJECTED and never applied. CRITICAL: the same
+    /// input WOULD have passed the old structural-only pre-check, proving Stage 1a
+    /// closed the hole.
+    #[tokio::test]
+    async fn test_forged_contribution_rejected_not_applied() {
+        let identity = Arc::new(NodeIdentity::generate());
+        let db = Arc::new(Database::in_memory().unwrap());
+        let (manager, _dir) = genesis_manager();
+        let genesis_hash = manager.current_params_hash();
+
+        let (new_params, mut contribution) = manager.generate_contribution("node1").unwrap();
+        let new_params = Arc::new(new_params);
+
+        // Tamper ONLY the Schnorr response (low byte → stays a valid scalar). The
+        // parameters and all hashes are untouched, so the structural pre-check and
+        // the fetched-params hash match both still pass — only the cryptographic
+        // proof check can catch this.
+        contribution.proof.tau_pok.response[0] ^= 0x01;
+        let msg = message_for(&contribution, &identity);
+
+        let handler = MpcHandler::new(Arc::clone(&identity), Arc::clone(&db))
+            .with_ceremony_manager(Arc::clone(&manager))
+            .with_params_fetcher(fetcher_returning(Arc::clone(&new_params)))
+            .with_state(0, false);
+
+        // PROOF the hole is closed: the OLD structural-only check approves this.
+        assert!(
+            handler.structural_precheck(&msg),
+            "the old structural-only check WOULD have passed the forged contribution"
+        );
+
+        insert_pending(&handler, &msg);
+        handler.verify_and_vote(&msg).await.unwrap();
+
+        // Never applied: no row, no state change.
+        assert!(
+            db.get_mpc_contribution(1).unwrap().is_none(),
+            "forged contribution must NOT be recorded"
+        );
+        assert_eq!(manager.contribution_count(), 0);
+        assert_eq!(
+            manager.current_params_hash(),
+            genesis_hash,
+            "current params must be unchanged"
+        );
+        if let Some(s) = db.get_mpc_ceremony_state().unwrap() {
+            assert_eq!(s.contribution_count, 0, "singleton must not advance");
+        }
+        // A reject vote was cast (not an approve).
+        let (approvals, rejections) = db.count_mpc_approvals(1).unwrap();
+        assert_eq!(approvals, 0);
+        assert!(rejections >= 1, "forged contribution must be rejected");
+    }
+
+    /// (3) A transient fetch failure makes the voter ABSTAIN: it casts NO vote (so
+    /// the 67% threshold is not dragged toward rejection), does not apply, and the
+    /// pending contribution survives — the ceremony is not stalled.
+    #[tokio::test]
+    async fn test_fetch_failure_abstains_no_stall() {
+        let identity = Arc::new(NodeIdentity::generate());
+        let db = Arc::new(Database::in_memory().unwrap());
+        let (manager, _dir) = genesis_manager();
+        let genesis_hash = manager.current_params_hash();
+
+        let (_new_params, contribution) = manager.generate_contribution("node1").unwrap();
+        let msg = message_for(&contribution, &identity);
+
+        let handler = MpcHandler::new(Arc::clone(&identity), Arc::clone(&db))
+            .with_ceremony_manager(Arc::clone(&manager))
+            .with_params_fetcher(fetcher_failing())
+            .with_state(0, false);
+        insert_pending(&handler, &msg);
+
+        handler.verify_and_vote(&msg).await.unwrap();
+
+        // No vote cast (abstained), nothing applied, params unchanged.
+        let (approvals, rejections) = db.count_mpc_approvals(1).unwrap();
+        assert_eq!(approvals, 0, "abstention casts no approve vote");
+        assert_eq!(rejections, 0, "abstention casts no reject vote");
+        assert!(db.get_mpc_contribution(1).unwrap().is_none());
+        assert_eq!(manager.contribution_count(), 0);
+        assert_eq!(manager.current_params_hash(), genesis_hash);
+        // Pending survives → ceremony not stalled (a later retry can still vote).
+        assert!(
+            handler
+                .pending_contributions
+                .read()
+                .contains_key(&msg.contribution_hash()),
+            "pending must survive an abstention"
+        );
+    }
+
+    /// (4) The crypto gate that BOTH the voter and `params_callback` enforce:
+    /// parameters whose NEW-params hash matches the contribution's claim are STILL
+    /// rejected when they do not verify against THIS node's own current params
+    /// (its prev). Hash-match alone is never sufficient. Here a contribution from a
+    /// foreign lineage A is offered to node B: the new hash matches, the structural
+    /// check passes, but verification against B's prev fails → reject, no adoption.
+    #[tokio::test]
+    async fn test_verify_gate_rejects_hash_matching_foreign_lineage() {
+        let identity = Arc::new(NodeIdentity::generate());
+        let db = Arc::new(Database::in_memory().unwrap());
+        let (manager_a, _da) = genesis_manager();
+        let (manager_b, _db_dir) = genesis_manager();
+
+        // Contribution generated on lineage A.
+        let (new_a, contribution_a) = manager_a.generate_contribution("nodeA").unwrap();
+        let new_a = Arc::new(new_a);
+
+        // The NEW-params hash genuinely matches the contribution's claim …
+        assert_eq!(
+            ghost_mpc::contribution::hash_parameters(&new_a).unwrap(),
+            contribution_a.new_params_hash,
+            "fetched params hash matches the claimed new_params_hash"
+        );
+
+        let msg = message_for(&contribution_a, &identity);
+
+        // … but node B (a different genesis lineage) must NOT adopt it.
+        let handler = MpcHandler::new(Arc::clone(&identity), Arc::clone(&db))
+            .with_ceremony_manager(Arc::clone(&manager_b))
+            .with_params_fetcher(fetcher_returning(Arc::clone(&new_a)))
+            .with_state(0, false);
+
+        // Structural + hash checks pass — proving hash match alone is insufficient.
+        assert!(handler.structural_precheck(&msg));
+        insert_pending(&handler, &msg);
+
+        handler.verify_and_vote(&msg).await.unwrap();
+
+        // Gate held: B refused the foreign-lineage params.
+        assert_eq!(manager_b.contribution_count(), 0);
+        assert!(db.get_mpc_contribution(1).unwrap().is_none());
+        let (approvals, rejections) = db.count_mpc_approvals(1).unwrap();
+        assert_eq!(approvals, 0, "must not approve on hash match alone");
+        assert!(
+            rejections >= 1,
+            "the verify gate must reject foreign-lineage params"
         );
     }
 }

--- a/crates/ghost-consensus/src/mpc_handler.rs
+++ b/crates/ghost-consensus/src/mpc_handler.rs
@@ -35,7 +35,7 @@
 //! 2. Contribution is broadcast to network
 //! 3. Current elders verify and vote on contribution
 //! 4. Bootstrap (positions 1-3): genesis node approves alone
-//!    Normal (position 4+): 75% (3/4) of elders must approve
+//!    Normal (position 4+): 67% supermajority of elders must approve
 //! 5. At elder 101, ceremony ossifies permanently
 //!
 //! ## Security Properties
@@ -64,22 +64,21 @@ use crate::message::{
     MpcParametersResponseMessage, MpcVerificationVoteMessage,
 };
 
-/// BFT threshold for MPC contribution approval (75% = 3/4)
-const MPC_BFT_THRESHOLD_PERCENT: u32 = 75;
-
-/// Minimum number of MPC contributors before BFT voting kicks in.
-/// During bootstrap (< 4 contributors), the genesis node can approve alone.
-/// Once 4+ elders exist, 75% (ceil(4*75/100)=3, i.e. 3/4) approval is required.
-/// NOTE: With 3 contributors, ceil(3*75/100)=3 requires unanimous agreement,
-/// which is too fragile (any single node offline blocks new contributions).
-const MPC_BFT_BOOTSTRAP_COUNT: u32 = 4;
+/// BFT threshold + bootstrap count for MPC contribution approval.
+///
+/// SINGLE SOURCE OF TRUTH: these come from `ghost_common::constants` (and are
+/// re-exported by `ghost-mpc`) so the quorum computed here matches every other
+/// node and every other MPC code path exactly. A divergence would split
+/// consensus — one node applying a contribution that another rejects.
+use ghost_common::constants::{MPC_BFT_BOOTSTRAP_COUNT, MPC_BFT_THRESHOLD_PERCENT};
 
 /// Compute BFT threshold for MPC contribution approval.
 ///
 /// During bootstrap (fewer than `MPC_BFT_BOOTSTRAP_COUNT` contributors) the
 /// genesis node can approve alone (threshold = 1).  Once the contributor count
-/// reaches `MPC_BFT_BOOTSTRAP_COUNT` (4), the threshold becomes a 75%
-/// supermajority: `ceil(contributor_count * 75 / 100)`.
+/// reaches `MPC_BFT_BOOTSTRAP_COUNT` (4), the threshold becomes a
+/// `MPC_BFT_THRESHOLD_PERCENT` (67%) supermajority:
+/// `ceil(contributor_count * 67 / 100)`.
 pub(crate) fn bft_threshold(contributor_count: u32) -> u32 {
     if contributor_count < MPC_BFT_BOOTSTRAP_COUNT {
         1
@@ -242,9 +241,16 @@ impl MpcHandler {
     ///
     /// This queries the database directly to ensure we have the latest count,
     /// since contributions can be applied outside this handler (e.g., during startup).
+    ///
+    /// Progression count = the `mpc_ceremony` singleton (authoritative), falling
+    /// back to `COUNT(mpc_contributions)` when the singleton is absent. The
+    /// helper also logs loudly if the two disagree. This is intentionally
+    /// DISTINCT from `mpc_contributor_count()` (raw COUNT), which sizes the
+    /// BFT voter set for `bft_threshold`.
     pub fn contribution_count(&self) -> u32 {
-        // Use database as single source of truth
-        self.mpc_contributor_count()
+        self.db
+            .mpc_contribution_count_authoritative()
+            .unwrap_or_else(|_| self.mpc_contributor_count())
     }
 
     /// Handle an incoming MPC contribution
@@ -805,26 +811,44 @@ mod tests {
 
     #[test]
     fn test_bft_threshold_4_contributors() {
-        // 4 contributors: ceil(4 * 75 / 100) = ceil(300/100) = 3
+        // 4 contributors: ceil(4 * 67 / 100) = ceil(268/100) = 3
         assert_eq!(bft_threshold(4), 3);
     }
 
     #[test]
     fn test_bft_threshold_10_contributors() {
-        // 10 contributors: ceil(10 * 75 / 100) = ceil(750/100) = 8
-        assert_eq!(bft_threshold(10), 8);
+        // 10 contributors: ceil(10 * 67 / 100) = ceil(670/100) = 7
+        assert_eq!(bft_threshold(10), 7);
     }
 
     #[test]
     fn test_bft_threshold_100_contributors() {
-        // 100 contributors: ceil(100 * 75 / 100) = ceil(7500/100) = 75
-        assert_eq!(bft_threshold(100), 75);
+        // 100 contributors: ceil(100 * 67 / 100) = ceil(6700/100) = 67
+        assert_eq!(bft_threshold(100), 67);
     }
 
     #[test]
     fn test_bft_threshold_101_max() {
-        // 101 contributors (max): ceil(101 * 75 / 100) = ceil(7575/100) = 76
-        assert_eq!(bft_threshold(101), 76);
+        // 101 contributors (max): ceil(101 * 67 / 100) = ceil(6767/100) = 68
+        assert_eq!(bft_threshold(101), 68);
+    }
+
+    /// Stage A task 1: the handler's quorum constant is the single shared
+    /// `ghost-common` value (== the `ghost-mpc` re-export), == documented 67%.
+    #[test]
+    fn test_bft_threshold_uses_shared_constant() {
+        assert_eq!(MPC_BFT_THRESHOLD_PERCENT, 67);
+        assert_eq!(MPC_BFT_BOOTSTRAP_COUNT, 4);
+        assert_eq!(
+            MPC_BFT_THRESHOLD_PERCENT,
+            ghost_common::constants::MPC_BFT_THRESHOLD_PERCENT
+        );
+        // The handler and the ghost-mpc library re-export must be identical.
+        assert_eq!(
+            MPC_BFT_THRESHOLD_PERCENT,
+            ghost_mpc::MPC_BFT_THRESHOLD_PERCENT
+        );
+        assert_eq!(MPC_BFT_BOOTSTRAP_COUNT, ghost_mpc::MPC_BFT_BOOTSTRAP_COUNT);
     }
 
     // --- Rate limiter tests ---

--- a/crates/ghost-consensus/src/mpc_handler.rs
+++ b/crates/ghost-consensus/src/mpc_handler.rs
@@ -135,6 +135,7 @@ enum VoteDecision {
 /// re-exported by `ghost-mpc`) so the quorum computed here matches every other
 /// node and every other MPC code path exactly. A divergence would split
 /// consensus — one node applying a contribution that another rejects.
+#[cfg(test)]
 use ghost_common::constants::{MPC_BFT_BOOTSTRAP_COUNT, MPC_BFT_THRESHOLD_PERCENT};
 
 /// Compute BFT threshold for MPC contribution approval.
@@ -145,11 +146,10 @@ use ghost_common::constants::{MPC_BFT_BOOTSTRAP_COUNT, MPC_BFT_THRESHOLD_PERCENT
 /// `MPC_BFT_THRESHOLD_PERCENT` (67%) supermajority:
 /// `ceil(contributor_count * 67 / 100)`.
 pub(crate) fn bft_threshold(contributor_count: u32) -> u32 {
-    if contributor_count < MPC_BFT_BOOTSTRAP_COUNT {
-        1
-    } else {
-        (contributor_count * MPC_BFT_THRESHOLD_PERCENT).div_ceil(100)
-    }
+    // Delegate to the single shared definition so the live voter and the
+    // genesis-anchored retained-quorum check (ghost-storage) apply EXACTLY the
+    // same rule under which a contribution was approved.
+    ghost_common::mpc::mpc_bft_threshold(contributor_count)
 }
 
 /// Rate limiting for MPC messages

--- a/crates/ghost-mpc/Cargo.toml
+++ b/crates/ghost-mpc/Cargo.toml
@@ -9,6 +9,12 @@ license = "MIT"
 default = []
 # Enable for testing without full MPC operations
 test-utils = []
+# TEST-ONLY: shrink MAX_CEREMONY_CONTRIBUTORS so the Stage D regtest lifecycle
+# harness can walk genesis -> contributions -> ossification in seconds. NOT a
+# default feature; never enabled by any shipping crate (ghost-pool / ghost-
+# consensus). The mainnet binary keeps the 101 cap. See crates/ghost-mpc/src/
+# lib.rs MAX_CEREMONY_CONTRIBUTORS and tests/mpc_lifecycle.rs.
+mpc-test-cap = []
 
 [dependencies]
 # ZK proving system (Groth16 via bellperson)
@@ -63,3 +69,6 @@ zeroize = { version = "1.7", features = ["derive"] }
 [dev-dependencies]
 tokio = { version = "1.36", features = ["rt-multi-thread", "macros"] }
 tempfile = "3.10"
+# Stage D lifecycle harness: model the GET /api/v1/mpc/votes/{position} response
+# shape for the autonomous catch-up rehearsal.
+serde_json = "1.0"

--- a/crates/ghost-mpc/src/contribution.rs
+++ b/crates/ghost-mpc/src/contribution.rs
@@ -505,28 +505,78 @@ fn schnorr_prove<R: RngCore + CryptoRng>(
     })
 }
 
-/// Verify a contribution proof
+/// Verify a contribution proof (LIVE path — enforces the ±1h timestamp skew).
 ///
-/// 4.22 SECURITY: ceremony_id is used to verify Schnorr proofs are bound to this ceremony
+/// 4.22 SECURITY: ceremony_id is used to verify Schnorr proofs are bound to this
+/// ceremony. Use this when verifying a contribution that is being proposed RIGHT
+/// NOW (the live voter / single-position incremental adoption): the skew window
+/// rejects stale replayed contributions.
 pub fn verify_contribution(
     prev_params: &Parameters<Bls12>,
     new_params: &Parameters<Bls12>,
     contribution: &MpcContribution,
     ceremony_id: &[u8; 32],
 ) -> MpcResult<bool> {
+    verify_contribution_inner(
+        prev_params,
+        new_params,
+        contribution,
+        ceremony_id,
+        /* enforce_timestamp_skew = */ true,
+    )
+}
+
+/// Verify a contribution proof for HISTORICAL catch-up / lineage re-verification
+/// (does NOT enforce the timestamp skew).
+///
+/// Stage C task 4: the genesis-anchored startup verification and the catch-up
+/// path re-verify contributions that were legitimately approved LONG ago (a node
+/// offline for days, or replaying the full chain at boot). Those contributions'
+/// timestamps are far outside any ±1h window, so the live skew check would
+/// wrongly reject them. The cryptographic guarantees that matter here — the
+/// Schnorr proof bound to `ceremony_id`, the hash chain, and the h/l pairing
+/// transform checks — are IDENTICAL to the live path; only the freshness window
+/// (a replay defence for *live* proposals, irrelevant once a contribution is
+/// already a BFT-approved part of the immutable lineage) is dropped.
+pub fn verify_contribution_lineage(
+    prev_params: &Parameters<Bls12>,
+    new_params: &Parameters<Bls12>,
+    contribution: &MpcContribution,
+    ceremony_id: &[u8; 32],
+) -> MpcResult<bool> {
+    verify_contribution_inner(
+        prev_params,
+        new_params,
+        contribution,
+        ceremony_id,
+        /* enforce_timestamp_skew = */ false,
+    )
+}
+
+/// Shared verification core. `enforce_timestamp_skew` toggles ONLY the ±1h
+/// freshness window; every cryptographic check is unconditional.
+fn verify_contribution_inner(
+    prev_params: &Parameters<Bls12>,
+    new_params: &Parameters<Bls12>,
+    contribution: &MpcContribution,
+    ceremony_id: &[u8; 32],
+    enforce_timestamp_skew: bool,
+) -> MpcResult<bool> {
     // SECURITY: Validate timestamp is within ±1 hour of current time
-    // This prevents replay attacks with old contributions
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0);
-    let timestamp_diff = now.abs_diff(contribution.timestamp);
-    const MAX_TIMESTAMP_SKEW_SECS: u64 = 3600; // 1 hour
-    if timestamp_diff > MAX_TIMESTAMP_SKEW_SECS {
-        return Err(MpcError::InvalidProof(format!(
-            "Contribution timestamp too far from current time: {} seconds",
-            timestamp_diff
-        )));
+    // This prevents replay attacks with old contributions (LIVE path only).
+    if enforce_timestamp_skew {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        let timestamp_diff = now.abs_diff(contribution.timestamp);
+        const MAX_TIMESTAMP_SKEW_SECS: u64 = 3600; // 1 hour
+        if timestamp_diff > MAX_TIMESTAMP_SKEW_SECS {
+            return Err(MpcError::InvalidProof(format!(
+                "Contribution timestamp too far from current time: {} seconds",
+                timestamp_diff
+            )));
+        }
     }
 
     // Verify hash chain

--- a/crates/ghost-mpc/src/lib.rs
+++ b/crates/ghost-mpc/src/lib.rs
@@ -82,5 +82,107 @@ pub const MAX_CEREMONY_CONTRIBUTORS: u32 = 101;
 /// Chunk size for P2P parameter transfer (1MB)
 pub const PARAM_CHUNK_SIZE: usize = 1024 * 1024;
 
-/// BFT threshold for contribution approval (67%)
-pub const MPC_BFT_THRESHOLD_PERCENT: u32 = 67;
+/// BFT threshold for contribution approval (67%).
+///
+/// Re-exported from `ghost-common` so `ghost-mpc` and `ghost-consensus`
+/// (the voter/quorum path) share ONE definition. Changing the quorum on only
+/// one side would split consensus — see `ghost_common::constants`.
+pub use ghost_common::constants::{MPC_BFT_BOOTSTRAP_COUNT, MPC_BFT_THRESHOLD_PERCENT};
+
+/// Cross-check that on-disk parameters match the recorded lineage head.
+///
+/// Stage A task 3: this is the pure decision used at startup before a node may
+/// enter the rolling ceremony. All three arguments are LINEAGE hashes
+/// (`hash_parameters` — structured VK + h + l), NOT raw-file pin hashes.
+///
+/// * `file_lineage` — `hash_parameters()` of the parameters loaded from disk.
+/// * `singleton_head` — `mpc_ceremony.current_params_hash`; `[0u8; 32]` means
+///   "unknown" (pre-backfill / not established) and is not enforced.
+/// * `contribution_head` — `mpc_contributions[MAX].new_params_hash`; `None`
+///   means no head row exists, which is a failure for an advanced ceremony.
+///
+/// Returns `true` only when `file_lineage` matches the contribution head AND
+/// (when known) the singleton head. Fail-closed: any missing/mismatched head
+/// returns `false`.
+pub fn lineage_head_matches(
+    file_lineage: &[u8; 32],
+    singleton_head: &[u8; 32],
+    contribution_head: Option<&[u8; 32]>,
+) -> bool {
+    // The contribution head must be present and must match.
+    match contribution_head {
+        Some(head) if head == file_lineage => {}
+        _ => return false,
+    }
+    // The singleton head, when established (non-zero), must also match.
+    if *singleton_head != [0u8; 32] && singleton_head != file_lineage {
+        return false;
+    }
+    true
+}
+
+#[cfg(test)]
+mod lineage_tests {
+    use super::lineage_head_matches;
+
+    const A: [u8; 32] = [0xAA; 32];
+    const B: [u8; 32] = [0xBB; 32];
+    const ZERO: [u8; 32] = [0u8; 32];
+
+    #[test]
+    fn test_lineage_matches_when_all_agree() {
+        assert!(lineage_head_matches(&A, &A, Some(&A)));
+    }
+
+    #[test]
+    fn test_lineage_matches_when_singleton_unknown() {
+        // Singleton head zero (pre-backfill) is not enforced; contribution head decides.
+        assert!(lineage_head_matches(&A, &ZERO, Some(&A)));
+    }
+
+    #[test]
+    fn test_lineage_rejects_mismatching_file_vs_contribution() {
+        // A mismatching on-disk file is rejected (the plan's "reject a mismatching file").
+        assert!(!lineage_head_matches(&B, &A, Some(&A)));
+    }
+
+    #[test]
+    fn test_lineage_rejects_mismatching_singleton() {
+        assert!(!lineage_head_matches(&A, &B, Some(&A)));
+    }
+
+    #[test]
+    fn test_lineage_rejects_missing_contribution_head() {
+        assert!(!lineage_head_matches(&A, &A, None));
+    }
+}
+
+#[cfg(test)]
+mod threshold_tests {
+    //! Stage A task 1: the MPC BFT threshold must be a single, documented value
+    //! (67%) shared between the `ghost-mpc` library and the `ghost-consensus`
+    //! voter/quorum path. A divergence here would split consensus.
+
+    /// The MPC quorum percentage is exactly the documented 67%.
+    #[test]
+    fn test_mpc_bft_threshold_is_67() {
+        assert_eq!(super::MPC_BFT_THRESHOLD_PERCENT, 67);
+        assert_eq!(super::MPC_BFT_BOOTSTRAP_COUNT, 4);
+    }
+
+    /// `ghost-mpc`'s re-export and the `ghost-common` source of truth agree.
+    /// The `ghost-consensus` handler also sources `bft_threshold()` from this
+    /// same `ghost_common::constants` value (see `mpc_handler::bft_threshold`),
+    /// so all three agree by construction.
+    #[test]
+    fn test_mpc_bft_threshold_single_source() {
+        assert_eq!(
+            super::MPC_BFT_THRESHOLD_PERCENT,
+            ghost_common::constants::MPC_BFT_THRESHOLD_PERCENT
+        );
+        assert_eq!(
+            super::MPC_BFT_BOOTSTRAP_COUNT,
+            ghost_common::constants::MPC_BFT_BOOTSTRAP_COUNT
+        );
+    }
+}

--- a/crates/ghost-mpc/src/lib.rs
+++ b/crates/ghost-mpc/src/lib.rs
@@ -69,7 +69,10 @@ pub mod params;
 pub mod sync;
 
 // Re-export main types
-pub use contribution::{ContributionProof, MpcContribution, MultiContributionResult};
+pub use contribution::{
+    verify_contribution, verify_contribution_lineage, ContributionProof, MpcContribution,
+    MultiContributionResult,
+};
 pub use errors::{MpcError, MpcResult};
 pub use manager::{CeremonyManager, CeremonyState};
 pub use params::{MpcParameters, ParameterFiles};
@@ -98,6 +101,11 @@ pub const PARAM_CHUNK_SIZE: usize = 1024 * 1024;
 /// (the voter/quorum path) share ONE definition. Changing the quorum on only
 /// one side would split consensus — see `ghost_common::constants`.
 pub use ghost_common::constants::{MPC_BFT_BOOTSTRAP_COUNT, MPC_BFT_THRESHOLD_PERCENT};
+
+/// Re-export the single shared BFT-threshold FUNCTION (not just the constants)
+/// so the ghost-mpc library, the ghost-consensus voter, and the ghost-storage
+/// retained-quorum check all compute the required approve-vote count identically.
+pub use ghost_common::mpc::mpc_bft_threshold;
 
 /// Cross-check that on-disk parameters match the recorded lineage head.
 ///

--- a/crates/ghost-mpc/src/lib.rs
+++ b/crates/ghost-mpc/src/lib.rs
@@ -90,7 +90,32 @@ pub type Groth16Params = bellperson::groth16::Parameters<blstrs::Bls12>;
 
 /// Maximum number of elders that contribute to the ceremony.
 /// After this, the ceremony ossifies and parameters are permanent.
+///
+/// CONSENSUS CONSTANT — the mainnet value is 101 and is NOT runtime-tunable.
+/// There is deliberately no environment variable or config knob: a consensus
+/// constant that could be lowered at runtime on a production node would let an
+/// attacker force an early ossification (or change the quorum geometry) on a
+/// single node and split it from the fleet.
+///
+/// The ONLY way to obtain a smaller value is the compile-time `mpc-test-cap`
+/// cargo feature, which exists solely so the regtest lifecycle harness (Stage D)
+/// can walk genesis → contributions → ossification in seconds instead of needing
+/// 101 multi-hundred-megabyte Groth16 contributions. The feature is:
+///   * NOT in `default` features,
+///   * never enabled by `ghost-pool`, `ghost-consensus`, or any shipping crate,
+///   * only ever turned on by an explicit `--features mpc-test-cap` on a targeted
+///     `-p ghost-mpc` test invocation,
+/// so the production build (`cargo build -p ghost-pool --features zk-production`)
+/// and a default `cargo build` both compile this as 101. A compile-time test
+/// (`cap_tests::test_cap_is_mainnet_value_without_feature`) locks the invariant.
+#[cfg(not(feature = "mpc-test-cap"))]
 pub const MAX_CEREMONY_CONTRIBUTORS: u32 = 101;
+
+/// TEST-ONLY ceremony cap (see [`MAX_CEREMONY_CONTRIBUTORS`] docs). Enabled ONLY
+/// under the non-default `mpc-test-cap` cargo feature so the Stage D regtest
+/// lifecycle harness can ossify quickly. NEVER compiled into a shipping binary.
+#[cfg(feature = "mpc-test-cap")]
+pub const MAX_CEREMONY_CONTRIBUTORS: u32 = 4;
 
 /// Chunk size for P2P parameter transfer (1MB)
 pub const PARAM_CHUNK_SIZE: usize = 1024 * 1024;
@@ -202,5 +227,47 @@ mod threshold_tests {
             super::MPC_BFT_BOOTSTRAP_COUNT,
             ghost_common::constants::MPC_BFT_BOOTSTRAP_COUNT
         );
+    }
+}
+
+#[cfg(test)]
+mod cap_tests {
+    //! Stage D: the ceremony cap must be the immutable mainnet value (101) in
+    //! every build that does NOT explicitly opt into the `mpc-test-cap` test
+    //! feature. This locks the invariant that the production binary keeps 101
+    //! and that the small test cap can never leak into a shipping build.
+
+    /// Without `mpc-test-cap`, the cap is exactly the mainnet 101. `cargo test
+    /// -p ghost-mpc` (no `--features`) runs this and fails if the test cap ever
+    /// leaks into the default build.
+    #[cfg(not(feature = "mpc-test-cap"))]
+    #[test]
+    fn test_cap_is_mainnet_value_without_feature() {
+        const {
+            assert!(
+                super::MAX_CEREMONY_CONTRIBUTORS == 101,
+                "MAX_CEREMONY_CONTRIBUTORS must be 101 unless mpc-test-cap is explicitly enabled"
+            )
+        };
+    }
+
+    /// With `mpc-test-cap`, the cap is small enough to ossify a real-crypto
+    /// ceremony in seconds, and is still strictly greater than the BFT bootstrap
+    /// count so the supermajority-vs-bootstrap boundary remains meaningful.
+    #[cfg(feature = "mpc-test-cap")]
+    #[test]
+    fn test_cap_is_small_under_test_feature() {
+        const {
+            assert!(
+                super::MAX_CEREMONY_CONTRIBUTORS < 101,
+                "test cap must be smaller than mainnet"
+            )
+        };
+        const {
+            assert!(
+                super::MAX_CEREMONY_CONTRIBUTORS >= super::MPC_BFT_BOOTSTRAP_COUNT,
+                "test cap should reach at least the bootstrap count"
+            )
+        };
     }
 }

--- a/crates/ghost-mpc/src/lib.rs
+++ b/crates/ghost-mpc/src/lib.rs
@@ -75,6 +75,16 @@ pub use manager::{CeremonyManager, CeremonyState};
 pub use params::{MpcParameters, ParameterFiles};
 pub use sync::ParameterSync;
 
+/// Concrete Groth16 proving-parameter type used throughout the ceremony.
+///
+/// Re-exported as a stable alias so downstream crates (notably
+/// `ghost-consensus`, which wires the BFT voter to real cryptographic
+/// verification) can name and hold the candidate parameters WITHOUT taking a
+/// direct dependency on `bellperson`/`blstrs`. This is exactly the type
+/// accepted by [`CeremonyManager::verify_contribution`] and
+/// [`CeremonyManager::apply_contribution_multi`].
+pub type Groth16Params = bellperson::groth16::Parameters<blstrs::Bls12>;
+
 /// Maximum number of elders that contribute to the ceremony.
 /// After this, the ceremony ossifies and parameters are permanent.
 pub const MAX_CEREMONY_CONTRIBUTORS: u32 = 101;

--- a/crates/ghost-mpc/src/manager.rs
+++ b/crates/ghost-mpc/src/manager.rs
@@ -581,7 +581,7 @@ impl CeremonyManager {
     /// chain or adopts an already-BFT-approved historical contribution, the
     /// live ±1h freshness window would wrongly reject it. This runs the SAME
     /// cryptographic checks (Schnorr proof bound to `ceremony_id`, hash chain,
-    /// h/l pairing transform) via [`verify_contribution_lineage`], omitting only
+    /// h/l pairing transform) via [`crate::contribution::verify_contribution_lineage`], omitting only
     /// the freshness window. Unlike [`Self::verify_contribution`] it does NOT
     /// require `contribution.position == count+1`, because catch-up validates a
     /// position relative to a supplied `prev` rather than the live head.

--- a/crates/ghost-mpc/src/manager.rs
+++ b/crates/ghost-mpc/src/manager.rs
@@ -575,6 +575,31 @@ impl CeremonyManager {
         )
     }
 
+    /// Verify a HISTORICAL contribution during catch-up (no timestamp skew).
+    ///
+    /// Stage C task 4: when a node that was offline for days re-verifies the
+    /// chain or adopts an already-BFT-approved historical contribution, the
+    /// live ±1h freshness window would wrongly reject it. This runs the SAME
+    /// cryptographic checks (Schnorr proof bound to `ceremony_id`, hash chain,
+    /// h/l pairing transform) via [`verify_contribution_lineage`], omitting only
+    /// the freshness window. Unlike [`Self::verify_contribution`] it does NOT
+    /// require `contribution.position == count+1`, because catch-up validates a
+    /// position relative to a supplied `prev` rather than the live head.
+    pub fn verify_contribution_catchup(
+        &self,
+        prev_params: &Parameters<Bls12>,
+        new_params: &Parameters<Bls12>,
+        contribution: &MpcContribution,
+    ) -> MpcResult<bool> {
+        let ceremony_id = self.state.read().ceremony_id;
+        crate::contribution::verify_contribution_lineage(
+            prev_params,
+            new_params,
+            contribution,
+            &ceremony_id,
+        )
+    }
+
     /// Apply a contribution after BFT approval
     ///
     /// This updates the ceremony state and hot-swaps the parameters.
@@ -1354,6 +1379,44 @@ mod tests {
             err.contains("commitment") || err.contains("not found"),
             "Error should mention commitment mismatch, got: {}",
             err
+        );
+    }
+
+    /// Stage C task 4: a contribution with a far-past timestamp (beyond the ±1h
+    /// live skew window) is REJECTED by the live verify but ACCEPTED by the
+    /// catch-up/lineage verify — every cryptographic check still passes, only the
+    /// freshness window is dropped.
+    #[test]
+    fn test_catchup_verify_accepts_old_timestamp_live_rejects() {
+        let (manager, _temp) = create_test_manager();
+        manager.ensure_genesis_initialized().unwrap();
+
+        // Capture genesis (the prev) before generating the contribution.
+        let genesis = manager.note_spend_params().unwrap();
+
+        let (new_params, mut contribution) = manager.generate_contribution("node1").unwrap();
+        // Backdate well beyond the ±1h skew window (2 days ago).
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        contribution.timestamp = now - 2 * 24 * 3600;
+
+        // Live verify must reject on the skew window.
+        let live = manager.verify_contribution(&new_params, &contribution);
+        assert!(
+            live.is_err(),
+            "live verify must reject a far-past timestamp (skew window)"
+        );
+        assert!(live.unwrap_err().to_string().contains("timestamp"));
+
+        // Catch-up/lineage verify must ACCEPT — crypto is identical, no skew.
+        let caught_up = manager
+            .verify_contribution_catchup(genesis.as_ref(), &new_params, &contribution)
+            .expect("catch-up verify must not error on an old but valid contribution");
+        assert!(
+            caught_up,
+            "catch-up verify must accept an old but cryptographically valid contribution"
         );
     }
 

--- a/crates/ghost-mpc/src/manager.rs
+++ b/crates/ghost-mpc/src/manager.rs
@@ -873,6 +873,11 @@ impl CeremonyManager {
 
         state.current_params_hash = params_hash;
         state.updated_at = now;
+        // 4.22 SECURITY: the ceremony_id is the stable, genesis-derived constant
+        // that all Schnorr proofs bind to. It equals the genesis parameters hash,
+        // which is exactly what position-1's `prev_params_hash` will be — so it
+        // stays identical fleet-wide for the life of the ceremony.
+        state.ceremony_id = params_hash;
 
         info!(
             params_hash = %hex::encode(params_hash),
@@ -941,6 +946,10 @@ impl CeremonyManager {
 
         state.current_params_hash = params_hash;
         state.updated_at = now;
+        // 4.22 SECURITY: stable genesis-derived ceremony_id (= genesis params
+        // hash = position-1 prev_params_hash). Identical fleet-wide; Schnorr
+        // proofs bind to it. See `initialize_genesis` for the rationale.
+        state.ceremony_id = params_hash;
 
         info!(
             params_hash = %hex::encode(params_hash),

--- a/crates/ghost-mpc/src/params.rs
+++ b/crates/ghost-mpc/src/params.rs
@@ -248,6 +248,17 @@ pub fn load_parameters(path: &Path) -> MpcResult<Parameters<Bls12>> {
     Ok(params)
 }
 
+/// Parse Groth16 parameters directly from an in-memory byte buffer.
+///
+/// Used by the BFT voter to verify a fetched candidate parameter set WITHOUT
+/// writing hundreds of megabytes to disk (verification is read-only; only the
+/// post-approval apply persists parameters). Mirrors [`load_parameters`]'s
+/// decoding (`checked = false`).
+pub fn read_parameters_from_bytes(bytes: &[u8]) -> MpcResult<Parameters<Bls12>> {
+    Parameters::read(std::io::Cursor::new(bytes), false)
+        .map_err(|e| MpcError::InvalidParams(e.to_string()))
+}
+
 /// Save a verifying key to a file
 ///
 /// S-5 SECURITY: Uses atomic write (temp file + rename) to prevent corruption.

--- a/crates/ghost-mpc/tests/mpc_lifecycle.rs
+++ b/crates/ghost-mpc/tests/mpc_lifecycle.rs
@@ -1,0 +1,1043 @@
+//|======================================================================================================================|
+//| PROJECT: Bitcoin Ghost                                                                                               |
+//| FILE: mpc_lifecycle.rs                                                                                               |
+//|======================================================================================================================|
+
+//! Stage D — regtest MPC rolling-ceremony lifecycle harness.
+//!
+//! This is the MANDATORY GATE before the mainnet un-pin of the resumed MPC
+//! rolling ceremony (`tasks/plan_mpc_rolling_resume.md`, Stage 5). It walks the
+//! full ceremony lifecycle against the SAME machinery the mainnet binary runs:
+//!
+//!   * real `ghost_mpc::CeremonyManager` with real Groth16 parameters (genesis +
+//!     each contribution is a genuine phase-2 transform),
+//!   * the real Schnorr + h/l pairing `verify_contribution` gate,
+//!   * the real `apply_contribution_multi` (disk write + symlink + hot-swap +
+//!     ossify) param swap,
+//!   * the real genesis-anchored lineage + retained-BFT-quorum startup verifier
+//!     (`Database::verify_mpc_genesis_anchored_lineage`, Stage C),
+//!   * real `ghost_common::identity` elder signatures over the real
+//!     `ghost_common::mpc::contribution_hash` / `vote_signing_message`,
+//!   * the real `ghost_zkp::select_startup_mode` un-pin selection.
+//!
+//! # Where this lives, and why (cap injection)
+//!
+//! The harness is a `ghost-mpc` integration test rather than a member of the
+//! live cluster-chaos suite (`tests/cluster_chaos_mod/`, which drives the real
+//! 4-node signet VMs over SSH/HTTP and cannot run here) precisely so the small
+//! ceremony cap can be injected with ZERO mainnet-reachability risk. The cap is
+//! the compile-time `mpc-test-cap` cargo feature on `ghost-mpc`
+//! (`MAX_CEREMONY_CONTRIBUTORS` = 4 instead of 101). Because the feature is not
+//! a default feature and is enabled ONLY by an explicit
+//! `--features mpc-test-cap` on a targeted `-p ghost-mpc` test run, it can never
+//! be unified into the production `ghost-pool` build, and there is no env var or
+//! runtime knob (a consensus constant must not be runtime-tunable). See
+//! `MAX_CEREMONY_CONTRIBUTORS` in `crates/ghost-mpc/src/lib.rs`.
+//!
+//! # How to run
+//!
+//! ```text
+//! # The full harness (real-crypto path included) — release for speed:
+//! cargo test -p ghost-mpc --release --features mpc-test-cap --test mpc_lifecycle -- --nocapture
+//!
+//! # The cheap pure-function / DB assertions alone (debug is fine):
+//! cargo test -p ghost-mpc --features mpc-test-cap --test mpc_lifecycle \
+//!     supermajority unpin catchup forged_old_structural -- --nocapture
+//! ```
+//!
+//! # Coverage map (each is a Stage-5 gate)
+//!
+//! | # | Assertion                                   | Level proven here                          |
+//! |---|---------------------------------------------|--------------------------------------------|
+//! | 1 | Genesis init, stable identical ceremony_id  | node-level (real managers) + DB            |
+//! | 2 | BFT-approved contributions converge + quorum| node-level convergence + DB retained quorum|
+//! | 3 | Hash evolves; restart re-validates, rejoins | node-level (real reload from disk)         |
+//! | 4 | Forged contribution REJECTED (hole closed)  | node-level real verify + pure no-forge     |
+//! | 5 | Ossify at cap; further contribution refused | node-level (real ossify)                   |
+//! | 6 | Post-ossification fresh node verify + can't | node-level (real reload) + DB lineage      |
+//! | 7 | Un-pin / catch-up rehearsal                  | env mode-flip + DB catch-up via vote shape |
+//!
+//! The ≥67% SUPERMAJORITY retained-quorum geometry is exercised at the
+//! pure-function / DB level (`supermajority_retained_quorum_db`) with a 6-position
+//! chain and real elder signatures: with the real-crypto cap of 4 every position
+//! sits in the BFT *bootstrap* regime (threshold = 1), so the supermajority math
+//! (`ceil(count * 67 / 100)`) is only reachable with ≥4 eligible voters, i.e.
+//! position ≥5. This split is the harness's deliberate, documented choice (the
+//! Stage-5 fallback): the node-level flow runs at whatever cap is feasible for
+//! real Groth16, and the supermajority assertion is proven on the pure verifier.
+
+use ghost_common::identity::NodeIdentity;
+use ghost_common::mpc::{contribution_hash, mpc_bft_threshold, vote_signing_message};
+use ghost_mpc::contribution::hash_parameters;
+use ghost_mpc::{CeremonyManager, Groth16Params, MpcError, MAX_CEREMONY_CONTRIBUTORS};
+use ghost_storage::queries::{MpcCeremonyState, MpcContributionRecord, MpcVerificationVote};
+use ghost_storage::Database;
+use tempfile::TempDir;
+
+// ============================================================================
+// Shared helpers
+// ============================================================================
+
+/// Generate one fresh set of genesis Groth16 parameters (the three ceremony
+/// circuits), mirroring `CeremonyManager::ensure_genesis_initialized`. Generated
+/// ONCE per harness run and cloned into every simulated node so they all share
+/// an identical genesis (as a real fleet does: node 1 generates, the rest fetch).
+fn generate_genesis_params() -> (Groth16Params, Groth16Params, Groth16Params) {
+    use bellperson::groth16::generate_random_parameters;
+    use blstrs::{Bls12, Scalar as Fr};
+    use ghost_zkp::circuit::{GhostNoteSpendCircuit, GhostUnshieldCircuit, NoteConsolidateCircuit};
+    use rand::rngs::OsRng;
+
+    let note = generate_random_parameters::<Bls12, _, _>(
+        GhostNoteSpendCircuit::<Fr>::dummy(20),
+        &mut OsRng,
+    )
+    .expect("genesis note-spend params");
+    let consolidate = generate_random_parameters::<Bls12, _, _>(
+        NoteConsolidateCircuit::<Fr>::dummy(20),
+        &mut OsRng,
+    )
+    .expect("genesis consolidation params");
+    let unshield = generate_random_parameters::<Bls12, _, _>(
+        GhostUnshieldCircuit::<Fr>::dummy(20),
+        &mut OsRng,
+    )
+    .expect("genesis unshield params");
+    (note, consolidate, unshield)
+}
+
+/// A simulated node: a real ceremony manager over its own params dir, plus its
+/// own database (the lightweight contribution-row + vote ledger it retains).
+struct Node {
+    manager: CeremonyManager,
+    db: Database,
+    _dir: TempDir,
+}
+
+impl Node {
+    /// Stand up a node sharing the supplied genesis params, persist the genesis
+    /// singleton, and return it ready at contribution_count 0.
+    fn genesis(
+        note: &Groth16Params,
+        consolidate: &Groth16Params,
+        unshield: &Groth16Params,
+    ) -> Self {
+        let dir = TempDir::new().unwrap();
+        let manager = CeremonyManager::new(dir.path().to_path_buf());
+        manager
+            .initialize_genesis_multi(note.clone(), consolidate.clone(), unshield.clone())
+            .expect("genesis init");
+        let db = Database::in_memory().unwrap();
+        // Persist the genesis singleton (contribution_count 0, head = anchor).
+        let st = manager.state();
+        db.save_mpc_ceremony_state(&MpcCeremonyState {
+            contribution_count: 0,
+            current_params_hash: st.current_params_hash,
+            is_ossified: false,
+            ossified_at: None,
+            block_vk_hash: None,
+            payout_vk_hash: None,
+            updated_at: st.updated_at,
+            ceremony_id: st.ceremony_id,
+        })
+        .unwrap();
+        Self {
+            manager,
+            db,
+            _dir: dir,
+        }
+    }
+}
+
+/// Persist the `mpc_ceremony` singleton from a manager's authoritative state —
+/// exactly what the production `persist_singleton` does after an apply.
+fn persist_singleton_from_manager(db: &Database, manager: &CeremonyManager) {
+    let st = manager.state();
+    db.save_mpc_ceremony_state(&MpcCeremonyState {
+        contribution_count: st.contribution_count,
+        current_params_hash: st.current_params_hash,
+        is_ossified: st.is_ossified,
+        ossified_at: st.ossified_at,
+        block_vk_hash: st.note_spend_vk_hash,
+        payout_vk_hash: st.payout_vk_hash,
+        updated_at: st.updated_at,
+        ceremony_id: st.ceremony_id,
+    })
+    .unwrap();
+}
+
+/// Persist a contribution row + the retained approve votes for `position` from
+/// the then-eligible elder set (contributors at positions `1..position`). Mirrors
+/// what a node records after BFT approval, and is exactly the data the
+/// genesis-anchored startup verifier re-checks.
+#[allow(clippy::too_many_arguments)]
+fn record_contribution_and_votes(
+    db: &Database,
+    position: u32,
+    contributor: &NodeIdentity,
+    electorate: &[&NodeIdentity],
+    prev_hash: [u8; 32],
+    new_hash: [u8; 32],
+    proof: Vec<u8>,
+    now: u64,
+) {
+    db.save_mpc_contribution(&MpcContributionRecord {
+        elder_position: position,
+        contributor_node_id: hex::encode(contributor.node_id()),
+        prev_params_hash: prev_hash,
+        new_params_hash: new_hash,
+        contribution_proof: proof,
+        epoch: 0,
+        created_at: now,
+    })
+    .unwrap();
+
+    // Every then-eligible elder approves (full participation). The signed bytes
+    // are byte-identical to what the live voter signs and what the startup
+    // verifier re-derives.
+    let ch = contribution_hash(&contributor.node_id(), position, &new_hash);
+    let approve_msg = vote_signing_message(&ch, true);
+    for elder in electorate {
+        db.save_mpc_vote(&MpcVerificationVote {
+            contribution_position: position,
+            voter_node_id: hex::encode(elder.node_id()),
+            approve: true,
+            signature: elder.sign(&approve_msg).to_vec(),
+            voted_at: now,
+        })
+        .unwrap();
+    }
+}
+
+/// The OLD structural-only pre-check (`mpc_handler::structural_precheck`), which
+/// Stage 1a proved insufficient. Replicated here (for position-1 / no-predecessor
+/// inputs) so assertion 4 can demonstrate that a forged contribution which the
+/// real cryptographic gate REJECTS would have sailed through the old gate. The
+/// chain-link branch is omitted because the forged input under test is position 1
+/// (genesis has no predecessor), exactly where the old check returned `true`.
+fn old_structural_precheck_genesis(
+    proof: &[u8],
+    prev_params_hash: &[u8; 32],
+    new_params_hash: &[u8; 32],
+) -> bool {
+    !proof.is_empty()
+        && *prev_params_hash != [0u8; 32]
+        && *new_params_hash != [0u8; 32]
+        && prev_params_hash != new_params_hash
+}
+
+fn now_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+// ============================================================================
+// (A) NODE-LEVEL REAL-CRYPTO LIFECYCLE — assertions 1,2,3,4,5,6
+// ============================================================================
+
+/// Drives the real ceremony end to end on TWO simulated nodes that share one
+/// genesis: forged-rejection probe → genesis → BFT-approved contributions (with
+/// per-node convergence + lineage + strictly-evolving hashes + retained quorum)
+/// → mid-ceremony restart/revalidate → ossify at the cap → post-ossification
+/// fresh node. One genesis is generated and reused so the whole real-crypto path
+/// stays within a couple of minutes in release.
+#[test]
+fn realcrypto_lifecycle() {
+    let cap = MAX_CEREMONY_CONTRIBUTORS;
+    assert!(
+        cap <= 8,
+        "this harness must run under --features mpc-test-cap (small cap); got {cap}"
+    );
+
+    let (g_note, g_consolidate, g_unshield) = generate_genesis_params();
+
+    // Two nodes from one genesis (a real fleet: node 1 generates, peers fetch).
+    let node_a = Node::genesis(&g_note, &g_consolidate, &g_unshield);
+    let mut node_b = Node::genesis(&g_note, &g_consolidate, &g_unshield);
+
+    // ---- Assertion 1: genesis init; stable, fleet-identical ceremony_id -------
+    let anchor = node_a.manager.current_params_hash();
+    assert_ne!(anchor, [0u8; 32], "genesis params hash must be non-zero");
+    assert_eq!(
+        node_a.manager.contribution_count(),
+        0,
+        "genesis node starts at contribution_count 0"
+    );
+    assert_eq!(
+        node_a.manager.state().ceremony_id,
+        anchor,
+        "ceremony_id must equal the genesis lineage hash (= position-1 prev)"
+    );
+    assert_eq!(
+        node_b.manager.current_params_hash(),
+        anchor,
+        "both nodes share an identical genesis head"
+    );
+    assert_eq!(
+        node_a.manager.state().ceremony_id,
+        node_b.manager.state().ceremony_id,
+        "ceremony_id is identical across nodes"
+    );
+    // Genesis singleton row exists on both, identical ceremony_id.
+    let sa = node_a.db.get_mpc_ceremony_state().unwrap().unwrap();
+    let sb = node_b.db.get_mpc_ceremony_state().unwrap().unwrap();
+    assert_eq!(sa.contribution_count, 0);
+    assert_eq!(sa.ceremony_id, sb.ceremony_id);
+    assert_eq!(sa.ceremony_id, anchor);
+    // Genesis-anchored verify of a fresh node holding only genesis params: the
+    // empty chain with head == anchor is trivially valid.
+    assert_eq!(
+        node_a
+            .db
+            .verify_mpc_genesis_anchored_lineage(&anchor, Some(&anchor))
+            .unwrap(),
+        0,
+        "a genesis-only node verifies against the anchor with an empty chain"
+    );
+
+    // ---- Assertion 4 (node level): forged contribution REJECTED ---------------
+    // A position-1 candidate with a TAMPERED Schnorr proof. Parameters + all
+    // hashes are untouched, so it is structurally perfect — only the real
+    // cryptographic gate can catch it. This is a read-only probe; the managers
+    // remain at count 0 for the real run below.
+    {
+        let candidate = NodeIdentity::generate();
+        let (forged_params, mut forged) = node_a
+            .manager
+            .generate_contribution(&hex::encode(candidate.node_id()))
+            .unwrap();
+        assert_eq!(forged.position, 1);
+        // Tamper only the low byte of the tau Schnorr response (stays a valid scalar).
+        forged.proof.tau_pok.response[0] ^= 0x01;
+
+        // PROOF the hole is closed: the OLD structural-only check would have
+        // approved this forged contribution.
+        assert!(
+            old_structural_precheck_genesis(
+                &serde_json::to_vec(&forged.proof).unwrap(),
+                &forged.prev_params_hash,
+                &forged.new_params_hash,
+            ),
+            "old structural-only pre-check WOULD have passed the forged contribution"
+        );
+
+        // The real gate REJECTS on BOTH nodes (Schnorr verification fails).
+        assert!(
+            node_a
+                .manager
+                .verify_contribution(&forged_params, &forged)
+                .is_err(),
+            "node A's real verify must reject the tampered proof"
+        );
+        assert!(
+            node_b
+                .manager
+                .verify_contribution(&forged_params, &forged)
+                .is_err(),
+            "node B's real verify must reject the tampered proof"
+        );
+
+        // Never applied: both nodes still at the genesis head, count 0.
+        assert_eq!(node_a.manager.contribution_count(), 0);
+        assert_eq!(node_b.manager.contribution_count(), 0);
+        assert_eq!(node_a.manager.current_params_hash(), anchor);
+        assert_eq!(node_b.manager.current_params_hash(), anchor);
+    }
+
+    // ---- Assertions 2 + 3: BFT-approved contributions, convergence, restart ---
+    // A distinct elder identity per position (index 1..=cap); index 0 unused.
+    let mut elders: Vec<NodeIdentity> = Vec::with_capacity(cap as usize + 1);
+    elders.push(NodeIdentity::generate()); // slot 0, unused
+    for _ in 1..=cap {
+        elders.push(NodeIdentity::generate());
+    }
+
+    let mut prev_head = anchor;
+    let mut hashes_seen = std::collections::HashSet::new();
+    hashes_seen.insert(anchor);
+
+    for p in 1..=cap {
+        let contributor = &elders[p as usize];
+        let (new_params, contribution) = node_a
+            .manager
+            .generate_contribution(&hex::encode(contributor.node_id()))
+            .unwrap();
+
+        assert_eq!(contribution.position, p, "positions are sequential");
+        assert_eq!(
+            contribution.prev_params_hash, prev_head,
+            "prev_params_hash chains from the previous head (lineage)"
+        );
+        // Hash strictly evolves and is never repeated.
+        assert_ne!(
+            contribution.new_params_hash, prev_head,
+            "each contribution must change the params hash"
+        );
+        assert!(
+            hashes_seen.insert(contribution.new_params_hash),
+            "every position's new hash is strictly new"
+        );
+
+        // BOTH nodes cryptographically verify (Schnorr + h/l pairing) BEFORE applying.
+        assert!(
+            node_a
+                .manager
+                .verify_contribution(&new_params, &contribution)
+                .unwrap(),
+            "node A verifies the contribution"
+        );
+        assert!(
+            node_b
+                .manager
+                .verify_contribution(&new_params, &contribution)
+                .unwrap(),
+            "node B verifies the contribution"
+        );
+
+        // Apply on both nodes (disk write + symlink + hot-swap + ossify check).
+        node_a
+            .manager
+            .apply_contribution(new_params.clone(), &contribution)
+            .unwrap();
+        node_b
+            .manager
+            .apply_contribution(new_params, &contribution)
+            .unwrap();
+
+        // Convergence: the new current_params_hash == new_params_hash on EVERY node.
+        assert_eq!(
+            node_a.manager.current_params_hash(),
+            contribution.new_params_hash,
+            "node A head == new_params_hash"
+        );
+        assert_eq!(
+            node_b.manager.current_params_hash(),
+            contribution.new_params_hash,
+            "node B head == new_params_hash"
+        );
+        assert_eq!(node_a.manager.contribution_count(), p);
+        assert_eq!(node_b.manager.contribution_count(), p);
+
+        // On-disk head really equals the recorded lineage head on every node.
+        assert_eq!(
+            hash_parameters(&node_a.manager.note_spend_params().unwrap()).unwrap(),
+            contribution.new_params_hash,
+            "node A on-disk params hash == singleton head"
+        );
+
+        // Record the row + retained approve votes (electorate = positions 1..p-1).
+        let electorate: Vec<&NodeIdentity> = (1..p).map(|i| &elders[i as usize]).collect();
+        let proof = serde_json::to_vec(&contribution.proof).unwrap();
+        assert!(!proof.is_empty(), "the contribution proof is retained");
+        for db in [&node_a.db, &node_b.db] {
+            record_contribution_and_votes(
+                db,
+                p,
+                contributor,
+                &electorate,
+                contribution.prev_params_hash,
+                contribution.new_params_hash,
+                proof.clone(),
+                now_secs(),
+            );
+        }
+        // Persist the singleton from the manager's authoritative state on both.
+        persist_singleton_from_manager(&node_a.db, &node_a.manager);
+        persist_singleton_from_manager(&node_b.db, &node_b.manager);
+
+        // A ≥ threshold quorum of approve votes is recorded for this position.
+        // Position 1 (the genesis contribution) has NO electorate — it is trusted
+        // solely via the immutable genesis anchor (exactly as the genesis-anchored
+        // verifier treats it: the quorum check runs only for positions >= 2). Every
+        // later position must carry a >= threshold(electorate) approve quorum.
+        let (approvals, rejections) = node_a.db.count_mpc_approvals(p).unwrap();
+        assert_eq!(rejections, 0, "no reject votes for an honest contribution");
+        if p == 1 {
+            assert_eq!(
+                approvals, 0,
+                "the genesis contribution has no electorate (anchor-trusted)"
+            );
+        } else {
+            let required = mpc_bft_threshold(p - 1);
+            assert!(
+                approvals >= required,
+                "position {p}: {approvals} approvals must meet the threshold {required}"
+            );
+        }
+
+        prev_head = contribution.new_params_hash;
+
+        // ---- Assertion 3: restart node B mid-ceremony, re-validate, rejoin ----
+        if p == cap / 2 && cap >= 2 {
+            let dir = node_b._dir.path().to_path_buf();
+            let head_at_restart = node_b.manager.current_params_hash();
+            // Reconstruct the state the node would load from its DB singleton.
+            let restored_state = ghost_mpc::CeremonyState {
+                contribution_count: p,
+                current_params_hash: head_at_restart,
+                ceremony_id: anchor,
+                ..Default::default()
+            };
+            let reloaded =
+                CeremonyManager::load_or_init(dir, Some(restored_state)).expect("node B restart");
+            // It reloaded the real params from disk and they match the head.
+            assert!(reloaded.has_current_params(), "restart reloads params");
+            assert_eq!(reloaded.current_params_hash(), head_at_restart);
+            assert_eq!(
+                hash_parameters(&reloaded.note_spend_params().unwrap()).unwrap(),
+                head_at_restart,
+                "on-disk params survive a restart and match the head"
+            );
+            // It re-validates via the genesis-anchored startup path.
+            assert_eq!(
+                node_b
+                    .db
+                    .verify_mpc_genesis_anchored_lineage(&anchor, Some(&head_at_restart))
+                    .unwrap(),
+                p,
+                "restarted node B re-validates the chain via the genesis anchor"
+            );
+            // Swap the reloaded manager in so it rejoins and keeps contributing.
+            node_b.manager = reloaded;
+        }
+    }
+
+    let final_head = prev_head;
+
+    // ---- Assertion 5: ossification at the cap -------------------------------
+    assert!(
+        node_a.manager.is_ossified(),
+        "node A ossifies at the cap ({cap})"
+    );
+    assert!(
+        node_b.manager.is_ossified(),
+        "node B ossifies at the cap ({cap})"
+    );
+    assert!(
+        node_a
+            .db
+            .get_mpc_ceremony_state()
+            .unwrap()
+            .unwrap()
+            .is_ossified,
+        "node A singleton persists is_ossified=1"
+    );
+    assert!(
+        node_b
+            .db
+            .get_mpc_ceremony_state()
+            .unwrap()
+            .unwrap()
+            .is_ossified,
+        "node B singleton persists is_ossified=1"
+    );
+    // A further contribution attempt is refused with CeremonyOssified.
+    let late = node_a.manager.generate_contribution("late-comer");
+    assert!(
+        matches!(late.as_ref().err(), Some(MpcError::CeremonyOssified(_))),
+        "a post-cap contribution must be rejected with CeremonyOssified, got is_err={}",
+        late.is_err()
+    );
+
+    // Full chain (with retained quorum at every position) verifies on both nodes.
+    assert_eq!(
+        node_a
+            .db
+            .verify_mpc_genesis_anchored_lineage(&anchor, Some(&final_head))
+            .unwrap(),
+        cap
+    );
+    assert_eq!(
+        node_b
+            .db
+            .verify_mpc_genesis_anchored_lineage(&anchor, Some(&final_head))
+            .unwrap(),
+        cap,
+        "node B (which restarted mid-ceremony) verifies the FULL ossified chain"
+    );
+
+    // ---- Assertion 6: post-ossification fresh node --------------------------
+    // A brand-new node fetches the final params (it loads them from disk here,
+    // standing in for the network fetch) + the lightweight chain rows, verifies
+    // via the lineage path, reports ossified, can serve, and CANNOT contribute.
+    {
+        let fresh_state = ghost_mpc::CeremonyState {
+            contribution_count: cap,
+            current_params_hash: final_head,
+            is_ossified: true,
+            ceremony_id: anchor,
+            ..Default::default()
+        };
+        // Reuse node A's on-disk params dir as the "fetched" final params.
+        let fresh =
+            CeremonyManager::load_or_init(node_a.manager.params_dir().clone(), Some(fresh_state))
+                .expect("fresh node load");
+        assert!(fresh.is_ossified(), "fresh node reports ossified");
+        assert!(fresh.has_current_params(), "fresh node can serve params");
+        let fetched_head = hash_parameters(&fresh.note_spend_params().unwrap()).unwrap();
+        assert_eq!(
+            fetched_head, final_head,
+            "fresh node really holds the final ossified params"
+        );
+        // It verifies the fetched params against the recorded lineage (node A's DB
+        // = the ledger it synced).
+        assert_eq!(
+            node_a
+                .db
+                .verify_mpc_genesis_anchored_lineage(&anchor, Some(&fetched_head))
+                .unwrap(),
+            cap,
+            "fresh node verifies the final params via the genesis-anchored lineage"
+        );
+        // It CANNOT contribute.
+        let attempt = fresh.generate_contribution("johnny-come-lately");
+        assert!(
+            matches!(attempt.as_ref().err(), Some(MpcError::CeremonyOssified(_))),
+            "fresh post-ossification node must not be able to contribute, got is_err={}",
+            attempt.is_err()
+        );
+    }
+}
+
+// ============================================================================
+// (B) ≥67% SUPERMAJORITY retained quorum — pure verifier + DB
+// ============================================================================
+
+/// Builds a 6-position chain (synthetic lineage hashes, but REAL elder
+/// signatures) and drives it through `Database::verify_mpc_genesis_anchored_
+/// lineage` so the genuine ≥67% supermajority threshold is exercised — at
+/// position 6 the electorate is the 5 prior elders and the threshold is
+/// `ceil(5 * 67 / 100) = 4`. (Under the real-crypto cap of 4 every position is in
+/// the bootstrap regime, so this is where the supermajority math is proven.)
+#[test]
+fn supermajority_retained_quorum_db() {
+    let anchor = [0xC9u8; 32];
+    let n: u32 = 6;
+
+    // Sanity: position 6 must actually be in the supermajority regime.
+    assert_eq!(mpc_bft_threshold(5), 4, "position 6 needs a 4-of-5 quorum");
+
+    let db = Database::in_memory().unwrap();
+    let elders: Vec<NodeIdentity> = (0..=n).map(|_| NodeIdentity::generate()).collect();
+
+    let tag = |p: u32| -> [u8; 32] {
+        let mut a = [0u8; 32];
+        a[0] = p as u8;
+        a[1] = 0xAB;
+        a
+    };
+
+    let mut prev = anchor;
+    for p in 1..=n {
+        let new = tag(p);
+        let electorate: Vec<&NodeIdentity> = (1..p).map(|i| &elders[i as usize]).collect();
+        record_contribution_and_votes(
+            &db,
+            p,
+            &elders[p as usize],
+            &electorate,
+            prev,
+            new,
+            vec![1, 2, 3],
+            1_000,
+        );
+        prev = new;
+    }
+    let head = tag(n);
+
+    // Full 4-of-5 (and below) quorum at every position → verifies.
+    assert_eq!(
+        db.verify_mpc_genesis_anchored_lineage(&anchor, Some(&head))
+            .unwrap(),
+        n,
+        "a fully-signed supermajority chain verifies"
+    );
+
+    // Boundary: dropping ONE of position 6's five signers leaves exactly 4 == the
+    // threshold → still verifies.
+    {
+        let db4 = Database::in_memory().unwrap();
+        let mut prev = anchor;
+        for p in 1..=n {
+            let new = tag(p);
+            // At position 6 drop one elder (elders[1]); elsewhere full participation.
+            let electorate: Vec<&NodeIdentity> = (1..p)
+                .filter(|&i| !(p == n && i == 1))
+                .map(|i| &elders[i as usize])
+                .collect();
+            record_contribution_and_votes(
+                &db4,
+                p,
+                &elders[p as usize],
+                &electorate,
+                prev,
+                new,
+                vec![9],
+                1_000,
+            );
+            prev = new;
+        }
+        assert_eq!(
+            db4.verify_mpc_genesis_anchored_lineage(&anchor, Some(&head))
+                .unwrap(),
+            n,
+            "exactly meeting the 4-of-5 threshold still verifies"
+        );
+    }
+
+    // Below threshold: dropping TWO of position 6's signers leaves 3 < 4 → reject.
+    {
+        let db3 = Database::in_memory().unwrap();
+        let mut prev = anchor;
+        for p in 1..=n {
+            let new = tag(p);
+            let electorate: Vec<&NodeIdentity> = (1..p)
+                .filter(|&i| !(p == n && (i == 1 || i == 2)))
+                .map(|i| &elders[i as usize])
+                .collect();
+            record_contribution_and_votes(
+                &db3,
+                p,
+                &elders[p as usize],
+                &electorate,
+                prev,
+                new,
+                vec![9],
+                1_000,
+            );
+            prev = new;
+        }
+        let res = db3.verify_mpc_genesis_anchored_lineage(&anchor, Some(&head));
+        assert!(
+            res.is_err(),
+            "3-of-5 (below the 4 supermajority) must fail closed, got {res:?}"
+        );
+    }
+}
+
+// ============================================================================
+// (C) Forged head cannot be laundered through the lineage (no-forge, DB level)
+// ============================================================================
+
+/// A forged head that chains structurally (valid prev link) but lacks a quorum
+/// of valid signatures is rejected by the genesis-anchored verifier — proving
+/// that hash/lineage continuity is never sufficient on its own at the DB layer.
+#[test]
+fn forged_head_without_quorum_rejected_db() {
+    let anchor = [0xC9u8; 32];
+    let db = Database::in_memory().unwrap();
+    let elders: Vec<NodeIdentity> = (0..=5).map(|_| NodeIdentity::generate()).collect();
+    let tag = |p: u32| {
+        let mut a = [0u8; 32];
+        a[0] = p as u8;
+        a[1] = 0xCD;
+        a
+    };
+
+    // Positions 1..4 fully signed.
+    let mut prev = anchor;
+    for p in 1..=4u32 {
+        let new = tag(p);
+        let electorate: Vec<&NodeIdentity> = (1..p).map(|i| &elders[i as usize]).collect();
+        record_contribution_and_votes(
+            &db,
+            p,
+            &elders[p as usize],
+            &electorate,
+            prev,
+            new,
+            vec![7],
+            1,
+        );
+        prev = new;
+    }
+    // Position 5: a structurally-valid link (prev == position-4 head) but NO votes.
+    let forged_new = tag(5);
+    let attacker = NodeIdentity::generate();
+    db.save_mpc_contribution(&MpcContributionRecord {
+        elder_position: 5,
+        contributor_node_id: hex::encode(attacker.node_id()),
+        prev_params_hash: prev,
+        new_params_hash: forged_new,
+        contribution_proof: vec![1, 2, 3],
+        epoch: 0,
+        created_at: 1,
+    })
+    .unwrap();
+
+    let res = db.verify_mpc_genesis_anchored_lineage(&anchor, Some(&forged_new));
+    assert!(
+        res.is_err(),
+        "a quorum-less but structurally-valid head must be rejected, got {res:?}"
+    );
+}
+
+// ============================================================================
+// (D) Un-pin / catch-up rehearsal — assertion 7
+// ============================================================================
+
+use std::sync::Mutex;
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+/// The Stage-4 dry run: startup-mode selection flips StaticPin ⇄
+/// GenesisAnchoredRolling as the operator removes / restores the static current
+/// pin, and the node enters rolling WITHOUT crashing (the genesis-anchored
+/// verify succeeds in rolling mode).
+#[test]
+fn unpin_rollback_env_mode_flip() {
+    use ghost_zkp::{
+        select_startup_mode, ZkStartupMode, ZK_GENESIS_PARAMS_HASH_ENV, ZK_PARAMS_HASH_ENV,
+    };
+
+    let _guard = ENV_LOCK.lock().unwrap();
+    // Clean slate.
+    std::env::remove_var(ZK_PARAMS_HASH_ENV);
+    std::env::remove_var(ZK_GENESIS_PARAMS_HASH_ENV);
+
+    // Build a small fully-signed chain + anchor we can verify in rolling mode.
+    let anchor = [0xA7u8; 32];
+    let anchor_hex = hex::encode(anchor);
+    let db = Database::in_memory().unwrap();
+    let elders: Vec<NodeIdentity> = (0..=3).map(|_| NodeIdentity::generate()).collect();
+    let tag = |p: u32| {
+        let mut a = [0u8; 32];
+        a[0] = p as u8;
+        a[1] = 0xEE;
+        a
+    };
+    let mut prev = anchor;
+    for p in 1..=3u32 {
+        let new = tag(p);
+        let electorate: Vec<&NodeIdentity> = (1..p).map(|i| &elders[i as usize]).collect();
+        record_contribution_and_votes(
+            &db,
+            p,
+            &elders[p as usize],
+            &electorate,
+            prev,
+            new,
+            vec![5],
+            1,
+        );
+        prev = new;
+    }
+    let head = tag(3);
+
+    // 1. Pinned (frozen): ZK_PARAMS_HASH set → StaticPin.
+    std::env::set_var(ZK_PARAMS_HASH_ENV, "BLOCK:00");
+    std::env::set_var(ZK_GENESIS_PARAMS_HASH_ENV, &anchor_hex);
+    assert_eq!(
+        select_startup_mode().unwrap(),
+        ZkStartupMode::StaticPin,
+        "with the static pin present the node stays frozen"
+    );
+
+    // 2. Un-pin: drop ZK_PARAMS_HASH, keep the genesis anchor → rolling.
+    std::env::remove_var(ZK_PARAMS_HASH_ENV);
+    match select_startup_mode().unwrap() {
+        ZkStartupMode::GenesisAnchoredRolling { genesis_anchor } => {
+            assert_eq!(genesis_anchor, anchor, "rolling carries the genesis anchor");
+        }
+        other => panic!("expected rolling after un-pin, got {other:?}"),
+    }
+    // Enters rolling WITHOUT crash: the genesis-anchored verify succeeds.
+    assert_eq!(
+        db.verify_mpc_genesis_anchored_lineage(&anchor, Some(&head))
+            .unwrap(),
+        3,
+        "rolling node validates its chain via the genesis anchor (no crash)"
+    );
+
+    // 3. Rollback: re-add the static pin → back to frozen.
+    std::env::set_var(ZK_PARAMS_HASH_ENV, "BLOCK:00");
+    assert_eq!(
+        select_startup_mode().unwrap(),
+        ZkStartupMode::StaticPin,
+        "re-adding the pin rolls back to frozen"
+    );
+
+    std::env::remove_var(ZK_PARAMS_HASH_ENV);
+    std::env::remove_var(ZK_GENESIS_PARAMS_HASH_ENV);
+}
+
+/// A FRESH node catches up purely via the `GET /api/v1/mpc/votes/{position}`
+/// data path: it fetches each position's contribution PROOF + retained votes,
+/// persists them into an empty DB, and its genesis-anchored startup quorum check
+/// then passes — proving the autonomous catch-up the mainnet un-pin depends on.
+///
+/// This drives the SAME JSON shape the live endpoint serves
+/// (`api_mpc_votes_handler`) and the SAME field extraction the live sync uses
+/// (`sync_mpc_proof_and_votes`), at the function level. The cross-process HTTP
+/// hop itself is covered by `ghost-verification`'s `test_mpc_votes_endpoint_
+/// roundtrip` and, end to end, by the docker regtest cluster (see module docs).
+#[test]
+fn catchup_via_votes_endpoint_shape() {
+    let anchor = [0x5Au8; 32];
+
+    // ---- "Server" node: a fully populated ledger. ----
+    let server = Database::in_memory().unwrap();
+    let elders: Vec<NodeIdentity> = (0..=5).map(|_| NodeIdentity::generate()).collect();
+    let tag = |p: u32| {
+        let mut a = [0u8; 32];
+        a[0] = p as u8;
+        a[1] = 0xF0;
+        a
+    };
+    let n = 5u32;
+    let mut prev = anchor;
+    for p in 1..=n {
+        let new = tag(p);
+        let electorate: Vec<&NodeIdentity> = (1..p).map(|i| &elders[i as usize]).collect();
+        record_contribution_and_votes(
+            &server,
+            p,
+            &elders[p as usize],
+            &electorate,
+            prev,
+            new,
+            vec![0xDE, 0xAD, 0xBE, 0xEF], // non-empty retained proof
+            1_000,
+        );
+        prev = new;
+    }
+    let head = tag(n);
+
+    // ---- Fresh node: empty DB, catches up position by position over the wire. ----
+    let fresh = Database::in_memory().unwrap();
+    for p in 1..=n {
+        let json = server_votes_json(&server, p);
+        // The endpoint carries the real proof (the field the /contributors
+        // endpoint drops) — assert it is non-empty as the fresh node sees it.
+        let proof_hex = json["contribution"]["contribution_proof"].as_str().unwrap();
+        assert!(
+            !proof_hex.is_empty(),
+            "votes endpoint serves the retained proof"
+        );
+        let persisted = apply_votes_json(&fresh, p, &json);
+        assert!(
+            persisted,
+            "fresh node persisted position {p} from the endpoint"
+        );
+    }
+
+    // The fresh node's genesis-anchored startup quorum check passes on the
+    // catch-up-only data — no historical param blobs needed.
+    assert_eq!(
+        fresh
+            .verify_mpc_genesis_anchored_lineage(&anchor, Some(&head))
+            .unwrap(),
+        n,
+        "fresh node verifies the synced chain via genesis-anchored quorum"
+    );
+
+    // And the retained proof bytes really landed in the fresh DB.
+    let row = fresh.get_mpc_contribution(n).unwrap().unwrap();
+    assert!(
+        !row.contribution_proof.is_empty(),
+        "the fresh node retained the non-empty proof"
+    );
+}
+
+/// Build the JSON the live `GET /api/v1/mpc/votes/{position}` endpoint serves
+/// (mirrors `api_mpc_votes_handler` in `ghost-verification`).
+fn server_votes_json(db: &Database, position: u32) -> serde_json::Value {
+    let rec = db.get_mpc_contribution(position).unwrap().unwrap();
+    let votes: Vec<serde_json::Value> = db
+        .get_mpc_votes(position)
+        .unwrap()
+        .into_iter()
+        .map(|v| {
+            serde_json::json!({
+                "voter_node_id": v.voter_node_id,
+                "approve": v.approve,
+                "signature": hex::encode(v.signature),
+                "voted_at": v.voted_at,
+            })
+        })
+        .collect();
+    serde_json::json!({
+        "contribution": {
+            "position": rec.elder_position,
+            "node_id": rec.contributor_node_id,
+            "prev_params_hash": hex::encode(rec.prev_params_hash),
+            "new_params_hash": hex::encode(rec.new_params_hash),
+            "contribution_proof": hex::encode(&rec.contribution_proof),
+            "epoch": rec.epoch,
+            "created_at": rec.created_at,
+        },
+        "votes": votes,
+        "vote_count": votes.len(),
+    })
+}
+
+/// Persist a fetched votes-endpoint response into a fresh DB (mirrors the field
+/// extraction in `sync_mpc_proof_and_votes` in `bins/ghost-pool/src/main.rs`).
+fn apply_votes_json(db: &Database, position: u32, data: &serde_json::Value) -> bool {
+    let mut persisted = false;
+
+    if let Some(c) = data.get("contribution") {
+        let proof_hex = c
+            .get("contribution_proof")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let node_id = c.get("node_id").and_then(|v| v.as_str()).unwrap_or("");
+        let prev = c
+            .get("prev_params_hash")
+            .and_then(|v| v.as_str())
+            .and_then(|h| hex::decode(h).ok())
+            .and_then(|b| <[u8; 32]>::try_from(b.as_slice()).ok());
+        let new = c
+            .get("new_params_hash")
+            .and_then(|v| v.as_str())
+            .and_then(|h| hex::decode(h).ok())
+            .and_then(|b| <[u8; 32]>::try_from(b.as_slice()).ok());
+        let created_at = c.get("created_at").and_then(|v| v.as_u64()).unwrap_or(0);
+        let epoch = c.get("epoch").and_then(|v| v.as_u64()).unwrap_or(0);
+
+        if let (false, Ok(proof_bytes), Some(prev), Some(new)) = (
+            proof_hex.is_empty() || node_id.is_empty(),
+            hex::decode(proof_hex),
+            prev,
+            new,
+        ) {
+            db.save_mpc_contribution(&MpcContributionRecord {
+                elder_position: position,
+                contributor_node_id: node_id.to_string(),
+                prev_params_hash: prev,
+                new_params_hash: new,
+                contribution_proof: proof_bytes,
+                epoch,
+                created_at,
+            })
+            .unwrap();
+            persisted = true;
+        }
+    }
+
+    if let Some(votes) = data.get("votes").and_then(|v| v.as_array()) {
+        for v in votes {
+            let voter = v.get("voter_node_id").and_then(|x| x.as_str());
+            let approve = v.get("approve").and_then(|x| x.as_bool());
+            let sig = v
+                .get("signature")
+                .and_then(|x| x.as_str())
+                .and_then(|h| hex::decode(h).ok());
+            let voted_at = v.get("voted_at").and_then(|x| x.as_u64()).unwrap_or(0);
+            if let (Some(voter), Some(approve), Some(sig)) = (voter, approve, sig) {
+                db.save_mpc_vote(&MpcVerificationVote {
+                    contribution_position: position,
+                    voter_node_id: voter.to_string(),
+                    approve,
+                    signature: sig,
+                    voted_at,
+                })
+                .unwrap();
+                persisted = true;
+            }
+        }
+    }
+
+    persisted
+}

--- a/crates/ghost-storage/src/lib.rs
+++ b/crates/ghost-storage/src/lib.rs
@@ -38,6 +38,7 @@ pub mod database;
 pub mod encryption;
 pub mod migrations;
 pub mod models;
+pub mod mpc_lineage;
 pub mod queries;
 pub mod snapshot;
 

--- a/crates/ghost-storage/src/migrations.rs
+++ b/crates/ghost-storage/src/migrations.rs
@@ -23,12 +23,12 @@
 //! Database migrations
 
 use rusqlite::Connection;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 use ghost_common::error::{GhostError, GhostResult};
 
 /// Current schema version
-const SCHEMA_VERSION: u32 = 38;
+const SCHEMA_VERSION: u32 = 39;
 
 /// Run all pending migrations
 pub fn run_migrations(conn: &Connection) -> GhostResult<()> {
@@ -94,6 +94,7 @@ pub fn run_migrations(conn: &Connection) -> GhostResult<()> {
         (36, migrate_v36),
         (37, migrate_v37),
         (38, migrate_v38),
+        (39, migrate_v39),
     ];
 
     for &(version, migrate_fn) in pre_v10 {
@@ -1940,6 +1941,119 @@ fn migrate_v38(conn: &Connection) -> GhostResult<()> {
     Ok(())
 }
 
+/// v39: MPC ceremony state foundation.
+///
+/// Two changes, both idempotent and safe on the live 5-contribution DBs as
+/// well as a fresh genesis DB.
+///
+/// Change 1 — add a stable `ceremony_id BLOB` column to the `mpc_ceremony`
+/// singleton. `ceremony_id` is the genesis-derived constant Schnorr proofs bind
+/// to (= position-1 `prev_params_hash`, the genesis lineage hash). It is
+/// nullable: legacy/pre-genesis rows carry NULL, which the reader treats as
+/// "not yet established" and the load path re-derives from position-1.
+///
+/// Change 2 — backfill the `mpc_ceremony` singleton (id=1) from existing
+/// contribution history when it is ABSENT but `mpc_contributions` has rows (the
+/// exact state of the live fleet: 5 contributions, empty singleton). The
+/// singleton then becomes the authoritative source of truth for progression,
+/// set as follows:
+///
+/// ```text
+/// contribution_count = MAX(elder_position)
+/// current_params_hash = mpc_contributions[MAX].new_params_hash  (lineage hash)
+/// is_ossified         = 0
+/// ceremony_id         = mpc_contributions[1].prev_params_hash
+/// updated_at          = now
+/// ```
+///
+/// An existing singleton is NEVER overwritten. If `mpc_contributions` is also
+/// empty (fresh genesis), the singleton is left for genesis init to create.
+fn migrate_v39(conn: &Connection) -> GhostResult<()> {
+    use rusqlite::OptionalExtension;
+
+    debug!("Running migration v39: Add mpc_ceremony.ceremony_id + backfill singleton");
+
+    // 1. Add the stable ceremony_id column.
+    conn.execute_batch("ALTER TABLE mpc_ceremony ADD COLUMN ceremony_id BLOB;")
+        .map_err(|e| GhostError::Migration(e.to_string()))?;
+
+    // 2. Idempotent backfill — never overwrite an existing singleton.
+    let singleton_exists: bool = conn
+        .query_row(
+            "SELECT EXISTS(SELECT 1 FROM mpc_ceremony WHERE id = 1)",
+            [],
+            |r| r.get::<_, i64>(0),
+        )
+        .map_err(|e| GhostError::Migration(e.to_string()))?
+        != 0;
+
+    if singleton_exists {
+        info!("v39: mpc_ceremony singleton already present — leaving it untouched");
+        return Ok(());
+    }
+
+    let max_position: Option<i64> = conn
+        .query_row(
+            "SELECT MAX(elder_position) FROM mpc_contributions",
+            [],
+            |r| r.get(0),
+        )
+        .map_err(|e| GhostError::Migration(e.to_string()))?;
+
+    let Some(max_position) = max_position else {
+        // No contributions — fresh genesis DB. Genesis init will create the row.
+        info!("v39: no mpc_contributions rows — leaving singleton empty for genesis init");
+        return Ok(());
+    };
+
+    // Lineage head: current_params_hash = new_params_hash at the highest position.
+    let current_params_hash: Vec<u8> = conn
+        .query_row(
+            "SELECT new_params_hash FROM mpc_contributions WHERE elder_position = ?1",
+            [max_position],
+            |r| r.get(0),
+        )
+        .map_err(|e| GhostError::Migration(e.to_string()))?;
+
+    // ceremony_id = genesis lineage hash = position-1 prev_params_hash.
+    // Defensive: if position 1 is somehow absent, store NULL (reader re-derives).
+    let ceremony_id: Option<Vec<u8>> = conn
+        .query_row(
+            "SELECT prev_params_hash FROM mpc_contributions WHERE elder_position = 1",
+            [],
+            |r| r.get(0),
+        )
+        .optional()
+        .map_err(|e| GhostError::Migration(e.to_string()))?;
+
+    if ceremony_id.is_none() {
+        warn!(
+            "v39: contribution position 1 missing — backfilling singleton with NULL ceremony_id \
+             (load path will re-derive once position 1 is available)"
+        );
+    }
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+
+    conn.execute(
+        "INSERT INTO mpc_ceremony
+            (id, contribution_count, current_params_hash, is_ossified, ossified_at,
+             block_vk_hash, payout_vk_hash, updated_at, ceremony_id)
+         VALUES (1, ?1, ?2, 0, NULL, NULL, NULL, ?3, ?4)",
+        rusqlite::params![max_position, current_params_hash, now, ceremony_id],
+    )
+    .map_err(|e| GhostError::Migration(e.to_string()))?;
+
+    info!(
+        contribution_count = max_position,
+        "v39: Backfilled mpc_ceremony singleton from existing contribution history"
+    );
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1969,6 +2083,164 @@ mod tests {
         let version = get_schema_version(&conn)
             .expect("MEDIUM-STOR-2: Failed to get schema version after idempotent migrations");
         assert_eq!(version, SCHEMA_VERSION);
+    }
+
+    // ========================================================================
+    // v39: mpc_ceremony.ceremony_id + singleton backfill (Stage A task 3)
+    // ========================================================================
+
+    /// Create the `mpc_ceremony` + `mpc_contributions` tables in their pre-v39
+    /// (v13) shape — i.e. WITHOUT the `ceremony_id` column — and stamp the DB at
+    /// schema version 38 so `run_migrations` runs only v39.
+    fn setup_pre_v39_mpc(conn: &Connection) {
+        conn.execute_batch(
+            r#"
+            CREATE TABLE mpc_ceremony (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                contribution_count INTEGER NOT NULL DEFAULT 0,
+                current_params_hash BLOB NOT NULL,
+                is_ossified INTEGER NOT NULL DEFAULT 0,
+                ossified_at INTEGER,
+                block_vk_hash BLOB,
+                payout_vk_hash BLOB,
+                updated_at INTEGER NOT NULL
+            );
+            CREATE TABLE mpc_contributions (
+                elder_position INTEGER PRIMARY KEY,
+                contributor_node_id TEXT NOT NULL,
+                prev_params_hash BLOB NOT NULL,
+                new_params_hash BLOB NOT NULL,
+                contribution_proof BLOB NOT NULL,
+                epoch INTEGER NOT NULL,
+                created_at INTEGER NOT NULL
+            );
+            "#,
+        )
+        .unwrap();
+        set_schema_version(conn, 38).unwrap();
+    }
+
+    /// Insert `n` synthetic contributions chaining lineage hashes:
+    /// pos 1 prev=[200;32] new=[1;32]; pos i prev=[i-1;32] new=[i;32].
+    fn insert_synthetic_contributions(conn: &Connection, n: u8) {
+        for pos in 1..=n {
+            let prev = if pos == 1 { [200u8; 32] } else { [pos - 1; 32] };
+            let new = [pos; 32];
+            conn.execute(
+                "INSERT INTO mpc_contributions
+                    (elder_position, contributor_node_id, prev_params_hash, new_params_hash,
+                     contribution_proof, epoch, created_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, 0, 0)",
+                rusqlite::params![
+                    pos as i64,
+                    format!("node{pos}"),
+                    &prev[..],
+                    &new[..],
+                    &[1u8, 2, 3][..]
+                ],
+            )
+            .unwrap();
+        }
+    }
+
+    fn read_singleton(conn: &Connection) -> Option<(i64, Vec<u8>, i64, Option<Vec<u8>>)> {
+        conn.query_row(
+            "SELECT contribution_count, current_params_hash, is_ossified, ceremony_id
+             FROM mpc_ceremony WHERE id = 1",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)),
+        )
+        .ok()
+    }
+
+    #[test]
+    fn test_v39_adds_ceremony_id_column() {
+        let conn = Connection::open_in_memory().unwrap();
+        run_migrations(&conn).unwrap();
+        let cols = get_column_names(&conn, "mpc_ceremony");
+        assert!(
+            cols.contains(&"ceremony_id".to_string()),
+            "v39 must add ceremony_id column; got {cols:?}"
+        );
+    }
+
+    #[test]
+    fn test_v39_backfills_singleton_from_five_contributions() {
+        let conn = Connection::open_in_memory().unwrap();
+        setup_pre_v39_mpc(&conn);
+        insert_synthetic_contributions(&conn, 5);
+
+        run_migrations(&conn).unwrap();
+
+        let (count, cph, ossified, cid) =
+            read_singleton(&conn).expect("singleton must be backfilled");
+        assert_eq!(count, 5, "contribution_count = MAX(elder_position)");
+        assert_eq!(
+            cph,
+            vec![5u8; 32],
+            "current_params_hash = contributions[5].new_params_hash"
+        );
+        assert_eq!(ossified, 0, "backfilled ceremony is not ossified");
+        assert_eq!(
+            cid,
+            Some(vec![200u8; 32]),
+            "ceremony_id = contributions[1].prev_params_hash"
+        );
+    }
+
+    #[test]
+    fn test_v39_backfill_is_idempotent_no_op_on_rerun() {
+        let conn = Connection::open_in_memory().unwrap();
+        setup_pre_v39_mpc(&conn);
+        insert_synthetic_contributions(&conn, 5);
+
+        run_migrations(&conn).unwrap();
+        // Re-running is version-gated and must not change the singleton.
+        run_migrations(&conn).unwrap();
+
+        let (count, cph, _ossified, cid) = read_singleton(&conn).unwrap();
+        assert_eq!(count, 5);
+        assert_eq!(cph, vec![5u8; 32]);
+        assert_eq!(cid, Some(vec![200u8; 32]));
+    }
+
+    #[test]
+    fn test_v39_never_overwrites_existing_singleton() {
+        let conn = Connection::open_in_memory().unwrap();
+        setup_pre_v39_mpc(&conn);
+        insert_synthetic_contributions(&conn, 5);
+        // A singleton already exists with a DIFFERENT count — must be preserved.
+        conn.execute(
+            "INSERT INTO mpc_ceremony
+                (id, contribution_count, current_params_hash, is_ossified, updated_at)
+             VALUES (1, 2, ?1, 0, 123)",
+            rusqlite::params![&[2u8; 32][..]],
+        )
+        .unwrap();
+
+        run_migrations(&conn).unwrap();
+
+        let (count, cph, _ossified, cid) = read_singleton(&conn).unwrap();
+        assert_eq!(count, 2, "existing singleton count must NOT be overwritten");
+        assert_eq!(cph, vec![2u8; 32], "existing current_params_hash preserved");
+        assert_eq!(
+            cid, None,
+            "existing row's ceremony_id left as NULL (not backfilled)"
+        );
+    }
+
+    #[test]
+    fn test_v39_empty_contributions_writes_no_singleton() {
+        let conn = Connection::open_in_memory().unwrap();
+        setup_pre_v39_mpc(&conn);
+        // No contributions at all (fresh genesis DB).
+
+        run_migrations(&conn).unwrap();
+
+        assert!(
+            read_singleton(&conn).is_none(),
+            "no singleton must be written when mpc_contributions is empty"
+        );
     }
 
     /// Helper: returns all table names from sqlite_master

--- a/crates/ghost-storage/src/mpc_lineage.rs
+++ b/crates/ghost-storage/src/mpc_lineage.rs
@@ -1,0 +1,792 @@
+//|======================================================================================================================|
+//|                                                                                                                      |
+//|  ▄▄▄▄    ██▓▄▄▄█████▓ ▄████▄   ▒█████   ██▓ ███▄    █      ▄████  ██░ ██  ▒█████    ██████ ▄▄▄█████▓   ▄████████▄    |
+//| ▓█████▄ ▓██▒▓  ██▒ ▓▒▒██▀ ▀█  ▒██▒  ██▒▓██▒ ██ ▀█   █     ██▒ ▀█▒▓██░ ██▒▒██▒  ██▒▒██    ▒ ▓  ██▒ ▓▒   ███▀██▀███    |
+//| ▒██▒ ▄██▒██▒▒ ▓██░ ▒░▒▓█    ▄ ▒██░  ██▒▒██▒▓██  ▀█ ██▒   ▒██░▄▄▄░▒██▀▀██░▒██░  ██▒░ ▓██▄   ▒ ▓██░ ▒░   ██████████░   |
+//| ▒██░█▀  ░██░░ ▓██▓ ░ ▒▓▓▄ ▄██▒▒██   ██░░██░▓██▒  ▐▌██▒   ░▓█  ██▓░▓█ ░██ ▒██   ██░  ▒   ██▒░ ▓██▓ ░    ██████████░░▒ |
+//| ░▓█  ▀█▓░██░  ▒██▒ ░ ▒ ▓███▀ ░░ ████▓▒░░██░▒██░   ▓██░   ░▒▓███▀▒░▓█▒░██▓░ ████▓▒░▒██████▒▒  ▒██▒ ░    ██▀▀██▀▀██░▒  |
+//|----------------------------------------------------------------------------------------------------------------------|
+//|             < B I T C O I N  G H O S T > < D E F E N W Y C K E > < R E A D  T H E  W H I T E P A P E R >             |
+//|----------------------------------------------------------------------------------------------------------------------|
+//| PROJECT: Bitcoin Ghost                                                                                               |
+//| FILE: mpc_lineage.rs                                                                                                |
+//|======================================================================================================================|
+
+//! Genesis-anchored MPC lineage verification (Stage C).
+//!
+//! This is the replacement for the static *current-params* file-hash pin during
+//! the rolling ceremony. Instead of trusting a single pinned SHA-256 of the
+//! current params (which changes every contribution and so cannot be pinned
+//! while rolling), a node validates the EVOLVING setup from an IMMUTABLE trust
+//! root — the genesis lineage anchor — plus the recorded lineage chain and a
+//! retained BFT quorum per position. The retained quorum is what lets a node
+//! trust positions it did not personally witness WITHOUT keeping every
+//! historical multi-hundred-megabyte parameter blob: it keeps only the head
+//! params on disk, plus the cheap contribution rows + vote signatures.
+//!
+//! # The check (fail-closed)
+//!
+//! Given the immutable `genesis_anchor` (a LINEAGE hash = `hash_parameters` of
+//! the genesis params = `mpc_contributions[1].prev_params_hash`) and the
+//! `head_lineage` (= `hash_parameters` of the on-disk current params):
+//!
+//! 1. The chain rows are exactly positions `1..=N`, contiguous.
+//! 2. `contributions[1].prev == genesis_anchor`            (anchor to the root).
+//! 3. `contributions[i].prev == contributions[i-1].new`    (lineage intact).
+//! 4. `contributions[N].new == head_lineage`               (on-disk head matches).
+//! 5. For each position `i >= 2`, a stored BFT quorum of VALID approve-vote
+//!    signatures from the then-eligible elder set (contributors at positions
+//!    `< i`) exists — `>= mpc_bft_threshold(i-1)` distinct valid voters.
+//!    Position 1 (genesis) has no electorate and is trusted solely via the
+//!    immutable anchor (step 2).
+//!
+//! Accept only if ALL hold; otherwise FAIL-CLOSED.
+//!
+//! # No forge window
+//!
+//! To make a node accept forged params as its head, an attacker must defeat ALL
+//! of the above. Swapping the on-disk head changes `head_lineage` (step 4), so
+//! they must also rewrite `contributions[N].new`, which breaks the chain link
+//! (step 3) unless they rewrite the whole chain back to `contributions[1].prev`
+//! — which is pinned to the immutable anchor (step 2). A full alternate chain
+//! additionally needs, at every position, `>= 67%` (steady state) genuine elder
+//! signatures over `contribution_hash(contributor, position, new_params_hash)`
+//! (step 5). Each such signature was only ever produced by an elder that itself
+//! ran `verify_contribution` (Schnorr + h/l pairing) before approving. So the
+//! attacker's only options are: (a) produce params that pass
+//! `verify_contribution` — a GENUINE valid transform, which preserves 1-of-N and
+//! is harmless; (b) forge `>=` quorum elder signatures — needs `> quorum` key
+//! compromise; or (c) break SHA-256 / the anchor. There is no fourth path.
+
+use crate::queries::MpcVerificationVote;
+use ghost_common::error::{GhostError, GhostResult};
+use ghost_common::identity::verify_signature;
+use ghost_common::mpc::{contribution_hash, mpc_bft_threshold, vote_signing_message};
+use ghost_common::types::NodeId;
+use std::collections::HashSet;
+
+/// One contribution row reduced to the fields the lineage check needs.
+#[derive(Debug, Clone)]
+pub struct ContribLineageRow {
+    pub position: u32,
+    /// Contributor (candidate) public key / node id, decoded to bytes.
+    pub contributor: NodeId,
+    pub prev_params_hash: [u8; 32],
+    pub new_params_hash: [u8; 32],
+}
+
+/// One retained vote reduced to what the quorum check needs.
+#[derive(Debug, Clone)]
+pub struct VoteLineageRow {
+    pub voter: NodeId,
+    pub approve: bool,
+    pub signature: [u8; 64],
+}
+
+/// Why a genesis-anchored lineage verification failed. Every variant is a hard,
+/// fail-closed rejection.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LineageError {
+    /// Contributions exist but no head params were loaded to cross-check.
+    MissingHead,
+    /// The chain rows are not the contiguous set `1..=N` (gap/duplicate).
+    NonContiguousChain { expected: u32, found: u32 },
+    /// `contributions[1].prev != genesis_anchor` — not rooted at the trust anchor.
+    AnchorMismatch,
+    /// `contributions[i].prev != contributions[i-1].new` — lineage broken.
+    ChainBreak { position: u32 },
+    /// `contributions[N].new != head_lineage` — on-disk head out of step.
+    HeadMismatch,
+    /// Position `i` lacks a retained BFT quorum of valid approve signatures.
+    QuorumNotMet {
+        position: u32,
+        valid: u32,
+        required: u32,
+    },
+}
+
+impl std::fmt::Display for LineageError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LineageError::MissingHead => write!(
+                f,
+                "on-disk head params are not loaded but the chain has contributions"
+            ),
+            LineageError::NonContiguousChain { expected, found } => write!(
+                f,
+                "contribution chain is not contiguous: expected position {expected}, found {found}"
+            ),
+            LineageError::AnchorMismatch => {
+                write!(f, "contributions[1].prev does not equal the genesis anchor")
+            }
+            LineageError::ChainBreak { position } => {
+                write!(
+                    f,
+                    "lineage break at position {position} (prev != previous.new)"
+                )
+            }
+            LineageError::HeadMismatch => {
+                write!(
+                    f,
+                    "on-disk head lineage hash does not match contributions[N].new"
+                )
+            }
+            LineageError::QuorumNotMet {
+                position,
+                valid,
+                required,
+            } => write!(
+                f,
+                "position {position} has only {valid} valid approve signatures, needs {required}"
+            ),
+        }
+    }
+}
+
+/// PURE genesis-anchored lineage verification.
+///
+/// `contributions` must be ALL recorded contributions (any order). `votes_for`
+/// returns the retained votes for a given position. `head_lineage` is the
+/// `hash_parameters` of the on-disk current params (`None` if not loaded).
+///
+/// Returns `Ok(n)` where `n` is the verified chain length, or `Err(LineageError)`
+/// (fail-closed). With `n == 0` (no contributions) the chain is trivially valid
+/// only when there is no head, or the head equals the genesis anchor (a
+/// genesis-forming / pre-rolling node holding only the genesis params).
+pub fn verify_genesis_anchored_chain<'a>(
+    genesis_anchor: &[u8; 32],
+    head_lineage: Option<&[u8; 32]>,
+    contributions: &'a [ContribLineageRow],
+    mut votes_for: impl FnMut(u32) -> &'a [VoteLineageRow],
+) -> Result<u32, LineageError> {
+    let n = contributions.len() as u32;
+
+    if n == 0 {
+        // Pre-genesis / genesis-forming. Nothing applied to cross-check.
+        return match head_lineage {
+            None => Ok(0),
+            Some(h) if h == genesis_anchor => Ok(0),
+            Some(_) => Err(LineageError::AnchorMismatch),
+        };
+    }
+
+    // Index by position and require the contiguous set 1..=N.
+    let mut by_pos: Vec<Option<&ContribLineageRow>> = vec![None; (n + 1) as usize];
+    for c in contributions {
+        if c.position == 0 || c.position > n {
+            return Err(LineageError::NonContiguousChain {
+                expected: n,
+                found: c.position,
+            });
+        }
+        let slot = &mut by_pos[c.position as usize];
+        if slot.is_some() {
+            // Duplicate position.
+            return Err(LineageError::NonContiguousChain {
+                expected: c.position,
+                found: c.position,
+            });
+        }
+        *slot = Some(c);
+    }
+    for pos in 1..=n {
+        if by_pos[pos as usize].is_none() {
+            return Err(LineageError::NonContiguousChain {
+                expected: pos,
+                found: 0,
+            });
+        }
+    }
+
+    // Step 2: anchor.
+    let first = by_pos[1].unwrap();
+    if &first.prev_params_hash != genesis_anchor {
+        return Err(LineageError::AnchorMismatch);
+    }
+
+    // Step 3: lineage links.
+    for pos in 2..=n {
+        let cur = by_pos[pos as usize].unwrap();
+        let prev = by_pos[(pos - 1) as usize].unwrap();
+        if cur.prev_params_hash != prev.new_params_hash {
+            return Err(LineageError::ChainBreak { position: pos });
+        }
+    }
+
+    // Step 4: head match.
+    let head = head_lineage.ok_or(LineageError::MissingHead)?;
+    let last = by_pos[n as usize].unwrap();
+    if &last.new_params_hash != head {
+        return Err(LineageError::HeadMismatch);
+    }
+
+    // Step 5: retained BFT quorum per position (i >= 2). Eligible voters for
+    // position i are the contributors at positions 1..i-1 (the elder set that
+    // existed when i was voted on). Position 1 (genesis) has no electorate and is
+    // trusted via the anchor alone.
+    let mut eligible: HashSet<NodeId> = HashSet::new();
+    eligible.insert(first.contributor); // contributor #1 becomes eligible for #2+
+    for pos in 2..=n {
+        let cur = by_pos[pos as usize].unwrap();
+        let eligible_count = pos - 1; // contributors 1..=pos-1
+        let required = mpc_bft_threshold(eligible_count);
+
+        // The message every honest elder signed to approve THIS contribution.
+        let ch = contribution_hash(&cur.contributor, pos, &cur.new_params_hash);
+        let approve_msg = vote_signing_message(&ch, true);
+
+        let mut counted: HashSet<NodeId> = HashSet::new();
+        for v in votes_for(pos) {
+            if !v.approve {
+                continue;
+            }
+            if !eligible.contains(&v.voter) {
+                continue; // vote from a non-elder (or future elder) does not count
+            }
+            if counted.contains(&v.voter) {
+                continue; // one vote per voter
+            }
+            match verify_signature(&v.voter, &approve_msg, &v.signature) {
+                Ok(true) => {
+                    counted.insert(v.voter);
+                }
+                _ => continue, // invalid signature does not count
+            }
+        }
+
+        let valid = counted.len() as u32;
+        if valid < required {
+            return Err(LineageError::QuorumNotMet {
+                position: pos,
+                valid,
+                required,
+            });
+        }
+
+        // This contributor joins the eligible set for later positions.
+        eligible.insert(cur.contributor);
+    }
+
+    Ok(n)
+}
+
+/// Map a DB vote row into the lineage-check shape, dropping malformed signatures.
+fn vote_row(v: &MpcVerificationVote) -> Option<VoteLineageRow> {
+    let voter = hex::decode(&v.voter_node_id)
+        .ok()
+        .and_then(|b| <[u8; 32]>::try_from(b.as_slice()).ok())?;
+    let signature = <[u8; 64]>::try_from(v.signature.as_slice()).ok()?;
+    Some(VoteLineageRow {
+        voter,
+        approve: v.approve,
+        signature,
+    })
+}
+
+impl crate::Database {
+    /// Genesis-anchored startup verification (Stage C task 2), DB-driven.
+    ///
+    /// Loads the ordered contribution chain + retained votes from the database
+    /// and runs [`verify_genesis_anchored_chain`] against the immutable
+    /// `genesis_anchor` and the supplied `head_lineage` (the `hash_parameters`
+    /// of the on-disk current params, or `None` if not loaded). Returns the
+    /// verified chain length on success; fail-closed `Err` otherwise.
+    pub fn verify_mpc_genesis_anchored_lineage(
+        &self,
+        genesis_anchor: &[u8; 32],
+        head_lineage: Option<&[u8; 32]>,
+    ) -> GhostResult<u32> {
+        // Load the chain.
+        let max = self.get_mpc_max_contribution_position()?.unwrap_or(0);
+        let mut rows: Vec<ContribLineageRow> = Vec::with_capacity(max as usize);
+        for pos in 1..=max {
+            let rec = self.get_mpc_contribution(pos)?.ok_or_else(|| {
+                GhostError::Database(format!(
+                    "MPC lineage: contribution row {pos} missing (chain gap)"
+                ))
+            })?;
+            let contributor = hex::decode(&rec.contributor_node_id)
+                .ok()
+                .and_then(|b| <[u8; 32]>::try_from(b.as_slice()).ok())
+                .ok_or_else(|| {
+                    GhostError::Database(format!(
+                        "MPC lineage: contributor_node_id at position {pos} is not a 32-byte hex node id"
+                    ))
+                })?;
+            rows.push(ContribLineageRow {
+                position: pos,
+                contributor,
+                prev_params_hash: rec.prev_params_hash,
+                new_params_hash: rec.new_params_hash,
+            });
+        }
+
+        // Pre-load votes per position (decoded), so the closure is allocation-free.
+        let mut votes_by_pos: Vec<Vec<VoteLineageRow>> = vec![Vec::new(); (max + 1) as usize];
+        for pos in 1..=max {
+            let raw = self.get_mpc_votes(pos)?;
+            votes_by_pos[pos as usize] = raw.iter().filter_map(vote_row).collect();
+        }
+        let empty: Vec<VoteLineageRow> = Vec::new();
+
+        verify_genesis_anchored_chain(genesis_anchor, head_lineage, &rows, |pos| {
+            votes_by_pos
+                .get(pos as usize)
+                .map(|v| v.as_slice())
+                .unwrap_or(empty.as_slice())
+        })
+        .map_err(|e| GhostError::Database(format!("MPC genesis-anchored lineage FAILED: {e}")))
+    }
+
+    /// Stage C task 5: true-up the `mpc_ceremony` singleton to the verified head.
+    ///
+    /// A node that abstained on some position (could not fetch it then) may carry
+    /// a lagged singleton. After the lineage+quorum verification succeeds, this
+    /// reconciles `contribution_count` / `current_params_hash` to match the
+    /// verified on-disk head + chain length. Other singleton fields (ceremony_id,
+    /// ossified, vk hashes) are PRESERVED. No-op when already in step; creates the
+    /// singleton if absent (using the genesis anchor as `ceremony_id`).
+    pub fn reconcile_mpc_singleton_to_head(
+        &self,
+        verified_count: u32,
+        verified_head: &[u8; 32],
+        genesis_anchor: &[u8; 32],
+        updated_at: u64,
+    ) -> GhostResult<bool> {
+        let existing = self.get_mpc_ceremony_state()?;
+        match existing {
+            Some(state) => {
+                if state.contribution_count == verified_count
+                    && &state.current_params_hash == verified_head
+                {
+                    return Ok(false); // already in step
+                }
+                let mut new_state = state.clone();
+                new_state.contribution_count = verified_count;
+                new_state.current_params_hash = *verified_head;
+                if new_state.updated_at < updated_at {
+                    new_state.updated_at = updated_at;
+                }
+                // Preserve a valid ceremony_id; backfill from the anchor if missing.
+                if new_state.ceremony_id == [0u8; 32] {
+                    new_state.ceremony_id = *genesis_anchor;
+                }
+                self.save_mpc_ceremony_state(&new_state)?;
+                Ok(true)
+            }
+            None => {
+                let new_state = crate::queries::MpcCeremonyState {
+                    contribution_count: verified_count,
+                    current_params_hash: *verified_head,
+                    is_ossified: verified_count >= 101,
+                    ossified_at: None,
+                    block_vk_hash: None,
+                    payout_vk_hash: None,
+                    updated_at,
+                    ceremony_id: *genesis_anchor,
+                };
+                self.save_mpc_ceremony_state(&new_state)?;
+                Ok(true)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ghost_common::identity::NodeIdentity;
+
+    const ANCHOR: [u8; 32] = [0xC9; 32];
+
+    /// A fully-built, internally-consistent chain of `n` contributions with the
+    /// retained approve votes for every position `>= 2` from ALL then-eligible
+    /// elders. This is the genesis-anchored happy path.
+    struct Chain {
+        contribs: Vec<ContribLineageRow>, // positions 1..=n (index 0 = pos1)
+        votes: Vec<Vec<VoteLineageRow>>,  // indexed by position; [0] unused
+        head: [u8; 32],
+    }
+
+    impl Chain {
+        fn votes_for(&self, pos: u32) -> &[VoteLineageRow] {
+            self.votes
+                .get(pos as usize)
+                .map(|v| v.as_slice())
+                .unwrap_or(&[])
+        }
+    }
+
+    fn tag(pos: u32) -> [u8; 32] {
+        let mut a = [0u8; 32];
+        a[0] = pos as u8;
+        a[1] = 0xAB;
+        a[2] = (pos >> 8) as u8;
+        a
+    }
+
+    fn build_valid_chain(n: u32) -> Chain {
+        let mut identities: Vec<NodeIdentity> = Vec::new();
+        let mut contribs: Vec<ContribLineageRow> = Vec::new();
+        let mut votes: Vec<Vec<VoteLineageRow>> = vec![Vec::new(); (n + 1) as usize];
+
+        let mut prev = ANCHOR;
+        for pos in 1..=n {
+            let id = NodeIdentity::generate();
+            let new = tag(pos);
+            contribs.push(ContribLineageRow {
+                position: pos,
+                contributor: id.node_id(),
+                prev_params_hash: prev,
+                new_params_hash: new,
+            });
+            identities.push(id);
+            prev = new;
+        }
+
+        // Build approve votes for positions 2..=n from all eligible elders
+        // (contributors at positions 1..pos-1).
+        for pos in 2..=n {
+            let c = &contribs[(pos - 1) as usize];
+            let ch = contribution_hash(&c.contributor, pos, &c.new_params_hash);
+            let msg = vote_signing_message(&ch, true);
+            let mut row = Vec::new();
+            for elder_idx in 0..(pos - 1) as usize {
+                let elder = &identities[elder_idx];
+                row.push(VoteLineageRow {
+                    voter: elder.node_id(),
+                    approve: true,
+                    signature: elder.sign(&msg),
+                });
+            }
+            votes[pos as usize] = row;
+        }
+
+        let head = contribs[(n - 1) as usize].new_params_hash;
+        let _ = &identities; // identities are only needed to produce the signatures above
+        Chain {
+            contribs,
+            votes,
+            head,
+        }
+    }
+
+    fn run(chain: &Chain) -> Result<u32, LineageError> {
+        verify_genesis_anchored_chain(&ANCHOR, Some(&chain.head), &chain.contribs, |p| {
+            chain.votes_for(p)
+        })
+    }
+
+    #[test]
+    fn test_happy_path_passes() {
+        // 6 positions (mirrors the live 6-node mesh) — spans bootstrap (2..4)
+        // and supermajority (5,6).
+        let chain = build_valid_chain(6);
+        assert_eq!(run(&chain).unwrap(), 6);
+    }
+
+    #[test]
+    fn test_empty_chain_with_no_head_ok() {
+        let empty: Vec<ContribLineageRow> = Vec::new();
+        assert_eq!(
+            verify_genesis_anchored_chain(&ANCHOR, None, &empty, |_| &[]).unwrap(),
+            0
+        );
+    }
+
+    #[test]
+    fn test_empty_chain_head_must_equal_anchor() {
+        let empty: Vec<ContribLineageRow> = Vec::new();
+        // Head == anchor (genesis params on disk) → ok.
+        assert_eq!(
+            verify_genesis_anchored_chain(&ANCHOR, Some(&ANCHOR), &empty, |_| &[]).unwrap(),
+            0
+        );
+        // Head != anchor with no contributions → reject.
+        let other = [0x77; 32];
+        assert_eq!(
+            verify_genesis_anchored_chain(&ANCHOR, Some(&other), &empty, |_| &[]),
+            Err(LineageError::AnchorMismatch)
+        );
+    }
+
+    #[test]
+    fn test_anchor_mismatch_fails_closed() {
+        let mut chain = build_valid_chain(5);
+        chain.contribs[0].prev_params_hash = [0xEE; 32]; // not the anchor
+        assert_eq!(run(&chain), Err(LineageError::AnchorMismatch));
+    }
+
+    #[test]
+    fn test_broken_lineage_link_fails_closed() {
+        let mut chain = build_valid_chain(5);
+        // Break the link into position 4.
+        chain.contribs[3].prev_params_hash = [0x12; 32];
+        assert_eq!(run(&chain), Err(LineageError::ChainBreak { position: 4 }));
+    }
+
+    #[test]
+    fn test_head_mismatch_fails_closed() {
+        let chain = build_valid_chain(5);
+        let forged_head = [0x99; 32];
+        let res =
+            verify_genesis_anchored_chain(&ANCHOR, Some(&forged_head), &chain.contribs, |p| {
+                chain.votes_for(p)
+            });
+        assert_eq!(res, Err(LineageError::HeadMismatch));
+    }
+
+    #[test]
+    fn test_missing_head_when_contributions_exist_fails_closed() {
+        let chain = build_valid_chain(3);
+        let res =
+            verify_genesis_anchored_chain(&ANCHOR, None, &chain.contribs, |p| chain.votes_for(p));
+        assert_eq!(res, Err(LineageError::MissingHead));
+    }
+
+    #[test]
+    fn test_missing_quorum_position_fails_closed() {
+        let mut chain = build_valid_chain(6);
+        // Remove ALL retained votes for position 5 (a supermajority position).
+        chain.votes[5].clear();
+        match run(&chain) {
+            Err(LineageError::QuorumNotMet {
+                position,
+                valid,
+                required,
+            }) => {
+                assert_eq!(position, 5);
+                assert_eq!(valid, 0);
+                assert_eq!(required, mpc_bft_threshold(4)); // = 3
+            }
+            other => panic!("expected QuorumNotMet at 5, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_non_contiguous_chain_fails_closed() {
+        let mut chain = build_valid_chain(4);
+        // Drop position 3 — leaves a gap (positions 1,2,4 → length 3 but pos 4 > n).
+        chain.contribs.remove(2);
+        let res = verify_genesis_anchored_chain(&ANCHOR, Some(&chain.head), &chain.contribs, |p| {
+            chain.votes_for(p)
+        });
+        assert!(matches!(res, Err(LineageError::NonContiguousChain { .. })));
+    }
+
+    // ---- NO-FORGE proofs ----
+
+    /// Forging the head's `new_params_hash` (and pointing `head_lineage` at it)
+    /// passes the head-match and chain-link checks for the LAST position only if
+    /// the attacker rewrites `contributions[N].new`. But the retained approve
+    /// signatures for position N were signed over the ORIGINAL new hash, so the
+    /// quorum recomputed over the forged hash no longer verifies → rejected.
+    /// This proves a head swap cannot be laundered through the lineage.
+    #[test]
+    fn test_no_forge_faked_head_lineage_breaks_quorum() {
+        let mut chain = build_valid_chain(6);
+        let forged = [0x5A; 32];
+        // Rewrite the recorded head row to the forged value AND point head at it,
+        // so the anchor, all links, and the head-match all still hold.
+        let last = chain.contribs.len() - 1;
+        chain.contribs[last].new_params_hash = forged;
+        chain.head = forged;
+        // The links are intact (we only changed the terminal .new, which nothing
+        // chains from), and head==contribs[N].new, so steps 2-4 pass …
+        match run(&chain) {
+            // … but the position-6 approve signatures were over the real hash, so
+            // the quorum over the forged hash collapses to zero valid votes.
+            Err(LineageError::QuorumNotMet {
+                position, valid, ..
+            }) => {
+                assert_eq!(position, 6);
+                assert_eq!(valid, 0, "forged head invalidates every retained signature");
+            }
+            other => panic!("expected QuorumNotMet at 6 for forged head, got {other:?}"),
+        }
+    }
+
+    /// A head that is a structurally-fine new position (valid chain link) but
+    /// carries NO quorum signatures is rejected — hash/lineage continuity is
+    /// never sufficient on its own.
+    #[test]
+    fn test_no_forge_valid_link_without_quorum_rejected() {
+        let mut chain = build_valid_chain(5);
+        // Append a 6th position that chains correctly but has zero votes.
+        let attacker = NodeIdentity::generate();
+        let new6 = tag(6);
+        chain.contribs.push(ContribLineageRow {
+            position: 6,
+            contributor: attacker.node_id(),
+            prev_params_hash: chain.contribs[4].new_params_hash, // valid link
+            new_params_hash: new6,
+        });
+        chain.votes.push(Vec::new()); // no votes for position 6
+        chain.head = new6;
+        match run(&chain) {
+            Err(LineageError::QuorumNotMet { position, .. }) => assert_eq!(position, 6),
+            other => panic!("expected QuorumNotMet at 6, got {other:?}"),
+        }
+    }
+
+    /// An approve vote from an INELIGIBLE node (not yet an elder at that position)
+    /// does not count toward quorum.
+    #[test]
+    fn test_ineligible_voter_does_not_count() {
+        let mut chain = build_valid_chain(6);
+        // Replace position 5's real elder votes with a single vote from a brand
+        // new (non-elder) identity that correctly signs the approve message.
+        let c5 = &chain.contribs[4];
+        let ch = contribution_hash(&c5.contributor, 5, &c5.new_params_hash);
+        let msg = vote_signing_message(&ch, true);
+        let outsider = NodeIdentity::generate();
+        chain.votes[5] = vec![VoteLineageRow {
+            voter: outsider.node_id(),
+            approve: true,
+            signature: outsider.sign(&msg),
+        }];
+        match run(&chain) {
+            Err(LineageError::QuorumNotMet {
+                position, valid, ..
+            }) => {
+                assert_eq!(position, 5);
+                assert_eq!(
+                    valid, 0,
+                    "an outsider's signature must not count toward quorum"
+                );
+            }
+            other => panic!("expected QuorumNotMet at 5, got {other:?}"),
+        }
+    }
+
+    /// A tampered (invalid) signature from an eligible elder does not count.
+    #[test]
+    fn test_tampered_signature_does_not_count() {
+        let mut chain = build_valid_chain(6);
+        for v in chain.votes[5].iter_mut() {
+            v.signature[0] ^= 0x01; // corrupt every signature at position 5
+        }
+        match run(&chain) {
+            Err(LineageError::QuorumNotMet {
+                position, valid, ..
+            }) => {
+                assert_eq!(position, 5);
+                assert_eq!(valid, 0);
+            }
+            other => panic!("expected QuorumNotMet at 5, got {other:?}"),
+        }
+    }
+
+    // ---- DB round-trip + singleton true-up ----
+
+    #[test]
+    fn test_db_roundtrip_and_singleton_trueup() {
+        use crate::queries::{MpcContributionRecord, MpcVerificationVote};
+        let db = crate::Database::in_memory().unwrap();
+        let chain = build_valid_chain(4);
+
+        // Persist contributions + votes exactly as the live/sync path would.
+        for c in &chain.contribs {
+            db.save_mpc_contribution(&MpcContributionRecord {
+                elder_position: c.position,
+                contributor_node_id: hex::encode(c.contributor),
+                prev_params_hash: c.prev_params_hash,
+                new_params_hash: c.new_params_hash,
+                contribution_proof: vec![1, 2, 3], // non-empty (proof retained)
+                epoch: 0,
+                created_at: 1000,
+            })
+            .unwrap();
+        }
+        for pos in 2..=4u32 {
+            for v in chain.votes_for(pos) {
+                db.save_mpc_vote(&MpcVerificationVote {
+                    contribution_position: pos,
+                    voter_node_id: hex::encode(v.voter),
+                    approve: v.approve,
+                    signature: v.signature.to_vec(),
+                    voted_at: 1000,
+                })
+                .unwrap();
+            }
+        }
+
+        // DB-driven verification passes against the head.
+        let n = db
+            .verify_mpc_genesis_anchored_lineage(&ANCHOR, Some(&chain.head))
+            .unwrap();
+        assert_eq!(n, 4);
+
+        // No singleton yet → true-up creates it at the verified head.
+        let changed = db
+            .reconcile_mpc_singleton_to_head(n, &chain.head, &ANCHOR, 2000)
+            .unwrap();
+        assert!(changed);
+        let s = db.get_mpc_ceremony_state().unwrap().unwrap();
+        assert_eq!(s.contribution_count, 4);
+        assert_eq!(s.current_params_hash, chain.head);
+        assert_eq!(s.ceremony_id, ANCHOR);
+
+        // Idempotent second true-up.
+        let changed2 = db
+            .reconcile_mpc_singleton_to_head(n, &chain.head, &ANCHOR, 2000)
+            .unwrap();
+        assert!(!changed2);
+    }
+
+    #[test]
+    fn test_db_trueup_advances_lagged_singleton() {
+        use crate::queries::{MpcCeremonyState, MpcContributionRecord, MpcVerificationVote};
+        let db = crate::Database::in_memory().unwrap();
+        let chain = build_valid_chain(5);
+        for c in &chain.contribs {
+            db.save_mpc_contribution(&MpcContributionRecord {
+                elder_position: c.position,
+                contributor_node_id: hex::encode(c.contributor),
+                prev_params_hash: c.prev_params_hash,
+                new_params_hash: c.new_params_hash,
+                contribution_proof: vec![9],
+                epoch: 0,
+                created_at: 1,
+            })
+            .unwrap();
+        }
+        for pos in 2..=5u32 {
+            for v in chain.votes_for(pos) {
+                db.save_mpc_vote(&MpcVerificationVote {
+                    contribution_position: pos,
+                    voter_node_id: hex::encode(v.voter),
+                    approve: v.approve,
+                    signature: v.signature.to_vec(),
+                    voted_at: 1,
+                })
+                .unwrap();
+            }
+        }
+        // Plant a LAGGED singleton (count 3, stale hash) as if the node abstained.
+        db.save_mpc_ceremony_state(&MpcCeremonyState {
+            contribution_count: 3,
+            current_params_hash: chain.contribs[2].new_params_hash,
+            is_ossified: false,
+            ossified_at: None,
+            block_vk_hash: None,
+            payout_vk_hash: None,
+            updated_at: 1,
+            ceremony_id: ANCHOR,
+        })
+        .unwrap();
+
+        let n = db
+            .verify_mpc_genesis_anchored_lineage(&ANCHOR, Some(&chain.head))
+            .unwrap();
+        assert_eq!(n, 5);
+        let changed = db
+            .reconcile_mpc_singleton_to_head(n, &chain.head, &ANCHOR, 9)
+            .unwrap();
+        assert!(changed, "lagged singleton must be advanced");
+        let s = db.get_mpc_ceremony_state().unwrap().unwrap();
+        assert_eq!(s.contribution_count, 5);
+        assert_eq!(s.current_params_hash, chain.head);
+        assert_eq!(s.ceremony_id, ANCHOR, "ceremony_id preserved");
+    }
+}

--- a/crates/ghost-storage/src/queries.rs
+++ b/crates/ghost-storage/src/queries.rs
@@ -6188,13 +6188,30 @@ impl Database {
         })
     }
 
-    /// Save an MPC contribution
+    /// Save an MPC contribution.
+    ///
+    /// Stage C: this is a SAFE proof-fill upsert. A first INSERT records the row.
+    /// On conflict (the position already exists) it ONLY fills in a previously
+    /// EMPTY `contribution_proof`, and ONLY when the incoming row has the SAME
+    /// identity (contributor + prev/new hashes). It NEVER rewrites the hashes or
+    /// replaces an already-present proof. This lets a node that first synced a
+    /// proof-less row (the old `/contributors` path) later upgrade it with the
+    /// real proof fetched from `/api/v1/mpc/votes/{position}` — needed for
+    /// catch-up re-verification — while a peer can never overwrite the lineage
+    /// hashes or substitute a different proof for an applied position.
     pub fn save_mpc_contribution(&self, contribution: &MpcContributionRecord) -> GhostResult<()> {
         self.with_connection(|conn| {
             conn.execute(
                 "INSERT INTO mpc_contributions (elder_position, contributor_node_id, prev_params_hash,
                                                 new_params_hash, contribution_proof, epoch, created_at)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+                 ON CONFLICT(elder_position) DO UPDATE SET
+                    contribution_proof = excluded.contribution_proof
+                 WHERE length(mpc_contributions.contribution_proof) = 0
+                   AND length(excluded.contribution_proof) > 0
+                   AND mpc_contributions.contributor_node_id = excluded.contributor_node_id
+                   AND mpc_contributions.prev_params_hash = excluded.prev_params_hash
+                   AND mpc_contributions.new_params_hash = excluded.new_params_hash",
                 params![
                     contribution.elder_position as i64,
                     contribution.contributor_node_id,

--- a/crates/ghost-storage/src/queries.rs
+++ b/crates/ghost-storage/src/queries.rs
@@ -6266,6 +6266,62 @@ impl Database {
         })
     }
 
+    /// Get an MPC contribution by its `new_params_hash` (lineage head produced
+    /// by that contribution).
+    ///
+    /// Used by the params-adoption path (a node fetching parameters it did not
+    /// itself vote on) to recover the full contribution record — proof, prev
+    /// hash, position — so it can re-run cryptographic `verify_contribution`
+    /// before hot-swapping, rather than trusting a bare hash match.
+    pub fn get_mpc_contribution_by_new_hash(
+        &self,
+        new_params_hash: &[u8; 32],
+    ) -> GhostResult<Option<MpcContributionRecord>> {
+        self.with_connection(|conn| {
+            let result: Option<(i64, String, Vec<u8>, Vec<u8>, i64, i64)> = conn
+                .query_row(
+                    "SELECT elder_position, contributor_node_id, prev_params_hash,
+                            contribution_proof, epoch, created_at
+                     FROM mpc_contributions WHERE new_params_hash = ?1",
+                    params![&new_params_hash[..]],
+                    |row| {
+                        Ok((
+                            row.get(0)?,
+                            row.get(1)?,
+                            row.get(2)?,
+                            row.get(3)?,
+                            row.get(4)?,
+                            row.get(5)?,
+                        ))
+                    },
+                )
+                .optional()
+                .map_err(|e| GhostError::Database(e.to_string()))?;
+
+            match result {
+                Some((position, node_id, prev_hash, proof, epoch, created_at)) => {
+                    let mut prev_params_hash = [0u8; 32];
+                    if prev_hash.len() == 32 {
+                        prev_params_hash.copy_from_slice(&prev_hash);
+                    }
+                    Ok(Some(MpcContributionRecord {
+                        elder_position: i64_to_u32_count(position, "elder_position")
+                            .map_err(|e| GhostError::Database(e.to_string()))?,
+                        contributor_node_id: node_id,
+                        prev_params_hash,
+                        new_params_hash: *new_params_hash,
+                        contribution_proof: proof,
+                        epoch: i64_to_u64(epoch, "mpc_epoch")
+                            .map_err(|e| GhostError::Database(e.to_string()))?,
+                        created_at: i64_to_u64(created_at, "mpc_created_at")
+                            .map_err(|e| GhostError::Database(e.to_string()))?,
+                    }))
+                }
+                None => Ok(None),
+            }
+        })
+    }
+
     /// Save an MPC verification vote
     pub fn save_mpc_vote(&self, vote: &MpcVerificationVote) -> GhostResult<()> {
         self.with_connection(|conn| {

--- a/crates/ghost-storage/src/queries.rs
+++ b/crates/ghost-storage/src/queries.rs
@@ -5993,7 +5993,11 @@ impl Database {
 // MPC CEREMONY QUERIES
 // =============================================================================
 
-/// MPC ceremony state record (singleton)
+/// MPC ceremony state record (singleton, id=1).
+///
+/// This row is the authoritative source of truth for ceremony progression
+/// (`contribution_count`, `current_params_hash`, `is_ossified`) and for the
+/// stable `ceremony_id` that Schnorr proofs bind to.
 #[derive(Debug, Clone)]
 pub struct MpcCeremonyState {
     pub contribution_count: u32,
@@ -6003,6 +6007,11 @@ pub struct MpcCeremonyState {
     pub block_vk_hash: Option<[u8; 32]>,
     pub payout_vk_hash: Option<[u8; 32]>,
     pub updated_at: u64,
+    /// Stable, genesis-derived ceremony identifier (= position-1
+    /// `prev_params_hash`, the genesis lineage hash). Identical fleet-wide for
+    /// the life of the ceremony. `[0u8; 32]` if not yet established (pre-genesis
+    /// or a legacy row written before this column existed).
+    pub ceremony_id: [u8; 32],
 }
 
 /// MPC contribution record
@@ -6044,6 +6053,7 @@ impl Database {
     #[allow(clippy::type_complexity)]
     pub fn get_mpc_ceremony_state(&self) -> GhostResult<Option<MpcCeremonyState>> {
         self.with_connection(|conn| {
+            #[allow(clippy::type_complexity)]
             let result: Option<(
                 i64,
                 Vec<u8>,
@@ -6052,10 +6062,11 @@ impl Database {
                 Option<Vec<u8>>,
                 Option<Vec<u8>>,
                 i64,
+                Option<Vec<u8>>,
             )> = conn
                 .query_row(
                     "SELECT contribution_count, current_params_hash, is_ossified, ossified_at,
-                            block_vk_hash, payout_vk_hash, updated_at
+                            block_vk_hash, payout_vk_hash, updated_at, ceremony_id
                      FROM mpc_ceremony WHERE id = 1",
                     [],
                     |row| {
@@ -6067,6 +6078,7 @@ impl Database {
                             row.get(4)?,
                             row.get(5)?,
                             row.get(6)?,
+                            row.get(7)?,
                         ))
                     },
                 )
@@ -6074,10 +6086,28 @@ impl Database {
                 .map_err(|e| GhostError::Database(e.to_string()))?;
 
             match result {
-                Some((count, hash_bytes, ossified, ossified_at, block_vk, payout_vk, updated)) => {
+                Some((
+                    count,
+                    hash_bytes,
+                    ossified,
+                    ossified_at,
+                    block_vk,
+                    payout_vk,
+                    updated,
+                    ceremony_id_bytes,
+                )) => {
                     let mut params_hash = [0u8; 32];
                     if hash_bytes.len() == 32 {
                         params_hash.copy_from_slice(&hash_bytes);
+                    }
+
+                    // ceremony_id is nullable for legacy rows written before the
+                    // column existed; a NULL or wrong-length value reads as zero.
+                    let mut ceremony_id = [0u8; 32];
+                    if let Some(ref cid) = ceremony_id_bytes {
+                        if cid.len() == 32 {
+                            ceremony_id.copy_from_slice(cid);
+                        }
                     }
 
                     let block_vk_hash = block_vk.and_then(|v| {
@@ -6117,6 +6147,7 @@ impl Database {
                         payout_vk_hash,
                         updated_at: i64_to_u64(updated, "updated_at")
                             .map_err(|e| GhostError::Database(e.to_string()))?,
+                        ceremony_id,
                     }))
                 }
                 None => Ok(None),
@@ -6129,8 +6160,9 @@ impl Database {
         self.with_connection(|conn| {
             conn.execute(
                 "INSERT INTO mpc_ceremony (id, contribution_count, current_params_hash, is_ossified,
-                                          ossified_at, block_vk_hash, payout_vk_hash, updated_at)
-                 VALUES (1, ?1, ?2, ?3, ?4, ?5, ?6, ?7)
+                                          ossified_at, block_vk_hash, payout_vk_hash, updated_at,
+                                          ceremony_id)
+                 VALUES (1, ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
                  ON CONFLICT(id) DO UPDATE SET
                     contribution_count = excluded.contribution_count,
                     current_params_hash = excluded.current_params_hash,
@@ -6138,7 +6170,8 @@ impl Database {
                     ossified_at = excluded.ossified_at,
                     block_vk_hash = excluded.block_vk_hash,
                     payout_vk_hash = excluded.payout_vk_hash,
-                    updated_at = excluded.updated_at",
+                    updated_at = excluded.updated_at,
+                    ceremony_id = excluded.ceremony_id",
                 params![
                     state.contribution_count as i64,
                     &state.current_params_hash[..],
@@ -6147,6 +6180,7 @@ impl Database {
                     state.block_vk_hash.as_ref().map(|v| &v[..]),
                     state.payout_vk_hash.as_ref().map(|v| &v[..]),
                     state.updated_at as i64,
+                    &state.ceremony_id[..],
                 ],
             )
             .map_err(|e| GhostError::Database(e.to_string()))?;
@@ -6531,6 +6565,76 @@ impl Database {
             i64_to_u32_count(count, "mpc_elder_count")
                 .map_err(|e| GhostError::Database(e.to_string()))
         })
+    }
+
+    /// Highest applied MPC contribution position (`MAX(elder_position)`).
+    ///
+    /// Returns `None` when no contributions exist. This is the lineage head's
+    /// position; `get_mpc_contribution(max)?.new_params_hash` is the lineage
+    /// hash of the current parameters.
+    pub fn get_mpc_max_contribution_position(&self) -> GhostResult<Option<u32>> {
+        self.with_connection(|conn| {
+            let max: Option<i64> = conn
+                .query_row(
+                    "SELECT MAX(elder_position) FROM mpc_contributions",
+                    [],
+                    |row| row.get(0),
+                )
+                .map_err(|e| GhostError::Database(e.to_string()))?;
+            match max {
+                Some(v) => Ok(Some(
+                    i64_to_u32_count(v, "mpc_max_position")
+                        .map_err(|e| GhostError::Database(e.to_string()))?,
+                )),
+                None => Ok(None),
+            }
+        })
+    }
+
+    /// Authoritative ceremony contribution count for *progression* (next
+    /// position) decisions.
+    ///
+    /// The `mpc_ceremony` singleton (id=1) is the source of truth. When the
+    /// singleton is present its `contribution_count` is returned; when it is
+    /// absent (pre-backfill / fresh genesis) this falls back to
+    /// `COUNT(*) mpc_contributions`.
+    ///
+    /// INVARIANT CHECK: if the singleton exists but its `contribution_count`
+    /// disagrees with `COUNT(*) mpc_contributions`, that is a corruption / split
+    /// signal — it is logged loudly. We still return the singleton value (the
+    /// authoritative one) rather than silently trusting either source.
+    ///
+    /// NOTE: this is distinct from `get_mpc_elder_count()`, which counts
+    /// contribution rows and is the correct input for *voter-set sizing*
+    /// (BFT quorum). Do not conflate the two.
+    pub fn mpc_contribution_count_authoritative(&self) -> GhostResult<u32> {
+        let row_count = self.get_mpc_elder_count()?;
+        match self.get_mpc_ceremony_state()? {
+            Some(state) => {
+                if state.contribution_count != row_count {
+                    warn!(
+                        singleton_count = state.contribution_count,
+                        contribution_rows = row_count,
+                        "MPC INVARIANT VIOLATION: mpc_ceremony.contribution_count disagrees with \
+                         COUNT(mpc_contributions) — possible state corruption or interrupted apply. \
+                         Trusting the authoritative singleton value."
+                    );
+                }
+                Ok(state.contribution_count)
+            }
+            None => Ok(row_count),
+        }
+    }
+
+    /// Stable, genesis-derived ceremony identifier.
+    ///
+    /// Defined as position-1's `prev_params_hash` (the genesis lineage hash),
+    /// which never changes for the life of the ceremony and is identical on
+    /// every node. Returns `None` before the genesis contribution exists.
+    /// This is the canonical source; the persisted `mpc_ceremony.ceremony_id`
+    /// column is a cache of the same value.
+    pub fn mpc_genesis_ceremony_id(&self) -> GhostResult<Option<[u8; 32]>> {
+        Ok(self.get_mpc_contribution(1)?.map(|c| c.prev_params_hash))
     }
 
     /// Get all MPC elder node IDs as parsed 32-byte arrays
@@ -11356,5 +11460,131 @@ mod tests {
             !caps2.public_mining,
             "no strict majority of challengers -> public_mining NOT qualified"
         );
+    }
+
+    // ========================================================================
+    // MPC ceremony state foundation (Stage A tasks 2 & 3)
+    // ========================================================================
+
+    fn mk_contribution(pos: u32) -> MpcContributionRecord {
+        let prev = if pos == 1 {
+            [200u8; 32]
+        } else {
+            [(pos - 1) as u8; 32]
+        };
+        MpcContributionRecord {
+            elder_position: pos,
+            contributor_node_id: format!("node{pos}"),
+            prev_params_hash: prev,
+            new_params_hash: [pos as u8; 32],
+            contribution_proof: vec![1, 2, 3],
+            epoch: 0,
+            created_at: 0,
+        }
+    }
+
+    #[test]
+    fn test_ceremony_state_roundtrips_ceremony_id() {
+        let db = Database::in_memory().expect("create in-memory db");
+        let state = MpcCeremonyState {
+            contribution_count: 5,
+            current_params_hash: [5u8; 32],
+            is_ossified: false,
+            ossified_at: None,
+            block_vk_hash: None,
+            payout_vk_hash: None,
+            updated_at: 42,
+            ceremony_id: [200u8; 32],
+        };
+        db.save_mpc_ceremony_state(&state).unwrap();
+
+        let loaded = db.get_mpc_ceremony_state().unwrap().expect("present");
+        assert_eq!(loaded.contribution_count, 5);
+        assert_eq!(loaded.current_params_hash, [5u8; 32]);
+        assert_eq!(loaded.ceremony_id, [200u8; 32]);
+        assert_eq!(loaded.updated_at, 42);
+    }
+
+    #[test]
+    fn test_authoritative_count_falls_back_to_row_count_when_singleton_absent() {
+        let db = Database::in_memory().expect("create in-memory db");
+        // No singleton yet; two contribution rows.
+        db.save_mpc_contribution(&mk_contribution(1)).unwrap();
+        db.save_mpc_contribution(&mk_contribution(2)).unwrap();
+
+        assert_eq!(
+            db.mpc_contribution_count_authoritative().unwrap(),
+            2,
+            "with no singleton, fall back to COUNT(mpc_contributions)"
+        );
+    }
+
+    #[test]
+    fn test_authoritative_count_prefers_singleton() {
+        let db = Database::in_memory().expect("create in-memory db");
+        db.save_mpc_contribution(&mk_contribution(1)).unwrap();
+        db.save_mpc_contribution(&mk_contribution(2)).unwrap();
+        db.save_mpc_contribution(&mk_contribution(3)).unwrap();
+        // Singleton agrees (count 3) — authoritative value returned.
+        db.save_mpc_ceremony_state(&MpcCeremonyState {
+            contribution_count: 3,
+            current_params_hash: [3u8; 32],
+            is_ossified: false,
+            ossified_at: None,
+            block_vk_hash: None,
+            payout_vk_hash: None,
+            updated_at: 0,
+            ceremony_id: [200u8; 32],
+        })
+        .unwrap();
+        assert_eq!(db.mpc_contribution_count_authoritative().unwrap(), 3);
+    }
+
+    #[test]
+    fn test_genesis_ceremony_id_derives_from_position_one() {
+        let db = Database::in_memory().expect("create in-memory db");
+        assert_eq!(
+            db.mpc_genesis_ceremony_id().unwrap(),
+            None,
+            "no contributions -> no ceremony_id yet"
+        );
+        db.save_mpc_contribution(&mk_contribution(1)).unwrap();
+        db.save_mpc_contribution(&mk_contribution(2)).unwrap();
+        assert_eq!(
+            db.mpc_genesis_ceremony_id().unwrap(),
+            Some([200u8; 32]),
+            "ceremony_id derives from position-1 prev_params_hash"
+        );
+    }
+
+    #[test]
+    fn test_ceremony_id_stable_across_reloads() {
+        // Simulate the main.rs load-path derivation across two restarts: the
+        // canonical ceremony_id (position-1 prev hash) never changes even as the
+        // lineage head (current_params_hash) advances.
+        let db = Database::in_memory().expect("create in-memory db");
+        for pos in 1..=3 {
+            db.save_mpc_contribution(&mk_contribution(pos)).unwrap();
+        }
+        let first = db.mpc_genesis_ceremony_id().unwrap();
+        // Advance the lineage head.
+        db.save_mpc_contribution(&mk_contribution(4)).unwrap();
+        db.save_mpc_contribution(&mk_contribution(5)).unwrap();
+        let second = db.mpc_genesis_ceremony_id().unwrap();
+        assert_eq!(
+            first, second,
+            "ceremony_id must be stable as lineage advances"
+        );
+        assert_eq!(second, Some([200u8; 32]));
+    }
+
+    #[test]
+    fn test_max_contribution_position() {
+        let db = Database::in_memory().expect("create in-memory db");
+        assert_eq!(db.get_mpc_max_contribution_position().unwrap(), None);
+        for pos in 1..=4 {
+            db.save_mpc_contribution(&mk_contribution(pos)).unwrap();
+        }
+        assert_eq!(db.get_mpc_max_contribution_position().unwrap(), Some(4));
     }
 }

--- a/crates/ghost-verification/src/routes.rs
+++ b/crates/ghost-verification/src/routes.rs
@@ -398,6 +398,10 @@ pub fn create_router(state: Arc<VerificationState>) -> Router {
             "/api/v1/mpc/contributors",
             get(api_mpc_contributors_handler),
         )
+        // Stage C: per-position contribution (WITH proof) + retained approve
+        // votes, so a catching-up node can re-verify proofs and check the
+        // retained BFT quorum (the contributors list above omits both).
+        .route("/api/v1/mpc/votes/:position", get(api_mpc_votes_handler))
         // Ghost Haze & Shroud endpoints
         .route("/api/v1/haze/status", get(api_haze_status_handler))
         .route("/api/v1/shroud/status", get(api_shroud_status_handler))
@@ -6283,6 +6287,83 @@ async fn api_mpc_contributors_handler(
     }))
 }
 
+/// Stage C: per-position contribution + retained votes handler.
+///
+/// Serves, for a single ceremony position: the FULL contribution record —
+/// including the (non-empty) `contribution_proof`, which the `/contributors`
+/// list deliberately omits — AND every retained verification vote (voter,
+/// approve, signature). This is exactly the data a catching-up node needs to
+/// (a) re-run `verify_contribution` on the fetched proof and (b) re-check the
+/// retained BFT quorum at startup, without keeping historical params blobs.
+async fn api_mpc_votes_handler(
+    State(state): State<Arc<VerificationState>>,
+    Path(position): Path<u32>,
+) -> impl IntoResponse {
+    let Some(ref db) = state.database else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(serde_json::json!({ "error": "no database" })),
+        );
+    };
+
+    let contribution = match db.get_mpc_contribution(position) {
+        Ok(Some(rec)) => serde_json::json!({
+            "position": rec.elder_position,
+            "node_id": rec.contributor_node_id,
+            "prev_params_hash": hex::encode(rec.prev_params_hash),
+            "new_params_hash": hex::encode(rec.new_params_hash),
+            // Hex-encoded serialized ContributionProof — the field the
+            // contributors endpoint drops. Empty string if not retained.
+            "contribution_proof": hex::encode(&rec.contribution_proof),
+            "epoch": rec.epoch,
+            "created_at": rec.created_at,
+        }),
+        Ok(None) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(
+                    serde_json::json!({ "error": "no contribution at position", "position": position }),
+                ),
+            );
+        }
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": e.to_string() })),
+            );
+        }
+    };
+
+    let votes = match db.get_mpc_votes(position) {
+        Ok(v) => v
+            .into_iter()
+            .map(|vote| {
+                serde_json::json!({
+                    "voter_node_id": vote.voter_node_id,
+                    "approve": vote.approve,
+                    "signature": hex::encode(vote.signature),
+                    "voted_at": vote.voted_at,
+                })
+            })
+            .collect::<Vec<_>>(),
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": e.to_string() })),
+            );
+        }
+    };
+
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({
+            "contribution": contribution,
+            "votes": votes,
+            "vote_count": votes.len(),
+        })),
+    )
+}
+
 // =============================================================================
 // Ghost Haze & Shroud endpoint handlers
 // =============================================================================
@@ -7674,5 +7755,164 @@ mod tests {
         assert_eq!(v["miner_count"], 0);
         assert_eq!(v["healthy"], false);
         assert!(v["capabilities"].is_object());
+    }
+
+    /// Stage C task 3 — sync endpoint round-trip:
+    /// a "server" node persists a chain (contributions WITH real proof + votes),
+    /// serves position 2 over `GET /api/v1/mpc/votes/2`, and a "fresh" node parses
+    /// the response, persists the non-empty proof + votes, and the genesis-anchored
+    /// startup quorum check then PASSES on the fresh node.
+    #[tokio::test]
+    async fn test_mpc_votes_endpoint_roundtrip() {
+        use axum::body::Body;
+        use axum::http::Request;
+        use ghost_common::identity::NodeIdentity;
+        use ghost_common::mpc::{contribution_hash, vote_signing_message};
+        use ghost_storage::queries::{MpcContributionRecord, MpcVerificationVote};
+        use ghost_storage::Database;
+        use tower::ServiceExt;
+
+        let anchor = [0xC9u8; 32];
+        let id1 = NodeIdentity::generate(); // contributor at position 1 (elder #1)
+        let id2 = NodeIdentity::generate(); // contributor at position 2
+        let new1 = [0x11u8; 32];
+        let new2 = [0x22u8; 32];
+
+        // Real (non-empty) proof bytes for each position. Their CONTENT is opaque
+        // to the quorum check (which binds votes to new_params_hash), so arbitrary
+        // non-empty bytes suffice to prove the proof survives the round-trip.
+        let proof1 = vec![0xDE, 0xAD, 0xBE, 0xEF];
+        let proof2 = vec![0x01, 0x02, 0x03, 0x04, 0x05];
+
+        // --- server DB ---
+        let server_db = Database::in_memory().unwrap();
+        server_db
+            .save_mpc_contribution(&MpcContributionRecord {
+                elder_position: 1,
+                contributor_node_id: hex::encode(id1.node_id()),
+                prev_params_hash: anchor,
+                new_params_hash: new1,
+                contribution_proof: proof1.clone(),
+                epoch: 0,
+                created_at: 100,
+            })
+            .unwrap();
+        server_db
+            .save_mpc_contribution(&MpcContributionRecord {
+                elder_position: 2,
+                contributor_node_id: hex::encode(id2.node_id()),
+                prev_params_hash: new1,
+                new_params_hash: new2,
+                contribution_proof: proof2.clone(),
+                epoch: 0,
+                created_at: 200,
+            })
+            .unwrap();
+        // Position 2's approve vote from elder #1 (the only then-eligible elder).
+        let ch2 = contribution_hash(&id2.node_id(), 2, &new2);
+        let approve_msg = vote_signing_message(&ch2, true);
+        let sig = id1.sign(&approve_msg);
+        server_db
+            .save_mpc_vote(&MpcVerificationVote {
+                contribution_position: 2,
+                voter_node_id: hex::encode(id1.node_id()),
+                approve: true,
+                signature: sig.to_vec(),
+                voted_at: 200,
+            })
+            .unwrap();
+
+        // --- serve position 2 over HTTP ---
+        let state = {
+            use ghost_common::types::NodeCapabilities;
+            use ghost_policy::PolicyProfile;
+            Arc::new(
+                crate::server::VerificationState::new(
+                    hex::encode(id1.node_id()),
+                    "1.0.0".to_string(),
+                    PolicyProfile::default(),
+                    NodeCapabilities::default(),
+                )
+                .with_database(server_db),
+            )
+        };
+        let app = super::create_router(state);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/api/v1/mpc/votes/2")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(response.into_body(), 10 * 1024 * 1024)
+            .await
+            .unwrap();
+        let data: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+
+        // The served proof is non-empty (the bug this endpoint fixes).
+        let served_proof_hex = data["contribution"]["contribution_proof"].as_str().unwrap();
+        assert_eq!(served_proof_hex, hex::encode(&proof2));
+        assert!(!served_proof_hex.is_empty());
+        assert_eq!(data["vote_count"].as_u64().unwrap(), 1);
+
+        // --- fresh node: parse + persist, then the quorum check passes ---
+        let fresh_db = Database::in_memory().unwrap();
+        // Position 1 (genesis) is anchored, no votes needed; persist its row.
+        fresh_db
+            .save_mpc_contribution(&MpcContributionRecord {
+                elder_position: 1,
+                contributor_node_id: hex::encode(id1.node_id()),
+                prev_params_hash: anchor,
+                new_params_hash: new1,
+                contribution_proof: proof1.clone(),
+                epoch: 0,
+                created_at: 100,
+            })
+            .unwrap();
+        // Persist position 2 exactly as the sync path would, from the served JSON.
+        let c = &data["contribution"];
+        let proof_bytes = hex::decode(c["contribution_proof"].as_str().unwrap()).unwrap();
+        assert!(
+            !proof_bytes.is_empty(),
+            "fresh node must persist a real proof"
+        );
+        fresh_db
+            .save_mpc_contribution(&MpcContributionRecord {
+                elder_position: c["position"].as_u64().unwrap() as u32,
+                contributor_node_id: c["node_id"].as_str().unwrap().to_string(),
+                prev_params_hash: hex::decode(c["prev_params_hash"].as_str().unwrap())
+                    .unwrap()
+                    .try_into()
+                    .unwrap(),
+                new_params_hash: hex::decode(c["new_params_hash"].as_str().unwrap())
+                    .unwrap()
+                    .try_into()
+                    .unwrap(),
+                contribution_proof: proof_bytes,
+                epoch: 0,
+                created_at: c["created_at"].as_u64().unwrap(),
+            })
+            .unwrap();
+        for v in data["votes"].as_array().unwrap() {
+            fresh_db
+                .save_mpc_vote(&MpcVerificationVote {
+                    contribution_position: 2,
+                    voter_node_id: v["voter_node_id"].as_str().unwrap().to_string(),
+                    approve: v["approve"].as_bool().unwrap(),
+                    signature: hex::decode(v["signature"].as_str().unwrap()).unwrap(),
+                    voted_at: v["voted_at"].as_u64().unwrap(),
+                })
+                .unwrap();
+        }
+
+        // The fresh node's genesis-anchored startup verification now passes.
+        let verified = fresh_db
+            .verify_mpc_genesis_anchored_lineage(&anchor, Some(&new2))
+            .expect("fresh node startup quorum check must pass after sync");
+        assert_eq!(verified, 2);
     }
 }

--- a/crates/ghost-zkp/src/lib.rs
+++ b/crates/ghost-zkp/src/lib.rs
@@ -203,6 +203,117 @@ pub const ZK_PARAMS_PATH_ENV: &str = "ZK_PARAMS_PATH";
 /// Example: "BLOCK:abc123..."
 pub const ZK_PARAMS_HASH_ENV: &str = "ZK_PARAMS_HASH";
 
+/// Stage C: Environment variable for the IMMUTABLE genesis lineage anchor.
+///
+/// This is the trust root for the unpinned, rolling-ceremony verification path.
+/// Unlike [`ZK_PARAMS_HASH_ENV`] (a raw-file SHA-256 of the *current* params,
+/// which changes on every contribution and therefore cannot be pinned while
+/// rolling), this is the STRUCTURED lineage hash (`ghost_mpc::contribution::
+/// hash_parameters`) of the GENESIS parameters — equivalently
+/// `mpc_contributions[1].prev_params_hash`. It is constant for the entire life
+/// of the ceremony, so an operator can pin/distribute it exactly like the old
+/// static hash.
+///
+/// Format: 64 lowercase hex characters (32 bytes), no `TYPE:` prefix. Example:
+/// `ZK_GENESIS_PARAMS_HASH=c9c907f688fc1102...` (64 hex). For mainnet this is
+/// `c9c907f688fc1102…` — the genesis anchor verified from production data.
+pub const ZK_GENESIS_PARAMS_HASH_ENV: &str = "ZK_GENESIS_PARAMS_HASH";
+
+/// Parse the immutable genesis lineage anchor from the environment.
+///
+/// * `Ok(None)` — the variable is unset.
+/// * `Ok(Some(hash))` — a well-formed 64-hex value (the 32-byte lineage anchor).
+/// * `Err(..)` — the variable is SET but malformed. Fail-closed: a malformed
+///   anchor must never be silently treated as "unset", which could downgrade a
+///   node out of the verified rolling path.
+pub fn genesis_params_hash() -> ZkResult<Option<[u8; 32]>> {
+    let raw = match std::env::var(ZK_GENESIS_PARAMS_HASH_ENV) {
+        Ok(v) => v,
+        Err(std::env::VarError::NotPresent) => return Ok(None),
+        Err(e) => {
+            return Err(ZkError::InvalidParams(format!(
+                "Failed to read {}: {}",
+                ZK_GENESIS_PARAMS_HASH_ENV, e
+            )))
+        }
+    };
+    let trimmed = raw.trim();
+    if trimmed.len() != 64 {
+        return Err(ZkError::InvalidParams(format!(
+            "{} must be exactly 64 hex chars (32-byte lineage hash), got {}",
+            ZK_GENESIS_PARAMS_HASH_ENV,
+            trimmed.len()
+        )));
+    }
+    let bytes: [u8; 32] = hex::decode(trimmed)
+        .map_err(|e| {
+            ZkError::InvalidParams(format!(
+                "{} is not valid hex: {}",
+                ZK_GENESIS_PARAMS_HASH_ENV, e
+            ))
+        })?
+        .try_into()
+        .map_err(|_| {
+            ZkError::InvalidParams(format!(
+                "{} decode to 32 bytes failed",
+                ZK_GENESIS_PARAMS_HASH_ENV
+            ))
+        })?;
+    Ok(Some(bytes))
+}
+
+/// Stage C: which trusted-setup verification path a node engages at startup.
+///
+/// These are MUTUALLY EXCLUSIVE and there is deliberately NO variant where the
+/// trusted setup is left unverified. The selection is made by
+/// [`select_startup_mode`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ZkStartupMode {
+    /// `ZK_PARAMS_HASH` is set: verify the on-disk *current* params against the
+    /// pinned raw-file SHA-256. This is the existing frozen/pinned behaviour and
+    /// the post-ossification path. Bit-identical to prior releases.
+    StaticPin,
+    /// `ZK_PARAMS_HASH` is ABSENT but `ZK_GENESIS_PARAMS_HASH` is set: the static
+    /// current pin is intentionally removed for rolling. The node instead
+    /// validates the evolving setup by the immutable genesis anchor + the lineage
+    /// chain + the retained BFT quorum per position (see ghost-storage). Carries
+    /// the genesis anchor (a LINEAGE hash) that roots the chain.
+    GenesisAnchoredRolling { genesis_anchor: [u8; 32] },
+}
+
+/// Stage C: choose the startup verification mode from the environment.
+///
+/// Precedence — explicit and mutually consistent:
+/// 1. `ZK_PARAMS_HASH` set            → [`ZkStartupMode::StaticPin`] (pinned/frozen
+///    or post-ossification). Unchanged from prior releases.
+/// 2. else `ZK_GENESIS_PARAMS_HASH`   → [`ZkStartupMode::GenesisAnchoredRolling`]
+///    (the new genesis-anchored lineage path engages ONLY when the static current
+///    pin is absent).
+/// 3. else                            → `Err`. There is NEVER a mode where nothing
+///    is verified; a mainnet node with neither pin refuses to start.
+///
+/// After ossification at 101 the operator re-pins `ZK_PARAMS_HASH` to the v101
+/// file hash and selection returns to `StaticPin` automatically.
+pub fn select_startup_mode() -> ZkResult<ZkStartupMode> {
+    let static_pin_set = std::env::var(ZK_PARAMS_HASH_ENV).is_ok();
+    if static_pin_set {
+        return Ok(ZkStartupMode::StaticPin);
+    }
+    match genesis_params_hash()? {
+        Some(genesis_anchor) => Ok(ZkStartupMode::GenesisAnchoredRolling { genesis_anchor }),
+        None => Err(ZkError::InvalidParams(format!(
+            "Trusted-setup verification is unconfigured: neither {} (static pin) nor {} \
+             (genesis anchor) is set. Refusing to start — the trusted setup must never run \
+             unverified. Set {} to the pinned current-params SHA-256 (frozen/ossified), or \
+             {} to the immutable genesis lineage hash (rolling).",
+            ZK_PARAMS_HASH_ENV,
+            ZK_GENESIS_PARAMS_HASH_ENV,
+            ZK_PARAMS_HASH_ENV,
+            ZK_GENESIS_PARAMS_HASH_ENV
+        ))),
+    }
+}
+
 /// 2.4 HIGH: Compute SHA-256 hash of a parameters file
 ///
 /// Streams the file to handle large parameter sets efficiently.
@@ -671,5 +782,101 @@ pub fn check_simulated_proofs_warning() {
         tracing::debug!(
             "L-8: Simulated proofs are disabled (GHOST_ALLOW_SIMULATED_PROOFS not set to 1)"
         );
+    }
+}
+
+// ============================================================================
+// Stage C: Genesis anchor + startup mode-selection tests
+// ============================================================================
+
+#[cfg(test)]
+mod startup_mode_tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    // Env vars are process-global; serialize the mode-selection tests so they
+    // do not clobber each other's `ZK_PARAMS_HASH` / `ZK_GENESIS_PARAMS_HASH`.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    /// RAII guard that clears both vars on entry and on drop, so each test runs
+    /// against a known-clean environment regardless of ordering.
+    struct EnvScrub;
+    impl EnvScrub {
+        fn new() -> Self {
+            std::env::remove_var(ZK_PARAMS_HASH_ENV);
+            std::env::remove_var(ZK_GENESIS_PARAMS_HASH_ENV);
+            EnvScrub
+        }
+    }
+    impl Drop for EnvScrub {
+        fn drop(&mut self) {
+            std::env::remove_var(ZK_PARAMS_HASH_ENV);
+            std::env::remove_var(ZK_GENESIS_PARAMS_HASH_ENV);
+        }
+    }
+
+    const ANCHOR_HEX: &str = "c9c907f688fc1102000000000000000000000000000000000000000000000000";
+
+    fn anchor_bytes() -> [u8; 32] {
+        hex::decode(ANCHOR_HEX).unwrap().try_into().unwrap()
+    }
+
+    #[test]
+    fn test_genesis_hash_unset_is_none() {
+        let _g = ENV_LOCK.lock().unwrap();
+        let _s = EnvScrub::new();
+        assert_eq!(genesis_params_hash().unwrap(), None);
+    }
+
+    #[test]
+    fn test_genesis_hash_valid_parses() {
+        let _g = ENV_LOCK.lock().unwrap();
+        let _s = EnvScrub::new();
+        std::env::set_var(ZK_GENESIS_PARAMS_HASH_ENV, ANCHOR_HEX);
+        assert_eq!(genesis_params_hash().unwrap(), Some(anchor_bytes()));
+    }
+
+    #[test]
+    fn test_genesis_hash_malformed_is_error_not_none() {
+        let _g = ENV_LOCK.lock().unwrap();
+        let _s = EnvScrub::new();
+        // Wrong length — must FAIL, never silently degrade to None.
+        std::env::set_var(ZK_GENESIS_PARAMS_HASH_ENV, "deadbeef");
+        assert!(genesis_params_hash().is_err());
+        // Non-hex of the right length — must FAIL.
+        std::env::set_var(ZK_GENESIS_PARAMS_HASH_ENV, "z".repeat(64));
+        assert!(genesis_params_hash().is_err());
+    }
+
+    #[test]
+    fn test_mode_static_pin_when_zk_params_hash_set() {
+        let _g = ENV_LOCK.lock().unwrap();
+        let _s = EnvScrub::new();
+        std::env::set_var(ZK_PARAMS_HASH_ENV, "BLOCK:00");
+        assert_eq!(select_startup_mode().unwrap(), ZkStartupMode::StaticPin);
+        // Static pin wins even if the genesis anchor is ALSO set (frozen path).
+        std::env::set_var(ZK_GENESIS_PARAMS_HASH_ENV, ANCHOR_HEX);
+        assert_eq!(select_startup_mode().unwrap(), ZkStartupMode::StaticPin);
+    }
+
+    #[test]
+    fn test_mode_rolling_when_only_genesis_anchor_set() {
+        let _g = ENV_LOCK.lock().unwrap();
+        let _s = EnvScrub::new();
+        std::env::set_var(ZK_GENESIS_PARAMS_HASH_ENV, ANCHOR_HEX);
+        assert_eq!(
+            select_startup_mode().unwrap(),
+            ZkStartupMode::GenesisAnchoredRolling {
+                genesis_anchor: anchor_bytes()
+            }
+        );
+    }
+
+    #[test]
+    fn test_mode_refuses_when_neither_set() {
+        let _g = ENV_LOCK.lock().unwrap();
+        let _s = EnvScrub::new();
+        // Neither pin present → never an unverified mode; selection errors.
+        assert!(select_startup_mode().is_err());
     }
 }


### PR DESCRIPTION
Resumes the rolling MPC trusted-setup ceremony so it evolves to 101 elders autonomously, replacing the static-pin freeze. Four reviewed + tested stages on one branch. **Does not itself un-pin mainnet** — that is a separate gated operational step (see `tasks/plan_mpc_rolling_resume.md`).

## Stages
- **A — foundation**: unify the 67% BFT threshold (was 75% vs 67%), stabilise `ceremony_id` to the genesis lineage hash, make `mpc_ceremony` the authoritative singleton + idempotent v39 backfill from existing contributions, startup lineage cross-check.
- **B — security core**: BFT voters now run real `verify_contribution` (Schnorr + h/l pairing) before approving — closes the dormant hole where a supermajority could approve cryptographically-unverified params. Wires `apply_contribution_multi` + `save_mpc_ceremony_state` on threshold; `params_callback` requires the verified result. Proven by `test_forged_contribution_rejected_not_applied` (and that the old structural-only path would have approved the same forgery).
- **C — genesis-anchored startup + sync**: `select_startup_mode` (StaticPin while pinned/ossified vs GenesisAnchoredRolling while rolling vs refuse-if-neither). Rolling startup verifies immutable genesis anchor → lineage chain → retained BFT quorum per position → on-disk head (`verify_genesis_anchored_chain`); never adopts on hash-match alone. New `GET /api/v1/mpc/votes/{position}` serves proof+votes so a fresh node self-verifies history; catch-up verify omits the live timestamp skew. No-forge argument + every fail-closed mode tested.
- **D — regtest lifecycle harness**: `mpc-test-cap` feature (cap=4, never mainnet-reachable) drives genesis → BFT-approved contributions → hash evolves + restart re-validates → forged rejected → ossify → fresh-node catch-up → un-pin rehearsal, with real Groth16/Schnorr/pairing. 67% supermajority geometry proven at the DB layer (4-of-5 holds, 3-of-5 fails closed).

## Safety
Production behaviour is **bit-identical while `ZK_PARAMS_HASH` stays pinned** (StaticPin mode = the existing path). The genesis-anchored rolling path only engages when the static pin is removed + the genesis anchor is set — the deliberate, canaried, reversible mainnet step. Current prod: 6 nodes, identical params, 5-of-N, frozen — unaffected by merging this.

## Tests
ghost-mpc (incl. cap + lineage), ghost-consensus `ceremony_vote_tests` 4/4, ghost-storage `mpc_lineage` 15/15, ghost-zkp `startup_mode` 6/6, harness 5/5. Builds clean default + `zk-production` (cap stays 101). Residual: live cross-process ZMQ/HTTP exercised by the mainnet canary un-pin (instant rollback) + optionally the docker regtest cluster.