### PR TITLE
release: v1.10.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-ghost-tests"
-version = "1.10.8"
+version = "1.10.9"
 dependencies = [
  "bitcoin",
  "chrono",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin_core_sv2"
-version = "1.10.8"
+version = "1.10.9"
 dependencies = [
  "async-channel 1.9.0",
  "bitcoin-capnp-types",
@@ -3083,7 +3083,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-accounting"
-version = "1.10.8"
+version = "1.10.9"
 dependencies = [
  "bitcoin",
  "ghost-common",
@@ -3097,7 +3097,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-buds"
-version = "1.10.8"
+version = "1.10.9"
 dependencies = [
  "bitcoin",
  "ghost-common",
@@ -3111,7 +3111,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-cli"
-version = "1.10.8"
+version = "1.10.9"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3129,7 +3129,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-common"
-version = "1.10.8"
+version = "1.10.9"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -3162,7 +3162,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-consensus"
-version = "1.10.8"
+version = "1.10.9"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3194,7 +3194,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-glyph"
-version = "1.10.8"
+version = "1.10.9"
 dependencies = [
  "hex",
  "serde",
@@ -3205,7 +3205,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-gsp"
-version = "1.10.8"
+version = "1.10.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3267,7 +3267,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-gsp-proto"
-version = "1.10.8"
+version = "1.10.9"
 dependencies = [
  "bitcoin",
  "chrono",
@@ -3284,7 +3284,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-keys"
-version = "1.10.8"
+version = "1.10.9"
 dependencies = [
  "bech32",
  "bitcoin",
@@ -3306,7 +3306,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-locks"
-version = "1.10.8"
+version = "1.10.9"
 dependencies = [
  "bitcoin",
  "getrandom 0.2.17",
@@ -3350,7 +3350,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-pay"
-version = "1.10.8"
+version = "1.10.9"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3398,7 +3398,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-policy"
-version = "1.10.8"
+version = "1.10.9"
 dependencies = [
  "bitcoin",
  "ghost-buds",
@@ -3411,7 +3411,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-pool"
-version = "1.10.8"
+version = "1.10.9"
 dependencies = [
  "anyhow",
  "async-channel 2.5.0",
@@ -3466,7 +3466,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-reaper"
-version = "1.10.8"
+version = "1.10.9"
 dependencies = [
  "bitcoin",
  "hex",
@@ -3478,7 +3478,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-reconciliation"
-version = "1.10.8"
+version = "1.10.9"
 dependencies = [
  "async-trait",
  "bitcoin",
@@ -3504,7 +3504,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-registry"
-version = "1.10.8"
+version = "1.10.9"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -3539,7 +3539,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-setup"
-version = "1.10.8"
+version = "1.10.9"
 dependencies = [
  "clap",
  "dirs 5.0.1",
@@ -3550,7 +3550,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-storage"
-version = "1.10.8"
+version = "1.10.9"
 dependencies = [
  "base64 0.22.1",
  "chacha20poly1305",
@@ -3571,7 +3571,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-tap-core"
-version = "1.10.8"
+version = "1.10.9"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3613,7 +3613,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-tap-desktop"
-version = "1.10.8"
+version = "1.10.9"
 dependencies = [
  "dirs 6.0.0",
  "getrandom 0.2.17",
@@ -3639,7 +3639,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-tap-integration"
-version = "1.10.8"
+version = "1.10.9"
 dependencies = [
  "ghost-gsp-proto",
  "ghost-tap-core",
@@ -3653,7 +3653,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-template"
-version = "1.10.8"
+version = "1.10.9"
 dependencies = [
  "bitcoin",
  "ghost-buds",
@@ -3669,7 +3669,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-verification"
-version = "1.10.8"
+version = "1.10.9"
 dependencies = [
  "axum 0.7.9",
  "bitcoin",
@@ -4641,7 +4641,7 @@ dependencies = [
 
 [[package]]
 name = "jd_client_sv2"
-version = "1.10.8"
+version = "1.10.9"
 dependencies = [
  "async-channel 1.9.0",
  "bitcoin_core_sv2",
@@ -4657,7 +4657,7 @@ dependencies = [
 
 [[package]]
 name = "jd_server_sv2"
-version = "1.10.8"
+version = "1.10.9"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -6158,7 +6158,7 @@ dependencies = [
 
 [[package]]
 name = "pool_sv2"
-version = "1.10.8"
+version = "1.10.9"
 dependencies = [
  "async-channel 1.9.0",
  "bitcoin_core_sv2",
@@ -7882,7 +7882,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stratum-apps"
-version = "1.10.8"
+version = "1.10.9"
 dependencies = [
  "async-channel 1.9.0",
  "axum 0.8.9",
@@ -9095,7 +9095,7 @@ dependencies = [
 
 [[package]]
 name = "translator_sv2"
-version = "1.10.8"
+version = "1.10.9"
 dependencies = [
  "async-channel 1.9.0",
  "clap",
@@ -10426,7 +10426,7 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "wraith-coordinator"
-version = "1.10.8"
+version = "1.10.9"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -10463,7 +10463,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-protocol"
-version = "1.10.8"
+version = "1.10.9"
 dependencies = [
  "bitcoin",
  "getrandom 0.2.17",
@@ -10484,7 +10484,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-cli"
-version = "1.10.8"
+version = "1.10.9"
 dependencies = [
  "clap",
  "clap_complete",
@@ -10497,7 +10497,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-core"
-version = "1.10.8"
+version = "1.10.9"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -10534,7 +10534,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-daemon"
-version = "1.10.8"
+version = "1.10.9"
 dependencies = [
  "axum 0.7.9",
  "base64 0.22.1",
@@ -10559,7 +10559,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-gui"
-version = "1.10.8"
+version = "1.10.9"
 dependencies = [
  "serde",
  "serde_json",
@@ -10573,7 +10573,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-ipc"
-version = "1.10.8"
+version = "1.10.9"
 dependencies = [
  "libc",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ exclude = []
 # Use scripts/build-all-wallets.sh to build all wallet types.
 
 [workspace.package]
-version = "1.10.8"
+version = "1.10.9"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Bitcoin Ghost Team"]


### PR DESCRIPTION
Version bump 1.10.8 → 1.10.9 capturing the resumed MPC rolling ceremony (#139). Production behaviour is bit-identical while pinned; the rolling path is a separate gated mainnet step. Tagging v1.10.9 after merge triggers the signed build.