### PR TITLE
Resume MPC rolling ceremony (positions 5-7 live) + cross-host contribution fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5122,6 +5122,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "mpc-xproc-harness"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "axum 0.7.9",
+ "bellperson",
+ "blstrs",
+ "ghost-common",
+ "ghost-mpc",
+ "ghost-policy",
+ "ghost-verification",
+ "ghost-zkp",
+ "hex",
+ "rand 0.8.6",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+]
+
+[[package]]
 name = "muda"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-ghost-tests"
-version = "1.10.10"
+version = "1.10.11"
 dependencies = [
  "bitcoin",
  "chrono",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin_core_sv2"
-version = "1.10.10"
+version = "1.10.11"
 dependencies = [
  "async-channel 1.9.0",
  "bitcoin-capnp-types",
@@ -3083,7 +3083,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-accounting"
-version = "1.10.10"
+version = "1.10.11"
 dependencies = [
  "bitcoin",
  "ghost-common",
@@ -3097,7 +3097,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-buds"
-version = "1.10.10"
+version = "1.10.11"
 dependencies = [
  "bitcoin",
  "ghost-common",
@@ -3111,7 +3111,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-cli"
-version = "1.10.10"
+version = "1.10.11"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3129,7 +3129,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-common"
-version = "1.10.10"
+version = "1.10.11"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -3162,7 +3162,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-consensus"
-version = "1.10.10"
+version = "1.10.11"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3194,7 +3194,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-glyph"
-version = "1.10.10"
+version = "1.10.11"
 dependencies = [
  "hex",
  "serde",
@@ -3205,7 +3205,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-gsp"
-version = "1.10.10"
+version = "1.10.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3267,7 +3267,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-gsp-proto"
-version = "1.10.10"
+version = "1.10.11"
 dependencies = [
  "bitcoin",
  "chrono",
@@ -3284,7 +3284,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-keys"
-version = "1.10.10"
+version = "1.10.11"
 dependencies = [
  "bech32",
  "bitcoin",
@@ -3306,7 +3306,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-locks"
-version = "1.10.10"
+version = "1.10.11"
 dependencies = [
  "bitcoin",
  "getrandom 0.2.17",
@@ -3350,7 +3350,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-pay"
-version = "1.10.10"
+version = "1.10.11"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3398,7 +3398,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-policy"
-version = "1.10.10"
+version = "1.10.11"
 dependencies = [
  "bitcoin",
  "ghost-buds",
@@ -3411,7 +3411,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-pool"
-version = "1.10.10"
+version = "1.10.11"
 dependencies = [
  "anyhow",
  "async-channel 2.5.0",
@@ -3466,7 +3466,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-reaper"
-version = "1.10.10"
+version = "1.10.11"
 dependencies = [
  "bitcoin",
  "hex",
@@ -3478,7 +3478,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-reconciliation"
-version = "1.10.10"
+version = "1.10.11"
 dependencies = [
  "async-trait",
  "bitcoin",
@@ -3504,7 +3504,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-registry"
-version = "1.10.10"
+version = "1.10.11"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -3539,7 +3539,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-setup"
-version = "1.10.10"
+version = "1.10.11"
 dependencies = [
  "clap",
  "dirs 5.0.1",
@@ -3550,7 +3550,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-storage"
-version = "1.10.10"
+version = "1.10.11"
 dependencies = [
  "base64 0.22.1",
  "chacha20poly1305",
@@ -3571,7 +3571,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-tap-core"
-version = "1.10.10"
+version = "1.10.11"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3613,7 +3613,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-tap-desktop"
-version = "1.10.10"
+version = "1.10.11"
 dependencies = [
  "dirs 6.0.0",
  "getrandom 0.2.17",
@@ -3639,7 +3639,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-tap-integration"
-version = "1.10.10"
+version = "1.10.11"
 dependencies = [
  "ghost-gsp-proto",
  "ghost-tap-core",
@@ -3653,7 +3653,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-template"
-version = "1.10.10"
+version = "1.10.11"
 dependencies = [
  "bitcoin",
  "ghost-buds",
@@ -3669,7 +3669,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-verification"
-version = "1.10.10"
+version = "1.10.11"
 dependencies = [
  "axum 0.7.9",
  "bitcoin",
@@ -4641,7 +4641,7 @@ dependencies = [
 
 [[package]]
 name = "jd_client_sv2"
-version = "1.10.10"
+version = "1.10.11"
 dependencies = [
  "async-channel 1.9.0",
  "bitcoin_core_sv2",
@@ -4657,7 +4657,7 @@ dependencies = [
 
 [[package]]
 name = "jd_server_sv2"
-version = "1.10.10"
+version = "1.10.11"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -6180,7 +6180,7 @@ dependencies = [
 
 [[package]]
 name = "pool_sv2"
-version = "1.10.10"
+version = "1.10.11"
 dependencies = [
  "async-channel 1.9.0",
  "bitcoin_core_sv2",
@@ -7904,7 +7904,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stratum-apps"
-version = "1.10.10"
+version = "1.10.11"
 dependencies = [
  "async-channel 1.9.0",
  "axum 0.8.9",
@@ -9117,7 +9117,7 @@ dependencies = [
 
 [[package]]
 name = "translator_sv2"
-version = "1.10.10"
+version = "1.10.11"
 dependencies = [
  "async-channel 1.9.0",
  "clap",
@@ -10448,7 +10448,7 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "wraith-coordinator"
-version = "1.10.10"
+version = "1.10.11"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -10485,7 +10485,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-protocol"
-version = "1.10.10"
+version = "1.10.11"
 dependencies = [
  "bitcoin",
  "getrandom 0.2.17",
@@ -10506,7 +10506,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-cli"
-version = "1.10.10"
+version = "1.10.11"
 dependencies = [
  "clap",
  "clap_complete",
@@ -10519,7 +10519,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-core"
-version = "1.10.10"
+version = "1.10.11"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -10556,7 +10556,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-daemon"
-version = "1.10.10"
+version = "1.10.11"
 dependencies = [
  "axum 0.7.9",
  "base64 0.22.1",
@@ -10581,7 +10581,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-gui"
-version = "1.10.10"
+version = "1.10.11"
 dependencies = [
  "serde",
  "serde_json",
@@ -10595,7 +10595,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-ipc"
-version = "1.10.10"
+version = "1.10.11"
 dependencies = [
  "libc",
  "proptest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-ghost-tests"
-version = "1.10.11"
+version = "1.10.12"
 dependencies = [
  "bitcoin",
  "chrono",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin_core_sv2"
-version = "1.10.11"
+version = "1.10.12"
 dependencies = [
  "async-channel 1.9.0",
  "bitcoin-capnp-types",
@@ -3083,7 +3083,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-accounting"
-version = "1.10.11"
+version = "1.10.12"
 dependencies = [
  "bitcoin",
  "ghost-common",
@@ -3097,7 +3097,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-buds"
-version = "1.10.11"
+version = "1.10.12"
 dependencies = [
  "bitcoin",
  "ghost-common",
@@ -3111,7 +3111,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-cli"
-version = "1.10.11"
+version = "1.10.12"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3129,7 +3129,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-common"
-version = "1.10.11"
+version = "1.10.12"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -3162,7 +3162,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-consensus"
-version = "1.10.11"
+version = "1.10.12"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3194,7 +3194,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-glyph"
-version = "1.10.11"
+version = "1.10.12"
 dependencies = [
  "hex",
  "serde",
@@ -3205,7 +3205,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-gsp"
-version = "1.10.11"
+version = "1.10.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3267,7 +3267,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-gsp-proto"
-version = "1.10.11"
+version = "1.10.12"
 dependencies = [
  "bitcoin",
  "chrono",
@@ -3284,7 +3284,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-keys"
-version = "1.10.11"
+version = "1.10.12"
 dependencies = [
  "bech32",
  "bitcoin",
@@ -3306,7 +3306,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-locks"
-version = "1.10.11"
+version = "1.10.12"
 dependencies = [
  "bitcoin",
  "getrandom 0.2.17",
@@ -3350,7 +3350,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-pay"
-version = "1.10.11"
+version = "1.10.12"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3398,7 +3398,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-policy"
-version = "1.10.11"
+version = "1.10.12"
 dependencies = [
  "bitcoin",
  "ghost-buds",
@@ -3411,7 +3411,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-pool"
-version = "1.10.11"
+version = "1.10.12"
 dependencies = [
  "anyhow",
  "async-channel 2.5.0",
@@ -3466,7 +3466,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-reaper"
-version = "1.10.11"
+version = "1.10.12"
 dependencies = [
  "bitcoin",
  "hex",
@@ -3478,7 +3478,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-reconciliation"
-version = "1.10.11"
+version = "1.10.12"
 dependencies = [
  "async-trait",
  "bitcoin",
@@ -3504,7 +3504,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-registry"
-version = "1.10.11"
+version = "1.10.12"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -3539,7 +3539,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-setup"
-version = "1.10.11"
+version = "1.10.12"
 dependencies = [
  "clap",
  "dirs 5.0.1",
@@ -3550,7 +3550,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-storage"
-version = "1.10.11"
+version = "1.10.12"
 dependencies = [
  "base64 0.22.1",
  "chacha20poly1305",
@@ -3571,7 +3571,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-tap-core"
-version = "1.10.11"
+version = "1.10.12"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3613,7 +3613,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-tap-desktop"
-version = "1.10.11"
+version = "1.10.12"
 dependencies = [
  "dirs 6.0.0",
  "getrandom 0.2.17",
@@ -3639,7 +3639,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-tap-integration"
-version = "1.10.11"
+version = "1.10.12"
 dependencies = [
  "ghost-gsp-proto",
  "ghost-tap-core",
@@ -3653,7 +3653,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-template"
-version = "1.10.11"
+version = "1.10.12"
 dependencies = [
  "bitcoin",
  "ghost-buds",
@@ -3669,7 +3669,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-verification"
-version = "1.10.11"
+version = "1.10.12"
 dependencies = [
  "axum 0.7.9",
  "bitcoin",
@@ -4641,7 +4641,7 @@ dependencies = [
 
 [[package]]
 name = "jd_client_sv2"
-version = "1.10.11"
+version = "1.10.12"
 dependencies = [
  "async-channel 1.9.0",
  "bitcoin_core_sv2",
@@ -4657,7 +4657,7 @@ dependencies = [
 
 [[package]]
 name = "jd_server_sv2"
-version = "1.10.11"
+version = "1.10.12"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -6180,7 +6180,7 @@ dependencies = [
 
 [[package]]
 name = "pool_sv2"
-version = "1.10.11"
+version = "1.10.12"
 dependencies = [
  "async-channel 1.9.0",
  "bitcoin_core_sv2",
@@ -7904,7 +7904,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stratum-apps"
-version = "1.10.11"
+version = "1.10.12"
 dependencies = [
  "async-channel 1.9.0",
  "axum 0.8.9",
@@ -9117,7 +9117,7 @@ dependencies = [
 
 [[package]]
 name = "translator_sv2"
-version = "1.10.11"
+version = "1.10.12"
 dependencies = [
  "async-channel 1.9.0",
  "clap",
@@ -10448,7 +10448,7 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "wraith-coordinator"
-version = "1.10.11"
+version = "1.10.12"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -10485,7 +10485,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-protocol"
-version = "1.10.11"
+version = "1.10.12"
 dependencies = [
  "bitcoin",
  "getrandom 0.2.17",
@@ -10506,7 +10506,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-cli"
-version = "1.10.11"
+version = "1.10.12"
 dependencies = [
  "clap",
  "clap_complete",
@@ -10519,7 +10519,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-core"
-version = "1.10.11"
+version = "1.10.12"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -10556,7 +10556,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-daemon"
-version = "1.10.11"
+version = "1.10.12"
 dependencies = [
  "axum 0.7.9",
  "base64 0.22.1",
@@ -10581,7 +10581,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-gui"
-version = "1.10.11"
+version = "1.10.12"
 dependencies = [
  "serde",
  "serde_json",
@@ -10595,7 +10595,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-ipc"
-version = "1.10.11"
+version = "1.10.12"
 dependencies = [
  "libc",
  "proptest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-ghost-tests"
-version = "1.10.9"
+version = "1.10.10"
 dependencies = [
  "bitcoin",
  "chrono",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin_core_sv2"
-version = "1.10.9"
+version = "1.10.10"
 dependencies = [
  "async-channel 1.9.0",
  "bitcoin-capnp-types",
@@ -3083,7 +3083,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-accounting"
-version = "1.10.9"
+version = "1.10.10"
 dependencies = [
  "bitcoin",
  "ghost-common",
@@ -3097,7 +3097,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-buds"
-version = "1.10.9"
+version = "1.10.10"
 dependencies = [
  "bitcoin",
  "ghost-common",
@@ -3111,7 +3111,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-cli"
-version = "1.10.9"
+version = "1.10.10"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3129,7 +3129,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-common"
-version = "1.10.9"
+version = "1.10.10"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -3162,7 +3162,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-consensus"
-version = "1.10.9"
+version = "1.10.10"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3194,7 +3194,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-glyph"
-version = "1.10.9"
+version = "1.10.10"
 dependencies = [
  "hex",
  "serde",
@@ -3205,7 +3205,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-gsp"
-version = "1.10.9"
+version = "1.10.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3267,7 +3267,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-gsp-proto"
-version = "1.10.9"
+version = "1.10.10"
 dependencies = [
  "bitcoin",
  "chrono",
@@ -3284,7 +3284,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-keys"
-version = "1.10.9"
+version = "1.10.10"
 dependencies = [
  "bech32",
  "bitcoin",
@@ -3306,7 +3306,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-locks"
-version = "1.10.9"
+version = "1.10.10"
 dependencies = [
  "bitcoin",
  "getrandom 0.2.17",
@@ -3350,7 +3350,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-pay"
-version = "1.10.9"
+version = "1.10.10"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3398,7 +3398,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-policy"
-version = "1.10.9"
+version = "1.10.10"
 dependencies = [
  "bitcoin",
  "ghost-buds",
@@ -3411,7 +3411,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-pool"
-version = "1.10.9"
+version = "1.10.10"
 dependencies = [
  "anyhow",
  "async-channel 2.5.0",
@@ -3466,7 +3466,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-reaper"
-version = "1.10.9"
+version = "1.10.10"
 dependencies = [
  "bitcoin",
  "hex",
@@ -3478,7 +3478,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-reconciliation"
-version = "1.10.9"
+version = "1.10.10"
 dependencies = [
  "async-trait",
  "bitcoin",
@@ -3504,7 +3504,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-registry"
-version = "1.10.9"
+version = "1.10.10"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -3539,7 +3539,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-setup"
-version = "1.10.9"
+version = "1.10.10"
 dependencies = [
  "clap",
  "dirs 5.0.1",
@@ -3550,7 +3550,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-storage"
-version = "1.10.9"
+version = "1.10.10"
 dependencies = [
  "base64 0.22.1",
  "chacha20poly1305",
@@ -3571,7 +3571,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-tap-core"
-version = "1.10.9"
+version = "1.10.10"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3613,7 +3613,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-tap-desktop"
-version = "1.10.9"
+version = "1.10.10"
 dependencies = [
  "dirs 6.0.0",
  "getrandom 0.2.17",
@@ -3639,7 +3639,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-tap-integration"
-version = "1.10.9"
+version = "1.10.10"
 dependencies = [
  "ghost-gsp-proto",
  "ghost-tap-core",
@@ -3653,7 +3653,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-template"
-version = "1.10.9"
+version = "1.10.10"
 dependencies = [
  "bitcoin",
  "ghost-buds",
@@ -3669,7 +3669,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-verification"
-version = "1.10.9"
+version = "1.10.10"
 dependencies = [
  "axum 0.7.9",
  "bitcoin",
@@ -4641,7 +4641,7 @@ dependencies = [
 
 [[package]]
 name = "jd_client_sv2"
-version = "1.10.9"
+version = "1.10.10"
 dependencies = [
  "async-channel 1.9.0",
  "bitcoin_core_sv2",
@@ -4657,7 +4657,7 @@ dependencies = [
 
 [[package]]
 name = "jd_server_sv2"
-version = "1.10.9"
+version = "1.10.10"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -6180,7 +6180,7 @@ dependencies = [
 
 [[package]]
 name = "pool_sv2"
-version = "1.10.9"
+version = "1.10.10"
 dependencies = [
  "async-channel 1.9.0",
  "bitcoin_core_sv2",
@@ -7904,7 +7904,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stratum-apps"
-version = "1.10.9"
+version = "1.10.10"
 dependencies = [
  "async-channel 1.9.0",
  "axum 0.8.9",
@@ -9117,7 +9117,7 @@ dependencies = [
 
 [[package]]
 name = "translator_sv2"
-version = "1.10.9"
+version = "1.10.10"
 dependencies = [
  "async-channel 1.9.0",
  "clap",
@@ -10448,7 +10448,7 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "wraith-coordinator"
-version = "1.10.9"
+version = "1.10.10"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -10485,7 +10485,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-protocol"
-version = "1.10.9"
+version = "1.10.10"
 dependencies = [
  "bitcoin",
  "getrandom 0.2.17",
@@ -10506,7 +10506,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-cli"
-version = "1.10.9"
+version = "1.10.10"
 dependencies = [
  "clap",
  "clap_complete",
@@ -10519,7 +10519,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-core"
-version = "1.10.9"
+version = "1.10.10"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -10556,7 +10556,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-daemon"
-version = "1.10.9"
+version = "1.10.10"
 dependencies = [
  "axum 0.7.9",
  "base64 0.22.1",
@@ -10581,7 +10581,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-gui"
-version = "1.10.9"
+version = "1.10.10"
 dependencies = [
  "serde",
  "serde_json",
@@ -10595,7 +10595,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-ipc"
-version = "1.10.9"
+version = "1.10.10"
 dependencies = [
  "libc",
  "proptest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-ghost-tests"
-version = "1.10.13"
+version = "1.10.14"
 dependencies = [
  "bitcoin",
  "chrono",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin_core_sv2"
-version = "1.10.13"
+version = "1.10.14"
 dependencies = [
  "async-channel 1.9.0",
  "bitcoin-capnp-types",
@@ -3083,7 +3083,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-accounting"
-version = "1.10.13"
+version = "1.10.14"
 dependencies = [
  "bitcoin",
  "ghost-common",
@@ -3097,7 +3097,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-buds"
-version = "1.10.13"
+version = "1.10.14"
 dependencies = [
  "bitcoin",
  "ghost-common",
@@ -3111,7 +3111,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-cli"
-version = "1.10.13"
+version = "1.10.14"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3129,7 +3129,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-common"
-version = "1.10.13"
+version = "1.10.14"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -3162,7 +3162,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-consensus"
-version = "1.10.13"
+version = "1.10.14"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3194,7 +3194,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-glyph"
-version = "1.10.13"
+version = "1.10.14"
 dependencies = [
  "hex",
  "serde",
@@ -3205,7 +3205,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-gsp"
-version = "1.10.13"
+version = "1.10.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3267,7 +3267,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-gsp-proto"
-version = "1.10.13"
+version = "1.10.14"
 dependencies = [
  "bitcoin",
  "chrono",
@@ -3284,7 +3284,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-keys"
-version = "1.10.13"
+version = "1.10.14"
 dependencies = [
  "bech32",
  "bitcoin",
@@ -3306,7 +3306,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-locks"
-version = "1.10.13"
+version = "1.10.14"
 dependencies = [
  "bitcoin",
  "getrandom 0.2.17",
@@ -3350,7 +3350,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-pay"
-version = "1.10.13"
+version = "1.10.14"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3398,7 +3398,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-policy"
-version = "1.10.13"
+version = "1.10.14"
 dependencies = [
  "bitcoin",
  "ghost-buds",
@@ -3411,7 +3411,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-pool"
-version = "1.10.13"
+version = "1.10.14"
 dependencies = [
  "anyhow",
  "async-channel 2.5.0",
@@ -3466,7 +3466,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-reaper"
-version = "1.10.13"
+version = "1.10.14"
 dependencies = [
  "bitcoin",
  "hex",
@@ -3478,7 +3478,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-reconciliation"
-version = "1.10.13"
+version = "1.10.14"
 dependencies = [
  "async-trait",
  "bitcoin",
@@ -3504,7 +3504,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-registry"
-version = "1.10.13"
+version = "1.10.14"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -3539,7 +3539,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-setup"
-version = "1.10.13"
+version = "1.10.14"
 dependencies = [
  "clap",
  "dirs 5.0.1",
@@ -3550,7 +3550,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-storage"
-version = "1.10.13"
+version = "1.10.14"
 dependencies = [
  "base64 0.22.1",
  "chacha20poly1305",
@@ -3571,7 +3571,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-tap-core"
-version = "1.10.13"
+version = "1.10.14"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3613,7 +3613,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-tap-desktop"
-version = "1.10.13"
+version = "1.10.14"
 dependencies = [
  "dirs 6.0.0",
  "getrandom 0.2.17",
@@ -3639,7 +3639,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-tap-integration"
-version = "1.10.13"
+version = "1.10.14"
 dependencies = [
  "ghost-gsp-proto",
  "ghost-tap-core",
@@ -3653,7 +3653,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-template"
-version = "1.10.13"
+version = "1.10.14"
 dependencies = [
  "bitcoin",
  "ghost-buds",
@@ -3669,7 +3669,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-verification"
-version = "1.10.13"
+version = "1.10.14"
 dependencies = [
  "axum 0.7.9",
  "bitcoin",
@@ -4641,7 +4641,7 @@ dependencies = [
 
 [[package]]
 name = "jd_client_sv2"
-version = "1.10.13"
+version = "1.10.14"
 dependencies = [
  "async-channel 1.9.0",
  "bitcoin_core_sv2",
@@ -4657,7 +4657,7 @@ dependencies = [
 
 [[package]]
 name = "jd_server_sv2"
-version = "1.10.13"
+version = "1.10.14"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -6180,7 +6180,7 @@ dependencies = [
 
 [[package]]
 name = "pool_sv2"
-version = "1.10.13"
+version = "1.10.14"
 dependencies = [
  "async-channel 1.9.0",
  "bitcoin_core_sv2",
@@ -7904,7 +7904,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stratum-apps"
-version = "1.10.13"
+version = "1.10.14"
 dependencies = [
  "async-channel 1.9.0",
  "axum 0.8.9",
@@ -9117,7 +9117,7 @@ dependencies = [
 
 [[package]]
 name = "translator_sv2"
-version = "1.10.13"
+version = "1.10.14"
 dependencies = [
  "async-channel 1.9.0",
  "clap",
@@ -10448,7 +10448,7 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "wraith-coordinator"
-version = "1.10.13"
+version = "1.10.14"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -10485,7 +10485,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-protocol"
-version = "1.10.13"
+version = "1.10.14"
 dependencies = [
  "bitcoin",
  "getrandom 0.2.17",
@@ -10506,7 +10506,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-cli"
-version = "1.10.13"
+version = "1.10.14"
 dependencies = [
  "clap",
  "clap_complete",
@@ -10519,7 +10519,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-core"
-version = "1.10.13"
+version = "1.10.14"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -10556,7 +10556,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-daemon"
-version = "1.10.13"
+version = "1.10.14"
 dependencies = [
  "axum 0.7.9",
  "base64 0.22.1",
@@ -10581,7 +10581,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-gui"
-version = "1.10.13"
+version = "1.10.14"
 dependencies = [
  "serde",
  "serde_json",
@@ -10595,7 +10595,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-ipc"
-version = "1.10.13"
+version = "1.10.14"
 dependencies = [
  "libc",
  "proptest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-ghost-tests"
-version = "1.10.12"
+version = "1.10.13"
 dependencies = [
  "bitcoin",
  "chrono",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin_core_sv2"
-version = "1.10.12"
+version = "1.10.13"
 dependencies = [
  "async-channel 1.9.0",
  "bitcoin-capnp-types",
@@ -3083,7 +3083,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-accounting"
-version = "1.10.12"
+version = "1.10.13"
 dependencies = [
  "bitcoin",
  "ghost-common",
@@ -3097,7 +3097,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-buds"
-version = "1.10.12"
+version = "1.10.13"
 dependencies = [
  "bitcoin",
  "ghost-common",
@@ -3111,7 +3111,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-cli"
-version = "1.10.12"
+version = "1.10.13"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3129,7 +3129,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-common"
-version = "1.10.12"
+version = "1.10.13"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -3162,7 +3162,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-consensus"
-version = "1.10.12"
+version = "1.10.13"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3194,7 +3194,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-glyph"
-version = "1.10.12"
+version = "1.10.13"
 dependencies = [
  "hex",
  "serde",
@@ -3205,7 +3205,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-gsp"
-version = "1.10.12"
+version = "1.10.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3267,7 +3267,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-gsp-proto"
-version = "1.10.12"
+version = "1.10.13"
 dependencies = [
  "bitcoin",
  "chrono",
@@ -3284,7 +3284,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-keys"
-version = "1.10.12"
+version = "1.10.13"
 dependencies = [
  "bech32",
  "bitcoin",
@@ -3306,7 +3306,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-locks"
-version = "1.10.12"
+version = "1.10.13"
 dependencies = [
  "bitcoin",
  "getrandom 0.2.17",
@@ -3350,7 +3350,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-pay"
-version = "1.10.12"
+version = "1.10.13"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3398,7 +3398,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-policy"
-version = "1.10.12"
+version = "1.10.13"
 dependencies = [
  "bitcoin",
  "ghost-buds",
@@ -3411,7 +3411,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-pool"
-version = "1.10.12"
+version = "1.10.13"
 dependencies = [
  "anyhow",
  "async-channel 2.5.0",
@@ -3466,7 +3466,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-reaper"
-version = "1.10.12"
+version = "1.10.13"
 dependencies = [
  "bitcoin",
  "hex",
@@ -3478,7 +3478,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-reconciliation"
-version = "1.10.12"
+version = "1.10.13"
 dependencies = [
  "async-trait",
  "bitcoin",
@@ -3504,7 +3504,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-registry"
-version = "1.10.12"
+version = "1.10.13"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -3539,7 +3539,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-setup"
-version = "1.10.12"
+version = "1.10.13"
 dependencies = [
  "clap",
  "dirs 5.0.1",
@@ -3550,7 +3550,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-storage"
-version = "1.10.12"
+version = "1.10.13"
 dependencies = [
  "base64 0.22.1",
  "chacha20poly1305",
@@ -3571,7 +3571,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-tap-core"
-version = "1.10.12"
+version = "1.10.13"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3613,7 +3613,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-tap-desktop"
-version = "1.10.12"
+version = "1.10.13"
 dependencies = [
  "dirs 6.0.0",
  "getrandom 0.2.17",
@@ -3639,7 +3639,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-tap-integration"
-version = "1.10.12"
+version = "1.10.13"
 dependencies = [
  "ghost-gsp-proto",
  "ghost-tap-core",
@@ -3653,7 +3653,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-template"
-version = "1.10.12"
+version = "1.10.13"
 dependencies = [
  "bitcoin",
  "ghost-buds",
@@ -3669,7 +3669,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-verification"
-version = "1.10.12"
+version = "1.10.13"
 dependencies = [
  "axum 0.7.9",
  "bitcoin",
@@ -4641,7 +4641,7 @@ dependencies = [
 
 [[package]]
 name = "jd_client_sv2"
-version = "1.10.12"
+version = "1.10.13"
 dependencies = [
  "async-channel 1.9.0",
  "bitcoin_core_sv2",
@@ -4657,7 +4657,7 @@ dependencies = [
 
 [[package]]
 name = "jd_server_sv2"
-version = "1.10.12"
+version = "1.10.13"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -6180,7 +6180,7 @@ dependencies = [
 
 [[package]]
 name = "pool_sv2"
-version = "1.10.12"
+version = "1.10.13"
 dependencies = [
  "async-channel 1.9.0",
  "bitcoin_core_sv2",
@@ -7904,7 +7904,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stratum-apps"
-version = "1.10.12"
+version = "1.10.13"
 dependencies = [
  "async-channel 1.9.0",
  "axum 0.8.9",
@@ -9117,7 +9117,7 @@ dependencies = [
 
 [[package]]
 name = "translator_sv2"
-version = "1.10.12"
+version = "1.10.13"
 dependencies = [
  "async-channel 1.9.0",
  "clap",
@@ -10448,7 +10448,7 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "wraith-coordinator"
-version = "1.10.12"
+version = "1.10.13"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -10485,7 +10485,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-protocol"
-version = "1.10.12"
+version = "1.10.13"
 dependencies = [
  "bitcoin",
  "getrandom 0.2.17",
@@ -10506,7 +10506,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-cli"
-version = "1.10.12"
+version = "1.10.13"
 dependencies = [
  "clap",
  "clap_complete",
@@ -10519,7 +10519,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-core"
-version = "1.10.12"
+version = "1.10.13"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -10556,7 +10556,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-daemon"
-version = "1.10.12"
+version = "1.10.13"
 dependencies = [
  "axum 0.7.9",
  "base64 0.22.1",
@@ -10581,7 +10581,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-gui"
-version = "1.10.12"
+version = "1.10.13"
 dependencies = [
  "serde",
  "serde_json",
@@ -10595,7 +10595,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-ipc"
-version = "1.10.12"
+version = "1.10.13"
 dependencies = [
  "libc",
  "proptest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-ghost-tests"
-version = "1.10.14"
+version = "1.10.15"
 dependencies = [
  "bitcoin",
  "chrono",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin_core_sv2"
-version = "1.10.14"
+version = "1.10.15"
 dependencies = [
  "async-channel 1.9.0",
  "bitcoin-capnp-types",
@@ -3083,7 +3083,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-accounting"
-version = "1.10.14"
+version = "1.10.15"
 dependencies = [
  "bitcoin",
  "ghost-common",
@@ -3097,7 +3097,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-buds"
-version = "1.10.14"
+version = "1.10.15"
 dependencies = [
  "bitcoin",
  "ghost-common",
@@ -3111,7 +3111,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-cli"
-version = "1.10.14"
+version = "1.10.15"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3129,7 +3129,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-common"
-version = "1.10.14"
+version = "1.10.15"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -3162,7 +3162,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-consensus"
-version = "1.10.14"
+version = "1.10.15"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3194,7 +3194,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-glyph"
-version = "1.10.14"
+version = "1.10.15"
 dependencies = [
  "hex",
  "serde",
@@ -3205,7 +3205,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-gsp"
-version = "1.10.14"
+version = "1.10.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3267,7 +3267,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-gsp-proto"
-version = "1.10.14"
+version = "1.10.15"
 dependencies = [
  "bitcoin",
  "chrono",
@@ -3284,7 +3284,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-keys"
-version = "1.10.14"
+version = "1.10.15"
 dependencies = [
  "bech32",
  "bitcoin",
@@ -3306,7 +3306,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-locks"
-version = "1.10.14"
+version = "1.10.15"
 dependencies = [
  "bitcoin",
  "getrandom 0.2.17",
@@ -3350,7 +3350,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-pay"
-version = "1.10.14"
+version = "1.10.15"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3398,7 +3398,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-policy"
-version = "1.10.14"
+version = "1.10.15"
 dependencies = [
  "bitcoin",
  "ghost-buds",
@@ -3411,7 +3411,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-pool"
-version = "1.10.14"
+version = "1.10.15"
 dependencies = [
  "anyhow",
  "async-channel 2.5.0",
@@ -3466,7 +3466,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-reaper"
-version = "1.10.14"
+version = "1.10.15"
 dependencies = [
  "bitcoin",
  "hex",
@@ -3478,7 +3478,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-reconciliation"
-version = "1.10.14"
+version = "1.10.15"
 dependencies = [
  "async-trait",
  "bitcoin",
@@ -3504,7 +3504,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-registry"
-version = "1.10.14"
+version = "1.10.15"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -3539,7 +3539,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-setup"
-version = "1.10.14"
+version = "1.10.15"
 dependencies = [
  "clap",
  "dirs 5.0.1",
@@ -3550,7 +3550,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-storage"
-version = "1.10.14"
+version = "1.10.15"
 dependencies = [
  "base64 0.22.1",
  "chacha20poly1305",
@@ -3571,7 +3571,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-tap-core"
-version = "1.10.14"
+version = "1.10.15"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3613,7 +3613,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-tap-desktop"
-version = "1.10.14"
+version = "1.10.15"
 dependencies = [
  "dirs 6.0.0",
  "getrandom 0.2.17",
@@ -3639,7 +3639,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-tap-integration"
-version = "1.10.14"
+version = "1.10.15"
 dependencies = [
  "ghost-gsp-proto",
  "ghost-tap-core",
@@ -3653,7 +3653,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-template"
-version = "1.10.14"
+version = "1.10.15"
 dependencies = [
  "bitcoin",
  "ghost-buds",
@@ -3669,7 +3669,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-verification"
-version = "1.10.14"
+version = "1.10.15"
 dependencies = [
  "axum 0.7.9",
  "bitcoin",
@@ -4641,7 +4641,7 @@ dependencies = [
 
 [[package]]
 name = "jd_client_sv2"
-version = "1.10.14"
+version = "1.10.15"
 dependencies = [
  "async-channel 1.9.0",
  "bitcoin_core_sv2",
@@ -4657,7 +4657,7 @@ dependencies = [
 
 [[package]]
 name = "jd_server_sv2"
-version = "1.10.14"
+version = "1.10.15"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -6180,7 +6180,7 @@ dependencies = [
 
 [[package]]
 name = "pool_sv2"
-version = "1.10.14"
+version = "1.10.15"
 dependencies = [
  "async-channel 1.9.0",
  "bitcoin_core_sv2",
@@ -7904,7 +7904,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stratum-apps"
-version = "1.10.14"
+version = "1.10.15"
 dependencies = [
  "async-channel 1.9.0",
  "axum 0.8.9",
@@ -9117,7 +9117,7 @@ dependencies = [
 
 [[package]]
 name = "translator_sv2"
-version = "1.10.14"
+version = "1.10.15"
 dependencies = [
  "async-channel 1.9.0",
  "clap",
@@ -10448,7 +10448,7 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "wraith-coordinator"
-version = "1.10.14"
+version = "1.10.15"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -10485,7 +10485,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-protocol"
-version = "1.10.14"
+version = "1.10.15"
 dependencies = [
  "bitcoin",
  "getrandom 0.2.17",
@@ -10506,7 +10506,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-cli"
-version = "1.10.14"
+version = "1.10.15"
 dependencies = [
  "clap",
  "clap_complete",
@@ -10519,7 +10519,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-core"
-version = "1.10.14"
+version = "1.10.15"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -10556,7 +10556,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-daemon"
-version = "1.10.14"
+version = "1.10.15"
 dependencies = [
  "axum 0.7.9",
  "base64 0.22.1",
@@ -10581,7 +10581,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-gui"
-version = "1.10.14"
+version = "1.10.15"
 dependencies = [
  "serde",
  "serde_json",
@@ -10595,7 +10595,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-ipc"
-version = "1.10.14"
+version = "1.10.15"
 dependencies = [
  "libc",
  "proptest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-ghost-tests"
-version = "1.10.15"
+version = "1.10.16"
 dependencies = [
  "bitcoin",
  "chrono",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin_core_sv2"
-version = "1.10.15"
+version = "1.10.16"
 dependencies = [
  "async-channel 1.9.0",
  "bitcoin-capnp-types",
@@ -3083,7 +3083,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-accounting"
-version = "1.10.15"
+version = "1.10.16"
 dependencies = [
  "bitcoin",
  "ghost-common",
@@ -3097,7 +3097,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-buds"
-version = "1.10.15"
+version = "1.10.16"
 dependencies = [
  "bitcoin",
  "ghost-common",
@@ -3111,7 +3111,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-cli"
-version = "1.10.15"
+version = "1.10.16"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3129,7 +3129,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-common"
-version = "1.10.15"
+version = "1.10.16"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -3162,7 +3162,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-consensus"
-version = "1.10.15"
+version = "1.10.16"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3194,7 +3194,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-glyph"
-version = "1.10.15"
+version = "1.10.16"
 dependencies = [
  "hex",
  "serde",
@@ -3205,7 +3205,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-gsp"
-version = "1.10.15"
+version = "1.10.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3267,7 +3267,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-gsp-proto"
-version = "1.10.15"
+version = "1.10.16"
 dependencies = [
  "bitcoin",
  "chrono",
@@ -3284,7 +3284,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-keys"
-version = "1.10.15"
+version = "1.10.16"
 dependencies = [
  "bech32",
  "bitcoin",
@@ -3306,7 +3306,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-locks"
-version = "1.10.15"
+version = "1.10.16"
 dependencies = [
  "bitcoin",
  "getrandom 0.2.17",
@@ -3350,7 +3350,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-pay"
-version = "1.10.15"
+version = "1.10.16"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3398,7 +3398,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-policy"
-version = "1.10.15"
+version = "1.10.16"
 dependencies = [
  "bitcoin",
  "ghost-buds",
@@ -3411,7 +3411,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-pool"
-version = "1.10.15"
+version = "1.10.16"
 dependencies = [
  "anyhow",
  "async-channel 2.5.0",
@@ -3466,7 +3466,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-reaper"
-version = "1.10.15"
+version = "1.10.16"
 dependencies = [
  "bitcoin",
  "hex",
@@ -3478,7 +3478,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-reconciliation"
-version = "1.10.15"
+version = "1.10.16"
 dependencies = [
  "async-trait",
  "bitcoin",
@@ -3504,7 +3504,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-registry"
-version = "1.10.15"
+version = "1.10.16"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -3539,7 +3539,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-setup"
-version = "1.10.15"
+version = "1.10.16"
 dependencies = [
  "clap",
  "dirs 5.0.1",
@@ -3550,7 +3550,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-storage"
-version = "1.10.15"
+version = "1.10.16"
 dependencies = [
  "base64 0.22.1",
  "chacha20poly1305",
@@ -3571,7 +3571,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-tap-core"
-version = "1.10.15"
+version = "1.10.16"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3613,7 +3613,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-tap-desktop"
-version = "1.10.15"
+version = "1.10.16"
 dependencies = [
  "dirs 6.0.0",
  "getrandom 0.2.17",
@@ -3639,7 +3639,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-tap-integration"
-version = "1.10.15"
+version = "1.10.16"
 dependencies = [
  "ghost-gsp-proto",
  "ghost-tap-core",
@@ -3653,7 +3653,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-template"
-version = "1.10.15"
+version = "1.10.16"
 dependencies = [
  "bitcoin",
  "ghost-buds",
@@ -3669,7 +3669,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-verification"
-version = "1.10.15"
+version = "1.10.16"
 dependencies = [
  "axum 0.7.9",
  "bitcoin",
@@ -4641,7 +4641,7 @@ dependencies = [
 
 [[package]]
 name = "jd_client_sv2"
-version = "1.10.15"
+version = "1.10.16"
 dependencies = [
  "async-channel 1.9.0",
  "bitcoin_core_sv2",
@@ -4657,7 +4657,7 @@ dependencies = [
 
 [[package]]
 name = "jd_server_sv2"
-version = "1.10.15"
+version = "1.10.16"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -6180,7 +6180,7 @@ dependencies = [
 
 [[package]]
 name = "pool_sv2"
-version = "1.10.15"
+version = "1.10.16"
 dependencies = [
  "async-channel 1.9.0",
  "bitcoin_core_sv2",
@@ -7904,7 +7904,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stratum-apps"
-version = "1.10.15"
+version = "1.10.16"
 dependencies = [
  "async-channel 1.9.0",
  "axum 0.8.9",
@@ -9117,7 +9117,7 @@ dependencies = [
 
 [[package]]
 name = "translator_sv2"
-version = "1.10.15"
+version = "1.10.16"
 dependencies = [
  "async-channel 1.9.0",
  "clap",
@@ -10448,7 +10448,7 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "wraith-coordinator"
-version = "1.10.15"
+version = "1.10.16"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -10485,7 +10485,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-protocol"
-version = "1.10.15"
+version = "1.10.16"
 dependencies = [
  "bitcoin",
  "getrandom 0.2.17",
@@ -10506,7 +10506,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-cli"
-version = "1.10.15"
+version = "1.10.16"
 dependencies = [
  "clap",
  "clap_complete",
@@ -10519,7 +10519,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-core"
-version = "1.10.15"
+version = "1.10.16"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -10556,7 +10556,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-daemon"
-version = "1.10.15"
+version = "1.10.16"
 dependencies = [
  "axum 0.7.9",
  "base64 0.22.1",
@@ -10581,7 +10581,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-gui"
-version = "1.10.15"
+version = "1.10.16"
 dependencies = [
  "serde",
  "serde_json",
@@ -10595,7 +10595,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-ipc"
-version = "1.10.15"
+version = "1.10.16"
 dependencies = [
  "libc",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ exclude = []
 # Use scripts/build-all-wallets.sh to build all wallet types.
 
 [workspace.package]
-version = "1.10.14"
+version = "1.10.15"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Bitcoin Ghost Team"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,8 @@ members = [
     # ZK-BFT Infrastructure
     "crates/ghost-zkp",
     "crates/ghost-mpc",
+    # Cross-process MPC ceremony contribution harness (test-only, feature-gated)
+    "crates/mpc-xproc-harness",
     # Visual Identity
     "crates/ghost-glyph",
     # GSP

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ exclude = []
 # Use scripts/build-all-wallets.sh to build all wallet types.
 
 [workspace.package]
-version = "1.10.11"
+version = "1.10.12"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Bitcoin Ghost Team"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ exclude = []
 # Use scripts/build-all-wallets.sh to build all wallet types.
 
 [workspace.package]
-version = "1.10.15"
+version = "1.10.16"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Bitcoin Ghost Team"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ exclude = []
 # Use scripts/build-all-wallets.sh to build all wallet types.
 
 [workspace.package]
-version = "1.10.10"
+version = "1.10.11"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Bitcoin Ghost Team"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ exclude = []
 # Use scripts/build-all-wallets.sh to build all wallet types.
 
 [workspace.package]
-version = "1.10.9"
+version = "1.10.10"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Bitcoin Ghost Team"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ exclude = []
 # Use scripts/build-all-wallets.sh to build all wallet types.
 
 [workspace.package]
-version = "1.10.12"
+version = "1.10.13"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Bitcoin Ghost Team"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ exclude = []
 # Use scripts/build-all-wallets.sh to build all wallet types.
 
 [workspace.package]
-version = "1.10.13"
+version = "1.10.14"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Bitcoin Ghost Team"]

--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -1223,6 +1223,357 @@ async fn fetch_ceremony_params_bundle(
     None
 }
 
+/// Load a note-spend CANDIDATE parameter set from THIS node's local serving
+/// directory, keyed by its lineage `new_params_hash`, and verify the parsed
+/// params hash to that head before returning.
+///
+/// This is the fast, network-free source for a contributor adopting its OWN
+/// applied contribution: the candidate it generated + wrote (never `current.bin`)
+/// hashes to exactly the `new_params_hash` the voters BFT-approved. Returns
+/// `None` when the file is absent, unreadable, unparsable, or the parsed hash
+/// does not match (a corrupt/stale candidate) — the caller then falls back to
+/// the network.
+#[cfg(feature = "mpc-ceremony")]
+fn load_local_candidate_note_spend(
+    params_dir: &std::path::Path,
+    new_params_hash: &[u8; 32],
+) -> Option<ghost_mpc::Groth16Params> {
+    let path = params_dir.join(ghost_common::mpc::candidate_note_spend_filename(
+        new_params_hash,
+    ));
+    let bytes = std::fs::read(&path).ok()?;
+    let params = ghost_mpc::params::read_parameters_from_bytes(&bytes).ok()?;
+    let h = ghost_mpc::contribution::hash_parameters(&params).ok()?;
+    if &h != new_params_hash {
+        tracing::warn!(
+            expected = %hex::encode(&new_params_hash[..8]),
+            got = %hex::encode(&h[..8]),
+            "MPC adopt: local candidate hash != recorded lineage head — ignoring (will try network)"
+        );
+        return None;
+    }
+    Some(params)
+}
+
+/// Reconstruct an [`ghost_mpc::MpcContribution`] from a persisted contribution
+/// row. The proof is parsed from the stored bytes when present; when it is empty
+/// or malformed (e.g. a row synced from `/contributors` before the real proof
+/// was back-filled) an all-empty proof is substituted. This is safe for the
+/// adopt/apply path because `apply_contribution_multi` reads only the position,
+/// hashes and timestamp — never the proof. Callers that adopt params they did
+/// NOT author still run [`ghost_mpc::CeremonyManager::verify_contribution_catchup`]
+/// separately, which requires a real proof.
+#[cfg(feature = "mpc-ceremony")]
+fn contribution_from_row(
+    row: &ghost_storage::queries::MpcContributionRecord,
+) -> ghost_mpc::MpcContribution {
+    let proof = serde_json::from_slice::<ghost_mpc::ContributionProof>(&row.contribution_proof)
+        .unwrap_or_else(|_| {
+            let empty_pok = || ghost_mpc::contribution::ProofOfKnowledge {
+                commitment_g1: Vec::new(),
+                challenge: [0u8; 32],
+                response: Vec::new(),
+            };
+            ghost_mpc::ContributionProof {
+                tau_g1: Vec::new(),
+                tau_g2: Vec::new(),
+                alpha_g1: Vec::new(),
+                beta_g1: Vec::new(),
+                beta_g2: Vec::new(),
+                tau_pok: empty_pok(),
+                alpha_pok: empty_pok(),
+                beta_pok: empty_pok(),
+            }
+        });
+    ghost_mpc::MpcContribution {
+        position: row.elder_position,
+        prev_params_hash: row.prev_params_hash,
+        new_params_hash: row.new_params_hash,
+        proof,
+        contributor: row.contributor_node_id.clone(),
+        timestamp: row.created_at,
+        commitment_hash: None,
+    }
+}
+
+/// Persist the `mpc_ceremony` singleton from the ceremony manager's AUTHORITATIVE
+/// post-apply state (count, current-params hash, ossification, vk hashes,
+/// ceremony_id). Mirrors the persistence the BFT `params_update_callback` does
+/// after it applies. Returns `false` on a DB error so callers never declare a
+/// consistent head while the singleton write failed.
+#[cfg(feature = "mpc-ceremony")]
+fn persist_singleton_from_manager(
+    ceremony_mgr: &ghost_mpc::CeremonyManager,
+    db: &ghost_storage::Database,
+) -> bool {
+    let s = ceremony_mgr.state();
+    let db_state = ghost_storage::queries::MpcCeremonyState {
+        contribution_count: s.contribution_count,
+        current_params_hash: s.current_params_hash,
+        is_ossified: s.is_ossified,
+        ossified_at: s.ossified_at,
+        block_vk_hash: s.note_spend_vk_hash,
+        payout_vk_hash: s.payout_vk_hash,
+        updated_at: s.updated_at,
+        ceremony_id: s.ceremony_id,
+    };
+    if let Err(e) = db.save_mpc_ceremony_state(&db_state) {
+        tracing::warn!(error = %e, "MPC adopt: failed to persist ceremony singleton");
+        return false;
+    }
+    true
+}
+
+/// Apply an already-obtained, hash-matched note-spend parameter set for
+/// `contribution` through the ONLY legitimate `current.bin` writer
+/// ([`ghost_mpc::CeremonyManager::apply_contribution_multi`]), then persist the
+/// `mpc_ceremony` singleton from the manager's authoritative state.
+///
+/// Returns `true` ONLY when the post-conditions hold: manager count ==
+/// `contribution.position` AND manager current-params hash ==
+/// `contribution.new_params_hash` (so `note_spend_params_current.bin` is the
+/// applied head) AND the singleton was persisted. A `false` return means the
+/// adopt did NOT complete cleanly and the caller MUST NOT declare success.
+///
+/// Payout/unshield ride the note-spend lineage (same toxic waste) and are
+/// intentionally left as `None` here: the note-spend hash is the BFT-chained
+/// trusted-setup head, and the contributor holds only its note-spend candidate.
+/// `update_current_params` copies only the versions that exist on disk, so the
+/// payout/unshield current pointers are left untouched (byte-identical to the
+/// applied head).
+#[cfg(feature = "mpc-ceremony")]
+fn apply_and_persist_adopted_note_spend(
+    ceremony_mgr: &ghost_mpc::CeremonyManager,
+    db: &ghost_storage::Database,
+    note_spend: ghost_mpc::Groth16Params,
+    contribution: &ghost_mpc::MpcContribution,
+) -> bool {
+    if let Err(e) = ceremony_mgr.apply_contribution_multi(note_spend, None, None, contribution) {
+        tracing::warn!(
+            error = %e,
+            position = contribution.position,
+            "MPC adopt: apply_contribution_multi failed"
+        );
+        return false;
+    }
+    if !persist_singleton_from_manager(ceremony_mgr, db) {
+        return false;
+    }
+    // Lineage invariant: the on-disk head + singleton now sit at our applied
+    // position. Verified against the recorded `new_params_hash`, so an adopted
+    // `current.bin` that failed to advance can never masquerade as success.
+    let ok = ceremony_mgr.contribution_count() == contribution.position
+        && ceremony_mgr.current_params_hash() == contribution.new_params_hash;
+    if !ok {
+        tracing::error!(
+            position = contribution.position,
+            count = ceremony_mgr.contribution_count(),
+            "MPC adopt: post-apply invariant violated (count/hash != applied position)"
+        );
+    }
+    ok
+}
+
+/// Adopt the BFT-applied contribution recorded at `position` into THIS node's
+/// on-disk `note_spend_params_current.bin` + `mpc_ceremony` singleton, advancing
+/// the ceremony manager from `position - 1` to `position`.
+///
+/// This closes the contributor self-adopt gap. A node that GENERATED a
+/// contribution never applies it through its own [`ghost_consensus::MpcHandler`]:
+/// the handler only applies contributions it RECEIVED into its
+/// `pending_contributions` map, and a node's own broadcast is never in that map.
+/// So once the voters reach quorum and BFT-apply, and the row gossips back into
+/// `mpc_contributions`, the contributor is recorded as an elder at `position`
+/// while its own `current.bin` + singleton stay at `position - 1` — a fail-closed
+/// crash-loop on restart (on-disk head < recorded chain tip). This drives the
+/// canonical adopt so the head catches up.
+///
+/// Params source, in order: (1) the node's OWN local candidate serving file
+/// (`note_spend_params_candidate_<new_hash>.bin`, hash-checked); (2) the network
+/// (a voter's applied head, hash-checked). For a position this node did NOT
+/// contribute, the fetched params are additionally run through the SAME catch-up
+/// crypto verification (Schnorr + pairing transform against OUR prev) a
+/// voter/callback runs — never adopt a foreign lineage on hash-match alone. An
+/// OWN contribution is self-authored (we produced `new_params_hash`) so the
+/// hash-match to our own BFT-approved row is the gate.
+///
+/// Returns `true` ONLY when the post-adopt invariant holds. `false` means the
+/// node did NOT reach a consistent applied head and the caller MUST NOT declare
+/// elder success.
+#[cfg(feature = "mpc-ceremony")]
+async fn adopt_applied_position(
+    ceremony_mgr: &Arc<ghost_mpc::CeremonyManager>,
+    db: &Arc<ghost_storage::Database>,
+    peers: &ghost_consensus::peer::PeerManager,
+    seeds: &[String],
+    our_node_id_hex: &str,
+    position: u32,
+) -> bool {
+    // The recorded (BFT-approved) row is the authority for what to adopt.
+    let row = match db.get_mpc_contribution(position) {
+        Ok(Some(r)) => r,
+        Ok(None) => {
+            tracing::warn!(
+                position,
+                "MPC adopt: no contribution row for position — cannot adopt"
+            );
+            return false;
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, position, "MPC adopt: contribution row lookup failed");
+            return false;
+        }
+    };
+
+    // Fast path: already at this applied head — just make sure the singleton
+    // reflects it (a lagged singleton on an otherwise-consistent head).
+    if ceremony_mgr.contribution_count() == position
+        && ceremony_mgr.current_params_hash() == row.new_params_hash
+    {
+        return persist_singleton_from_manager(ceremony_mgr, db);
+    }
+
+    // apply_contribution_multi only accepts the IMMEDIATE next position
+    // (position == count + 1). Callers advance positions in order, so this holds.
+    if ceremony_mgr.contribution_count() + 1 != position {
+        tracing::warn!(
+            position,
+            count = ceremony_mgr.contribution_count(),
+            "MPC adopt: manager not positioned at position-1 — cannot apply out of order"
+        );
+        return false;
+    }
+
+    let is_own = row.contributor_node_id == our_node_id_hex;
+    let params_dir = ceremony_mgr.params_dir().clone();
+    let new_hash = row.new_params_hash;
+
+    // Serialise param writes against the other writers (startup fetch, BFT apply,
+    // params_callback) on the shared parameter files.
+    let _param_write_guard = param_write_lock().lock().await;
+
+    // (1) Local candidate serving file first (parse off the async thread).
+    let local = {
+        let dir = params_dir.clone();
+        tokio::task::spawn_blocking(move || load_local_candidate_note_spend(&dir, &new_hash))
+            .await
+            .ok()
+            .flatten()
+    };
+
+    let note_spend = match local {
+        Some(p) => {
+            tracing::info!(position, is_own, "MPC adopt: using local candidate params");
+            p
+        }
+        None => {
+            // (2) Network fallback: a voter serves the applied head by hash. A
+            // contributor adopting its OWN lost candidate resolves nothing for
+            // itself (it is not its own peer) → seeds-only, and any voter's
+            // current.bin now hashes to `new_hash`.
+            let contributor_addr = if is_own {
+                None
+            } else {
+                hex::decode(&row.contributor_node_id)
+                    .ok()
+                    .and_then(|b| <[u8; 32]>::try_from(b.as_slice()).ok())
+                    .and_then(|c| resolve_contributor_addr(peers, db, &c))
+            };
+            let sources = ordered_fetch_sources(contributor_addr.as_deref(), seeds);
+            match fetch_ceremony_params_bundle(&sources, new_hash).await {
+                Some(b) => {
+                    tracing::info!(
+                        position,
+                        is_own,
+                        "MPC adopt: fetched applied params from network"
+                    );
+                    (*b.note_spend).clone()
+                }
+                None => {
+                    tracing::warn!(
+                        position,
+                        "MPC adopt: no local candidate and no network source served matching params"
+                    );
+                    return false;
+                }
+            }
+        }
+    };
+
+    let contribution = contribution_from_row(&row);
+
+    // Never adopt a FOREIGN lineage on hash-match alone: run the same catch-up
+    // crypto verification (Schnorr proof bound to ceremony_id + h/l pairing
+    // transform against OUR prev) a voter/callback runs. OWN contributions are
+    // self-authored and gated by the hash-match to our own approved row (their
+    // proof may not even be locally present yet).
+    if !is_own && position >= 2 && ceremony_mgr.has_current_params() {
+        let prev = match ceremony_mgr.note_spend_params() {
+            Some(p) => p,
+            None => {
+                tracing::warn!(
+                    position,
+                    "MPC adopt: no current params to verify a non-own contribution against"
+                );
+                return false;
+            }
+        };
+        let mgr = Arc::clone(ceremony_mgr);
+        let ns = note_spend.clone();
+        let c = contribution.clone();
+        let verified =
+            tokio::task::spawn_blocking(move || mgr.verify_contribution_catchup(&prev, &ns, &c))
+                .await;
+        if !matches!(verified, Ok(Ok(true))) {
+            tracing::warn!(
+                position,
+                result = ?verified,
+                "MPC adopt: non-own candidate FAILED catch-up verification — refusing"
+            );
+            return false;
+        }
+    }
+
+    // Apply through the manager + persist the singleton, off the async thread.
+    let mgr = Arc::clone(ceremony_mgr);
+    let db2 = Arc::clone(db);
+    let applied = tokio::task::spawn_blocking(move || {
+        apply_and_persist_adopted_note_spend(&mgr, &db2, note_spend, &contribution)
+    })
+    .await;
+    matches!(applied, Ok(true))
+}
+
+/// Catch THIS node's on-disk head + singleton up to the recorded chain tip by
+/// adopting every un-adopted applied position in order. Used both when a
+/// contributor first learns (via gossip) that its contribution was BFT-applied
+/// and at startup for a contributor whose head lags the chain (the restart
+/// self-heal). Returns `true` only when the manager count reaches the recorded
+/// max position (`get_mpc_max_contribution_position`) with each step's invariant
+/// satisfied; `false` if any position could not be adopted (caller then avoids
+/// declaring elder success and lets a later retry / restart heal it).
+#[cfg(feature = "mpc-ceremony")]
+async fn adopt_all_applied_positions(
+    ceremony_mgr: &Arc<ghost_mpc::CeremonyManager>,
+    db: &Arc<ghost_storage::Database>,
+    peers: &ghost_consensus::peer::PeerManager,
+    seeds: &[String],
+    our_node_id_hex: &str,
+) -> bool {
+    let max_pos = db
+        .get_mpc_max_contribution_position()
+        .ok()
+        .flatten()
+        .unwrap_or(0);
+    while ceremony_mgr.contribution_count() < max_pos {
+        let next = ceremony_mgr.contribution_count() + 1;
+        if !adopt_applied_position(ceremony_mgr, db, peers, seeds, our_node_id_hex, next).await {
+            return false;
+        }
+    }
+    true
+}
+
 /// Stage C task 3: fetch a single position's FULL contribution (with the real
 /// `contribution_proof`) AND its retained approve/reject votes from a peer's
 /// `/api/v1/mpc/votes/{position}` endpoint, and persist BOTH locally.
@@ -3124,6 +3475,57 @@ async fn main() -> Result<()> {
         // a node that abstained on some position is reconciled to the verified
         // head + chain length.
         if let Some(genesis_anchor) = zk_rolling_anchor {
+            // 7th contribution-flow gap — CONTRIBUTOR restart self-heal (fail-safe,
+            // runs BEFORE the FATAL verification below).
+            //
+            // A node that GENERATED a contribution never applies it through its own
+            // MpcHandler (the handler applies only contributions it RECEIVED into
+            // `pending_contributions`; a node's own broadcast is never there). So
+            // after the voters BFT-apply it and the row gossips back into
+            // `mpc_contributions`, the contributor is an elder at the new position
+            // while its own `current.bin` + singleton stay at the previous head. On
+            // restart the genesis-anchored verification below sees
+            // `contributions[MAX].new != on-disk head` and fails closed → crash-loop
+            // (the exact node5→position-5 incident).
+            //
+            // Catch the on-disk head + singleton up to the recorded chain tip by
+            // adopting each un-adopted position from THIS node's own local candidate
+            // (network fallback if the candidate is gone). This only advances
+            // positions this node contributed (or ones it can fetch + crypto-verify),
+            // and is a no-op once the head already equals the chain tip (voters, and
+            // an already-healed contributor). If it cannot fully heal we do NOT force
+            // it — the verification below stays authoritative and fail-closed.
+            let our_node_id_hex = hex::encode(identity.node_id());
+            let max_pos = db
+                .get_mpc_max_contribution_position()
+                .ok()
+                .flatten()
+                .unwrap_or(0);
+            if ceremony_manager.contribution_count() < max_pos {
+                if adopt_all_applied_positions(
+                    &ceremony_manager,
+                    &db,
+                    mesh.peers(),
+                    &config.network.seed_nodes,
+                    &our_node_id_hex,
+                )
+                .await
+                {
+                    info!(
+                        head = ceremony_manager.contribution_count(),
+                        "MPC restart self-heal: adopted own applied contribution(s) into on-disk head \
+                         before genesis-anchored verification"
+                    );
+                } else {
+                    warn!(
+                        head = ceremony_manager.contribution_count(),
+                        max_pos,
+                        "MPC restart self-heal: could not fully adopt applied position(s) — \
+                         genesis-anchored verification may fail-close"
+                    );
+                }
+            }
+
             // Head lineage hash of the on-disk current params (None if not loaded).
             let head_lineage: Option<[u8; 32]> = ceremony_manager
                 .note_spend_params()
@@ -3482,6 +3884,26 @@ async fn main() -> Result<()> {
                 let position = db_for_mpc
                     .get_mpc_elder_position(&node_id_hex)
                     .unwrap_or(None);
+                // Self-heal (idempotent): a recorded elder whose own `current.bin`
+                // + singleton lag its applied position must catch up (the restart
+                // scenario). The synchronous restart self-heal above already ran in
+                // rolling mode; this covers non-rolling starts and any residual lag.
+                // A no-op when the head already equals the applied position.
+                if !adopt_all_applied_positions(
+                    &ceremony_manager_for_startup,
+                    &db_for_mpc,
+                    mesh_for_mpc_startup.peers(),
+                    &seed_nodes_for_mpc,
+                    &node_id_hex,
+                )
+                .await
+                {
+                    warn!(
+                        position = ?position,
+                        "MPC: elder on record but could not self-heal on-disk head to its applied \
+                         position — will re-attempt on next restart"
+                    );
+                }
                 info!(position = ?position, "Already an MPC contributor (elder)");
                 return;
             }
@@ -3550,14 +3972,42 @@ async fn main() -> Result<()> {
                     let position = db_for_mpc
                         .get_mpc_elder_position(&node_id_hex)
                         .unwrap_or(None);
-                    info!(position = ?position, "Now an MPC contributor (elder)");
-                    // Update live capabilities so health pings reflect elder status
-                    mesh_for_mpc_startup.update_elder_status(true);
-                    let mut updated_caps = initial_capabilities;
-                    updated_caps.elder_status = true;
-                    round_manager_for_mpc
-                        .update_node_capabilities(identity_for_mpc.node_id(), updated_caps);
-                    return;
+                    // ADOPT our own BFT-applied contribution BEFORE declaring elder
+                    // success. The handler never self-applied it (a node's own
+                    // broadcast is not in its `pending_contributions`), so our
+                    // `current.bin` + `mpc_ceremony` singleton still lag the applied
+                    // position that gossiped back into `mpc_contributions`. Catch the
+                    // head up (own local candidate first, network fallback) so it
+                    // matches the chain tip — otherwise the next restart fails closed
+                    // (on-disk head < chain tip) and crash-loops.
+                    if adopt_all_applied_positions(
+                        &ceremony_manager_for_startup,
+                        &db_for_mpc,
+                        mesh_for_mpc_startup.peers(),
+                        &seed_nodes_for_mpc,
+                        &node_id_hex,
+                    )
+                    .await
+                    {
+                        info!(position = ?position, "Now an MPC contributor (elder)");
+                        // Update live capabilities so health pings reflect elder status
+                        mesh_for_mpc_startup.update_elder_status(true);
+                        let mut updated_caps = initial_capabilities;
+                        updated_caps.elder_status = true;
+                        round_manager_for_mpc
+                            .update_node_capabilities(identity_for_mpc.node_id(), updated_caps);
+                        return;
+                    }
+                    // Could not adopt yet (e.g. candidate gone AND seeds unreachable).
+                    // Do NOT declare elder success on a lagging head; wait and re-check
+                    // (the next iteration retries the adopt; a restart also self-heals).
+                    warn!(
+                        position = ?position,
+                        "MPC: became an elder but could not adopt applied params yet — retrying \
+                         (not declaring success on a lagging head)"
+                    );
+                    tokio::time::sleep(tokio::time::Duration::from_secs(10)).await;
+                    continue;
                 }
 
                 // Ensure we have parameters loaded.
@@ -6870,6 +7320,238 @@ mod tests {
         assert_eq!(fetch_host_of("host.example:8080"), "host.example");
         assert_eq!(fetch_host_of("tcp://1.2.3.4:8559"), "1.2.3.4");
         assert_eq!(fetch_host_of("[2001:db8::1]:8559"), "2001:db8::1");
+    }
+
+    // ── contributor self-adopt (7th contribution-flow gap) ───────────
+    //
+    // A node that GENERATES a contribution never applies it through its own
+    // MpcHandler, so after the voters BFT-apply it and the row gossips back,
+    // the contributor is an elder on record while its own `current.bin` +
+    // singleton stay at the PREVIOUS position. These lock in the fix: the adopt
+    // path advances the on-disk head + singleton to the applied position.
+
+    /// Build a fresh in-memory DB + a genesis+position-1 ceremony manager in
+    /// `dir`, returning the manager, the DB, the node id hex, and the position-1
+    /// lineage hash. After this the manager is an applied-position-1 head.
+    #[cfg(feature = "mpc-ceremony")]
+    fn ceremony_at_position_1(
+        dir: &Path,
+    ) -> (
+        std::sync::Arc<ghost_mpc::CeremonyManager>,
+        std::sync::Arc<ghost_storage::Database>,
+        String,
+        [u8; 32],
+    ) {
+        use ghost_common::identity::NodeIdentity;
+
+        let manager = std::sync::Arc::new(ghost_mpc::CeremonyManager::new(dir.to_path_buf()));
+        manager.ensure_genesis_initialized().expect("genesis init");
+
+        let id = NodeIdentity::generate();
+        let id_hex = hex::encode(id.node_id());
+
+        // Position 1 contributed + applied by this node → manager count 0 -> 1.
+        let (p1, c1) = manager
+            .generate_contribution(&id_hex)
+            .expect("generate position 1");
+        manager
+            .apply_contribution(p1, &c1)
+            .expect("apply position 1");
+
+        let db = std::sync::Arc::new(ghost_storage::Database::in_memory().expect("in-memory db"));
+        db.save_mpc_contribution(&ghost_storage::queries::MpcContributionRecord {
+            elder_position: 1,
+            contributor_node_id: id_hex.clone(),
+            prev_params_hash: c1.prev_params_hash,
+            new_params_hash: c1.new_params_hash,
+            contribution_proof: serde_json::to_vec(&c1.proof).unwrap(),
+            epoch: 0,
+            created_at: c1.timestamp,
+        })
+        .expect("save position 1 row");
+        // Singleton reflects the applied head (count 1).
+        persist_singleton_from_manager(&manager, &db);
+
+        (manager, db, id_hex, c1.new_params_hash)
+    }
+
+    /// The core self-adopt: a contributor whose own position-2 contribution was
+    /// BFT-applied by the voters (row gossiped back) but whose manager +
+    /// singleton still sit at position 1 must advance its `current.bin` +
+    /// singleton to position 2 when it adopts its OWN local candidate.
+    ///
+    /// Pre-fix behaviour was to detect elder status and RETURN without adopting
+    /// (the asserted PRE state below); the fix drives the candidate through
+    /// `apply_contribution_multi` + persists the singleton (the asserted POST
+    /// state). The POST assertions FAIL under the pre-fix "return without adopt".
+    #[cfg(feature = "mpc-ceremony")]
+    #[test]
+    fn contributor_adopts_own_applied_position_from_local_candidate() {
+        let dir = tempfile::tempdir().unwrap();
+        let (manager, db, id_hex, p1_hash) = ceremony_at_position_1(dir.path());
+
+        // Generate our position-2 candidate WITHOUT applying it (mirrors the
+        // contributor: it writes a candidate serving file, never current.bin).
+        let (p2, c2) = manager
+            .generate_contribution_at_position(&id_hex, 2)
+            .expect("generate position 2");
+        let mut buf = Vec::new();
+        p2.write(&mut buf).expect("serialize position 2 params");
+        write_candidate_note_spend_params(dir.path(), &c2.new_params_hash, &buf)
+            .expect("write candidate");
+
+        // The voters applied position 2 and it gossiped back: our DB has the
+        // position-2 row (contributed by US), but our manager/singleton lag at 1.
+        db.save_mpc_contribution(&ghost_storage::queries::MpcContributionRecord {
+            elder_position: 2,
+            contributor_node_id: id_hex.clone(),
+            prev_params_hash: c2.prev_params_hash,
+            new_params_hash: c2.new_params_hash,
+            contribution_proof: serde_json::to_vec(&c2.proof).unwrap(),
+            epoch: 0,
+            created_at: c2.timestamp,
+        })
+        .expect("save position 2 row");
+
+        // ---- PRE (the bug state the pre-fix "return without adopt" leaves) ----
+        assert_eq!(
+            manager.contribution_count(),
+            1,
+            "pre-adopt: manager head lags at position 1"
+        );
+        assert_eq!(
+            manager.current_params_hash(),
+            p1_hash,
+            "pre-adopt: current.bin is still the position-1 params"
+        );
+        assert_eq!(
+            db.get_mpc_ceremony_state()
+                .unwrap()
+                .unwrap()
+                .contribution_count,
+            1,
+            "pre-adopt: singleton lags at position 1"
+        );
+
+        // ---- ADOPT (the fix): load our own candidate + apply + persist --------
+        let params = load_local_candidate_note_spend(dir.path(), &c2.new_params_hash)
+            .expect("local candidate must load + hash-match the applied head");
+        let row = db.get_mpc_contribution(2).unwrap().unwrap();
+        let contribution = contribution_from_row(&row);
+        assert!(
+            apply_and_persist_adopted_note_spend(&manager, &db, params, &contribution),
+            "adopt must satisfy the post-apply invariant"
+        );
+
+        // ---- POST (fails under pre-fix; passes after) -------------------------
+        assert_eq!(
+            manager.contribution_count(),
+            2,
+            "post-adopt: manager head advanced to position 2"
+        );
+        assert_eq!(
+            manager.current_params_hash(),
+            c2.new_params_hash,
+            "post-adopt: current.bin is the position-2 applied head"
+        );
+        // On-disk current params re-hash to the applied head (lineage).
+        let on_disk = ghost_mpc::contribution::hash_parameters(
+            &manager.note_spend_params().expect("current params loaded"),
+        )
+        .expect("hash current params");
+        assert_eq!(
+            on_disk, c2.new_params_hash,
+            "post-adopt: note_spend_params_current.bin is the applied head"
+        );
+        let singleton = db.get_mpc_ceremony_state().unwrap().unwrap();
+        assert_eq!(
+            singleton.contribution_count, 2,
+            "post-adopt: singleton advanced to position 2"
+        );
+        assert_eq!(
+            singleton.current_params_hash, c2.new_params_hash,
+            "post-adopt: singleton head == applied head"
+        );
+    }
+
+    /// Restart self-heal: a contributor restarts with its recorded chain AHEAD of
+    /// its on-disk head (mpc_contributions has position 2, but current.bin +
+    /// singleton are at position 1 — node5's exact restart state). Pre-fix, the
+    /// genesis-anchored startup verification sees `contributions[MAX].new !=
+    /// on-disk head` and fail-closes → crash-loop. This proves the self-heal
+    /// advances the head so that mismatch is gone.
+    #[cfg(feature = "mpc-ceremony")]
+    #[test]
+    fn restart_self_heal_advances_lagging_contributor_head() {
+        let dir = tempfile::tempdir().unwrap();
+        let (manager, db, id_hex, _p1_hash) = ceremony_at_position_1(dir.path());
+
+        let (p2, c2) = manager
+            .generate_contribution_at_position(&id_hex, 2)
+            .expect("generate position 2");
+        let mut buf = Vec::new();
+        p2.write(&mut buf).expect("serialize position 2 params");
+        write_candidate_note_spend_params(dir.path(), &c2.new_params_hash, &buf)
+            .expect("write candidate");
+        db.save_mpc_contribution(&ghost_storage::queries::MpcContributionRecord {
+            elder_position: 2,
+            contributor_node_id: id_hex.clone(),
+            prev_params_hash: c2.prev_params_hash,
+            new_params_hash: c2.new_params_hash,
+            contribution_proof: serde_json::to_vec(&c2.proof).unwrap(),
+            epoch: 0,
+            created_at: c2.timestamp,
+        })
+        .expect("save position 2 row");
+
+        // The exact fail-closed condition: recorded chain tip != on-disk head.
+        let chain_tip = db.get_mpc_max_contribution_position().unwrap().unwrap();
+        let head_pre =
+            ghost_mpc::contribution::hash_parameters(&manager.note_spend_params().unwrap())
+                .unwrap();
+        let tip_hash = db
+            .get_mpc_contribution(chain_tip)
+            .unwrap()
+            .unwrap()
+            .new_params_hash;
+        assert_eq!(chain_tip, 2);
+        assert_ne!(
+            head_pre, tip_hash,
+            "pre-heal: on-disk head lags the chain tip (the crash-loop condition)"
+        );
+
+        // Self-heal by adopting each un-adopted position in order (what the
+        // startup restart self-heal / retry-loop drivers do, sans network).
+        while manager.contribution_count() < chain_tip {
+            let next = manager.contribution_count() + 1;
+            let params = load_local_candidate_note_spend(dir.path(), &tip_hash)
+                .expect("local candidate available for the lagging position");
+            let row = db.get_mpc_contribution(next).unwrap().unwrap();
+            let contribution = contribution_from_row(&row);
+            assert!(apply_and_persist_adopted_note_spend(
+                &manager,
+                &db,
+                params,
+                &contribution
+            ));
+        }
+
+        // Post-heal: on-disk head now equals the chain tip — verification passes.
+        let head_post =
+            ghost_mpc::contribution::hash_parameters(&manager.note_spend_params().unwrap())
+                .unwrap();
+        assert_eq!(
+            head_post, tip_hash,
+            "post-heal: on-disk head == chain tip (fail-closed mismatch resolved)"
+        );
+        assert_eq!(manager.contribution_count(), 2);
+        assert_eq!(
+            db.get_mpc_ceremony_state()
+                .unwrap()
+                .unwrap()
+                .contribution_count,
+            2
+        );
     }
 
     // ── reaper_config_from_settings ──────────────────────────────────

--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -116,6 +116,49 @@ const RECORD_WINDOWS: [(&str, i64); 4] = [
     ("month", 2_592_000),
 ];
 
+/// MPC contribution retry window (a joining node broadcasting its candidate).
+///
+/// A joining node broadcasts a signed contribution candidate and then waits for
+/// the existing elders to fetch its (~2.8 MB) parameters, run the heavy Groth16
+/// `verify_contribution` pairing check, gossip votes, reach BFT quorum, apply
+/// the contribution and propagate the new head back. On release builds that full
+/// round trip routinely takes well over a minute per candidate. The window must
+/// therefore be generous: we rebroadcast the SAME stable candidate on every
+/// attempt (see `cached_contribution_still_valid`) so votes accumulate for one
+/// `new_hash`, and give voters ~15-20 min total to converge instead of giving up
+/// after ~5 minutes (the old 5-attempt / 10-100s loop that let the candidate
+/// hash keep changing faster than voters could verify — the "moving target").
+///
+/// 15 attempts with a randomised 60-90s delay ⇒ 14 sleeps × ~75s ≈ 17.5 min.
+/// These are consensus-affecting timings and are deliberately NOT env-tunable.
+const MPC_CONTRIBUTION_MAX_ATTEMPTS: u32 = 15;
+/// Minimum per-attempt retry delay — enough for a voter to fetch the candidate,
+/// run the Groth16 verify, gossip its vote, reach quorum, apply and propagate
+/// back on a release build before we rebroadcast.
+const MPC_CONTRIBUTION_RETRY_DELAY_MIN_SECS: u64 = 60;
+/// Maximum per-attempt retry delay. The delay is randomised in
+/// `[MIN, MAX]` to avoid a thundering herd when several nodes retry at once.
+const MPC_CONTRIBUTION_RETRY_DELAY_MAX_SECS: u64 = 90;
+
+/// Decide whether a cached MPC contribution candidate is still valid to
+/// rebroadcast unchanged on the next retry.
+///
+/// A candidate is generated for ceremony position `cached_count + 1`, chained
+/// onto the applied head at authoritative count `cached_count`. It stays valid
+/// for as long as the authoritative contribution count has NOT advanced: no new
+/// contribution has been applied, so our candidate still targets the correct
+/// position and chains onto the correct head. In that case we rebroadcast the
+/// SAME candidate (identical `new_hash`) so voters accumulate votes toward
+/// quorum instead of chasing a fresh hash every attempt.
+///
+/// If the count has ADVANCED (`current_count != cached_count`, i.e. another
+/// contribution was applied while we waited), our candidate is built on a stale
+/// head and MUST be regenerated (rebased) onto the new head — its
+/// `prev_params_hash` would otherwise fail hash-chain validation.
+fn cached_contribution_still_valid(cached_count: u32, current_count: u32) -> bool {
+    current_count == cached_count
+}
+
 /// Build this node's best (rarest) valid share per records window from the
 /// local DB, shaped exactly like the `/api/v1/pool/records` response (redacted
 /// miner_id, achieved difficulty from the hash). Gossiped in health pings so
@@ -3373,15 +3416,19 @@ async fn main() -> Result<()> {
                 return;
             }
 
-            // Retry loop: attempt contribution up to 5 times with random 10-100s intervals.
+            // Retry loop: attempt contribution up to MPC_CONTRIBUTION_MAX_ATTEMPTS
+            // times with a randomised 60-90s interval (~15-20 min total window).
             // This handles race conditions where multiple nodes try the same position
-            // simultaneously — the loser retries at the next position.
-            // Between retries: sync contributors, re-fetch latest params from network
-            // (prevents stale prev_params_hash), and randomize delay to avoid races.
-            // Cache the signed message so retries broadcast the same hash (votes accumulate).
+            // simultaneously — the loser rebases onto the new head and retries at the
+            // next position.
+            // Between retries: sync contributors, and ONLY when the ceremony position
+            // has actually advanced, re-fetch the latest applied params (prevents stale
+            // prev_params_hash) and regenerate. When the position is UNCHANGED we keep
+            // the cached candidate and rebroadcast the SAME signed message so voters
+            // accumulate votes for one hash toward quorum (no "moving target").
             let mut cached_msg: Option<(ghost_consensus::message::MpcContributionMessage, u32)> =
                 None;
-            for attempt in 1..=5u32 {
+            for attempt in 1..=MPC_CONTRIBUTION_MAX_ATTEMPTS {
                 // Re-check if we became an elder (e.g., via P2P sync of our own contribution)
                 if db_for_mpc.is_mpc_elder(&node_id_hex).unwrap_or(false) {
                     let position = db_for_mpc
@@ -3848,12 +3895,17 @@ async fn main() -> Result<()> {
                     }
                 }
 
-                // Wait random 10-100s before retry to prevent race conditions
-                // where multiple nodes fight for the same position simultaneously.
-                if attempt < 5 {
+                // Wait a randomised 60-90s before retry: long enough for voters to
+                // fetch + Groth16-verify + vote + reach quorum + apply + propagate
+                // back, and randomised to prevent races where multiple nodes fight
+                // for the same position simultaneously.
+                if attempt < MPC_CONTRIBUTION_MAX_ATTEMPTS {
                     let delay_secs = {
                         use rand::Rng;
-                        rand::thread_rng().gen_range(10..=100)
+                        rand::thread_rng().gen_range(
+                            MPC_CONTRIBUTION_RETRY_DELAY_MIN_SECS
+                                ..=MPC_CONTRIBUTION_RETRY_DELAY_MAX_SECS,
+                        )
                     };
                     info!(
                         attempt,
@@ -3946,10 +3998,45 @@ async fn main() -> Result<()> {
                         }
                     }
 
-                    // Re-fetch latest MPC params from network before next attempt.
-                    // Without this, the ceremony manager holds stale params and any
-                    // new contribution will fail hash-chain validation because
-                    // prev_params_hash won't match the latest applied contribution.
+                    // Decide whether to re-fetch + regenerate, or keep our stable
+                    // candidate. Read the authoritative count AFTER the contributor
+                    // sync above: if a new contribution was applied while we waited,
+                    // our candidate is chained onto a stale head and must be rebased
+                    // (re-fetch the new applied head + regenerate). If the position is
+                    // UNCHANGED, re-fetching would invalidate the cache and force the
+                    // next attempt to regenerate a DIFFERENT candidate with fresh
+                    // randomness (the "moving target" that stopped voters converging) —
+                    // so we skip it and rebroadcast the SAME cached candidate next
+                    // attempt, letting votes accumulate for one hash toward quorum.
+                    let current_count = db_for_mpc
+                        .mpc_contribution_count_authoritative()
+                        .unwrap_or(db_count);
+                    let position_advanced = match &cached_msg {
+                        Some((_, cached_count)) => {
+                            !cached_contribution_still_valid(*cached_count, current_count)
+                        }
+                        // No cached candidate (generation failed this attempt): re-fetch
+                        // so the next attempt regenerates on the freshest head.
+                        None => true,
+                    };
+                    if !position_advanced {
+                        info!(
+                            attempt,
+                            db_count = current_count,
+                            "MPC: ceremony position unchanged — keeping cached candidate, \
+                             will rebroadcast the same hash next attempt"
+                        );
+                        continue;
+                    }
+
+                    // Position ADVANCED (or no cache): re-fetch the latest applied MPC
+                    // params before the next attempt so we rebase onto the new head.
+                    // Without this, the ceremony manager holds stale params and the
+                    // regenerated contribution would fail hash-chain validation because
+                    // prev_params_hash won't match the latest applied contribution. Note
+                    // this writes the genuinely-newer APPLIED head to current.bin, which
+                    // is correct — the candidate-serving rule only forbids writing our
+                    // own UN-applied candidate to current.bin.
                     let params_dir = ceremony_manager_for_startup.params_dir().clone();
                     for seed in &seed_nodes_for_mpc {
                         let host = seed.split(':').next().unwrap_or(seed);
@@ -4111,7 +4198,10 @@ async fn main() -> Result<()> {
                 round_manager_for_mpc
                     .update_node_capabilities(identity_for_mpc.node_id(), updated_caps);
             } else {
-                warn!("MPC: Failed to contribute after 5 attempts. Node will not be an elder.");
+                warn!(
+                    attempts = MPC_CONTRIBUTION_MAX_ATTEMPTS,
+                    "MPC: Failed to contribute after all attempts. Node will not be an elder."
+                );
             }
         });
         info!("MPC auto-contribution task scheduled (15s delay)");
@@ -6663,6 +6753,41 @@ mod tests {
         assert_eq!(cfg.min_drop_data_size, 64);
         // valid for the analyzer
         assert!(cfg.validate().is_ok());
+    }
+
+    // ── cached_contribution_still_valid (MPC retry loop) ─────────────
+
+    #[test]
+    fn cached_contribution_valid_when_position_unchanged() {
+        // Candidate generated at authoritative count N (targets position N+1).
+        // A retry where the count is STILL N must keep the cached candidate so
+        // the SAME new_hash is rebroadcast and votes accumulate toward quorum
+        // (the fix for the "moving target" that stalled node5 on mainnet).
+        let cached_count = 6u32;
+        let current_count = 6u32;
+        assert!(
+            cached_contribution_still_valid(cached_count, current_count),
+            "unchanged position must NOT invalidate the cached candidate"
+        );
+    }
+
+    #[test]
+    fn cached_contribution_invalid_when_position_advanced() {
+        // Another contribution was applied while we waited (count N -> N+1):
+        // our candidate is chained onto a stale head and MUST be regenerated
+        // (rebased) onto the new head, so it is no longer valid to rebroadcast.
+        let cached_count = 6u32;
+        let current_count = 7u32;
+        assert!(
+            !cached_contribution_still_valid(cached_count, current_count),
+            "advanced position MUST invalidate the cached candidate (rebase)"
+        );
+    }
+
+    #[test]
+    fn cached_contribution_invalid_on_multi_step_advance() {
+        // Robust to more than one applied contribution during a long wait.
+        assert!(!cached_contribution_still_valid(6, 9));
     }
 
     // ── expand_path ──────────────────────────────────────────────────

--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -159,6 +159,31 @@ fn cached_contribution_still_valid(cached_count: u32, current_count: u32) -> boo
     current_count == cached_count
 }
 
+/// The ceremony position this node should target next, accounting for a node
+/// whose adopted head lags the recorded chain tip.
+///
+/// * `authoritative_count` — the `mpc_ceremony` singleton count. This is advanced
+///   ONLY when a position is actually ADOPTED (params applied + singleton
+///   persisted).
+/// * `max_position` — the `mpc_contributions` MAX. This is advanced whenever an
+///   applied-contribution ROW arrives (startup contributor sync OR live gossip),
+///   even before this node has adopted the corresponding params.
+///
+/// A node that joined / un-pinned while the ceremony had already advanced sees
+/// its `max_position` climb via gossip while its `authoritative_count` stays put,
+/// because merely receiving the row never drives the on-disk head forward. If it
+/// naïvely targeted `authoritative_count + 1` it would try to contribute an
+/// ALREADY-FILLED position forever (the node6→stuck-at-5 incident). The correct
+/// target is one past the recorded chain tip, so the node contributes the next
+/// FREE position — after first catching its head up to that tip. Returning
+/// `max(count, tip) + 1` makes the target robust whether or not the catch-up has
+/// completed this instant, and reduces to the normal `count + 1` when the head is
+/// already at the tip (`count == tip`).
+#[cfg(feature = "mpc-ceremony")]
+fn mpc_next_contribution_position(authoritative_count: u32, max_position: u32) -> u32 {
+    authoritative_count.max(max_position) + 1
+}
+
 /// Build this node's best (rarest) valid share per records window from the
 /// local DB, shaped exactly like the `/api/v1/pool/records` response (redacted
 /// miner_id, achieved difficulty from the hash). Gossiped in health pings so
@@ -1567,6 +1592,20 @@ async fn adopt_all_applied_positions(
         .unwrap_or(0);
     while ceremony_mgr.contribution_count() < max_pos {
         let next = ceremony_mgr.contribution_count() + 1;
+        // Before adopting, make sure this position's FULL data is present locally.
+        // A row that arrived via lightweight gossip (or the proof-less
+        // `/contributors` sync) carries an EMPTY proof and NO retained votes, so:
+        //   * a FOREIGN lineage could not be re-verified (`verify_contribution_catchup`
+        //     needs the real Schnorr/pairing proof), and
+        //   * a later restart's genesis-anchored check would fail closed (it
+        //     requires the retained ≥quorum BFT votes for every position 2..N).
+        // Pull the real proof + retained votes from a peer's
+        // `/api/v1/mpc/votes/{pos}` endpoint (best-effort; safe proof-fill upsert
+        // preserves an applied row). If no seed serves it we still attempt the
+        // adopt with whatever is local — an OWN position needs neither, and a
+        // FOREIGN one without a valid proof simply fails the crypto verify below
+        // and we stop (fail-safe), never adopting on hash-match alone.
+        sync_mpc_proof_and_votes(seeds, next, db).await;
         if !adopt_applied_position(ceremony_mgr, db, peers, seeds, our_node_id_hex, next).await {
             return false;
         }
@@ -4277,14 +4316,88 @@ async fn main() -> Result<()> {
                     return;
                 }
 
+                // ── Attempt-start catch-up (behind-the-head rolling gap) ─────────
+                // A node that joined / un-pinned while the ceremony had ALREADY
+                // advanced receives the applied-contribution ROWS via gossip (its
+                // `mpc_contributions` MAX climbs) but NOTHING drives its on-disk
+                // head + `mpc_ceremony` singleton forward — so its authoritative
+                // count lags the recorded chain tip. Left unhandled it computes
+                // `next_position = count + 1` and keeps contributing an
+                // ALREADY-FILLED position forever (the node6→stuck-at-5 incident)
+                // instead of catching up and contributing the next FREE one.
+                //
+                // "Behind" = authoritative singleton count < recorded MAX position.
+                // Catch the head up by adopting every un-adopted applied position in
+                // order via the shared adopt driver: params are fetched
+                // contributor-aware + hash-checked, FOREIGN lineages are additionally
+                // crypto-verified (`verify_contribution_catchup`), and each
+                // position's retained BFT quorum votes are synced so a later
+                // restart's genesis-anchored check still passes. `next_position`
+                // below is then recomputed from the advanced count.
+                //
+                // Idempotent + free when NOT behind: the inner while-loop is a no-op
+                // (count == max_pos) and no fetch happens — the normal same-position
+                // rolling path is untouched. Fail-safe: if catch-up can't complete
+                // (peer unreachable / a position won't verify) we do NOT contribute a
+                // stale position — wait and let the next attempt / a restart retry.
+                {
+                    let authoritative = db_for_mpc
+                        .mpc_contribution_count_authoritative()
+                        .unwrap_or(0);
+                    let chain_tip = db_for_mpc
+                        .get_mpc_max_contribution_position()
+                        .ok()
+                        .flatten()
+                        .unwrap_or(0);
+                    if authoritative < chain_tip {
+                        info!(
+                            authoritative,
+                            chain_tip,
+                            "MPC: adopted head lags the recorded chain tip — catching up before \
+                             computing the next contribution position"
+                        );
+                        if adopt_all_applied_positions(
+                            &ceremony_manager_for_startup,
+                            &db_for_mpc,
+                            mesh_for_mpc_startup.peers(),
+                            &seed_nodes_for_mpc,
+                            &node_id_hex,
+                        )
+                        .await
+                        {
+                            info!(
+                                head = ceremony_manager_for_startup.contribution_count(),
+                                "MPC: caught up to the recorded chain tip"
+                            );
+                        } else {
+                            warn!(
+                                head = ceremony_manager_for_startup.contribution_count(),
+                                chain_tip,
+                                "MPC: could not fully catch up to the chain tip this attempt — \
+                                 NOT contributing a stale position; will retry"
+                            );
+                            tokio::time::sleep(tokio::time::Duration::from_secs(10)).await;
+                            continue;
+                        }
+                    }
+                }
+
                 // Determine position from DB (authoritative source, not stale in-memory state).
                 // Progression count comes from the mpc_ceremony singleton (falls back to
                 // COUNT(mpc_contributions) when absent). Voter-set sizing still uses
                 // get_mpc_elder_count() in the handler — these are deliberately distinct.
+                // After the catch-up above, `db_count == chain_tip`, so targeting one
+                // past the tip (via `mpc_next_contribution_position`) is the next FREE
+                // position — never an already-filled one.
                 let db_count = db_for_mpc
                     .mpc_contribution_count_authoritative()
                     .unwrap_or(0);
-                let next_position = db_count + 1;
+                let chain_tip = db_for_mpc
+                    .get_mpc_max_contribution_position()
+                    .ok()
+                    .flatten()
+                    .unwrap_or(0);
+                let next_position = mpc_next_contribution_position(db_count, chain_tip);
 
                 info!(
                     attempt,
@@ -7552,6 +7665,284 @@ mod tests {
                 .contribution_count,
             2
         );
+    }
+
+    // ── attempt-start catch-up (behind-the-head rolling gap) ─────────
+    //
+    // A node that joined / un-pinned while the ceremony had already advanced
+    // receives applied-contribution ROWS via gossip (its `mpc_contributions` MAX
+    // climbs) but nothing drives its adopted head + singleton forward. Pre-fix it
+    // computed `next_position = singleton_count + 1` and contributed an
+    // ALREADY-FILLED position forever (node6→stuck-at-5). These lock in the fix:
+    // detect "behind", catch the head up by adopting every un-adopted position,
+    // then target one past the recorded chain tip (the next FREE position).
+
+    /// Directly write a note-spend candidate serving file WITHOUT the
+    /// supersede-cleanup that `write_candidate_note_spend_params` performs, so a
+    /// multi-step test can stage several positions' candidates simultaneously.
+    #[cfg(feature = "mpc-ceremony")]
+    fn stage_candidate(dir: &Path, new_hash: &[u8; 32], params: &ghost_mpc::Groth16Params) {
+        let mut buf = Vec::new();
+        params.write(&mut buf).expect("serialize candidate params");
+        let name = ghost_common::mpc::candidate_note_spend_filename(new_hash);
+        std::fs::write(dir.join(name), &buf).expect("write candidate file");
+    }
+
+    #[cfg(feature = "mpc-ceremony")]
+    fn foreign_row(
+        position: u32,
+        contributor: &str,
+        c: &ghost_mpc::MpcContribution,
+    ) -> ghost_storage::queries::MpcContributionRecord {
+        ghost_storage::queries::MpcContributionRecord {
+            elder_position: position,
+            contributor_node_id: contributor.to_string(),
+            prev_params_hash: c.prev_params_hash,
+            new_params_hash: c.new_params_hash,
+            contribution_proof: serde_json::to_vec(&c.proof).unwrap(),
+            epoch: 0,
+            created_at: c.timestamp,
+        }
+    }
+
+    /// The pure targeting decision, at the EXACT node6 numbers. Pre-fix targeted
+    /// `count + 1` off a lagging singleton (an already-filled position); the fix
+    /// targets one past the recorded chain tip (the next free position).
+    #[cfg(feature = "mpc-ceremony")]
+    #[test]
+    fn mpc_next_contribution_position_targets_next_free_after_catchup() {
+        // node6: adopted head (singleton) lagged at 4 while the chain tip advanced
+        // to 5. The PRE-FIX formula `count + 1` == 5 — ALREADY node5's position.
+        assert_eq!(
+            4 + 1,
+            5,
+            "pre-fix formula targets the FILLED position (bug)"
+        );
+        // The FIX targets one past the tip → 6 (next FREE), both before the
+        // catch-up (count 4) and after it advances the head to the tip (count 5).
+        assert_eq!(mpc_next_contribution_position(4, 5), 6);
+        assert_eq!(mpc_next_contribution_position(5, 5), 6);
+        // Behind by two (count 4, tip 6): target 7 (after adopting 5 then 6).
+        assert_eq!(mpc_next_contribution_position(4, 6), 7);
+        assert_eq!(mpc_next_contribution_position(6, 6), 7);
+        // Not behind (fresh genesis / already caught up): normal count+1, and never
+        // a phantom advance past the head.
+        assert_eq!(mpc_next_contribution_position(0, 0), 1);
+        assert_eq!(mpc_next_contribution_position(3, 3), 4);
+    }
+
+    /// node6 reproduction: singleton at 1 while the chain tip advanced to a FOREIGN
+    /// position 2 (received only as a row). The attempt-start catch-up must ADOPT
+    /// position 2 (params + singleton advance to 2), after which the node targets
+    /// position 3 — NOT the already-filled 2. Pre-fix (no catch-up) it stayed
+    /// stuck targeting 2.
+    #[cfg(feature = "mpc-ceremony")]
+    #[tokio::test]
+    async fn attempt_start_catchup_adopts_foreign_position_and_targets_next_free() {
+        let dir = tempfile::tempdir().unwrap();
+        let (manager, db, our_id, _p1) = ceremony_at_position_1(dir.path());
+
+        // A DIFFERENT node contributed position 2 (a VALID foreign lineage
+        // transform of our position-1 head). We are the "behind" node: we received
+        // the ROW + the contributor's candidate params but never adopted the head.
+        let foreign_id = hex::encode(NodeIdentity::generate().node_id());
+        let (p2, c2) = manager
+            .generate_contribution_at_position(&foreign_id, 2)
+            .expect("generate foreign position 2");
+        stage_candidate(dir.path(), &c2.new_params_hash, &p2);
+        db.save_mpc_contribution(&foreign_row(2, &foreign_id, &c2))
+            .unwrap();
+
+        // ── PRE (the node6 stuck state) ──────────────────────────────────────
+        let pre_count = db.mpc_contribution_count_authoritative().unwrap();
+        let tip = db.get_mpc_max_contribution_position().unwrap().unwrap();
+        assert_eq!(pre_count, 1, "adopted head still lags at position 1");
+        assert_eq!(tip, 2, "the chain tip advanced to position 2 via the row");
+        // Pre-fix targeted `count + 1` == 2 — the position ALREADY filled by the
+        // foreign contributor. That is the forever-stuck condition.
+        assert_eq!(pre_count + 1, tip, "pre-fix targets the FILLED position");
+
+        // ── CATCH UP (the fix) ───────────────────────────────────────────────
+        let peers = ghost_consensus::peer::PeerManager::new([0u8; 32], 100);
+        assert!(
+            adopt_all_applied_positions(&manager, &db, &peers, &[], &our_id).await,
+            "attempt-start catch-up must adopt the foreign applied position"
+        );
+
+        // ── POST (fails under pre-fix) ───────────────────────────────────────
+        assert_eq!(manager.contribution_count(), 2, "head advanced to the tip");
+        assert_eq!(
+            manager.current_params_hash(),
+            c2.new_params_hash,
+            "current.bin is the position-2 applied head"
+        );
+        let post_count = db.mpc_contribution_count_authoritative().unwrap();
+        assert_eq!(post_count, 2, "singleton advanced to the tip");
+        // Now the node targets position 3 — the next FREE position, not the filled 2.
+        assert_eq!(
+            mpc_next_contribution_position(post_count, tip),
+            3,
+            "after catch-up the node targets the next FREE position (3), not 2"
+        );
+    }
+
+    /// Multi-step catch-up: behind by two. The singleton sits at 1 while the chain
+    /// tip advanced to position 3 (rows for 2 and 3 received). The catch-up must
+    /// adopt 2 THEN 3 in order, after which the node targets 4.
+    #[cfg(feature = "mpc-ceremony")]
+    #[tokio::test]
+    async fn attempt_start_catchup_multi_step_adopts_all_positions() {
+        let dir = tempfile::tempdir().unwrap();
+        let (manager, db, our_id, _p1) = ceremony_at_position_1(dir.path());
+
+        // Our own positions 2 and 3 were BFT-applied and gossiped back as rows; we
+        // hold both candidate serving files but adopted neither (singleton at 1).
+        let (p2, c2) = manager
+            .generate_contribution_at_position(&our_id, 2)
+            .expect("generate position 2");
+        let (p3, c3) = manager
+            .generate_contribution_at_position(&our_id, 3)
+            .expect("generate position 3");
+        stage_candidate(dir.path(), &c2.new_params_hash, &p2);
+        stage_candidate(dir.path(), &c3.new_params_hash, &p3);
+        db.save_mpc_contribution(&foreign_row(2, &our_id, &c2))
+            .unwrap();
+        db.save_mpc_contribution(&foreign_row(3, &our_id, &c3))
+            .unwrap();
+
+        let pre_count = db.mpc_contribution_count_authoritative().unwrap();
+        let tip = db.get_mpc_max_contribution_position().unwrap().unwrap();
+        assert_eq!(pre_count, 1);
+        assert_eq!(tip, 3, "behind by two positions");
+
+        let peers = ghost_consensus::peer::PeerManager::new([0u8; 32], 100);
+        assert!(
+            adopt_all_applied_positions(&manager, &db, &peers, &[], &our_id).await,
+            "catch-up must adopt BOTH lagging positions in order"
+        );
+
+        assert_eq!(manager.contribution_count(), 3, "head advanced 1 -> 2 -> 3");
+        assert_eq!(manager.current_params_hash(), c3.new_params_hash);
+        let post_count = db.mpc_contribution_count_authoritative().unwrap();
+        assert_eq!(post_count, 3);
+        assert_eq!(
+            mpc_next_contribution_position(post_count, tip),
+            4,
+            "after a two-step catch-up the node targets position 4"
+        );
+    }
+
+    /// Fail-closed on FOREIGN lineage: a caught-up position this node did NOT
+    /// author is adopted ONLY after cryptographic `verify_contribution_catchup`
+    /// (Schnorr + pairing transform), never on hash-match alone. A forged
+    /// candidate whose file hashes to the recorded head but whose params are not a
+    /// valid transform must be REJECTED and must NOT advance the head.
+    #[cfg(feature = "mpc-ceremony")]
+    #[tokio::test]
+    async fn catchup_rejects_forged_foreign_candidate() {
+        let dir = tempfile::tempdir().unwrap();
+        let (manager, db, our_id, p1_hash) = ceremony_at_position_1(dir.path());
+
+        // Borrow a foreign node's REAL position-2 proof (valid Schnorr bound to
+        // this ceremony_id), so the forgery clears the proof checks and is caught
+        // specifically by the pairing TRANSFORM check.
+        let foreign_id = hex::encode(NodeIdentity::generate().node_id());
+        let (_p2, c2) = manager
+            .generate_contribution_at_position(&foreign_id, 2)
+            .expect("generate foreign position 2 (for its valid proof)");
+
+        // FORGERY: the "position-2 params" are actually the UNCHANGED position-1
+        // params (an identity transform that applied no tau). The candidate file
+        // hashes to the row's new_params_hash (hash-match PASSES), but
+        // e(new_h, tau_G2) != e(old_h, G2) when new_h == old_h and tau != 1, so
+        // `verify_contribution_catchup` MUST reject it.
+        let prev = manager.note_spend_params().unwrap();
+        let forged_hash = ghost_mpc::contribution::hash_parameters(&prev).unwrap();
+        assert_eq!(
+            forged_hash, p1_hash,
+            "forged candidate == the position-1 head"
+        );
+        stage_candidate(dir.path(), &forged_hash, &prev);
+        db.save_mpc_contribution(&ghost_storage::queries::MpcContributionRecord {
+            elder_position: 2,
+            contributor_node_id: foreign_id.clone(),
+            prev_params_hash: p1_hash,
+            new_params_hash: forged_hash,
+            contribution_proof: serde_json::to_vec(&c2.proof).unwrap(),
+            epoch: 0,
+            created_at: c2.timestamp,
+        })
+        .unwrap();
+
+        let peers = ghost_consensus::peer::PeerManager::new([0u8; 32], 100);
+        let adopted = adopt_all_applied_positions(&manager, &db, &peers, &[], &our_id).await;
+
+        assert!(!adopted, "a forged foreign candidate must NOT be adopted");
+        assert_eq!(
+            manager.contribution_count(),
+            1,
+            "head must stay at position 1 — no false advance on a rejected forgery"
+        );
+        assert_eq!(
+            db.get_mpc_ceremony_state()
+                .unwrap()
+                .unwrap()
+                .contribution_count,
+            1,
+            "singleton must not advance on a rejected forgery"
+        );
+    }
+
+    /// Restart-safety of a caught-up position: after adopting position N the node
+    /// must hold params AND the retained ≥quorum BFT votes for it, so a later
+    /// restart's genesis-anchored startup check passes without manual backfill
+    /// (the node6 votes I had to backfill by hand). The network vote sync runs
+    /// against a peer's `/api/v1/mpc/votes/{pos}` endpoint (no HTTP server in a
+    /// unit test); here the votes are seeded as that sync would deliver them, and
+    /// we assert they SURVIVE the adopt and are queryable for the restart check.
+    #[cfg(feature = "mpc-ceremony")]
+    #[tokio::test]
+    async fn catchup_retains_votes_for_restart_safety() {
+        let dir = tempfile::tempdir().unwrap();
+        let (manager, db, our_id, _p1) = ceremony_at_position_1(dir.path());
+
+        let foreign_id = hex::encode(NodeIdentity::generate().node_id());
+        let (p2, c2) = manager
+            .generate_contribution_at_position(&foreign_id, 2)
+            .expect("generate foreign position 2");
+        stage_candidate(dir.path(), &c2.new_params_hash, &p2);
+        db.save_mpc_contribution(&foreign_row(2, &foreign_id, &c2))
+            .unwrap();
+
+        // The retained BFT quorum votes for position 2 (as the votes endpoint
+        // would serve them).
+        for i in 0..3u8 {
+            let voter = hex::encode(NodeIdentity::generate().node_id());
+            db.save_mpc_vote(&ghost_storage::queries::MpcVerificationVote {
+                contribution_position: 2,
+                voter_node_id: voter,
+                approve: true,
+                signature: vec![i.wrapping_add(1); 64],
+                voted_at: 1_700_000_000 + i as u64,
+            })
+            .unwrap();
+        }
+
+        let peers = ghost_consensus::peer::PeerManager::new([0u8; 32], 100);
+        assert!(adopt_all_applied_positions(&manager, &db, &peers, &[], &our_id).await);
+
+        // Params present at the adopted head …
+        assert_eq!(manager.contribution_count(), 2);
+        assert_eq!(manager.current_params_hash(), c2.new_params_hash);
+        // … AND the retained quorum votes for the caught-up position survive, so
+        // the genesis-anchored restart verification has what it needs.
+        let votes = db.get_mpc_votes(2).unwrap();
+        assert_eq!(
+            votes.len(),
+            3,
+            "retained BFT votes for the caught-up position are present after catch-up"
+        );
+        assert!(votes.iter().all(|v| v.approve));
     }
 
     // ── reaper_config_from_settings ──────────────────────────────────

--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -1120,21 +1120,93 @@ async fn fetch_and_parse_params(
     .ok()?
 }
 
+/// Host portion of an `address` that may be a bare host, `host:port`,
+/// `[ipv6]:port`, or carry a `scheme://` prefix. Mirrors the mesh's own
+/// `extract_host_from_address` so a contributor's advertised mesh address
+/// (`ip:8559`) reduces to just the host we then hit on the fetch port (`:8080`).
+#[cfg(feature = "mpc-ceremony")]
+fn fetch_host_of(address: &str) -> String {
+    let s = match address.find("://") {
+        Some(i) => &address[i + 3..],
+        None => address,
+    };
+    if let Some(rest) = s.strip_prefix('[') {
+        if let Some(end) = rest.find(']') {
+            return rest[..end].to_string();
+        }
+    }
+    match s.rfind(':') {
+        Some(i) if !s[i + 1..].is_empty() && s[i + 1..].chars().all(|c| c.is_ascii_digit()) => {
+            s[..i].to_string()
+        }
+        _ => s.to_string(),
+    }
+}
+
+/// Resolve a contributor node id to its reachable address: the live mesh peer
+/// registry FIRST (freshest — the same registry the mesh uses for Noise/health),
+/// then the persisted `nodes` table. Empty strings are treated as unresolved.
+/// `None` means we could not find an address and must fall back to seeds only.
+#[cfg(feature = "mpc-ceremony")]
+fn resolve_contributor_addr(
+    peers: &ghost_consensus::peer::PeerManager,
+    db: &ghost_storage::Database,
+    contributor: &ghost_common::types::NodeId,
+) -> Option<String> {
+    peers
+        .get_peer(contributor)
+        .map(|p| p.public_address)
+        .filter(|a| !a.is_empty())
+        .or_else(|| {
+            db.get_node(&hex::encode(contributor))
+                .ok()
+                .flatten()
+                .and_then(|n| n.public_address)
+        })
+        .filter(|a| !a.is_empty())
+}
+
+/// Build the ordered list of fetch hosts for a candidate parameter bundle: the
+/// CONTRIBUTOR first (the only node serving its un-applied candidate), then the
+/// configured seeds. Entries are reduced to host-only and de-duplicated by host
+/// so the contributor is never retried as a seed and duplicate seeds are dropped.
+/// When `contributor_addr` is `None` (address unresolved) the result is exactly
+/// the seed hosts — preserving the prior seeds-only behaviour as a fallback.
+#[cfg(feature = "mpc-ceremony")]
+fn ordered_fetch_sources(contributor_addr: Option<&str>, seeds: &[String]) -> Vec<String> {
+    let mut out: Vec<String> = Vec::with_capacity(seeds.len() + 1);
+    if let Some(addr) = contributor_addr {
+        let h = fetch_host_of(addr);
+        if !h.is_empty() {
+            out.push(h);
+        }
+    }
+    for seed in seeds {
+        let h = fetch_host_of(seed);
+        if h.is_empty() || out.iter().any(|existing| existing == &h) {
+            continue;
+        }
+        out.push(h);
+    }
+    out
+}
+
 /// Fetch a full candidate parameter bundle (note-spend + payout + unshield) from
 /// the network for one contribution.
 ///
 /// The primary note-spend parameters MUST hash-match `expected_note_spend_hash`
 /// (the contribution's claimed lineage head) — only then is a bundle returned.
 /// `payout`/`unshield` ride along best-effort (they share the same toxic waste).
-/// Returns `None` if no seed can supply matching note-spend parameters, which
-/// forces the voter to ABSTAIN rather than approve blind.
+/// Returns `None` if no source can supply matching note-spend parameters, which
+/// forces the voter to ABSTAIN rather than approve blind. Sources are tried in
+/// the given order (contributor-first per [`ordered_fetch_sources`]).
 #[cfg(feature = "mpc-ceremony")]
 async fn fetch_ceremony_params_bundle(
-    seeds: &[String],
+    sources: &[String],
     expected_note_spend_hash: [u8; 32],
 ) -> Option<ghost_consensus::mpc_handler::FetchedCeremonyParams> {
-    for seed in seeds {
-        let host = seed.split(':').next().unwrap_or(seed);
+    for source in sources {
+        let host = source.split(':').next().unwrap_or(source);
         let note_spend =
             match fetch_and_parse_params(host, "params", Some(expected_note_spend_hash)).await {
                 Some(p) => p,
@@ -3135,13 +3207,16 @@ async fn main() -> Result<()> {
         let ceremony_mgr_for_callback = Arc::clone(&ceremony_manager);
         let seed_nodes_for_callback = config.network.seed_nodes.clone();
         let db_for_callback = Arc::clone(&db);
+        let peers_for_callback = Arc::clone(mesh.peers());
         type ParamsUpdateFn = dyn Fn(&[u8; 32], &[u8; 32]) + Send + Sync;
         let params_update_callback: Arc<ParamsUpdateFn> = Arc::new(
-            move |expected_hash: &[u8; 32], _contributor: &[u8; 32]| {
+            move |expected_hash: &[u8; 32], contributor: &[u8; 32]| {
                 let ceremony_mgr = Arc::clone(&ceremony_mgr_for_callback);
                 let seeds = seed_nodes_for_callback.clone();
                 let db = Arc::clone(&db_for_callback);
+                let peers = Arc::clone(&peers_for_callback);
                 let expected = *expected_hash;
+                let contributor = *contributor;
                 tokio::spawn(async move {
                     // Small delay to let the contributing node finish writing.
                     tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
@@ -3195,12 +3270,24 @@ async fn main() -> Result<()> {
                     let _param_write_guard = param_write_lock().lock().await;
 
                     // Fetch the candidate bundle (note-spend hash MUST match).
-                    let bundle = match fetch_ceremony_params_bundle(&seeds, expected).await {
+                    // Same root-cause fix as the voter path: the contributor is
+                    // the only node serving its un-applied candidate, so resolve
+                    // its address and try it FIRST, then the seeds (a peer that has
+                    // already adopted the head can serve a historical catch-up).
+                    let contributor_addr = resolve_contributor_addr(&peers, &db, &contributor);
+                    if contributor_addr.is_none() {
+                        tracing::info!(
+                            contributor = %hex::encode(&contributor[..8]),
+                            "MPC params_callback: contributor address unresolved — seeds only"
+                        );
+                    }
+                    let sources = ordered_fetch_sources(contributor_addr.as_deref(), &seeds);
+                    let bundle = match fetch_ceremony_params_bundle(&sources, expected).await {
                         Some(b) => b,
                         None => {
                             tracing::warn!(
                                 expected = %hex::encode(&expected[..8]),
-                                "MPC params_callback: no peer had matching params"
+                                "MPC params_callback: no source had matching params"
                             );
                             return;
                         }
@@ -3307,12 +3394,41 @@ async fn main() -> Result<()> {
         // Stage 1a: the network fetcher the voter uses to obtain a candidate's
         // parameters before running real cryptographic verification. Fetches the
         // bundle in memory (no disk writes — verification is read-only).
+        //
+        // ROOT-CAUSE FIX: the contributor's freshly-generated candidate is served
+        // ONLY by the contributor node (from a separate candidate file, never
+        // `current.bin`), so the seeds return their own applied params whose hash
+        // never matches and the voter abstained forever. The fetcher now resolves
+        // the contributor's reachable address from the mesh peer registry (the
+        // same registry the mesh uses for Noise/health) — falling back to the
+        // persisted `nodes` table — and tries the CONTRIBUTOR FIRST, then the
+        // seeds. If the address cannot be resolved we log and fall back to seeds
+        // only (a peer that already adopted the candidate could still serve it),
+        // preserving the fail-closed posture (no hash-match ⇒ abstain).
         let seed_nodes_for_fetch = config.network.seed_nodes.clone();
-        let params_fetcher: ghost_consensus::mpc_handler::MpcParamsFetchFn =
-            Arc::new(move |expected: [u8; 32]| {
+        let peers_for_fetch = Arc::clone(mesh.peers());
+        let db_for_fetch = Arc::clone(&db);
+        let params_fetcher: ghost_consensus::mpc_handler::MpcParamsFetchFn = Arc::new(
+            move |expected: [u8; 32], contributor: ghost_common::types::NodeId| {
                 let seeds = seed_nodes_for_fetch.clone();
-                Box::pin(async move { fetch_ceremony_params_bundle(&seeds, expected).await })
-            });
+                let peers = Arc::clone(&peers_for_fetch);
+                let db = Arc::clone(&db_for_fetch);
+                Box::pin(async move {
+                    // Resolve the contributor's reachable host: live mesh peer
+                    // registry first (freshest), then the persisted nodes table.
+                    let contributor_addr = resolve_contributor_addr(&peers, &db, &contributor);
+                    if contributor_addr.is_none() {
+                        tracing::info!(
+                            contributor = %hex::encode(&contributor[..8]),
+                            "MPC fetch: contributor address unresolved from mesh/db — \
+                             falling back to seeds only"
+                        );
+                    }
+                    let sources = ordered_fetch_sources(contributor_addr.as_deref(), &seeds);
+                    fetch_ceremony_params_bundle(&sources, expected).await
+                })
+            },
+        );
 
         let mpc_handler = Arc::new(
             MpcHandler::new(Arc::clone(&identity), Arc::clone(&db))
@@ -6713,6 +6829,48 @@ fn resolve_signer_path(
 mod tests {
     use super::*;
     use std::path::Path;
+
+    // ── ordered_fetch_sources (MPC candidate fetch ordering) ─────────
+    //
+    // These lock in the contributor-first-then-seeds ordering that lets a voter
+    // reach the candidate parameters served ONLY by the contributor node.
+
+    #[cfg(feature = "mpc-ceremony")]
+    #[test]
+    fn test_ordered_fetch_sources_contributor_first() {
+        let seeds = vec!["seed1.example:8559".to_string(), "9.9.9.9:8559".to_string()];
+        let got = ordered_fetch_sources(Some("1.2.3.4:8559"), &seeds);
+        // Contributor host leads, then the seeds — all reduced to host-only.
+        assert_eq!(got, vec!["1.2.3.4", "seed1.example", "9.9.9.9"]);
+    }
+
+    #[cfg(feature = "mpc-ceremony")]
+    #[test]
+    fn test_ordered_fetch_sources_dedups_contributor_that_is_also_a_seed() {
+        let seeds = vec!["1.2.3.4:8559".to_string(), "9.9.9.9:8559".to_string()];
+        // The contributor is also a configured seed → it must appear ONCE, first.
+        let got = ordered_fetch_sources(Some("1.2.3.4:8559"), &seeds);
+        assert_eq!(got, vec!["1.2.3.4", "9.9.9.9"]);
+    }
+
+    #[cfg(feature = "mpc-ceremony")]
+    #[test]
+    fn test_ordered_fetch_sources_unresolved_contributor_falls_back_to_seeds() {
+        let seeds = vec!["seed1.example:8559".to_string(), "9.9.9.9:8559".to_string()];
+        // Address unresolved → seeds-only (prior behaviour), never empty/hard-fail.
+        let got = ordered_fetch_sources(None, &seeds);
+        assert_eq!(got, vec!["seed1.example", "9.9.9.9"]);
+    }
+
+    #[cfg(feature = "mpc-ceremony")]
+    #[test]
+    fn test_fetch_host_of_variants() {
+        assert_eq!(fetch_host_of("1.2.3.4:8559"), "1.2.3.4");
+        assert_eq!(fetch_host_of("1.2.3.4"), "1.2.3.4");
+        assert_eq!(fetch_host_of("host.example:8080"), "host.example");
+        assert_eq!(fetch_host_of("tcp://1.2.3.4:8559"), "1.2.3.4");
+        assert_eq!(fetch_host_of("[2001:db8::1]:8559"), "2001:db8::1");
+    }
 
     // ── reaper_config_from_settings ──────────────────────────────────
 

--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -37,7 +37,7 @@ use anyhow::Result;
 use clap::Parser;
 use std::path::PathBuf;
 use std::sync::{Arc, OnceLock};
-use tokio::sync::{broadcast, Semaphore};
+use tokio::sync::broadcast;
 use tracing::{debug, error, info, warn, Level};
 use tracing_subscriber::FmtSubscriber;
 
@@ -5742,206 +5742,18 @@ async fn main() -> Result<()> {
     });
     info!("P2P mesh network started");
 
-    // C-1: Start Noise Protocol listener for encrypted P2P connections
-    // This listens for incoming encrypted TCP connections from peers
-    if let Some(noise_pool) = mesh.noise_pool() {
-        let noise_pool_clone = Arc::clone(noise_pool);
+    // C-1: Start the Noise Protocol RECEIVE listener for encrypted P2P.
+    // The accept/handshake/dispatch loop now lives in MeshNetwork
+    // (`run_noise_listener`) so the receive side of the Noise plane is owned and
+    // tested alongside the send side, instead of being hand-rolled here.
+    if mesh.noise_pool().is_some() {
         let mesh_for_noise = Arc::clone(&mesh);
-        let noise_port = ghost_consensus::mesh::DEFAULT_NOISE_PORT;
-
-        // M-17 SECURITY: Limit concurrent Noise connections to prevent resource exhaustion.
-        // 100 concurrent connections is sufficient for a healthy P2P mesh while preventing
-        // DoS attacks that exhaust file descriptors or memory.
-        let noise_connection_limit = Arc::new(Semaphore::new(100));
-        let mut noise_shutdown = shutdown_tx.subscribe();
-        // MESH REGISTRATION FIX: an inbound Noise connection (a node dialling us)
-        // must trigger a reverse SUB-dial back to that node. Health pings are
-        // ZMQ PUB/SUB broadcasts, so the ONLY way we register a peer is by
-        // subscribing to its PUB sockets — which the SUB loop only does for peers
-        // already in the PeerManager. A dynamically-joining node dials us over
-        // Noise (so its verifications arrive, but are rejected as "unknown
-        // challenger"); without dialling back we never receive its health pings
-        // and never learn it. Only the static seed list got this today, so
-        // non-seed nodes could never join. Captured into the listener task below.
+        let noise_shutdown = shutdown_tx.subscribe();
         let noise_is_mainnet = is_mainnet_round;
-        let noise_disc_port = config.network.p2p.discovery;
-        let reverse_subscribed: Arc<std::sync::Mutex<std::collections::HashSet<std::net::IpAddr>>> =
-            Arc::new(std::sync::Mutex::new(std::collections::HashSet::new()));
-
         tokio::spawn(async move {
-            use tokio::net::TcpListener;
-
-            let bind_addr = format!("0.0.0.0:{}", noise_port);
-            let listener = match TcpListener::bind(&bind_addr).await {
-                Ok(l) => {
-                    info!(
-                        port = noise_port,
-                        max_connections = 100,
-                        "Noise Protocol listener started (encrypted P2P)"
-                    );
-                    l
-                }
-                Err(e) => {
-                    error!(error = %e, port = noise_port, "Failed to start Noise listener");
-                    return;
-                }
-            };
-
-            loop {
-                // M-17: Acquire permit before accepting connection
-                let permit = match noise_connection_limit.clone().acquire_owned().await {
-                    Ok(p) => p,
-                    Err(_) => {
-                        // Semaphore closed - should not happen
-                        error!("Noise connection semaphore closed unexpectedly");
-                        return;
-                    }
-                };
-
-                let accept_result = tokio::select! {
-                    result = listener.accept() => result,
-                    _ = noise_shutdown.recv() => {
-                        tracing::info!("Noise listener shutting down");
-                        return;
-                    }
-                };
-
-                match accept_result {
-                    Ok((stream, addr)) => {
-                        let pool = Arc::clone(&noise_pool_clone);
-                        let mesh = Arc::clone(&mesh_for_noise);
-                        let conn_is_mainnet = noise_is_mainnet;
-                        let conn_disc_port = noise_disc_port;
-                        let conn_rev_sub = Arc::clone(&reverse_subscribed);
-
-                        tokio::spawn(async move {
-                            // M-17: Hold permit for connection lifetime - released when dropped
-                            let _permit = permit;
-
-                            // H2: Timeout Noise handshake to prevent resource exhaustion
-                            // from peers that connect but never complete the handshake
-                            let accept_result = tokio::time::timeout(
-                                std::time::Duration::from_secs(30),
-                                pool.accept_connection(stream),
-                            )
-                            .await;
-
-                            let accept_result = match accept_result {
-                                Ok(result) => result,
-                                Err(_) => {
-                                    tracing::warn!(
-                                        peer = %addr,
-                                        "Noise handshake timed out after 30s"
-                                    );
-                                    return;
-                                }
-                            };
-
-                            match accept_result {
-                                Ok(conn) => {
-                                    tracing::debug!(
-                                        peer = %addr,
-                                        peer_key = %hex::encode(&conn.peer_key[..8]),
-                                        "Accepted Noise connection"
-                                    );
-
-                                    // MESH REGISTRATION FIX: reverse-subscribe to this
-                                    // inbound peer so we receive its PUB/SUB health pings
-                                    // (the only path that registers it in the PeerManager).
-                                    // connect_peer mints a placeholder peer; the SUB loop
-                                    // dials its 8555-8562 PUBs; the real node_id then arrives
-                                    // via the first PoW-gated, signed health ping and retires
-                                    // the placeholder. No new trust is granted — counting a
-                                    // peer still requires that valid health ping. Skip
-                                    // private/reserved source IPs on mainnet (SSRF guard) and
-                                    // dial back only once per host (the addr.ip() is the real
-                                    // TCP source of a completed handshake).
-                                    {
-                                        let ip = addr.ip();
-                                        let routable = if conn_is_mainnet {
-                                            match ip {
-                                                std::net::IpAddr::V4(v4) => {
-                                                    !(v4.is_loopback()
-                                                        || v4.is_private()
-                                                        || v4.is_link_local()
-                                                        || v4.is_unspecified())
-                                                }
-                                                std::net::IpAddr::V6(v6) => {
-                                                    !(v6.is_loopback() || v6.is_unspecified())
-                                                }
-                                            }
-                                        } else {
-                                            true
-                                        };
-                                        let first_time = routable
-                                            && conn_rev_sub
-                                                .lock()
-                                                .map(|mut s| s.insert(ip))
-                                                .unwrap_or(false);
-                                        if first_time {
-                                            let mesh_cb = Arc::clone(&mesh);
-                                            let addr_str = format!("{}:{}", ip, conn_disc_port);
-                                            tokio::spawn(async move {
-                                                match mesh_cb.connect_peer(&addr_str).await {
-                                                    Ok(()) => tracing::info!(
-                                                        peer = %addr_str,
-                                                        "Reverse-subscribed to inbound peer (mesh registration)"
-                                                    ),
-                                                    Err(e) => tracing::debug!(
-                                                        peer = %addr_str,
-                                                        error = %e,
-                                                        "Reverse-subscribe connect_peer failed"
-                                                    ),
-                                                }
-                                            });
-                                        }
-                                    }
-
-                                    // Handle incoming messages from this connection
-                                    // Messages are received, validated, and dispatched to handlers
-                                    loop {
-                                        match conn.recv().await {
-                                            Ok(payload) => {
-                                                // Process received encrypted message through the mesh handler
-                                                if let Err(e) = mesh.handle_received(&payload).await
-                                                {
-                                                    tracing::debug!(
-                                                        peer = %addr,
-                                                        error = %e,
-                                                        "Error handling Noise message"
-                                                    );
-                                                }
-                                            }
-                                            Err(e) => {
-                                                tracing::debug!(
-                                                    peer = %addr,
-                                                    error = %e,
-                                                    "Noise connection error"
-                                                );
-                                                // Remove broken connection
-                                                pool.remove_connection(&conn.peer_key);
-                                                break;
-                                            }
-                                        }
-                                    }
-                                }
-                                Err(e) => {
-                                    tracing::warn!(
-                                        peer = %addr,
-                                        error = %e,
-                                        "Noise handshake failed"
-                                    );
-                                }
-                            }
-                        });
-                    }
-                    Err(e) => {
-                        tracing::error!(error = %e, "Noise accept error");
-                        // Drop permit on error so we don't leak it
-                        drop(permit);
-                    }
-                }
-            }
+            mesh_for_noise
+                .run_noise_listener(noise_is_mainnet, noise_shutdown)
+                .await;
         });
     } else {
         warn!("Noise Protocol DISABLED - P2P traffic is unencrypted");

--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -1613,6 +1613,128 @@ async fn adopt_all_applied_positions(
     true
 }
 
+/// Reconcile the `mpc_ceremony` singleton to the recorded contribution-chain
+/// head. The SINGLE source of the "singleton count == chain tip == head lineage
+/// hash" invariant shared by the fresh-join SYNC path (Part A) and the startup
+/// self-heal guard (Part B).
+///
+/// * ZERO contribution rows → returns `Ok(None)` and writes NOTHING: the node
+///   is legitimately pre-genesis (a brand-new genesis node) and must stay so.
+/// * `n > 0` rows AND singleton absent-or-BEHIND → creates / advances the
+///   singleton to `contribution_count = n` with
+///   `current_params_hash = mpc_contributions[n].new_params_hash` (the lineage
+///   head) and `ceremony_id = position-1.prev_params_hash` (the genesis anchor).
+/// * `n > 0` rows AND singleton already at/ahead of `n` → no-op, `Ok(Some(n))`.
+///
+/// Fail-CLOSED + honest: it reconciles ONLY to contributions that actually
+/// exist, never fabricates a genesis or invents a head, and NEVER lowers an
+/// already-ahead singleton (that would be a rollback).
+#[cfg(feature = "mpc-ceremony")]
+fn reconcile_singleton_to_recorded_head(
+    db: &ghost_storage::Database,
+) -> anyhow::Result<Option<u32>> {
+    let max_pos = match db.get_mpc_max_contribution_position()? {
+        Some(n) if n > 0 => n,
+        // No contribution rows: genuinely pre-genesis — leave the DB untouched.
+        _ => return Ok(None),
+    };
+
+    // Only create-if-absent or advance-if-behind; never lower an ahead singleton.
+    if let Some(state) = db.get_mpc_ceremony_state()? {
+        if state.contribution_count >= max_pos {
+            return Ok(Some(max_pos));
+        }
+    }
+
+    let head = db.get_mpc_contribution(max_pos)?.ok_or_else(|| {
+        anyhow::anyhow!("MPC: chain tip position {max_pos} has no contribution row")
+    })?;
+    // Canonical ceremony anchor = position-1's prev_params_hash (genesis lineage).
+    let anchor = db.mpc_genesis_ceremony_id()?.unwrap_or([0u8; 32]);
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    db.reconcile_mpc_singleton_to_head(max_pos, &head.new_params_hash, &anchor, now)?;
+    Ok(Some(max_pos))
+}
+
+/// Ensure the on-disk `note_spend_params_current.bin` IS the recorded
+/// contribution-chain head (`mpc_contributions[MAX].new_params_hash`).
+///
+/// If the manager already holds head parameters whose lineage
+/// [`hash_parameters`] equals the recorded head, this is a no-op (`Ok(true)`) —
+/// the common case for both a fresh join (the generic params fetch already
+/// installed the head) and a node7-style restart (the head is on disk, only the
+/// singleton was missing). Otherwise the head is fetched BY ITS LINEAGE HASH
+/// (contributor-first, then seeds; hash-checked inside
+/// [`fetch_ceremony_params_bundle`]) and installed through the manager's atomic
+/// params writer ([`ghost_mpc::CeremonyManager::install_synced_head`]), then the
+/// on-disk head is guaranteed to match.
+///
+/// Returns `Ok(false)` when there is no recorded head (zero contributions —
+/// pre-genesis). Returns `Err` (fail-safe) when a head is recorded but no source
+/// can supply matching parameters, so the caller does NOT persist a singleton it
+/// cannot back with on-disk params.
+#[cfg(feature = "mpc-ceremony")]
+async fn ensure_recorded_head_installed(
+    ceremony_mgr: &Arc<ghost_mpc::CeremonyManager>,
+    db: &ghost_storage::Database,
+    peers: &ghost_consensus::peer::PeerManager,
+    seeds: &[String],
+) -> anyhow::Result<bool> {
+    let max_pos = match db.get_mpc_max_contribution_position()? {
+        Some(n) if n > 0 => n,
+        _ => return Ok(false),
+    };
+    let head = db.get_mpc_contribution(max_pos)?.ok_or_else(|| {
+        anyhow::anyhow!("MPC: chain tip position {max_pos} has no contribution row")
+    })?;
+
+    // Already at the recorded head on disk (loaded into the manager)?
+    let on_disk_ok = ceremony_mgr
+        .note_spend_params()
+        .and_then(|p| ghost_mpc::contribution::hash_parameters(&p).ok())
+        .map(|h| h == head.new_params_hash)
+        .unwrap_or(false);
+    if on_disk_ok {
+        return Ok(true);
+    }
+
+    // current.bin is missing / stale: fetch the exact head by its lineage hash
+    // and install it through the atomic params writer. Serialise against the
+    // other trusted-setup writers on the shared parameter files.
+    let _guard = param_write_lock().lock().await;
+    let contributor_addr = hex::decode(&head.contributor_node_id)
+        .ok()
+        .and_then(|b| <[u8; 32]>::try_from(b.as_slice()).ok())
+        .and_then(|c| resolve_contributor_addr(peers, db, &c));
+    let sources = ordered_fetch_sources(contributor_addr.as_deref(), seeds);
+    let bundle = fetch_ceremony_params_bundle(&sources, head.new_params_hash)
+        .await
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "MPC: no source served head params matching recorded lineage at position {max_pos}"
+            )
+        })?;
+    let note_spend = (*bundle.note_spend).clone();
+    let new_hash = head.new_params_hash;
+    // `install_synced_head` is CPU-heavy (serialise + hash hundreds of MB); run it
+    // off the async runtime on a blocking thread (mirrors the adopt path).
+    let mgr = Arc::clone(ceremony_mgr);
+    let installed = tokio::task::spawn_blocking(move || {
+        mgr.install_synced_head(max_pos, &note_spend, new_hash)
+    })
+    .await;
+    match installed {
+        Ok(Ok(())) => Ok(true),
+        Ok(Err(e)) => Err(anyhow::anyhow!("MPC: install_synced_head failed: {e}")),
+        Err(e) => Err(anyhow::anyhow!(
+            "MPC: install_synced_head task join failed: {e}"
+        )),
+    }
+}
+
 /// Stage C task 3: fetch a single position's FULL contribution (with the real
 /// `contribution_proof`) AND its retained approve/reject votes from a peer's
 /// `/api/v1/mpc/votes/{position}` endpoint, and persist BOTH locally.
@@ -3372,7 +3494,50 @@ async fn main() -> Result<()> {
         use ghost_consensus::MpcHandler;
         use ghost_mpc::CeremonyManager;
 
-        // Load MPC ceremony state from database (the backfilled singleton)
+        // Part B — defensive startup self-heal (node7 recovery).
+        //
+        // A node that SYNCED contribution rows (+ proofs/votes) but never
+        // persisted the `mpc_ceremony` singleton (the fresh-join gap Part A fixes
+        // at the source) would otherwise fall through `load_or_init(None)` into
+        // the PRE-GENESIS branch and DISCARD its synced position-1..n state,
+        // regenerating genesis. Detect that inconsistency BEFORE `load_or_init`
+        // and reconcile the singleton to the recorded chain-tip head, so the
+        // manager loads the synced position cleanly instead.
+        //
+        // "Inconsistent" = contribution rows EXIST (`max_pos > 0`) AND the
+        // singleton is absent, or present but BEHIND the recorded chain tip
+        // (`count < max_pos`). A node with ZERO contribution rows is left
+        // untouched — it is legitimately pre-genesis (this is how a brand-new
+        // genesis node starts). Fail-CLOSED + honest: reconcile only from
+        // contributions that actually exist; never fabricate a genesis or head.
+        {
+            let singleton_count = db.get_mpc_ceremony_state()?.map(|s| s.contribution_count);
+            let max_pos = db.get_mpc_max_contribution_position()?.unwrap_or(0);
+            let inconsistent = max_pos > 0 && singleton_count.map(|c| c < max_pos).unwrap_or(true);
+            if inconsistent {
+                match reconcile_singleton_to_recorded_head(&db) {
+                    Ok(Some(head)) => info!(
+                        head,
+                        had_singleton = singleton_count.is_some(),
+                        prior_count = singleton_count.unwrap_or(0),
+                        "MPC startup self-heal: reconciled mpc_ceremony singleton to the recorded \
+                         contribution-chain head (contributions present but singleton absent/behind) \
+                         — loading the synced position instead of re-initialising pre-genesis"
+                    ),
+                    Ok(None) => {}
+                    Err(e) => warn!(
+                        error = %e,
+                        "MPC startup self-heal: singleton reconcile failed — startup verification \
+                         will decide (fail-closed)"
+                    ),
+                }
+            }
+        }
+
+        // Load MPC ceremony state from database (reconciled above if it was
+        // absent/behind, so a synced node now passes `Some(state)` — with
+        // `count == chain tip` — into `load_or_init` and loads current.bin,
+        // rather than the pre-genesis `None` path).
         let mpc_state = db.get_mpc_ceremony_state()?;
 
         // Stage A task 2: derive the STABLE ceremony_id.
@@ -3428,6 +3593,40 @@ async fn main() -> Result<()> {
                 Arc::new(CeremonyManager::new(mpc_params_dir))
             }
         };
+
+        // Part B — current.bin consistency for the reconciled head.
+        //
+        // The Part-B guard above ensured the singleton == chain tip, so
+        // `load_or_init` above loaded whatever `note_spend_params_current.bin`
+        // holds at that count. In the node7 case current.bin IS the synced head
+        // (the fetch installed it), so this is a no-op. But if current.bin is
+        // MISSING or STALE (e.g. a partial sync, or a head fetched under a
+        // pre-reconcile count), a synced node has no sequential apply path to
+        // rebuild it (`adopt_all_applied_positions` is a no-op once
+        // count == chain tip). Re-install the recorded head by its lineage hash
+        // through the atomic params writer so the genesis-anchored FATAL check
+        // below passes on a genuinely-consistent head — rather than the node
+        // silently proving against stale params or falsely advancing.
+        // Fail-CLOSED: if the head can't be installed we leave current.bin as-is
+        // and let the FATAL verification decide.
+        if ceremony_manager.contribution_count() > 0 {
+            match ensure_recorded_head_installed(
+                &ceremony_manager,
+                &db,
+                mesh.peers(),
+                &config.network.seed_nodes,
+            )
+            .await
+            {
+                Ok(true) => {}
+                Ok(false) => {}
+                Err(e) => warn!(
+                    error = %e,
+                    "MPC startup self-heal: could not (re)install the recorded head to current.bin \
+                     — genesis-anchored verification will decide (fail-closed)"
+                ),
+            }
+        }
 
         // Stage A task 3: startup lineage cross-check (fail-closed).
         //
@@ -4295,6 +4494,51 @@ async fn main() -> Result<()> {
                         if !fetched || !ceremony_manager_for_startup.has_current_params() {
                             warn!("MPC: Failed to fetch genesis parameters from network. Use --genesis on the first node.");
                             return;
+                        }
+
+                        // Part A — persist a CONSISTENT synced head.
+                        //
+                        // The sync above populated `mpc_contributions` (+ proofs/
+                        // votes) and fetched the head params into current.bin, but
+                        // it never wrote the `mpc_ceremony` singleton. Left there,
+                        // the next restart reads NO singleton, re-initialises
+                        // PRE-GENESIS, and DISCARDS the synced position-1..n state
+                        // (the node7 onboarding bug). Leave the node fully
+                        // consistent at the synced head:
+                        //   1. guarantee current.bin IS the recorded chain-tip head
+                        //      (re-fetch by lineage hash + atomic install if the
+                        //      generic fetch left it stale), then
+                        //   2. persist the singleton (count == chain tip ==
+                        //      on-disk head lineage hash).
+                        // Fail-SAFE: if the head can't be made consistent we do NOT
+                        // persist a singleton we cannot back with on-disk params —
+                        // the next attempt / restart re-syncs.
+                        match ensure_recorded_head_installed(
+                            &ceremony_manager_for_startup,
+                            &db_for_mpc,
+                            mesh_for_mpc_startup.peers(),
+                            &seed_nodes_for_mpc,
+                        )
+                        .await
+                        {
+                            Ok(true) => match reconcile_singleton_to_recorded_head(&db_for_mpc) {
+                                Ok(Some(head)) => info!(
+                                    head,
+                                    "MPC: persisted synced ceremony head (current.bin + mpc_ceremony \
+                                     singleton) — the node will load this position cleanly on restart"
+                                ),
+                                Ok(None) => {}
+                                Err(e) => warn!(
+                                    error = %e,
+                                    "MPC: failed to persist synced ceremony singleton"
+                                ),
+                            },
+                            Ok(false) => {}
+                            Err(e) => warn!(
+                                error = %e,
+                                "MPC: could not install the synced head params to current.bin; \
+                                 singleton NOT persisted — a restart will re-sync (fail-safe)"
+                            ),
                         }
                     }
                 }
@@ -7665,6 +7909,184 @@ mod tests {
                 .contribution_count,
             2
         );
+    }
+
+    // ── fresh-join singleton self-heal (node7 onboarding gap) ────────
+    //
+    // node7 joined genesis-anchored, synced the full lineage (contribution rows
+    // + proofs + votes) and fetched the head params into current.bin, but the
+    // sync NEVER wrote the `mpc_ceremony` singleton. On restart
+    // `get_mpc_ceremony_state()` returned None, `load_or_init(None)`
+    // re-initialised PRE-GENESIS, and the node DISCARDED its synced position-1..n
+    // state. These lock in the fix: with contribution rows present but no
+    // singleton, the startup reconcile creates the singleton at the chain tip
+    // (current_params_hash == contributions[MAX].new_params_hash) so the node is
+    // NOT pre-genesis; with ZERO contributions it stays pre-genesis.
+
+    /// Build a node7-shaped state in `dir`: an in-memory DB with contribution
+    /// rows 1..=n (+ proofs) and an on-disk head (`current.bin`) at position n,
+    /// but DELIBERATELY no `mpc_ceremony` singleton (the fresh-join sync gap).
+    #[cfg(feature = "mpc-ceremony")]
+    fn synced_ceremony_no_singleton(
+        dir: &Path,
+        n: u32,
+    ) -> (
+        std::sync::Arc<ghost_mpc::CeremonyManager>,
+        std::sync::Arc<ghost_storage::Database>,
+        String,
+    ) {
+        use ghost_common::identity::NodeIdentity;
+
+        let manager = std::sync::Arc::new(ghost_mpc::CeremonyManager::new(dir.to_path_buf()));
+        manager.ensure_genesis_initialized().expect("genesis init");
+        let id_hex = hex::encode(NodeIdentity::generate().node_id());
+        let db = std::sync::Arc::new(ghost_storage::Database::in_memory().expect("in-memory db"));
+
+        // Position 1 (genesis contribution), then 2..=n, applied in order so
+        // current.bin ends at the position-n head; every position saved as a row.
+        let (p1, c1) = manager
+            .generate_contribution(&id_hex)
+            .expect("generate position 1");
+        manager
+            .apply_contribution(p1, &c1)
+            .expect("apply position 1");
+        db.save_mpc_contribution(&foreign_row(1, &id_hex, &c1))
+            .unwrap();
+        for pos in 2..=n {
+            let (p, c) = manager
+                .generate_contribution_at_position(&id_hex, pos)
+                .expect("generate position");
+            manager.apply_contribution(p, &c).expect("apply position");
+            db.save_mpc_contribution(&foreign_row(pos, &id_hex, &c))
+                .unwrap();
+        }
+        // NODE7 GAP: deliberately do NOT persist the mpc_ceremony singleton.
+        assert!(
+            db.get_mpc_ceremony_state().unwrap().is_none(),
+            "helper must reproduce the node7 state: rows present, NO singleton"
+        );
+        (manager, db, id_hex)
+    }
+
+    /// Storage/reconcile: N contribution rows (+ proofs) but NO singleton → the
+    /// startup reconcile CREATES the singleton at count=N with
+    /// `current_params_hash == contributions[N].new_params_hash` (NOT pre-genesis).
+    /// Pre-fix this scenario stayed singleton-less → pre-genesis on restart.
+    #[cfg(feature = "mpc-ceremony")]
+    #[test]
+    fn startup_reconcile_creates_singleton_from_synced_contributions() {
+        let dir = tempfile::tempdir().unwrap();
+        let (manager, db, _id) = synced_ceremony_no_singleton(dir.path(), 3);
+
+        assert_eq!(db.get_mpc_max_contribution_position().unwrap(), Some(3));
+        let head_hash = db.get_mpc_contribution(3).unwrap().unwrap().new_params_hash;
+
+        // ── the fix ─────────────────────────────────────────────────────────
+        let n = reconcile_singleton_to_recorded_head(&db).unwrap();
+        assert_eq!(n, Some(3));
+
+        let singleton = db
+            .get_mpc_ceremony_state()
+            .unwrap()
+            .expect("singleton created — node is NO LONGER pre-genesis");
+        assert_eq!(
+            singleton.contribution_count, 3,
+            "singleton count == chain tip"
+        );
+        assert_eq!(
+            singleton.current_params_hash, head_hash,
+            "singleton head == recorded contributions[MAX].new_params_hash (lineage hash)"
+        );
+        // Invariant: singleton head == on-disk current.bin head lineage hash.
+        let on_disk =
+            ghost_mpc::contribution::hash_parameters(&manager.note_spend_params().unwrap())
+                .unwrap();
+        assert_eq!(
+            on_disk, head_hash,
+            "singleton head == on-disk current.bin head"
+        );
+    }
+
+    /// The genuine pre-genesis path is preserved: ZERO contribution rows AND no
+    /// singleton → the reconcile is a no-op and the node stays pre-genesis (this
+    /// is how a brand-new genesis node starts). No singleton is fabricated.
+    #[cfg(feature = "mpc-ceremony")]
+    #[test]
+    fn startup_reconcile_zero_contributions_stays_pregenesis() {
+        let db = std::sync::Arc::new(ghost_storage::Database::in_memory().unwrap());
+        assert!(db.get_mpc_ceremony_state().unwrap().is_none());
+        assert_eq!(db.get_mpc_max_contribution_position().unwrap(), None);
+
+        assert_eq!(
+            reconcile_singleton_to_recorded_head(&db).unwrap(),
+            None,
+            "no contributions → pre-genesis, nothing to reconcile"
+        );
+        assert!(
+            db.get_mpc_ceremony_state().unwrap().is_none(),
+            "must NOT fabricate a singleton for a brand-new genesis node"
+        );
+    }
+
+    /// Sync-path (Part A): after the finalize runs, the singleton is present at
+    /// the synced count AND current.bin on disk hashes to the head lineage hash.
+    /// (current.bin was already installed by the params fetch, so no network is
+    /// needed — `ensure_recorded_head_installed` returns Ok(true) immediately.)
+    #[cfg(feature = "mpc-ceremony")]
+    #[tokio::test]
+    async fn sync_path_persists_head_and_singleton() {
+        let dir = tempfile::tempdir().unwrap();
+        let (manager, db, _id) = synced_ceremony_no_singleton(dir.path(), 2);
+        let head_hash = db.get_mpc_contribution(2).unwrap().unwrap().new_params_hash;
+
+        let peers = ghost_consensus::peer::PeerManager::new([0u8; 32], 100);
+        assert!(
+            ensure_recorded_head_installed(&manager, &db, &peers, &[])
+                .await
+                .unwrap(),
+            "current.bin already at the recorded head — no re-fetch needed"
+        );
+        assert_eq!(reconcile_singleton_to_recorded_head(&db).unwrap(), Some(2));
+
+        let singleton = db.get_mpc_ceremony_state().unwrap().unwrap();
+        assert_eq!(singleton.contribution_count, 2);
+        assert_eq!(singleton.current_params_hash, head_hash);
+
+        // current.bin on disk hashes to the head lineage hash.
+        let current = dir.path().join("note_spend_params_current.bin");
+        let on_disk = ghost_mpc::contribution::hash_parameters(
+            &ghost_mpc::params::load_parameters(&current).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            on_disk, head_hash,
+            "on-disk current.bin == head lineage hash"
+        );
+    }
+
+    /// Regression: the caller reconciles BEFORE `load_or_init`, so the ceremony
+    /// state handed to `load_or_init` is `Some(state)` — never `None` — when
+    /// contributions are present. `load_or_init(dir, None)` with contributions is
+    /// the exact node7 crash-path and must be unreachable after the guard.
+    #[cfg(feature = "mpc-ceremony")]
+    #[test]
+    fn load_or_init_receives_some_after_startup_reconcile() {
+        let dir = tempfile::tempdir().unwrap();
+        let (_manager, db, _id) = synced_ceremony_no_singleton(dir.path(), 2);
+
+        // Pre-reconcile: state is None — load_or_init(None) would go PRE-GENESIS.
+        assert!(db.get_mpc_ceremony_state().unwrap().is_none());
+
+        // Part B guard runs the reconcile before load_or_init.
+        reconcile_singleton_to_recorded_head(&db).unwrap();
+
+        // The value load_or_init now receives is Some(state), count == chain tip.
+        let state = db.get_mpc_ceremony_state().unwrap();
+        assert!(
+            state.is_some(),
+            "caller must pass Some(state) to load_or_init after reconcile, never None"
+        );
+        assert_eq!(state.unwrap().contribution_count, 2);
     }
 
     // ── attempt-start catch-up (behind-the-head rolling gap) ─────────

--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -687,6 +687,50 @@ fn sha256_file(path: &std::path::Path) -> std::io::Result<[u8; 32]> {
     Ok(hasher.finalize().into())
 }
 
+/// Persist a freshly generated note-spend CANDIDATE (un-applied) parameter set
+/// for serving to voters, keyed by its lineage `new_params_hash`.
+///
+/// SECURITY (Bug-1 fix): the candidate is written to a SEPARATE serving file
+/// (`note_spend_params_candidate_<hash>.bin`) and NEVER to the active
+/// `note_spend_params_current.bin`. The node's `current.bin` must remain the
+/// last BFT-APPLIED params until a contribution is actually applied through
+/// `CeremonyManager::apply_contribution_multi` (the sole legitimate writer of
+/// `current.bin`). Writing the un-applied candidate over `current.bin` is what
+/// crash-looped node5: on restart the genesis-anchored cross-check saw on-disk
+/// candidate ≠ chain head and failed closed.
+///
+/// Stale candidates from superseded positions are purged best-effort so the
+/// serving directory does not accumulate multi-hundred-megabyte blobs. Returns
+/// the candidate file path on success.
+#[cfg(feature = "mpc-ceremony")]
+fn write_candidate_note_spend_params(
+    params_dir: &std::path::Path,
+    new_params_hash: &[u8; 32],
+    serialized: &[u8],
+) -> std::io::Result<std::path::PathBuf> {
+    std::fs::create_dir_all(params_dir)?;
+
+    // Drop candidate files for other (superseded) positions. Keep only the one
+    // we are about to (re)write so a long retry loop never bloats the dir.
+    let keep = ghost_common::mpc::candidate_note_spend_filename(new_params_hash);
+    if let Ok(entries) = std::fs::read_dir(params_dir) {
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            if name.starts_with(ghost_common::mpc::CANDIDATE_NOTE_SPEND_PREFIX)
+                && name.ends_with(".bin")
+                && name != keep
+            {
+                let _ = std::fs::remove_file(entry.path());
+            }
+        }
+    }
+
+    let candidate_path = params_dir.join(&keep);
+    std::fs::write(&candidate_path, serialized)?;
+    Ok(candidate_path)
+}
+
 /// True iff `note_spend_params_current.bin` exists in `params_dir` and — when a
 /// hash is pinned — its SHA-256 matches.
 ///
@@ -985,7 +1029,22 @@ async fn fetch_and_parse_params(
     endpoint: &str,
     expected_hash: Option<[u8; 32]>,
 ) -> Option<ghost_mpc::Groth16Params> {
-    let url = format!("http://{}:8080/api/v1/mpc/{}", host, endpoint);
+    // When we are after a specific (candidate) lineage hash, ask the peer to
+    // serve THAT candidate by hash. The contributor stores its un-applied
+    // candidate in a separate serving file keyed by `new_hash` (its active
+    // current.bin stays at the applied head), so a bare GET would return the
+    // applied params and the hash filter below would reject every peer. With
+    // `?new_hash=` the contributor serves the candidate; peers without it fall
+    // back to their current.bin (which won't match, so we skip them).
+    let url = match expected_hash {
+        Some(h) => format!(
+            "http://{}:8080/api/v1/mpc/{}?new_hash={}",
+            host,
+            endpoint,
+            hex::encode(h)
+        ),
+        None => format!("http://{}:8080/api/v1/mpc/{}", host, endpoint),
+    };
     let resp = reqwest::Client::new()
         .get(&url)
         .timeout(std::time::Duration::from_secs(60))
@@ -3673,23 +3732,41 @@ async fn main() -> Result<()> {
                                     }
                                 }
                             } else {
-                                // Non-genesis: save params to disk for serving via API.
-                                // We can't use apply_contribution here because it modifies
-                                // internal state (contribution_count) which breaks retries
-                                // if BFT rejects. Instead, write the binary directly.
+                                // Non-genesis: save the generated CANDIDATE to a
+                                // SEPARATE serving file keyed by its lineage hash —
+                                // NEVER the active note_spend_params_current.bin.
+                                //
+                                // We can't use apply_contribution here because it
+                                // modifies internal state (contribution_count) which
+                                // breaks retries if BFT rejects. And we must NOT
+                                // overwrite current.bin (the last BFT-APPLIED head):
+                                // doing so left node5 serving an un-applied candidate
+                                // as its "current" params and crash-looped it on
+                                // restart (on-disk candidate != chain head). Voters
+                                // fetch this candidate by hash via
+                                // GET /api/v1/mpc/params?new_hash=<hash>; our own
+                                // current.bin only advances when (and if) the apply
+                                // path runs after BFT approval.
                                 let params_dir = ceremony_manager_for_startup.params_dir().clone();
-                                let _ = std::fs::create_dir_all(&params_dir);
-                                let current_path = params_dir.join("note_spend_params_current.bin");
                                 let mut buf = Vec::new();
                                 if new_params.write(&mut buf).is_ok() {
-                                    if let Err(e) = std::fs::write(&current_path, &buf) {
-                                        warn!(error = %e, "MPC: Failed to save params to disk");
-                                    } else {
-                                        info!(
-                                            position = position,
-                                            size = buf.len(),
-                                            "MPC: Saved generated params to disk for serving"
-                                        );
+                                    match write_candidate_note_spend_params(
+                                        &params_dir,
+                                        &contribution.new_params_hash,
+                                        &buf,
+                                    ) {
+                                        Ok(candidate_path) => {
+                                            info!(
+                                                position = position,
+                                                size = buf.len(),
+                                                new_hash = %hex::encode(&contribution.new_params_hash[..8]),
+                                                path = %candidate_path.display(),
+                                                "MPC: Saved generated CANDIDATE params for serving (active current.bin unchanged)"
+                                            );
+                                        }
+                                        Err(e) => {
+                                            warn!(error = %e, "MPC: Failed to save candidate params to disk");
+                                        }
                                     }
                                 }
                             }
@@ -7106,6 +7183,47 @@ mod tests {
         assert!(current.exists());
         assert!(v0.exists());
         assert_eq!(sha256_file(&current).unwrap(), pinned);
+    }
+
+    /// Bug-1 regression: generating a candidate must write a SEPARATE serving
+    /// file keyed by its lineage hash and must NEVER touch the active
+    /// `note_spend_params_current.bin`. Writing the un-applied candidate over
+    /// current.bin crash-looped node5 (on-disk candidate != BFT chain head).
+    #[cfg(feature = "mpc-ceremony")]
+    #[test]
+    fn write_candidate_does_not_touch_current() {
+        let dir = tempfile::tempdir().unwrap();
+        // Pre-existing applied head — must remain byte-for-byte untouched.
+        let current = dir.path().join("note_spend_params_current.bin");
+        let applied = vec![0x11u8; 4096];
+        std::fs::write(&current, &applied).unwrap();
+
+        let new_hash = [0xCDu8; 32];
+        let candidate_blob = vec![0x22u8; 2048];
+        let path =
+            write_candidate_note_spend_params(dir.path(), &new_hash, &candidate_blob).unwrap();
+
+        // The candidate lives in its own hash-keyed file, distinct from current.
+        assert_eq!(
+            path.file_name().unwrap().to_string_lossy(),
+            ghost_common::mpc::candidate_note_spend_filename(&new_hash)
+        );
+        assert_ne!(path, current);
+        assert_eq!(std::fs::read(&path).unwrap(), candidate_blob);
+        // The active current.bin is unchanged — only the apply path may move it.
+        assert_eq!(std::fs::read(&current).unwrap(), applied);
+
+        // Writing a candidate for a NEW position purges the stale one but keeps
+        // current.bin intact (serving dir never accumulates blobs).
+        let new_hash2 = [0xEFu8; 32];
+        let path2 =
+            write_candidate_note_spend_params(dir.path(), &new_hash2, &vec![0x33u8; 1024]).unwrap();
+        assert!(path2.exists());
+        assert!(
+            !path.exists(),
+            "stale candidate from old position must be purged"
+        );
+        assert_eq!(std::fs::read(&current).unwrap(), applied);
     }
 
     /// SECURITY: if the on-disk file does not match the pinned hash after the

--- a/crates/ghost-common/src/mpc.rs
+++ b/crates/ghost-common/src/mpc.rs
@@ -103,6 +103,37 @@ pub fn mpc_bft_threshold(contributor_count: u32) -> u32 {
     }
 }
 
+/// Filename prefix for an on-disk note-spend CANDIDATE (un-applied) parameter
+/// file. Kept distinct from the active `note_spend_params_current.bin` so the
+/// two are never confused on disk or in the serving directory.
+pub const CANDIDATE_NOTE_SPEND_PREFIX: &str = "note_spend_params_candidate_";
+
+/// Filesystem name of the serving file for a note-spend CANDIDATE (un-applied)
+/// parameter set, keyed by its lineage `new_params_hash`.
+///
+/// A contributor writes its freshly generated candidate here — NEVER to the
+/// active `note_spend_params_current.bin`, which only the BFT apply path
+/// (`CeremonyManager::apply_contribution_multi`) or the install/self-heal fetch
+/// may repoint. The params-serving endpoint resolves a voter's by-hash request
+/// (`GET /api/v1/mpc/params?new_hash=<hex>`) to this file, so a voter fetching
+/// position-N's candidate gets the candidate while the contributor's own active
+/// params stay at the last BFT-applied head.
+///
+/// SINGLE SOURCE OF TRUTH: the writer (`ghost-pool`) and the server
+/// (`ghost-verification`) both derive the name here so they can never drift.
+/// Keying the filename by the hex lineage hash lets the serving side answer a
+/// by-hash fetch with a direct filesystem lookup (no re-hashing of params), and
+/// lets distinct candidates coexist without clobbering one another. The hex is
+/// fixed-width lower-case (64 chars), so a decoded-and-re-encoded request hash
+/// can never contain path separators.
+pub fn candidate_note_spend_filename(new_params_hash: &[u8; 32]) -> String {
+    format!(
+        "{}{}.bin",
+        CANDIDATE_NOTE_SPEND_PREFIX,
+        hex::encode(new_params_hash)
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -144,6 +175,28 @@ mod tests {
         hasher.update([1u8]);
         let expected: [u8; 32] = hasher.finalize().into();
         assert_eq!(approve, expected);
+    }
+
+    #[test]
+    fn test_candidate_note_spend_filename_keyed_by_hash() {
+        let h1 = [0x11u8; 32];
+        let h2 = [0x22u8; 32];
+        let n1 = candidate_note_spend_filename(&h1);
+        let n2 = candidate_note_spend_filename(&h2);
+
+        // Distinct candidates get distinct files (no clobbering).
+        assert_ne!(n1, n2);
+        // Pinned layout: prefix + 64 lower-case hex chars + ".bin".
+        assert_eq!(
+            n1,
+            "note_spend_params_candidate_1111111111111111111111111111111111111111111111111111111111111111.bin"
+        );
+        assert!(n1.starts_with(CANDIDATE_NOTE_SPEND_PREFIX));
+        assert!(n1.ends_with(".bin"));
+        // NEVER the active current-params file — these must stay distinct.
+        assert_ne!(n1, "note_spend_params_current.bin");
+        // Fixed-width hex (64) ⇒ no path separators can ever appear.
+        assert!(!n1.contains('/') && !n1.contains("..") && !n1.contains('\\'));
     }
 
     #[test]

--- a/crates/ghost-consensus/src/mesh.rs
+++ b/crates/ghost-consensus/src/mesh.rs
@@ -2142,6 +2142,186 @@ impl MeshNetwork {
         Ok(())
     }
 
+    /// Run the Noise-encrypted P2P RECEIVE listener — the receive counterpart of
+    /// the send side (`send_encrypted` / `broadcast`).
+    ///
+    /// Binds the configured `noise_port`, accepts inbound encrypted connections,
+    /// completes the Noise handshake, and dispatches every decrypted message
+    /// through [`handle_received`](Self::handle_received) to the registered
+    /// handlers. Point-to-point message types (MPC contributions/votes, shares,
+    /// consensus votes, payouts, …) are delivered over Noise, so WITHOUT this
+    /// loop a node emits Noise traffic but never receives any — the broadcast
+    /// reaches the peer's TCP stack but is never dispatched to a handler.
+    ///
+    /// This loop was previously hand-rolled in `bins/ghost-pool` and the
+    /// `MeshNetwork` owned no receive path of its own (the `NoiseReceiver` /
+    /// `NoiseMessageHandler` types were never wired in). Making it a first-class
+    /// `MeshNetwork` method keeps the send and receive sides symmetric and lets
+    /// integration tests exercise the REAL dispatch path.
+    ///
+    /// Runs until `shutdown` fires or the mesh stops. `is_mainnet` gates the
+    /// SSRF guard on the reverse-subscribe dial-back (private/reserved source IPs
+    /// are skipped on mainnet).
+    pub async fn run_noise_listener(
+        self: &Arc<Self>,
+        is_mainnet: bool,
+        mut shutdown: tokio::sync::broadcast::Receiver<()>,
+    ) {
+        let pool = match self.noise_pool.as_ref() {
+            Some(p) => Arc::clone(p),
+            None => {
+                warn!("run_noise_listener called but Noise is disabled — no receive path");
+                return;
+            }
+        };
+        let noise_port = self.config.noise_port;
+        let disc_port = self.config.ports.discovery;
+
+        // M-17: cap concurrent inbound Noise connections to bound resource use.
+        let connection_limit = Arc::new(tokio::sync::Semaphore::new(100));
+        // Dial back at most once per inbound host (mesh-registration reverse-sub).
+        let reverse_subscribed: Arc<std::sync::Mutex<std::collections::HashSet<std::net::IpAddr>>> =
+            Arc::new(std::sync::Mutex::new(std::collections::HashSet::new()));
+
+        let bind_addr = format!("0.0.0.0:{}", noise_port);
+        let listener = match tokio::net::TcpListener::bind(&bind_addr).await {
+            Ok(l) => {
+                info!(
+                    port = noise_port,
+                    max_connections = 100,
+                    "Noise Protocol listener started (encrypted P2P receive plane)"
+                );
+                l
+            }
+            Err(e) => {
+                error!(error = %e, port = noise_port, "Failed to start Noise listener");
+                return;
+            }
+        };
+
+        loop {
+            // M-17: acquire a permit before accepting a connection.
+            let permit = match connection_limit.clone().acquire_owned().await {
+                Ok(p) => p,
+                Err(_) => {
+                    error!("Noise connection semaphore closed unexpectedly");
+                    return;
+                }
+            };
+
+            let accept_result = tokio::select! {
+                result = listener.accept() => result,
+                _ = shutdown.recv() => {
+                    info!("Noise listener shutting down");
+                    return;
+                }
+            };
+
+            let (stream, addr) = match accept_result {
+                Ok(pair) => pair,
+                Err(e) => {
+                    error!(error = %e, "Noise accept error");
+                    drop(permit);
+                    continue;
+                }
+            };
+
+            let pool = Arc::clone(&pool);
+            let mesh = Arc::clone(self);
+            let conn_rev_sub = Arc::clone(&reverse_subscribed);
+
+            tokio::spawn(async move {
+                // M-17: hold the permit for the connection lifetime.
+                let _permit = permit;
+
+                // H2: bound the handshake so a peer that connects but never
+                // completes the handshake cannot pin resources.
+                let handshake = tokio::time::timeout(
+                    std::time::Duration::from_secs(30),
+                    pool.accept_connection(stream),
+                )
+                .await;
+
+                let conn = match handshake {
+                    Ok(Ok(conn)) => conn,
+                    Ok(Err(e)) => {
+                        warn!(peer = %addr, error = %e, "Noise handshake failed");
+                        return;
+                    }
+                    Err(_) => {
+                        warn!(peer = %addr, "Noise handshake timed out after 30s");
+                        return;
+                    }
+                };
+
+                debug!(
+                    peer = %addr,
+                    peer_key = %hex::encode(&conn.peer_key[..8]),
+                    "Accepted Noise connection"
+                );
+
+                // MESH REGISTRATION: reverse-subscribe to this inbound peer so we
+                // receive its ZMQ health pings (the path that registers it in the
+                // PeerManager). connect_peer mints a placeholder that the first
+                // signed health ping retires — no trust is granted here. Skip
+                // private/reserved source IPs on mainnet (SSRF guard) and dial
+                // back only once per host.
+                let ip = addr.ip();
+                let routable = if is_mainnet {
+                    match ip {
+                        std::net::IpAddr::V4(v4) => {
+                            !(v4.is_loopback()
+                                || v4.is_private()
+                                || v4.is_link_local()
+                                || v4.is_unspecified())
+                        }
+                        std::net::IpAddr::V6(v6) => !(v6.is_loopback() || v6.is_unspecified()),
+                    }
+                } else {
+                    true
+                };
+                let first_time = routable
+                    && conn_rev_sub
+                        .lock()
+                        .map(|mut s| s.insert(ip))
+                        .unwrap_or(false);
+                if first_time {
+                    let mesh_cb = Arc::clone(&mesh);
+                    let addr_str = format!("{}:{}", ip, disc_port);
+                    tokio::spawn(async move {
+                        match mesh_cb.connect_peer(&addr_str).await {
+                            Ok(()) => info!(
+                                peer = %addr_str,
+                                "Reverse-subscribed to inbound peer (mesh registration)"
+                            ),
+                            Err(e) => debug!(
+                                peer = %addr_str,
+                                error = %e,
+                                "Reverse-subscribe connect_peer failed"
+                            ),
+                        }
+                    });
+                }
+
+                // Receive, validate, and dispatch every message on this connection.
+                loop {
+                    match conn.recv().await {
+                        Ok(payload) => {
+                            if let Err(e) = mesh.handle_received(&payload).await {
+                                debug!(peer = %addr, error = %e, "Error handling Noise message");
+                            }
+                        }
+                        Err(e) => {
+                            debug!(peer = %addr, error = %e, "Noise connection error");
+                            pool.remove_connection(&conn.peer_key);
+                            break;
+                        }
+                    }
+                }
+            });
+        }
+    }
+
     /// Get validation statistics for monitoring
     pub fn validation_stats(&self) -> ValidationStats {
         self.validation_stats.read().clone()

--- a/crates/ghost-consensus/src/mpc_handler.rs
+++ b/crates/ghost-consensus/src/mpc_handler.rs
@@ -93,15 +93,25 @@ pub struct FetchedCeremonyParams {
 
 /// Async callback that fetches a candidate's parameter bundle from the network.
 ///
-/// Input: the expected note-spend lineage hash (`hash_parameters`) of the new
-/// parameters. Output: `Some(bundle)` only when a peer supplied parameters whose
+/// Inputs:
+/// - `expected`: the expected note-spend lineage hash (`hash_parameters`) of the
+///   new parameters.
+/// - `contributor`: the node id of the contributor whose freshly-generated
+///   candidate is being verified. This is LOAD-BEARING: the contributor is the
+///   ONLY node that holds its un-applied candidate (served from a separate
+///   candidate file, never `current.bin`), so the fetcher must be able to reach
+///   the contributor directly — the seed nodes only serve their own applied
+///   parameters. The fetcher resolves the contributor's reachable address from
+///   the mesh peer registry and tries it FIRST, then falls back to the seeds.
+///
+/// Output: `Some(bundle)` only when a source supplied parameters whose
 /// `hash_parameters()` matches the request; `None` on any fetch/parse/mismatch.
 ///
 /// A `None` result means the voter could not obtain the parameters and MUST
 /// abstain — it must never weaken verification or vote approve blind.
 #[cfg(feature = "mpc-ceremony")]
 pub type MpcParamsFetchFn = Arc<
-    dyn Fn([u8; 32]) -> Pin<Box<dyn Future<Output = Option<FetchedCeremonyParams>> + Send>>
+    dyn Fn([u8; 32], NodeId) -> Pin<Box<dyn Future<Output = Option<FetchedCeremonyParams>> + Send>>
         + Send
         + Sync,
 >;
@@ -616,13 +626,17 @@ impl MpcHandler {
         };
 
         // 1. Fetch the candidate's parameters. None => cannot verify => ABSTAIN.
+        //    The contributor (`msg.candidate`) is the ONLY node holding its
+        //    un-applied candidate, so it is passed to the fetcher which tries the
+        //    contributor's address first, then the seeds.
         let claimed = msg.new_params_hash;
-        let bundle = match fetcher(claimed).await {
+        let bundle = match fetcher(claimed, msg.candidate).await {
             Some(b) => b,
             None => {
                 info!(
                     position = msg.elder_position,
                     expected = %hex::encode(&claimed[..8]),
+                    contributor = %hex::encode(&msg.candidate[..8]),
                     "MPC: could not fetch candidate parameters — abstaining (fail-closed)"
                 );
                 return VoteDecision::Abstain;
@@ -1395,7 +1409,7 @@ mod ceremony_vote_tests {
     }
 
     fn fetcher_returning(params: Arc<Groth16Params>) -> MpcParamsFetchFn {
-        Arc::new(move |_expected| {
+        Arc::new(move |_expected, _contributor| {
             let p = Arc::clone(&params);
             Box::pin(async move {
                 Some(FetchedCeremonyParams {
@@ -1408,7 +1422,48 @@ mod ceremony_vote_tests {
     }
 
     fn fetcher_failing() -> MpcParamsFetchFn {
-        Arc::new(move |_expected| Box::pin(async move { Option::<FetchedCeremonyParams>::None }))
+        Arc::new(move |_expected, _contributor| {
+            Box::pin(async move { Option::<FetchedCeremonyParams>::None })
+        })
+    }
+
+    /// A fetcher that models the real network topology: the candidate params are
+    /// held ONLY by the contributor node (keyed by its node id), exactly as in
+    /// production where the contributor serves its un-applied candidate and the
+    /// seeds serve only their own applied `current.bin`.
+    ///
+    /// `serving` maps `contributor_node_id -> that contributor's candidate params`.
+    /// The fetcher returns the params ONLY when asked for the matching contributor
+    /// AND the hash lines up. If `use_contributor_arg` is false it IGNORES the
+    /// contributor argument entirely (the pre-fix `seeds`-only behaviour), so the
+    /// candidate — reachable only via the contributor — can never be found.
+    fn fetcher_serving_from_contributor(
+        serving: std::collections::HashMap<NodeId, Arc<Groth16Params>>,
+        use_contributor_arg: bool,
+    ) -> MpcParamsFetchFn {
+        Arc::new(move |expected, contributor| {
+            // Pre-fix model: a seeds-only fetcher never consults the contributor,
+            // so it cannot reach the candidate that only the contributor serves.
+            let lookup = if use_contributor_arg {
+                serving.get(&contributor).cloned()
+            } else {
+                None
+            };
+            Box::pin(async move {
+                let p = lookup?;
+                // Preserve the production hash filter: a source must serve params
+                // whose lineage hash matches the claim, else it is skipped.
+                let h = ghost_mpc::contribution::hash_parameters(&p).ok()?;
+                if h != expected {
+                    return None;
+                }
+                Some(FetchedCeremonyParams {
+                    note_spend: p,
+                    payout: None,
+                    unshield: None,
+                })
+            })
+        })
     }
 
     fn insert_pending(handler: &MpcHandler, msg: &MpcContributionMessage) {
@@ -1612,5 +1667,141 @@ mod ceremony_vote_tests {
             rejections >= 1,
             "the verify gate must reject foreign-lineage params"
         );
+    }
+
+    /// (5) FETCH-FROM-CONTRIBUTOR — the exact mainnet scenario that stalled the
+    /// ceremony. The candidate parameters exist ONLY on the contributor's serving
+    /// path (never on the voter's seeds). The voter must therefore fetch them FROM
+    /// THE CONTRIBUTOR, which requires the contributor's node id to be threaded to
+    /// the fetcher. With that in place the contribution verifies, is approved, and
+    /// applies.
+    ///
+    /// The paired assertion below (`test_seeds_only_fetch_abstains_repro`) drives
+    /// the SAME serving map through a fetcher that ignores the contributor id (the
+    /// pre-fix `seeds`-only behaviour) and shows it abstains — proving the id is
+    /// what closes the gap.
+    #[tokio::test]
+    async fn test_fetch_from_contributor_approves_and_applies() {
+        let voter_identity = Arc::new(NodeIdentity::generate());
+        // The CONTRIBUTOR is a DIFFERENT node — its id is what the voter must use
+        // to locate the candidate (matching production, where `msg.candidate` is
+        // the remote contributor, not the local voter).
+        let contributor_identity = Arc::new(NodeIdentity::generate());
+        let db = Arc::new(Database::in_memory().unwrap());
+        let (manager, _dir) = genesis_manager();
+
+        let (new_params, contribution) = manager.generate_contribution("node1").unwrap();
+        let new_params = Arc::new(new_params);
+        let msg = message_for(&contribution, &contributor_identity);
+
+        // Model the network: only the contributor serves its candidate.
+        let mut serving = std::collections::HashMap::new();
+        serving.insert(contributor_identity.node_id(), Arc::clone(&new_params));
+
+        let handler = MpcHandler::new(Arc::clone(&voter_identity), Arc::clone(&db))
+            .with_ceremony_manager(Arc::clone(&manager))
+            // use_contributor_arg = true → the fixed fetcher reaches the contributor.
+            .with_params_fetcher(fetcher_serving_from_contributor(serving, true))
+            .with_state(0, false);
+        insert_pending(&handler, &msg);
+
+        handler.verify_and_vote(&msg).await.unwrap();
+
+        // Fetched from the contributor, verified, approved, and APPLIED.
+        let row = db.get_mpc_contribution(1).unwrap();
+        assert!(
+            row.is_some(),
+            "contribution must apply after contributor fetch"
+        );
+        assert_eq!(row.unwrap().new_params_hash, contribution.new_params_hash);
+        assert_eq!(manager.contribution_count(), 1);
+        assert_eq!(manager.current_params_hash(), contribution.new_params_hash);
+        let (approvals, rejections) = db.count_mpc_approvals(1).unwrap();
+        assert_eq!(approvals, 1);
+        assert_eq!(rejections, 0);
+    }
+
+    /// (5-repro) PRE-FIX REGRESSION GUARD. Same candidate, same serving map, but
+    /// the fetcher IGNORES the contributor id — modelling the old `seeds`-only
+    /// fetcher whose signature could not carry the contributor. The candidate is
+    /// unreachable, so the voter ABSTAINS (fail-closed): no vote, no apply, and the
+    /// pending contribution survives. This is the precise mainnet stall this fix
+    /// removes — it FAILS (would apply) only if the contributor id were reachable.
+    #[tokio::test]
+    async fn test_seeds_only_fetch_abstains_repro() {
+        let voter_identity = Arc::new(NodeIdentity::generate());
+        let contributor_identity = Arc::new(NodeIdentity::generate());
+        let db = Arc::new(Database::in_memory().unwrap());
+        let (manager, _dir) = genesis_manager();
+        let genesis_hash = manager.current_params_hash();
+
+        let (new_params, contribution) = manager.generate_contribution("node1").unwrap();
+        let new_params = Arc::new(new_params);
+        let msg = message_for(&contribution, &contributor_identity);
+
+        // The candidate IS being served by the contributor …
+        let mut serving = std::collections::HashMap::new();
+        serving.insert(contributor_identity.node_id(), Arc::clone(&new_params));
+
+        let handler = MpcHandler::new(Arc::clone(&voter_identity), Arc::clone(&db))
+            .with_ceremony_manager(Arc::clone(&manager))
+            // … but use_contributor_arg = false → seeds-only, never asks the
+            // contributor, so it cannot find the candidate.
+            .with_params_fetcher(fetcher_serving_from_contributor(serving, false))
+            .with_state(0, false);
+        insert_pending(&handler, &msg);
+
+        handler.verify_and_vote(&msg).await.unwrap();
+
+        // Abstained: no vote, nothing applied, pending survives (ceremony stalled
+        // — exactly the observed mainnet behaviour before the fix).
+        let (approvals, rejections) = db.count_mpc_approvals(1).unwrap();
+        assert_eq!(approvals, 0, "seeds-only fetch must not approve");
+        assert_eq!(rejections, 0, "seeds-only fetch abstains, casts no vote");
+        assert!(db.get_mpc_contribution(1).unwrap().is_none());
+        assert_eq!(manager.contribution_count(), 0);
+        assert_eq!(manager.current_params_hash(), genesis_hash);
+        assert!(
+            handler
+                .pending_contributions
+                .read()
+                .contains_key(&msg.contribution_hash()),
+            "pending must survive the abstention"
+        );
+    }
+
+    /// (6) NEGATIVE — contributor UNREACHABLE. The fetcher is contributor-aware,
+    /// but the contributor's address cannot be resolved (its id is absent from the
+    /// serving set, mirroring an unresolved mesh address with no matching seed).
+    /// The voter must ABSTAIN (fail-closed) — never vote on unverified params.
+    #[tokio::test]
+    async fn test_contributor_unreachable_abstains() {
+        let voter_identity = Arc::new(NodeIdentity::generate());
+        let contributor_identity = Arc::new(NodeIdentity::generate());
+        let db = Arc::new(Database::in_memory().unwrap());
+        let (manager, _dir) = genesis_manager();
+        let genesis_hash = manager.current_params_hash();
+
+        let (_new_params, contribution) = manager.generate_contribution("node1").unwrap();
+        let msg = message_for(&contribution, &contributor_identity);
+
+        // Empty serving set → contributor unreachable, no seed can supply it.
+        let serving: std::collections::HashMap<NodeId, Arc<Groth16Params>> =
+            std::collections::HashMap::new();
+
+        let handler = MpcHandler::new(Arc::clone(&voter_identity), Arc::clone(&db))
+            .with_ceremony_manager(Arc::clone(&manager))
+            .with_params_fetcher(fetcher_serving_from_contributor(serving, true))
+            .with_state(0, false);
+        insert_pending(&handler, &msg);
+
+        handler.verify_and_vote(&msg).await.unwrap();
+
+        let (approvals, rejections) = db.count_mpc_approvals(1).unwrap();
+        assert_eq!(approvals, 0, "unreachable contributor must not approve");
+        assert_eq!(rejections, 0, "unreachable contributor abstains, no vote");
+        assert!(db.get_mpc_contribution(1).unwrap().is_none());
+        assert_eq!(manager.contribution_count(), 0);
+        assert_eq!(manager.current_params_hash(), genesis_hash);
     }
 }

--- a/crates/ghost-consensus/src/mpc_handler.rs
+++ b/crates/ghost-consensus/src/mpc_handler.rs
@@ -139,6 +139,28 @@ enum VoteDecision {
     Abstain,
 }
 
+/// Outcome of the cheap structural + hash-chain pre-check.
+///
+/// The pre-check must distinguish a DETERMINISTIC structural failure (which
+/// every honest node sees identically, so it is safe to REJECT) from a purely
+/// LOCAL / transient condition (our own view is momentarily behind — the
+/// predecessor contribution is not yet in our DB, or the lookup errored). A
+/// local condition is NOT proof the candidate is bad, so it must ABSTAIN and be
+/// re-evaluated on the next rebroadcast — never recorded as a permanent reject.
+enum StructuralOutcome {
+    /// Structure well-formed and (for position > 1) the chain link is confirmed
+    /// against a predecessor we hold. Proceed to cryptographic verification.
+    Pass,
+    /// Deterministic structural failure visible identically to every node
+    /// (empty proof, zero/duplicate hashes, or a predecessor we HOLD whose hash
+    /// does not match the claimed `prev_params_hash`). Cast a reject.
+    Reject(String),
+    /// Indeterminate / local: we do not yet hold the predecessor (mid-catch-up,
+    /// or the contributor just restarted and our view lags) or the lookup
+    /// errored. We cannot judge the chain — abstain, do not reject.
+    Indeterminate(String),
+}
+
 /// BFT threshold + bootstrap count for MPC contribution approval.
 ///
 /// SINGLE SOURCE OF TRUTH: these come from `ghost_common::constants` (and are
@@ -236,15 +258,44 @@ impl RateLimiter {
 /// Maximum age for pending contributions before cleanup (30 minutes)
 const PENDING_CONTRIBUTION_TIMEOUT_SECS: u64 = 30 * 60;
 
+/// Minimum interval between heavy re-verifications of the SAME still-pending
+/// candidate on rebroadcast.
+///
+/// A contributor rebroadcasts its stable candidate roughly every 60-90s until it
+/// converges. When we have NOT yet approved a position (no vote, or a prior
+/// transient reject we must heal), each rebroadcast is an opportunity to re-run
+/// the real cryptographic verification and, if it now passes, upgrade our vote.
+/// This throttle sits comfortably under the rebroadcast cadence so every genuine
+/// rebroadcast re-evaluates, while capping repeated multi-second Groth16 verifies
+/// under a duplicate flood (a peer replaying the same hash faster than that).
+const MPC_REEVAL_MIN_INTERVAL_SECS: u64 = 30;
+
 /// Pending contribution awaiting verification
 #[derive(Clone)]
 struct PendingContribution {
     message: MpcContributionMessage,
     received_at: Instant,
-    approval_count: u32,
-    rejection_count: u32,
-    /// Track which voters have already voted (prevents duplicate vote inflation)
-    voters: std::collections::HashSet<NodeId>,
+    /// Last time we ran (or re-ran) verify+vote for this candidate. Throttles the
+    /// heavy re-verification triggered by rebroadcasts / duplicate floods.
+    last_evaluated: Instant,
+    /// Latest vote from each voter (`voter -> approve`). LATEST-WINS: a voter that
+    /// first cast a transient reject and later fetches + verifies the candidate has
+    /// its `approve` supersede the stale reject (and a repeat of the same value is
+    /// idempotent — no double counting). This is what lets a stuck reject heal
+    /// toward quorum without waiting for the 30-minute pending reclaim.
+    votes: std::collections::HashMap<NodeId, bool>,
+}
+
+impl PendingContribution {
+    /// Number of voters whose latest vote is `approve`.
+    fn approval_count(&self) -> u32 {
+        self.votes.values().filter(|&&approve| approve).count() as u32
+    }
+
+    /// Number of voters whose latest vote is `reject`.
+    fn rejection_count(&self) -> u32 {
+        self.votes.values().filter(|&&approve| !approve).count() as u32
+    }
 }
 
 /// MPC ceremony handler
@@ -435,15 +486,15 @@ impl MpcHandler {
             return Ok(());
         }
 
-        // Store as pending
+        // Store as pending — or, for a rebroadcast of an already-pending
+        // candidate, decide whether to RE-EVALUATE it.
         let contribution_hash = msg.contribution_hash();
+        let our_id = self.identity.node_id();
         {
             let mut pending = self.pending_contributions.write();
-            if pending.contains_key(&contribution_hash) {
-                debug!("Duplicate MPC contribution, ignoring");
-                return Ok(());
-            }
-            // Clean up stale pending contributions before inserting
+
+            // Clean up stale pending contributions first, so a long-aged entry
+            // never blocks a fresh candidate at the same hash.
             pending.retain(|_, c| {
                 c.received_at.elapsed().as_secs() < PENDING_CONTRIBUTION_TIMEOUT_SECS
             });
@@ -455,16 +506,43 @@ impl MpcHandler {
                 c.inserted_at.elapsed().as_secs() < PENDING_CONTRIBUTION_TIMEOUT_SECS
             });
 
-            pending.insert(
-                contribution_hash,
-                PendingContribution {
-                    message: msg.clone(),
-                    received_at: Instant::now(),
-                    approval_count: 0,
-                    rejection_count: 0,
-                    voters: std::collections::HashSet::new(),
-                },
-            );
+            if let Some(existing) = pending.get_mut(&contribution_hash) {
+                // Rebroadcast of a candidate we are already tracking. Re-evaluate
+                // ONLY when we have NOT yet approved it (no vote yet, or a prior
+                // transient reject that must heal) AND a throttle interval has
+                // elapsed — this lets a stuck reject recover on a later rebroadcast
+                // without re-running the heavy Groth16 verify on every duplicate.
+                // A candidate we have already approved needs no re-work, and a
+                // definitively-invalid one is simply re-rejected by the same real
+                // verification each time — never approved by retrying.
+                let already_approved = existing.votes.get(&our_id) == Some(&true);
+                let throttle_elapsed =
+                    existing.last_evaluated.elapsed().as_secs() >= MPC_REEVAL_MIN_INTERVAL_SECS;
+                if already_approved || !throttle_elapsed {
+                    debug!(
+                        position = msg.elder_position,
+                        already_approved,
+                        "Duplicate MPC contribution — no re-evaluation (already approved or throttled)"
+                    );
+                    return Ok(());
+                }
+                // Arm the throttle and fall through to re-run verify+vote below.
+                existing.last_evaluated = Instant::now();
+                debug!(
+                    position = msg.elder_position,
+                    "Re-evaluating rebroadcast MPC contribution (not yet approved)"
+                );
+            } else {
+                pending.insert(
+                    contribution_hash,
+                    PendingContribution {
+                        message: msg.clone(),
+                        received_at: Instant::now(),
+                        last_evaluated: Instant::now(),
+                        votes: std::collections::HashMap::new(),
+                    },
+                );
+            }
         }
 
         info!(
@@ -527,51 +605,70 @@ impl MpcHandler {
 
     /// Cheap structural + hash-chain pre-check (the FAST REJECT).
     ///
-    /// Returns `true` only when the proof is present, the hashes are well-formed
-    /// and distinct, AND `prev_params_hash` chains from the recorded previous
-    /// contribution. This is necessary but NOT sufficient — it does NOT prove
-    /// the contribution is a valid cryptographic transformation. Approval
+    /// Distinguishes a DETERMINISTIC structural failure ([`StructuralOutcome::Reject`])
+    /// from an INDETERMINATE local condition ([`StructuralOutcome::Indeterminate`],
+    /// e.g. the predecessor contribution is not yet in OUR database because we are
+    /// mid-catch-up or the contributor just restarted). Only the former is a
+    /// permanent, everyone-sees-it verdict safe to record as a reject; the latter
+    /// must ABSTAIN so it is re-evaluated on the next rebroadcast rather than
+    /// blocking quorum forever with a stale reject.
+    ///
+    /// A [`StructuralOutcome::Pass`] is necessary but NOT sufficient — it does NOT
+    /// prove the contribution is a valid cryptographic transformation. Approval
     /// additionally requires [`MpcHandler::crypto_decide`].
-    fn structural_precheck(&self, msg: &MpcContributionMessage) -> bool {
-        // Structural validation: proof exists, hashes are non-zero and different
+    fn structural_precheck(&self, msg: &MpcContributionMessage) -> StructuralOutcome {
+        // Structural validation: proof exists, hashes are non-zero and different.
+        // These fields are part of the signed payload every node sees identically,
+        // so a failure here is a DETERMINISTIC reject.
         let structurally_valid = !msg.contribution_proof.is_empty()
             && msg.prev_params_hash != [0u8; 32]
             && msg.new_params_hash != [0u8; 32]
             && msg.prev_params_hash != msg.new_params_hash;
         if !structurally_valid {
-            return false;
+            return StructuralOutcome::Reject("Malformed contribution structure".to_string());
         }
 
         // Hash chain validation: verify prev_params_hash matches the latest contribution.
         if msg.elder_position == 1 {
             // Genesis contribution has no predecessor to validate against.
-            return true;
+            return StructuralOutcome::Pass;
         }
         match self.db.get_mpc_contribution(msg.elder_position - 1) {
             Ok(Some(prev)) => {
                 if prev.new_params_hash != msg.prev_params_hash {
+                    // We HOLD the predecessor and its hash does not match the
+                    // claimed link — the chain is definitively broken. Every node
+                    // holding this predecessor sees the same mismatch → reject.
                     warn!(
                         position = msg.elder_position,
                         expected = %hex::encode(&prev.new_params_hash[..8]),
                         got = %hex::encode(&msg.prev_params_hash[..8]),
                         "MPC contribution prev_params_hash does not chain from previous contribution"
                     );
-                    false
+                    StructuralOutcome::Reject(
+                        "prev_params_hash does not chain from previous contribution".to_string(),
+                    )
                 } else {
-                    true
+                    StructuralOutcome::Pass
                 }
             }
             Ok(None) => {
+                // We do NOT yet hold the predecessor (our view lags — mid-catch-up,
+                // or the contributor just restarted). We cannot judge the chain, so
+                // ABSTAIN and re-evaluate later rather than casting a stale reject.
                 warn!(
                     position = msg.elder_position,
                     prev_position = msg.elder_position - 1,
-                    "Cannot verify hash chain: previous contribution not found"
+                    "Cannot verify hash chain: previous contribution not present locally — abstaining"
                 );
-                false
+                StructuralOutcome::Indeterminate(
+                    "previous contribution not present locally".to_string(),
+                )
             }
             Err(e) => {
-                warn!(error = %e, "Failed to look up previous MPC contribution for chain verification");
-                false
+                // A local lookup error is not proof of forgery — abstain.
+                warn!(error = %e, "Failed to look up previous MPC contribution for chain verification — abstaining");
+                StructuralOutcome::Indeterminate(format!("previous-contribution lookup error: {e}"))
             }
         }
     }
@@ -586,8 +683,17 @@ impl MpcHandler {
     /// so a flaky node never approves blind and never drags the 67% threshold
     /// toward rejection.
     async fn decide_vote(&self, msg: &MpcContributionMessage) -> VoteDecision {
-        if !self.structural_precheck(msg) {
-            return VoteDecision::Reject("Invalid structure or hash chain".to_string());
+        match self.structural_precheck(msg) {
+            StructuralOutcome::Reject(reason) => return VoteDecision::Reject(reason),
+            StructuralOutcome::Indeterminate(reason) => {
+                info!(
+                    position = msg.elder_position,
+                    reason = %reason,
+                    "MPC: structural pre-check indeterminate — abstaining (will re-evaluate on rebroadcast)"
+                );
+                return VoteDecision::Abstain;
+            }
+            StructuralOutcome::Pass => {}
         }
 
         #[cfg(feature = "mpc-ceremony")]
@@ -783,29 +889,25 @@ impl MpcHandler {
         let should_apply = {
             let mut pending = self.pending_contributions.write();
             if let Some(contribution) = pending.get_mut(&contribution_hash) {
-                // H-4: Insert our node ID into voters set before incrementing count.
+                // H-4 / latest-wins: record our node's LATEST verdict. Re-inserting
+                // the same value is idempotent (no double counting); a re-vote that
+                // upgrades a prior transient reject to approve supersedes it.
                 let our_id = self.identity.node_id();
-                if !contribution.voters.insert(our_id) {
-                    return Ok(());
-                }
-                if approve {
-                    contribution.approval_count += 1;
-                } else {
-                    contribution.rejection_count += 1;
-                }
+                contribution.votes.insert(our_id, approve);
 
+                let approval_count = contribution.approval_count();
                 let contributor_count = self.mpc_contributor_count();
                 let threshold = bft_threshold(contributor_count);
 
                 info!(
-                    approvals = contribution.approval_count,
-                    rejections = contribution.rejection_count,
+                    approvals = approval_count,
+                    rejections = contribution.rejection_count(),
                     mpc_contributors = contributor_count,
                     threshold = threshold,
                     "Self-vote counted for MPC contribution"
                 );
 
-                contribution.approval_count >= threshold
+                approval_count >= threshold
             } else {
                 false
             }
@@ -851,38 +953,37 @@ impl MpcHandler {
             return Ok(());
         }
 
-        // Update pending contribution (with duplicate vote prevention)
+        // Update pending contribution. LATEST-WINS: a repeat of the same vote value
+        // is idempotent (no double counting), while a voter that upgrades a prior
+        // transient reject to an approve on a rebroadcast has its approve counted
+        // toward quorum — this is what lets a stuck reject heal without waiting for
+        // the pending entry to be reclaimed.
         let should_apply = {
             let mut pending = self.pending_contributions.write();
             if let Some(contribution) = pending.get_mut(&msg.contribution_hash) {
-                // Reject duplicate votes from the same voter
-                if !contribution.voters.insert(msg.voter) {
+                let prior = contribution.votes.insert(msg.voter, msg.approve);
+                if prior == Some(msg.approve) {
                     debug!(
                         voter = %hex::encode(&msg.voter[..8]),
-                        "Duplicate MPC vote from same voter, ignoring"
+                        "Duplicate MPC vote (same value) from voter, no change"
                     );
-                    return Ok(());
                 }
 
-                if msg.approve {
-                    contribution.approval_count += 1;
-                } else {
-                    contribution.rejection_count += 1;
-                }
+                let approval_count = contribution.approval_count();
 
                 // Check if we have BFT threshold
                 let contributor_count = self.mpc_contributor_count();
                 let threshold = bft_threshold(contributor_count);
 
                 debug!(
-                    approvals = contribution.approval_count,
-                    rejections = contribution.rejection_count,
+                    approvals = approval_count,
+                    rejections = contribution.rejection_count(),
                     mpc_contributors = contributor_count,
                     threshold = threshold,
                     "MPC vote counted"
                 );
 
-                contribution.approval_count >= threshold
+                approval_count >= threshold
             } else {
                 false
             }
@@ -1427,6 +1528,35 @@ mod ceremony_vote_tests {
         })
     }
 
+    /// A fetcher whose reachability is toggled at runtime. While `reachable` is
+    /// false the contributor is unreachable (fetch returns `None`, the transient
+    /// condition); once flipped true it serves the candidate params (subject to the
+    /// production hash filter). Models a contributor that was momentarily down
+    /// (e.g. just-restarted) and then comes back.
+    fn fetcher_toggle(
+        params: Arc<Groth16Params>,
+        reachable: Arc<std::sync::atomic::AtomicBool>,
+    ) -> MpcParamsFetchFn {
+        Arc::new(move |expected, _contributor| {
+            let p = Arc::clone(&params);
+            let reachable = Arc::clone(&reachable);
+            Box::pin(async move {
+                if !reachable.load(std::sync::atomic::Ordering::SeqCst) {
+                    return None; // contributor unreachable — transient
+                }
+                let h = ghost_mpc::contribution::hash_parameters(&p).ok()?;
+                if h != expected {
+                    return None;
+                }
+                Some(FetchedCeremonyParams {
+                    note_spend: p,
+                    payout: None,
+                    unshield: None,
+                })
+            })
+        })
+    }
+
     /// A fetcher that models the real network topology: the candidate params are
     /// held ONLY by the contributor node (keyed by its node id), exactly as in
     /// production where the contributor serves its un-applied candidate and the
@@ -1472,9 +1602,8 @@ mod ceremony_vote_tests {
             PendingContribution {
                 message: msg.clone(),
                 received_at: Instant::now(),
-                approval_count: 0,
-                rejection_count: 0,
-                voters: std::collections::HashSet::new(),
+                last_evaluated: Instant::now(),
+                votes: std::collections::HashMap::new(),
             },
         );
     }
@@ -1555,7 +1684,7 @@ mod ceremony_vote_tests {
 
         // PROOF the hole is closed: the OLD structural-only check approves this.
         assert!(
-            handler.structural_precheck(&msg),
+            matches!(handler.structural_precheck(&msg), StructuralOutcome::Pass),
             "the old structural-only check WOULD have passed the forged contribution"
         );
 
@@ -1653,7 +1782,10 @@ mod ceremony_vote_tests {
             .with_state(0, false);
 
         // Structural + hash checks pass — proving hash match alone is insufficient.
-        assert!(handler.structural_precheck(&msg));
+        assert!(matches!(
+            handler.structural_precheck(&msg),
+            StructuralOutcome::Pass
+        ));
         insert_pending(&handler, &msg);
 
         handler.verify_and_vote(&msg).await.unwrap();
@@ -1803,5 +1935,178 @@ mod ceremony_vote_tests {
         assert!(db.get_mpc_contribution(1).unwrap().is_none());
         assert_eq!(manager.contribution_count(), 0);
         assert_eq!(manager.current_params_hash(), genesis_hash);
+    }
+
+    /// (7) STRUCTURAL INDETERMINATE — the exact ~1-second mainnet fast-reject.
+    /// A contribution arrives for a position whose predecessor we do NOT yet hold
+    /// (our view lags, the contributor just restarted). The old pre-check collapsed
+    /// this "cannot verify the chain yet" condition into a permanent `approve=false`
+    /// reject. Post-fix it is INDETERMINATE → ABSTAIN: no vote is stored, so it no
+    /// longer blocks quorum forever, and the pending survives to be re-evaluated on
+    /// the next rebroadcast once the predecessor arrives.
+    #[tokio::test]
+    async fn test_structural_indeterminate_abstains_not_reject() {
+        let voter = Arc::new(NodeIdentity::generate());
+        let contributor = Arc::new(NodeIdentity::generate());
+        let db = Arc::new(Database::in_memory().unwrap());
+        let (manager, _dir) = genesis_manager();
+
+        // Position-2 contribution whose predecessor (position 1) is absent from OUR db.
+        let mut msg = MpcContributionMessage {
+            candidate: contributor.node_id(),
+            elder_position: 2,
+            prev_params_hash: [7u8; 32],
+            new_params_hash: [9u8; 32],
+            contribution_proof: vec![1, 2, 3, 4],
+            signature: [0u8; 64],
+            timestamp: 0,
+        };
+        let sm = msg.signing_message();
+        msg.signature = contributor.sign(&sm);
+
+        let handler = MpcHandler::new(Arc::clone(&voter), Arc::clone(&db))
+            .with_ceremony_manager(Arc::clone(&manager))
+            .with_params_fetcher(fetcher_failing())
+            .with_state(1, false);
+
+        // The precise fix: a missing predecessor is INDETERMINATE, not a Reject.
+        assert!(
+            matches!(
+                handler.structural_precheck(&msg),
+                StructuralOutcome::Indeterminate(_)
+            ),
+            "missing predecessor must be indeterminate, not a definitive reject"
+        );
+
+        insert_pending(&handler, &msg);
+        handler.verify_and_vote(&msg).await.unwrap();
+
+        // Pre-fix stored approve=false here and blocked position 2 forever.
+        // Post-fix: NO vote at all — nothing to unstick.
+        let (approvals, rejections) = db.count_mpc_approvals(2).unwrap();
+        assert_eq!(approvals, 0);
+        assert_eq!(
+            rejections, 0,
+            "an indeterminate structural check must NOT record a reject"
+        );
+        assert!(
+            handler
+                .pending_contributions
+                .read()
+                .contains_key(&msg.contribution_hash()),
+            "pending must survive so a later rebroadcast re-evaluates"
+        );
+    }
+
+    /// (8) STUCK-REJECT SELF-HEAL — transient-then-reachable with idempotent UPSERT.
+    /// A prior transient `approve=false` row already sits in the DB (exactly node7's
+    /// mainnet state, written by the old binary). The contributor is first
+    /// unreachable — the voter ABSTAINS and must NOT disturb the stale reject — then
+    /// becomes reachable, the candidate verifies, and the voter UPSERTs its vote to
+    /// `approve=true`, superseding the reject and (at the bootstrap threshold)
+    /// applying. This is the recovery that needs no manual vote-clearing.
+    #[tokio::test]
+    async fn test_stuck_transient_reject_heals_to_approve_on_retry() {
+        let identity = Arc::new(NodeIdentity::generate());
+        let db = Arc::new(Database::in_memory().unwrap());
+        let (manager, _dir) = genesis_manager();
+
+        let (new_params, contribution) = manager.generate_contribution("node1").unwrap();
+        let new_params = Arc::new(new_params);
+        let msg = message_for(&contribution, &identity);
+
+        // Seed the mainnet stuck state: a prior transient reject for us at position 1.
+        db.save_mpc_vote(&DbMpcVote {
+            contribution_position: 1,
+            voter_node_id: hex::encode(identity.node_id()),
+            approve: false,
+            signature: vec![0u8; 64],
+            voted_at: 0,
+        })
+        .unwrap();
+        assert_eq!(db.count_mpc_approvals(1).unwrap(), (0, 1));
+
+        let reachable = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let handler = MpcHandler::new(Arc::clone(&identity), Arc::clone(&db))
+            .with_ceremony_manager(Arc::clone(&manager))
+            .with_params_fetcher(fetcher_toggle(
+                Arc::clone(&new_params),
+                Arc::clone(&reachable),
+            ))
+            .with_state(0, false);
+        insert_pending(&handler, &msg);
+
+        // Retry 1 — contributor still unreachable → ABSTAIN. The stale reject is
+        // NOT overwritten (abstain casts no vote), nothing applies.
+        handler.verify_and_vote(&msg).await.unwrap();
+        assert_eq!(
+            db.count_mpc_approvals(1).unwrap(),
+            (0, 1),
+            "abstain must leave the stuck reject untouched (never flip a vote blind)"
+        );
+        assert!(db.get_mpc_contribution(1).unwrap().is_none());
+
+        // Retry 2 — contributor reachable, candidate verifies → APPROVE upserts the
+        // reject→approve, bootstrap threshold (1) met → applied.
+        reachable.store(true, std::sync::atomic::Ordering::SeqCst);
+        handler.verify_and_vote(&msg).await.unwrap();
+        let (approvals, rejections) = db.count_mpc_approvals(1).unwrap();
+        assert_eq!(
+            approvals, 1,
+            "a successful re-verify upserts the stuck reject to approve"
+        );
+        assert_eq!(
+            rejections, 0,
+            "the stale reject row was superseded, not left alongside"
+        );
+        assert!(
+            db.get_mpc_contribution(1).unwrap().is_some(),
+            "the healed contribution applies without manual vote-clearing"
+        );
+        assert_eq!(manager.contribution_count(), 1);
+    }
+
+    /// (9) DEFINITIVE-INVALID STAYS REJECTED — no retry-until-approve hole. A forged
+    /// candidate (tampered Schnorr) fetches fine but FAILS the real pairing check.
+    /// Re-evaluating on every rebroadcast runs the SAME full verification, which
+    /// fails identically each time: it stays rejected and is NEVER approved or
+    /// downgraded to abstain by retrying.
+    #[tokio::test]
+    async fn test_definitive_reject_stays_rejected_on_retry() {
+        let identity = Arc::new(NodeIdentity::generate());
+        let db = Arc::new(Database::in_memory().unwrap());
+        let (manager, _dir) = genesis_manager();
+
+        let (new_params, mut contribution) = manager.generate_contribution("node1").unwrap();
+        let new_params = Arc::new(new_params);
+        contribution.proof.tau_pok.response[0] ^= 0x01; // tamper → hard crypto fail
+        let msg = message_for(&contribution, &identity);
+
+        let handler = MpcHandler::new(Arc::clone(&identity), Arc::clone(&db))
+            .with_ceremony_manager(Arc::clone(&manager))
+            .with_params_fetcher(fetcher_returning(Arc::clone(&new_params)))
+            .with_state(0, false);
+        insert_pending(&handler, &msg);
+
+        // First evaluation → definitive crypto FAIL → reject.
+        handler.verify_and_vote(&msg).await.unwrap();
+        let (a1, r1) = db.count_mpc_approvals(1).unwrap();
+        assert_eq!(a1, 0);
+        assert!(r1 >= 1, "forged candidate must be rejected");
+        assert!(db.get_mpc_contribution(1).unwrap().is_none());
+
+        // Re-evaluation (rebroadcast retry) → same real verification, same FAIL.
+        handler.verify_and_vote(&msg).await.unwrap();
+        let (a2, r2) = db.count_mpc_approvals(1).unwrap();
+        assert_eq!(
+            a2, 0,
+            "a genuinely invalid candidate is NEVER approved by retrying"
+        );
+        assert!(
+            r2 >= 1,
+            "a definitive crypto fail remains a reject on retry"
+        );
+        assert!(db.get_mpc_contribution(1).unwrap().is_none());
+        assert_eq!(manager.contribution_count(), 0);
     }
 }

--- a/crates/ghost-consensus/tests/mpc_mesh_dispatch.rs
+++ b/crates/ghost-consensus/tests/mpc_mesh_dispatch.rs
@@ -1,0 +1,509 @@
+//! Mesh-INCLUSIVE reproduction for MPC "Bug 3": a broadcast `MpcContribution`
+//! must reach every eligible voter's registered handler.
+//!
+//! Unlike the in-process `ghost-mpc/tests/mpc_lifecycle.rs` (no mesh) and the
+//! `mpc-xproc-harness` (drives the params fetch DIRECTLY, no broadcast/dispatch),
+//! this test drives the REAL [`MeshNetwork`] transport: two mesh nodes on
+//! localhost connected over the actual ZMQ + Noise ports. The "contributor"
+//! calls `broadcast_message(MessageType::MpcContribution, ..)` and we assert the
+//! "voter" node's registered [`MessageHandler`] actually receives and dispatches
+//! it. This exercises the broadcast -> receive -> dispatch -> handler path that
+//! was previously untested.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use ghost_common::config::P2PPortConfig;
+use ghost_common::error::GhostResult;
+use ghost_common::identity::NodeIdentity;
+use ghost_consensus::mesh::{MeshConfig, MeshNetwork, MessageHandler};
+use ghost_consensus::message::{MessageEnvelope, MessageType, MpcContributionMessage};
+use tokio::sync::Notify;
+
+#[cfg(feature = "mpc-ceremony")]
+use ghost_consensus::mpc_handler::MpcHandler;
+#[cfg(feature = "mpc-ceremony")]
+use ghost_storage::Database;
+
+/// A minimal handler that records every `MpcContribution` envelope it is
+/// dispatched. Stands in for the real `MpcHandler` at the transport boundary —
+/// if this fires, the broadcast reached a registered handler on the voter.
+struct RecordingHandler {
+    mpc_received: Arc<AtomicUsize>,
+    notify: Arc<Notify>,
+}
+
+#[async_trait]
+impl MessageHandler for RecordingHandler {
+    async fn handle_message(&self, envelope: Arc<MessageEnvelope>) -> GhostResult<()> {
+        if envelope.msg_type == MessageType::MpcContribution {
+            self.mpc_received.fetch_add(1, Ordering::SeqCst);
+            self.notify.notify_waiters();
+        }
+        Ok(())
+    }
+}
+
+/// Distinct ZMQ port block per node (so both can bind their PUB/SUB sockets on
+/// localhost). Both nodes share a single `noise_port` because the SENDER dials
+/// `peer_host:<its own config.noise_port>` (in prod every node uses the shared
+/// DEFAULT_NOISE_PORT). Only the voter actually binds a Noise listener here.
+fn mesh_config(zmq_base: u16, noise_port: u16) -> MeshConfig {
+    MeshConfig {
+        public_address: "127.0.0.1".to_string(),
+        ports: P2PPortConfig {
+            share_propagation: zmq_base,
+            block_announcement: zmq_base + 1,
+            consensus_voting: zmq_base + 2,
+            health_monitoring: zmq_base + 3,
+            discovery: zmq_base + 4,
+            elder_management: zmq_base + 5,
+            payout_proposal: zmq_base + 6,
+            payout_transaction: zmq_base + 7,
+        },
+        noise_enabled: true,
+        noise_port,
+        // Keep the focus on dispatch, not Noise policy: ephemeral keys, no
+        // hard requirement (broadcast still routes MpcContribution over Noise
+        // because the noise pool is present).
+        noise_required: true,
+        ..MeshConfig::default()
+    }
+}
+
+/// Spawn the REAL mesh-owned Noise receive listener (`MeshNetwork::run_noise_listener`,
+/// the same code path production runs) on `mesh`. `is_mainnet=false` so the
+/// loopback reverse-subscribe SSRF guard doesn't skip 127.0.0.1. The shutdown
+/// sender is kept alive inside the task so the listener runs for the whole test.
+fn spawn_noise_listener(mesh: Arc<MeshNetwork>, _noise_port: u16) {
+    let (tx, rx) = tokio::sync::broadcast::channel::<()>(1);
+    tokio::spawn(async move {
+        let _keep_shutdown_open = tx; // dropping tx would trigger shutdown
+        mesh.run_noise_listener(false, rx).await;
+    });
+}
+
+fn sample_contribution() -> MpcContributionMessage {
+    MpcContributionMessage {
+        candidate: [0x55; 32],
+        elder_position: 5,
+        prev_params_hash: [0x11; 32],
+        new_params_hash: [0x22; 32],
+        contribution_proof: vec![0xAB; 128],
+        signature: [0u8; 64],
+        timestamp: chrono::Utc::now().timestamp_millis() as u64,
+    }
+}
+
+/// Bug 3 reproduction: contributor broadcasts an `MpcContribution`; the voter's
+/// registered handler must receive it. Pre-fix this FAILS (silent drop).
+#[tokio::test]
+async fn mpc_contribution_broadcast_reaches_voter_handler() {
+    let noise_port = 19199u16;
+
+    let voter_id = Arc::new(NodeIdentity::generate());
+    let voter = Arc::new(
+        MeshNetwork::try_new(Arc::clone(&voter_id), mesh_config(19100, noise_port))
+            .expect("voter mesh init"),
+    );
+
+    let mpc_received = Arc::new(AtomicUsize::new(0));
+    let notify = Arc::new(Notify::new());
+    voter.register_handler(Arc::new(RecordingHandler {
+        mpc_received: Arc::clone(&mpc_received),
+        notify: Arc::clone(&notify),
+    }));
+
+    let contributor_id = Arc::new(NodeIdentity::generate());
+    let contributor = Arc::new(
+        MeshNetwork::try_new(Arc::clone(&contributor_id), mesh_config(19110, noise_port))
+            .expect("contributor mesh init"),
+    );
+
+    voter.start().await.expect("voter mesh start");
+    contributor.start().await.expect("contributor mesh start");
+
+    // Voter serves inbound Noise (the prod receive plane).
+    spawn_noise_listener(Arc::clone(&voter), noise_port);
+
+    // Give the listener a moment to bind.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // Contributor registers the voter as a connected peer, then broadcasts.
+    contributor
+        .connect_peer("127.0.0.1")
+        .await
+        .expect("connect_peer");
+
+    let sent = contributor
+        .broadcast_message(MessageType::MpcContribution, &sample_contribution())
+        .await
+        .expect("broadcast MpcContribution");
+    assert!(sent >= 1, "contributor should have sent to the voter peer");
+
+    // Wait up to 5s for the voter handler to receive the contribution.
+    let waited = tokio::time::timeout(Duration::from_secs(5), notify.notified()).await;
+
+    assert!(
+        waited.is_ok() && mpc_received.load(Ordering::SeqCst) >= 1,
+        "Bug 3: voter's registered handler never received the broadcast MpcContribution \
+         (received={})",
+        mpc_received.load(Ordering::SeqCst)
+    );
+}
+
+/// Build a genesis (position 1) contribution signed by `signer`. The genesis
+/// auto-approve path needs a valid candidate signature and position == 1; the
+/// hashes only have to be non-zero/distinct.
+#[cfg(feature = "mpc-ceremony")]
+fn signed_genesis_contribution(signer: &NodeIdentity) -> MpcContributionMessage {
+    let mut msg = MpcContributionMessage {
+        candidate: signer.node_id(),
+        elder_position: 1,
+        prev_params_hash: [0x11; 32],
+        new_params_hash: [0x22; 32],
+        contribution_proof: vec![0xAB; 128],
+        signature: [0u8; 64],
+        timestamp: chrono::Utc::now().timestamp_millis() as u64,
+    };
+    let sm = msg.signing_message();
+    msg.signature = signer.sign(&sm);
+    msg
+}
+
+/// Bug 3 reproduction with the REAL `MpcHandler`: a broadcast genesis
+/// `MpcContribution` must drive the voter's handler all the way through
+/// `handle_message -> handle_contribution -> apply_contribution`, recording the
+/// contribution in the voter's DB. This is the broadcast -> receive -> dispatch
+/// -> handler -> ACT path that both prior harnesses skipped (mpc_lifecycle is
+/// in-process, mpc-xproc drove the fetch directly).
+#[cfg(feature = "mpc-ceremony")]
+#[tokio::test]
+async fn mpc_genesis_contribution_broadcast_is_processed_by_real_handler() {
+    let noise_port = 19299u16;
+
+    // Voter with a real MpcHandler over an in-memory DB (fresh ceremony: 0
+    // contributors, so a position-1 contribution is genesis auto-approved).
+    let voter_id = Arc::new(NodeIdentity::generate());
+    let voter = Arc::new(
+        MeshNetwork::try_new(Arc::clone(&voter_id), mesh_config(19200, noise_port))
+            .expect("voter mesh init"),
+    );
+
+    let db = Arc::new(Database::in_memory().expect("in-memory db"));
+    let handler = Arc::new(MpcHandler::new(Arc::clone(&voter_id), Arc::clone(&db)));
+    handler.init_self_ref();
+    voter.register_handler(Arc::clone(&handler) as Arc<dyn MessageHandler>);
+
+    let contributor_id = Arc::new(NodeIdentity::generate());
+    let contributor = Arc::new(
+        MeshNetwork::try_new(Arc::clone(&contributor_id), mesh_config(19210, noise_port))
+            .expect("contributor mesh init"),
+    );
+
+    voter.start().await.expect("voter mesh start");
+    contributor.start().await.expect("contributor mesh start");
+    spawn_noise_listener(Arc::clone(&voter), noise_port);
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    contributor
+        .connect_peer("127.0.0.1")
+        .await
+        .expect("connect_peer");
+
+    let sent = contributor
+        .broadcast_message(
+            MessageType::MpcContribution,
+            &signed_genesis_contribution(&contributor_id),
+        )
+        .await
+        .expect("broadcast MpcContribution");
+    assert!(sent >= 1, "contributor should have sent to the voter peer");
+
+    // Poll up to 5s for the voter to record the applied genesis contribution.
+    let mut recorded = false;
+    for _ in 0..50 {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        if db.get_mpc_contribution(1).ok().flatten().is_some() {
+            recorded = true;
+            break;
+        }
+    }
+
+    assert!(
+        recorded,
+        "Bug 3: the broadcast MpcContribution never drove the real handler to \
+         record/apply the contribution (position 1 not in DB)"
+    );
+}
+
+/// Bug 3 reproduction, position >= 2 (the LIVE rolling-ceremony path the node5
+/// mainnet attempt exercised): an elder voter receives a broadcast
+/// `MpcContribution` and must drive it through `handle_message ->
+/// handle_contribution -> verify_and_vote` (fetch + real crypto verify) and
+/// record its approve vote. This is the exact broadcast -> dispatch -> vote seam
+/// that the in-process crypto test (calls `verify_and_vote` directly) and the
+/// xproc harness (drives the fetch directly) both bypass.
+#[cfg(feature = "mpc-ceremony")]
+#[tokio::test]
+async fn mpc_position2_contribution_broadcast_drives_voter_vote() {
+    use ghost_consensus::mpc_handler::{FetchedCeremonyParams, MpcParamsFetchFn};
+    use ghost_mpc::CeremonyManager;
+    use ghost_storage::queries::MpcContributionRecord;
+
+    let noise_port = 19399u16;
+    let tmp = tempfile::tempdir().unwrap();
+
+    // ---- Voter ceremony state: genesis + an applied position-1 so the voter is
+    // an elder (is_mpc_contributor) and the lineage head is position 1. --------
+    let manager = Arc::new(CeremonyManager::new(tmp.path().to_path_buf()));
+    manager.ensure_genesis_initialized().expect("genesis init");
+
+    let voter_id = Arc::new(NodeIdentity::generate());
+    let db = Arc::new(Database::in_memory().expect("in-memory db"));
+
+    // Position 1, contributed by the VOTER itself → applies to the manager
+    // (count 0 -> 1) and is recorded in the DB with contributor == voter, which
+    // is what `is_mpc_elder(voter)` checks.
+    let (p1_params, contrib1) = manager
+        .generate_contribution(&hex::encode(voter_id.node_id()))
+        .expect("generate position 1");
+    manager
+        .apply_contribution(p1_params, &contrib1)
+        .expect("apply position 1");
+    db.save_mpc_contribution(&MpcContributionRecord {
+        elder_position: 1,
+        contributor_node_id: hex::encode(voter_id.node_id()),
+        prev_params_hash: contrib1.prev_params_hash,
+        new_params_hash: contrib1.new_params_hash,
+        contribution_proof: serde_json::to_vec(&contrib1.proof).unwrap(),
+        epoch: 0,
+        created_at: contrib1.timestamp,
+    })
+    .expect("save position 1 row");
+
+    // ---- Position 2 candidate generated from the (count==1) manager ----------
+    let (p2_params, contrib2) = manager
+        .generate_contribution("contributor-2")
+        .expect("generate position 2");
+    let p2_params = Arc::new(p2_params);
+    let claimed_hash = contrib2.new_params_hash;
+
+    // The fetcher the voter uses to obtain the candidate params for verification.
+    let fetch_params = Arc::clone(&p2_params);
+    let fetcher: MpcParamsFetchFn = Arc::new(move |_expected: [u8; 32]| {
+        let p = Arc::clone(&fetch_params);
+        Box::pin(async move {
+            Some(FetchedCeremonyParams {
+                note_spend: p,
+                payout: None,
+                unshield: None,
+            })
+        })
+    });
+
+    let handler = Arc::new(
+        MpcHandler::new(Arc::clone(&voter_id), Arc::clone(&db))
+            .with_ceremony_manager(Arc::clone(&manager))
+            .with_params_fetcher(fetcher),
+    );
+    handler.init_self_ref();
+
+    let voter = Arc::new(
+        MeshNetwork::try_new(Arc::clone(&voter_id), mesh_config(19300, noise_port))
+            .expect("voter mesh init"),
+    );
+    voter.register_handler(Arc::clone(&handler) as Arc<dyn MessageHandler>);
+
+    // ---- Contributor node broadcasts the position-2 contribution -------------
+    let contributor_id = Arc::new(NodeIdentity::generate());
+    let mut msg = MpcContributionMessage {
+        candidate: contributor_id.node_id(),
+        elder_position: 2,
+        prev_params_hash: contrib2.prev_params_hash,
+        new_params_hash: claimed_hash,
+        contribution_proof: serde_json::to_vec(&contrib2.proof).unwrap(),
+        signature: [0u8; 64],
+        timestamp: contrib2.timestamp,
+    };
+    let sm = msg.signing_message();
+    msg.signature = contributor_id.sign(&sm);
+
+    let contributor = Arc::new(
+        MeshNetwork::try_new(Arc::clone(&contributor_id), mesh_config(19310, noise_port))
+            .expect("contributor mesh init"),
+    );
+
+    voter.start().await.expect("voter mesh start");
+    contributor.start().await.expect("contributor mesh start");
+    spawn_noise_listener(Arc::clone(&voter), noise_port);
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    contributor
+        .connect_peer("127.0.0.1")
+        .await
+        .expect("connect_peer");
+
+    let sent = contributor
+        .broadcast_message(MessageType::MpcContribution, &msg)
+        .await
+        .expect("broadcast MpcContribution");
+    assert!(sent >= 1, "contributor should have sent to the voter peer");
+
+    // Poll up to 20s for the voter to cast (and record) its approve vote for
+    // position 2 — proof that the broadcast drove verify_and_vote over the mesh.
+    let mut approvals = 0u32;
+    for _ in 0..1200 {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        if let Ok((a, _r)) = db.count_mpc_approvals(2) {
+            if a >= 1 {
+                approvals = a;
+                break;
+            }
+        }
+    }
+
+    assert!(
+        approvals >= 1,
+        "Bug 3: the broadcast position-2 MpcContribution never drove the voter to \
+         verify_and_vote (no approve vote recorded for position 2)"
+    );
+}
+
+/// Bug 3 reproduction, MULTI-VOTER quorum (the real fleet path): with a
+/// contributor count of 4 the BFT threshold is 3, so a contribution only
+/// applies once THREE elders' votes aggregate on a node. This exercises the
+/// broadcast -> dispatch -> `handle_verification_vote` -> quorum -> apply path
+/// across nodes — the exact "no apply, ceremony can't advance" symptom, which
+/// every threshold-1 test (self-vote applies alone) structurally cannot show.
+#[cfg(feature = "mpc-ceremony")]
+#[tokio::test]
+async fn mpc_crossnode_votes_aggregate_to_quorum_and_apply() {
+    use ghost_storage::queries::MpcContributionRecord;
+
+    let noise_port = 19499u16;
+
+    // Four elders (positions 1..4); `voter` is one of them. count == 4 → the
+    // shared BFT threshold is 3.
+    let voter_id = Arc::new(NodeIdentity::generate());
+    let e2 = NodeIdentity::generate();
+    let e3 = NodeIdentity::generate();
+    let e4 = NodeIdentity::generate();
+    let elders = [
+        (1u32, voter_id.node_id(), [0x01u8; 32], [0x11u8; 32]),
+        (2u32, e2.node_id(), [0x11u8; 32], [0x22u8; 32]),
+        (3u32, e3.node_id(), [0x22u8; 32], [0x33u8; 32]),
+        (4u32, e4.node_id(), [0x33u8; 32], [0x44u8; 32]),
+    ];
+
+    let db = Arc::new(Database::in_memory().expect("in-memory db"));
+    for (pos, id, prev, new) in elders {
+        db.save_mpc_contribution(&MpcContributionRecord {
+            elder_position: pos,
+            contributor_node_id: hex::encode(id),
+            prev_params_hash: prev,
+            new_params_hash: new,
+            contribution_proof: vec![0xAB; 32],
+            epoch: 0,
+            created_at: 0,
+        })
+        .expect("save elder row");
+    }
+    assert_eq!(
+        db.get_mpc_elder_count().unwrap(),
+        4,
+        "count==4 → threshold 3"
+    );
+
+    // Real handler WITHOUT a ceremony manager: the voter abstains on its own
+    // crypto verify (no self-vote), so the apply is driven PURELY by the three
+    // aggregated cross-node votes — isolating the quorum path.
+    let handler = Arc::new(MpcHandler::new(Arc::clone(&voter_id), Arc::clone(&db)));
+    handler.init_self_ref();
+
+    let voter = Arc::new(
+        MeshNetwork::try_new(Arc::clone(&voter_id), mesh_config(19400, noise_port))
+            .expect("voter mesh init"),
+    );
+    voter.register_handler(Arc::clone(&handler) as Arc<dyn MessageHandler>);
+
+    // Position-5 contribution (prev chains from position 4's new hash).
+    let contributor_id = Arc::new(NodeIdentity::generate());
+    let mut contribution = MpcContributionMessage {
+        candidate: contributor_id.node_id(),
+        elder_position: 5,
+        prev_params_hash: [0x44u8; 32],
+        new_params_hash: [0x55u8; 32],
+        contribution_proof: vec![0xCD; 128],
+        signature: [0u8; 64],
+        timestamp: chrono::Utc::now().timestamp_millis() as u64,
+    };
+    let sm = contribution.signing_message();
+    contribution.signature = contributor_id.sign(&sm);
+    let contribution_hash = contribution.contribution_hash();
+
+    let contributor = Arc::new(
+        MeshNetwork::try_new(Arc::clone(&contributor_id), mesh_config(19410, noise_port))
+            .expect("contributor mesh init"),
+    );
+
+    voter.start().await.expect("voter mesh start");
+    contributor.start().await.expect("contributor mesh start");
+    spawn_noise_listener(Arc::clone(&voter), noise_port);
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    contributor
+        .connect_peer("127.0.0.1")
+        .await
+        .expect("connect_peer");
+
+    // 1) Deliver the contribution so the voter holds it pending (it abstains).
+    contributor
+        .broadcast_message(MessageType::MpcContribution, &contribution)
+        .await
+        .expect("broadcast contribution");
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // 2) Three elders broadcast approve votes; they must aggregate to quorum (3)
+    //    on the voter and drive the apply.
+    for elder in [&e2, &e3, &e4] {
+        let mut vote = ghost_consensus::message::MpcVerificationVoteMessage {
+            contribution_hash,
+            voter: elder.node_id(),
+            approve: true,
+            rejection_reason: None,
+            signature: [0u8; 64],
+            timestamp: chrono::Utc::now().timestamp_millis() as u64,
+        };
+        vote.signature = elder.sign(&vote.signing_message());
+        // Relay pre-serialized (matches the production vote relay which uses
+        // create_envelope_raw over the serialized vote payload).
+        let payload = serde_json::to_vec(&vote).unwrap();
+        let envelope = contributor
+            .create_envelope_raw(MessageType::MpcVerificationVote, payload)
+            .expect("envelope");
+        contributor
+            .broadcast(envelope)
+            .await
+            .expect("broadcast vote");
+        tokio::time::sleep(Duration::from_millis(150)).await;
+    }
+
+    // The three aggregated votes (threshold 3) must apply the contribution.
+    let mut applied = false;
+    for _ in 0..100 {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        if db.get_mpc_contribution(5).ok().flatten().is_some() {
+            applied = true;
+            break;
+        }
+    }
+
+    assert!(
+        applied,
+        "Bug 3: three cross-node approve votes did not aggregate to quorum and apply \
+         position 5 (approvals recorded: {:?})",
+        db.count_mpc_approvals(5)
+    );
+}

--- a/crates/ghost-consensus/tests/mpc_mesh_dispatch.rs
+++ b/crates/ghost-consensus/tests/mpc_mesh_dispatch.rs
@@ -17,8 +17,10 @@ use std::time::Duration;
 use async_trait::async_trait;
 use ghost_common::config::P2PPortConfig;
 use ghost_common::error::GhostResult;
-use ghost_common::types::NodeId;
 use ghost_common::identity::NodeIdentity;
+// Only referenced by the `mpc-ceremony`-gated fetcher tests below.
+#[cfg(feature = "mpc-ceremony")]
+use ghost_common::types::NodeId;
 use ghost_consensus::mesh::{MeshConfig, MeshNetwork, MessageHandler};
 use ghost_consensus::message::{MessageEnvelope, MessageType, MpcContributionMessage};
 use tokio::sync::Notify;
@@ -507,4 +509,130 @@ async fn mpc_crossnode_votes_aggregate_to_quorum_and_apply() {
          position 5 (approvals recorded: {:?})",
         db.count_mpc_approvals(5)
     );
+}
+
+/// 7th contribution-flow gap (mesh-inclusive ROOT): the CONTRIBUTOR of a
+/// position never applies its OWN contribution through its own handler. A node's
+/// `MpcHandler` only ever applies contributions it RECEIVED via
+/// `handle_contribution` (which inserts them into `pending_contributions`); a
+/// node's own broadcast is never delivered back to itself, so it is never in
+/// that map. Therefore cross-node approve votes that reach quorum find NO pending
+/// entry on the contributor and drive NO apply — the contributor's `current.bin`
+/// + singleton stay behind even though the voters advanced. This is exactly why
+/// `ghost-pool` must SELF-ADOPT (from its local candidate, once the applied row
+/// gossips back) rather than relying on the handler.
+///
+/// This is the negative counterpart to
+/// `mpc_crossnode_votes_aggregate_to_quorum_and_apply`: identical wiring, except
+/// the node under test is the CONTRIBUTOR (it never received its own
+/// contribution into pending), so the same three quorum votes do NOT apply.
+#[cfg(feature = "mpc-ceremony")]
+#[tokio::test]
+async fn contributor_own_contribution_not_applied_by_handler_via_votes() {
+    use ghost_storage::queries::MpcContributionRecord;
+
+    let noise_port = 19599u16;
+
+    // Four elders (positions 1..4) recorded in the contributor's DB so incoming
+    // votes pass the `is_node_mpc_contributor(voter)` gate. count == 4 → the
+    // shared BFT threshold is 3.
+    let e1 = NodeIdentity::generate();
+    let e2 = NodeIdentity::generate();
+    let e3 = NodeIdentity::generate();
+    let e4 = NodeIdentity::generate();
+    let elders = [
+        (1u32, e1.node_id(), [0x01u8; 32], [0x11u8; 32]),
+        (2u32, e2.node_id(), [0x11u8; 32], [0x22u8; 32]),
+        (3u32, e3.node_id(), [0x22u8; 32], [0x33u8; 32]),
+        (4u32, e4.node_id(), [0x33u8; 32], [0x44u8; 32]),
+    ];
+
+    let db = Arc::new(Database::in_memory().expect("in-memory db"));
+    for (pos, id, prev, new) in elders {
+        db.save_mpc_contribution(&MpcContributionRecord {
+            elder_position: pos,
+            contributor_node_id: hex::encode(id),
+            prev_params_hash: prev,
+            new_params_hash: new,
+            contribution_proof: vec![0xAB; 32],
+            epoch: 0,
+            created_at: 0,
+        })
+        .expect("save elder row");
+    }
+
+    // The node under test IS the contributor of position 5 (a 5th identity, not
+    // an elder). Its handler NEVER receives its own contribution → no pending
+    // entry. No ceremony manager: it cannot self-vote either.
+    let contributor_id = Arc::new(NodeIdentity::generate());
+    let handler = Arc::new(MpcHandler::new(
+        Arc::clone(&contributor_id),
+        Arc::clone(&db),
+    ));
+    handler.init_self_ref();
+
+    let node = Arc::new(
+        MeshNetwork::try_new(Arc::clone(&contributor_id), mesh_config(19500, noise_port))
+            .expect("contributor mesh init"),
+    );
+    node.register_handler(Arc::clone(&handler) as Arc<dyn MessageHandler>);
+
+    // The position-5 contribution the node authored (its own candidate).
+    let mut contribution = MpcContributionMessage {
+        candidate: contributor_id.node_id(),
+        elder_position: 5,
+        prev_params_hash: [0x44u8; 32],
+        new_params_hash: [0x55u8; 32],
+        contribution_proof: vec![0xCD; 128],
+        signature: [0u8; 64],
+        timestamp: chrono::Utc::now().timestamp_millis() as u64,
+    };
+    let sm = contribution.signing_message();
+    contribution.signature = contributor_id.sign(&sm);
+    let contribution_hash = contribution.contribution_hash();
+
+    // A separate peer relays the three elder votes to the contributor.
+    let relay_id = Arc::new(NodeIdentity::generate());
+    let relay = Arc::new(
+        MeshNetwork::try_new(Arc::clone(&relay_id), mesh_config(19510, noise_port))
+            .expect("relay mesh init"),
+    );
+
+    node.start().await.expect("contributor mesh start");
+    relay.start().await.expect("relay mesh start");
+    spawn_noise_listener(Arc::clone(&node), noise_port);
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    relay.connect_peer("127.0.0.1").await.expect("connect_peer");
+
+    // Three elders broadcast approve votes for the authored contribution. On a
+    // VOTER (which held it pending) these would aggregate to quorum and apply;
+    // on the CONTRIBUTOR there is no pending entry, so they must NOT apply.
+    for elder in [&e2, &e3, &e4] {
+        let mut vote = ghost_consensus::message::MpcVerificationVoteMessage {
+            contribution_hash,
+            voter: elder.node_id(),
+            approve: true,
+            rejection_reason: None,
+            signature: [0u8; 64],
+            timestamp: chrono::Utc::now().timestamp_millis() as u64,
+        };
+        vote.signature = elder.sign(&vote.signing_message());
+        let payload = serde_json::to_vec(&vote).unwrap();
+        let envelope = relay
+            .create_envelope_raw(MessageType::MpcVerificationVote, payload)
+            .expect("envelope");
+        relay.broadcast(envelope).await.expect("broadcast vote");
+        tokio::time::sleep(Duration::from_millis(150)).await;
+    }
+
+    // Give the handler time to (not) act, then confirm position 5 was NOT applied
+    // — the contributor's head cannot advance from cross-node votes alone.
+    for _ in 0..20 {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert!(
+            db.get_mpc_contribution(5).ok().flatten().is_none(),
+            "gap: the contributor applied its OWN position 5 purely from cross-node votes \
+             (handler has no pending self-entry) — ghost-pool self-adopt is what must close this"
+        );
+    }
 }

--- a/crates/ghost-consensus/tests/mpc_mesh_dispatch.rs
+++ b/crates/ghost-consensus/tests/mpc_mesh_dispatch.rs
@@ -17,6 +17,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use ghost_common::config::P2PPortConfig;
 use ghost_common::error::GhostResult;
+use ghost_common::types::NodeId;
 use ghost_common::identity::NodeIdentity;
 use ghost_consensus::mesh::{MeshConfig, MeshNetwork, MessageHandler};
 use ghost_consensus::message::{MessageEnvelope, MessageType, MpcContributionMessage};
@@ -293,7 +294,7 @@ async fn mpc_position2_contribution_broadcast_drives_voter_vote() {
 
     // The fetcher the voter uses to obtain the candidate params for verification.
     let fetch_params = Arc::clone(&p2_params);
-    let fetcher: MpcParamsFetchFn = Arc::new(move |_expected: [u8; 32]| {
+    let fetcher: MpcParamsFetchFn = Arc::new(move |_expected: [u8; 32], _contributor: NodeId| {
         let p = Arc::clone(&fetch_params);
         Box::pin(async move {
             Some(FetchedCeremonyParams {

--- a/crates/ghost-mpc/src/manager.rs
+++ b/crates/ghost-mpc/src/manager.rs
@@ -721,6 +721,86 @@ impl CeremonyManager {
         Ok(())
     }
 
+    /// Durably install an already-obtained, hash-verified note-spend parameter
+    /// set as the CURRENT head for a node that SYNCED the ceremony mid-flight.
+    ///
+    /// A node that joins after the ceremony has already advanced fetches the
+    /// applied contribution ROWS (+ proofs/votes) and the head parameters from a
+    /// peer, but it never ran the sequential [`apply_contribution_multi`] for the
+    /// intermediate positions (it holds neither the toxic waste nor the
+    /// intermediate parameter files). Such a node cannot reach its head through
+    /// the position-`count + 1` apply path. This method records the fetched head
+    /// through the SAME S-5/S-6 atomic writers (`save_parameters` +
+    /// `update_current_params`) the apply path uses, so a restart loads
+    /// `note_spend_params_current.bin` cleanly instead of re-initialising
+    /// pre-genesis.
+    ///
+    /// This is NOT a contribution — it does not transform parameters; it only
+    /// makes the ALREADY-AGREED head durable on THIS node. It is fail-CLOSED:
+    /// both the provided params AND the on-disk copy after write MUST re-hash
+    /// (lineage [`hash_parameters`]) to `head_hash` (the recorded
+    /// `mpc_contributions[version].new_params_hash`), else the install is
+    /// rejected and no mismatched head is left as current.
+    pub fn install_synced_head(
+        &self,
+        version: u32,
+        params: &Parameters<Bls12>,
+        head_hash: [u8; 32],
+    ) -> MpcResult<()> {
+        // Refuse to install anything that is not the claimed head lineage: the
+        // caller fetched `params` by `head_hash`, but re-check here so this
+        // method is safe in isolation and never persists a mismatched head.
+        let provided = hash_parameters(params)?;
+        if provided != head_hash {
+            return Err(MpcError::InvalidParams(format!(
+                "install_synced_head: provided params hash {} != expected head {}",
+                hex::encode(&provided[..8]),
+                hex::encode(&head_hash[..8])
+            )));
+        }
+
+        self.files.ensure_dir()?;
+        let note_spend_path = self.files.note_spend_params_path(version);
+        save_parameters(&note_spend_path, params)?;
+        save_verifying_key(&self.files.note_spend_vk_path(), &params.vk)?;
+        // Atomically repoint note_spend_params_current.bin at the version we just
+        // wrote (the one legitimate current.bin writer, shared with apply).
+        update_current_params(&self.files, version)?;
+
+        // Verify-after-write: the on-disk current head must re-hash to `head_hash`.
+        let installed = load_parameters(&self.files.current_note_spend_params_path())?;
+        let on_disk = hash_parameters(&installed)?;
+        if on_disk != head_hash {
+            return Err(MpcError::InvalidParams(format!(
+                "install_synced_head: verify-after-write failed — on-disk head {} != expected {}",
+                hex::encode(&on_disk[..8]),
+                hex::encode(&head_hash[..8])
+            )));
+        }
+
+        // Hot-swap into memory and set the in-memory state to the synced head.
+        let vk = prepare_verifying_key(&installed.vk);
+        *self.note_spend_params.write() = Some(Arc::new(installed));
+        *self.note_spend_vk.write() = Some(Arc::new(vk));
+        let mut state = self.state.write();
+        if version > state.contribution_count {
+            state.contribution_count = version;
+        }
+        state.current_params_hash = head_hash;
+        state.note_spend_vk_hash = Some(head_hash);
+        state.updated_at = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+
+        info!(
+            version,
+            head = %hex::encode(&head_hash[..8]),
+            "MPC: installed synced ceremony head (current.bin) via the atomic params writer"
+        );
+        Ok(())
+    }
+
     /// Mark the ceremony as ossified
     ///
     /// This is called when elder 101 contributes, permanently closing
@@ -1439,6 +1519,79 @@ mod tests {
             manager.contribution_count(),
             10,
             "Contribution count must not decrease — lower network counts are rejected"
+        );
+    }
+
+    /// `install_synced_head` durably installs a fetched head for a node that
+    /// joined mid-flight (no sequential apply path). It must write current.bin
+    /// through the atomic writer, load it into memory, advance the in-memory
+    /// state to the synced head, and leave the on-disk head hashing to the
+    /// recorded lineage hash — so a subsequent `load_or_init` loads it cleanly.
+    #[test]
+    fn test_install_synced_head_persists_current_bin() {
+        // Produce a real position-1 head on a "donor" manager.
+        let (donor, _donor_tmp) = create_test_manager();
+        donor.ensure_genesis_initialized().unwrap();
+        let (head_params, c1) = donor.generate_contribution("donor").unwrap();
+        let head_hash = c1.new_params_hash;
+
+        // A FRESH node (own dir, never ran genesis/apply) installs the synced head.
+        let (joiner, tmp) = create_test_manager();
+        assert!(!joiner.has_current_params());
+        joiner
+            .install_synced_head(1, &head_params, head_hash)
+            .expect("install synced head");
+
+        // In-memory state advanced to the synced head.
+        assert_eq!(joiner.contribution_count(), 1);
+        assert_eq!(joiner.current_params_hash(), head_hash);
+        assert!(joiner.has_current_params());
+
+        // On-disk current.bin exists and re-hashes to the recorded lineage head.
+        let current = tmp.path().join("note_spend_params_current.bin");
+        assert!(current.exists(), "current.bin must be written");
+        let on_disk = crate::contribution::hash_parameters(&load_parameters(&current).unwrap())
+            .expect("hash on-disk head");
+        assert_eq!(
+            on_disk, head_hash,
+            "on-disk current.bin must be the recorded lineage head"
+        );
+
+        // A restart (load_or_init with the persisted count) loads it — NOT pre-genesis.
+        let reloaded = CeremonyManager::load_or_init(
+            tmp.path().to_path_buf(),
+            Some(CeremonyState {
+                contribution_count: 1,
+                current_params_hash: head_hash,
+                ..CeremonyState::default()
+            }),
+        )
+        .unwrap();
+        assert_eq!(reloaded.contribution_count(), 1);
+        assert!(
+            reloaded.has_current_params(),
+            "restart must load the installed head, not re-init pre-genesis"
+        );
+    }
+
+    /// `install_synced_head` is fail-CLOSED: a params set that does not hash to
+    /// the claimed head lineage is REJECTED (never written as the current head).
+    #[test]
+    fn test_install_synced_head_rejects_hash_mismatch() {
+        let (donor, _donor_tmp) = create_test_manager();
+        donor.ensure_genesis_initialized().unwrap();
+        let (head_params, _c1) = donor.generate_contribution("donor").unwrap();
+
+        let (joiner, _tmp) = create_test_manager();
+        let wrong_hash = [0x11u8; 32];
+        let result = joiner.install_synced_head(1, &head_params, wrong_hash);
+        assert!(
+            result.is_err(),
+            "params not matching the claimed head hash must be rejected"
+        );
+        assert!(
+            !joiner.has_current_params(),
+            "a rejected install must not leave a head loaded"
         );
     }
 }

--- a/crates/ghost-mpc/src/manager.rs
+++ b/crates/ghost-mpc/src/manager.rs
@@ -726,7 +726,7 @@ impl CeremonyManager {
     ///
     /// A node that joins after the ceremony has already advanced fetches the
     /// applied contribution ROWS (+ proofs/votes) and the head parameters from a
-    /// peer, but it never ran the sequential [`apply_contribution_multi`] for the
+    /// peer, but it never ran the sequential `apply_contribution_multi` for the
     /// intermediate positions (it holds neither the toxic waste nor the
     /// intermediate parameter files). Such a node cannot reach its head through
     /// the position-`count + 1` apply path. This method records the fetched head

--- a/crates/ghost-mpc/tests/mpc_lifecycle.rs
+++ b/crates/ghost-mpc/tests/mpc_lifecycle.rs
@@ -602,6 +602,114 @@ fn realcrypto_lifecycle() {
 }
 
 // ============================================================================
+// (A2) BUG-1 INVARIANT — candidate generation must not move current.bin
+// ============================================================================
+
+/// Bug-1 regression (the node5 crash-loop): GENERATING a contribution must NOT
+/// advance the node's active params. Only `apply_contribution_multi` (after BFT
+/// approval) may move `current.bin` / `current_params_hash`.
+///
+/// Walks the real machinery the mainnet binary uses:
+///   1. genesis → active head = anchor (on disk AND in the manager).
+///   2. `generate_contribution_at_position` → candidate params + contribution;
+///      the manager's `current_params_hash` is UNCHANGED (anchor) and the
+///      on-disk `note_spend_params_current.bin` STILL hashes to anchor.
+///   3. the candidate is written to its SEPARATE serving file (the exact
+///      `ghost_common::mpc::candidate_note_spend_filename` the contributor uses)
+///      and is retrievable + hashes to the contribution's `new_params_hash` —
+///      WITHOUT having disturbed current.bin.
+///   4. only after `apply_contribution_multi` do the manager head AND the
+///      on-disk current.bin become the candidate (`new_params_hash`).
+#[test]
+fn generate_does_not_advance_current_only_apply_does() {
+    use ghost_mpc::params::load_parameters;
+
+    let (note, consolidate, unshield) = generate_genesis_params();
+    let node = Node::genesis(&note, &consolidate, &unshield);
+
+    let params_dir = node.manager.params_dir().clone();
+    let current_bin = params_dir.join("note_spend_params_current.bin");
+    assert!(current_bin.exists(), "genesis must install current.bin");
+
+    // The applied head before any contribution.
+    let anchor = node.manager.current_params_hash();
+    let ondisk_anchor =
+        hash_parameters(&load_parameters(&current_bin).expect("load genesis current")).unwrap();
+    assert_eq!(
+        ondisk_anchor, anchor,
+        "on-disk current.bin must hash to the manager's head at genesis"
+    );
+
+    // (2) Generate position-1 candidate. This must NOT touch active state.
+    let contributor = NodeIdentity::generate();
+    let (new_params, contribution) = node
+        .manager
+        .generate_contribution_at_position(&hex::encode(contributor.node_id()), 1)
+        .expect("generate candidate");
+    assert_ne!(
+        contribution.new_params_hash, anchor,
+        "a real phase-2 transform must change the lineage hash"
+    );
+    assert_eq!(
+        node.manager.current_params_hash(),
+        anchor,
+        "GENERATION must not advance the manager head"
+    );
+    assert_eq!(
+        hash_parameters(&load_parameters(&current_bin).expect("reload current")).unwrap(),
+        anchor,
+        "GENERATION must not rewrite the on-disk current.bin"
+    );
+
+    // (3) Write the candidate to its hash-keyed serving file (what the
+    // contributor does) and confirm it is retrievable + correct, and STILL has
+    // not disturbed current.bin.
+    let mut buf = Vec::new();
+    new_params.write(&mut buf).expect("serialize candidate");
+    let candidate_path = params_dir.join(ghost_common::mpc::candidate_note_spend_filename(
+        &contribution.new_params_hash,
+    ));
+    std::fs::write(&candidate_path, &buf).expect("write candidate");
+    assert_ne!(
+        candidate_path, current_bin,
+        "candidate file must be separate"
+    );
+
+    let served = load_parameters(&candidate_path).expect("load served candidate");
+    assert_eq!(
+        hash_parameters(&served).unwrap(),
+        contribution.new_params_hash,
+        "candidate served by hash must be the un-applied params the voter verifies"
+    );
+    assert_eq!(
+        node.manager.current_params_hash(),
+        anchor,
+        "writing the candidate serving file must not move the manager head"
+    );
+    assert_eq!(
+        hash_parameters(&load_parameters(&current_bin).unwrap()).unwrap(),
+        anchor,
+        "writing the candidate serving file must not rewrite current.bin"
+    );
+
+    // (4) Apply through the manager (the ONLY legitimate writer of current.bin).
+    node.manager
+        .apply_contribution_multi(new_params, None, None, &contribution)
+        .expect("apply contribution");
+    assert_eq!(
+        node.manager.current_params_hash(),
+        contribution.new_params_hash,
+        "apply must advance the manager head to the candidate"
+    );
+    assert_eq!(
+        hash_parameters(&load_parameters(&current_bin).expect("reload current after apply"))
+            .unwrap(),
+        contribution.new_params_hash,
+        "apply must repoint on-disk current.bin to the candidate"
+    );
+}
+
+// ============================================================================
 // (B) ≥67% SUPERMAJORITY retained quorum — pure verifier + DB
 // ============================================================================
 

--- a/crates/ghost-verification/src/routes.rs
+++ b/crates/ghost-verification/src/routes.rs
@@ -6073,7 +6073,11 @@ fn resolve_mpc_note_spend_path(
     base_dir.join("note_spend_params_current.bin")
 }
 
-async fn api_mpc_params_handler(
+// NOTE: `pub` so the cross-process MPC ceremony harness
+// (`crates/mpc-xproc-harness`) can mount this EXACT production handler in a
+// minimal router and prove the `?new_hash=` candidate-vs-current serving works
+// across real OS process boundaries. Behaviour is unchanged.
+pub async fn api_mpc_params_handler(
     State(_state): State<Arc<VerificationState>>,
     Query(query): Query<MpcParamsQuery>,
 ) -> impl IntoResponse {

--- a/crates/ghost-verification/src/routes.rs
+++ b/crates/ghost-verification/src/routes.rs
@@ -6034,11 +6034,55 @@ async fn api_glyph_relay_registered_handler(
     }
 }
 
-async fn api_mpc_params_handler(State(_state): State<Arc<VerificationState>>) -> impl IntoResponse {
-    // Get MPC params path from home directory
-    let params_path =
+/// Optional query for the note-spend params endpoint.
+///
+/// A BFT voter fetching a specific CANDIDATE (un-applied) parameter set passes
+/// `?new_hash=<64-hex>` — the candidate's lineage hash. Absent (the self-heal /
+/// refresh / manifest callers), the endpoint serves the applied current head.
+#[derive(Debug, Default, Deserialize)]
+pub struct MpcParamsQuery {
+    /// Hex of the candidate lineage `new_params_hash` to serve, if any.
+    #[serde(default)]
+    pub new_hash: Option<String>,
+}
+
+/// Resolve which note-spend parameter file the params endpoint should serve.
+///
+/// When `requested_hash` is a well-formed 32-byte hex lineage hash AND the
+/// matching CANDIDATE file exists, serve the candidate (so a voter gets the
+/// un-applied params it must cryptographically verify). Otherwise — no / blank /
+/// malformed hash, or no such candidate on disk — serve the active
+/// `note_spend_params_current.bin` (applied head), preserving the self-heal /
+/// refresh / manifest behaviour. The hash is decoded and re-encoded through the
+/// shared `ghost_common::mpc` helper, so a malicious `new_hash` can never escape
+/// the params directory (no path traversal).
+fn resolve_mpc_note_spend_path(
+    base_dir: &std::path::Path,
+    requested_hash: Option<&str>,
+) -> std::path::PathBuf {
+    if let Some(h) = requested_hash.filter(|h| !h.is_empty()) {
+        if let Some(bytes) = hex::decode(h).ok().filter(|b| b.len() == 32) {
+            let mut arr = [0u8; 32];
+            arr.copy_from_slice(&bytes);
+            let candidate = base_dir.join(ghost_common::mpc::candidate_note_spend_filename(&arr));
+            if candidate.exists() {
+                return candidate;
+            }
+        }
+    }
+    base_dir.join("note_spend_params_current.bin")
+}
+
+async fn api_mpc_params_handler(
+    State(_state): State<Arc<VerificationState>>,
+    Query(query): Query<MpcParamsQuery>,
+) -> impl IntoResponse {
+    // Get MPC params dir from home directory, then resolve to the applied head
+    // or — when a voter asks by `new_hash` — the matching candidate file.
+    let base_dir =
         std::path::PathBuf::from(std::env::var("HOME").unwrap_or_else(|_| "/root".to_string()))
-            .join(".ghost/mpc_params/note_spend_params_current.bin");
+            .join(".ghost/mpc_params");
+    let params_path = resolve_mpc_note_spend_path(&base_dir, query.new_hash.as_deref());
 
     if !params_path.exists() {
         return (
@@ -7341,6 +7385,48 @@ async fn api_system_mempool_handler(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_resolve_mpc_note_spend_path_serves_candidate_then_current() {
+        let dir = tempfile::tempdir().unwrap();
+        let base = dir.path();
+        let current = base.join("note_spend_params_current.bin");
+        std::fs::write(&current, b"applied-head").unwrap();
+
+        let new_hash = [0xABu8; 32];
+        let candidate = base.join(ghost_common::mpc::candidate_note_spend_filename(&new_hash));
+        let hash_hex = hex::encode(new_hash);
+
+        // No hash → always the applied current head.
+        assert_eq!(resolve_mpc_note_spend_path(base, None), current);
+        assert_eq!(resolve_mpc_note_spend_path(base, Some("")), current);
+
+        // A by-hash request BEFORE the candidate exists falls back to current
+        // (never a 404 that would break the applied-params refresh path).
+        assert_eq!(resolve_mpc_note_spend_path(base, Some(&hash_hex)), current);
+
+        // Once the contributor has written the candidate, the by-hash request
+        // resolves to the candidate — while a bare request still serves current.
+        std::fs::write(&candidate, b"un-applied-candidate").unwrap();
+        assert_eq!(
+            resolve_mpc_note_spend_path(base, Some(&hash_hex)),
+            candidate
+        );
+        assert_eq!(resolve_mpc_note_spend_path(base, None), current);
+
+        // A request for a DIFFERENT candidate hash (none on disk) → current.
+        let other = hex::encode([0x01u8; 32]);
+        assert_eq!(resolve_mpc_note_spend_path(base, Some(&other)), current);
+
+        // Malformed / traversal attempts can never escape the params dir.
+        for bad in ["../../etc/passwd", "zz", "not-hex", "%2e%2e", "ab/cd"] {
+            assert_eq!(
+                resolve_mpc_note_spend_path(base, Some(bad)),
+                current,
+                "malformed new_hash {bad:?} must fall back to current"
+            );
+        }
+    }
 
     #[test]
     fn test_share_difficulty_from_hash_hex() {

--- a/crates/mpc-xproc-harness/Cargo.toml
+++ b/crates/mpc-xproc-harness/Cargo.toml
@@ -1,0 +1,51 @@
+[package]
+name = "mpc-xproc-harness"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+publish = false
+description = """
+Cross-PROCESS MPC rolling-ceremony contribution harness. Spawns real, separate
+OS processes (`mpc-xnode`) that serve un-applied candidate params over real HTTP
+(`GET /api/v1/mpc/params?new_hash=<hex>`, the exact production handler), fetch +
+cryptographically verify each other's candidates, vote, reach a BFT threshold,
+and apply — proving the fix for the node5 crash-loop (candidate NEVER overwrites
+the active current.bin) holds across a genuine process boundary. Gate before the
+mainnet un-pin (tasks/plan_mpc_rolling_resume.md, Stage 5 / Stage D)."""
+
+[[bin]]
+name = "mpc-xnode"
+path = "src/main.rs"
+
+[features]
+# Shrink MAX_CEREMONY_CONTRIBUTORS (101 -> 4) so the cross-process ceremony can
+# reach ossification in a few real phase-2 transforms. Propagates to ghost-mpc's
+# own compile-time cap. NEVER a default feature; enabled only on an explicit
+# `--features mpc-test-cap` targeted run, exactly like the in-process Stage D
+# harness. See crates/ghost-mpc/src/lib.rs::MAX_CEREMONY_CONTRIBUTORS.
+mpc-test-cap = ["ghost-mpc/mpc-test-cap"]
+
+[dependencies]
+# The real ceremony machinery — same crate the mainnet binary runs.
+ghost-mpc = { path = "../ghost-mpc" }
+ghost-common = { path = "../ghost-common" }
+# The REAL params-serving handler (api_mpc_params_handler + resolve path).
+ghost-verification = { path = "../ghost-verification" }
+ghost-policy = { path = "../ghost-policy" }
+
+axum = { workspace = true }
+tokio = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+hex = { workspace = true }
+anyhow = { workspace = true }
+
+[dev-dependencies]
+# The driver test generates ONE shared genesis (like fleet node 1) then spawns
+# the node processes; it needs the ZK circuits + curve/param crates for genesis.
+ghost-zkp = { path = "../ghost-zkp" }
+bellperson = "0.26"
+blstrs = "0.7"
+rand = "0.8"
+tempfile = "3.10"

--- a/crates/mpc-xproc-harness/src/main.rs
+++ b/crates/mpc-xproc-harness/src/main.rs
@@ -136,8 +136,8 @@ async fn run_node(argv: &[String]) {
         ceremony_id,
         ..Default::default()
     };
-    let manager = CeremonyManager::load_or_init(params_dir.clone(), Some(state))
-        .expect("load_or_init");
+    let manager =
+        CeremonyManager::load_or_init(params_dir.clone(), Some(state)).expect("load_or_init");
     // Force the on-disk current params into memory even at count 0 (a genesis
     // holder must be able to generate/verify against them).
     manager.load_current_params().expect("load_current_params");
@@ -248,9 +248,16 @@ async fn run_node(argv: &[String]) {
             }
             "fetch_verify" => {
                 let url = cmd.get("url").and_then(|v| v.as_str()).unwrap().to_string();
-                let new_hash = cmd.get("new_hash").and_then(|v| v.as_str()).unwrap().to_string();
-                let contribution_json =
-                    cmd.get("contribution").and_then(|v| v.as_str()).unwrap().to_string();
+                let new_hash = cmd
+                    .get("new_hash")
+                    .and_then(|v| v.as_str())
+                    .unwrap()
+                    .to_string();
+                let contribution_json = cmd
+                    .get("contribution")
+                    .and_then(|v| v.as_str())
+                    .unwrap()
+                    .to_string();
                 let resp = do_fetch_verify(&manager, &url, &new_hash, &contribution_json).await;
                 if let Some(p) = resp.1 {
                     params_cache.insert(new_hash.clone(), p);
@@ -258,22 +265,31 @@ async fn run_node(argv: &[String]) {
                 emit_resp(&resp.0);
             }
             "apply" => {
-                let new_hash = cmd.get("new_hash").and_then(|v| v.as_str()).unwrap().to_string();
-                let contribution_json =
-                    cmd.get("contribution").and_then(|v| v.as_str()).unwrap().to_string();
+                let new_hash = cmd
+                    .get("new_hash")
+                    .and_then(|v| v.as_str())
+                    .unwrap()
+                    .to_string();
+                let contribution_json = cmd
+                    .get("contribution")
+                    .and_then(|v| v.as_str())
+                    .unwrap()
+                    .to_string();
                 let contrib: ghost_mpc::contribution::MpcContribution =
                     serde_json::from_str(&contribution_json).unwrap();
                 match params_cache.remove(&new_hash) {
-                    Some(params) => match manager.apply_contribution_multi(params, None, None, &contrib) {
-                        Ok(()) => emit_resp(&json!({
-                            "ok": true,
-                            "count": manager.contribution_count(),
-                            "mgr_head": hex::encode(manager.current_params_hash()),
-                            "current_bin_hash": current_bin_lineage_hash(&params_dir),
-                            "ossified": manager.is_ossified(),
-                        })),
-                        Err(e) => emit_resp(&json!({"ok": false, "err": err_kind(&e)})),
-                    },
+                    Some(params) => {
+                        match manager.apply_contribution_multi(params, None, None, &contrib) {
+                            Ok(()) => emit_resp(&json!({
+                                "ok": true,
+                                "count": manager.contribution_count(),
+                                "mgr_head": hex::encode(manager.current_params_hash()),
+                                "current_bin_hash": current_bin_lineage_hash(&params_dir),
+                                "ossified": manager.is_ossified(),
+                            })),
+                            Err(e) => emit_resp(&json!({"ok": false, "err": err_kind(&e)})),
+                        }
+                    }
                     None => emit_resp(&json!({
                         "ok": false,
                         "err": "no cached params for new_hash (node never fetched/generated it)"
@@ -285,7 +301,10 @@ async fn run_node(argv: &[String]) {
             // lineage hash, since `verify_contribution` refuses once ossified.
             "fetch_head" => {
                 let url = cmd.get("url").and_then(|v| v.as_str()).unwrap().to_string();
-                let new_hash = cmd.get("new_hash").and_then(|v| v.as_str()).map(|s| s.to_string());
+                let new_hash = cmd
+                    .get("new_hash")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
                 let full = match &new_hash {
                     Some(h) => format!("{url}?new_hash={h}"),
                     None => url,
@@ -304,10 +323,14 @@ async fn run_node(argv: &[String]) {
                                 "fetched_hash": hex::encode(hash_parameters(&p).unwrap()),
                                 "size": data.len(),
                             })),
-                            Err(e) => emit_resp(&json!({"ok": false, "err": format!("parse: {e}")})),
+                            Err(e) => {
+                                emit_resp(&json!({"ok": false, "err": format!("parse: {e}")}))
+                            }
                         }
                     }
-                    Ok(r) => emit_resp(&json!({"ok": false, "err": format!("status {}", r.status())})),
+                    Ok(r) => {
+                        emit_resp(&json!({"ok": false, "err": format!("status {}", r.status())}))
+                    }
                     Err(e) => emit_resp(&json!({"ok": false, "err": format!("http: {e}")})),
                 }
             }
@@ -317,9 +340,7 @@ async fn run_node(argv: &[String]) {
                     .and_then(|v| v.as_str())
                     .unwrap_or("late-comer");
                 match manager.generate_contribution(contributor) {
-                    Ok((_p, cnt)) => {
-                        emit_resp(&json!({"ok": true, "position": cnt.position}))
-                    }
+                    Ok((_p, cnt)) => emit_resp(&json!({"ok": true, "position": cnt.position})),
                     Err(e) => emit_resp(&json!({"ok": false, "err": err_kind(&e)})),
                 }
             }
@@ -328,7 +349,11 @@ async fn run_node(argv: &[String]) {
             // restart must then crash-loop (startup guard fails), proving the
             // guard has teeth and that the fixed path (separate file) avoids it.
             "simulate_old_bug_overwrite_current" => {
-                let new_hash = cmd.get("new_hash").and_then(|v| v.as_str()).unwrap().to_string();
+                let new_hash = cmd
+                    .get("new_hash")
+                    .and_then(|v| v.as_str())
+                    .unwrap()
+                    .to_string();
                 match params_cache.get(&new_hash) {
                     Some(params) => {
                         let mut buf = Vec::new();
@@ -389,30 +414,58 @@ async fn do_fetch_verify(
         .await
     {
         Ok(r) => r,
-        Err(e) => return (json!({"verify_ok": false, "err": format!("http: {e}")}), None),
+        Err(e) => {
+            return (
+                json!({"verify_ok": false, "err": format!("http: {e}")}),
+                None,
+            )
+        }
     };
     if !resp.status().is_success() {
-        return (json!({"verify_ok": false, "err": format!("status {}", resp.status())}), None);
+        return (
+            json!({"verify_ok": false, "err": format!("status {}", resp.status())}),
+            None,
+        );
     }
     let data = match resp.bytes().await {
         Ok(b) => b,
-        Err(e) => return (json!({"verify_ok": false, "err": format!("body: {e}")}), None),
+        Err(e) => {
+            return (
+                json!({"verify_ok": false, "err": format!("body: {e}")}),
+                None,
+            )
+        }
     };
     if data.len() <= 1000 {
         return (json!({"verify_ok": false, "err": "params too small"}), None);
     }
     let params = match read_parameters_from_bytes(&data) {
         Ok(p) => p,
-        Err(e) => return (json!({"verify_ok": false, "err": format!("parse: {e}")}), None),
+        Err(e) => {
+            return (
+                json!({"verify_ok": false, "err": format!("parse: {e}")}),
+                None,
+            )
+        }
     };
     let fetched_hash = match hash_parameters(&params) {
         Ok(h) => hex::encode(h),
-        Err(e) => return (json!({"verify_ok": false, "err": format!("hash: {e}")}), None),
+        Err(e) => {
+            return (
+                json!({"verify_ok": false, "err": format!("hash: {e}")}),
+                None,
+            )
+        }
     };
     let contrib: ghost_mpc::contribution::MpcContribution =
         match serde_json::from_str(contribution_json) {
             Ok(c) => c,
-            Err(e) => return (json!({"verify_ok": false, "err": format!("contrib json: {e}")}), None),
+            Err(e) => {
+                return (
+                    json!({"verify_ok": false, "err": format!("contrib json: {e}")}),
+                    None,
+                )
+            }
         };
     let verify_ok = matches!(manager.verify_contribution(&params, &contrib), Ok(true));
     (
@@ -441,7 +494,10 @@ async fn spawn_params_server(port: u16, node_id: String) {
     // Mount ONLY the real params handler — same code path the mainnet node
     // serves `/api/v1/mpc/params?new_hash=` through, minus unrelated middleware.
     let app = axum::Router::new()
-        .route("/api/v1/mpc/params", axum::routing::get(api_mpc_params_handler))
+        .route(
+            "/api/v1/mpc/params",
+            axum::routing::get(api_mpc_params_handler),
+        )
         .with_state(state);
     let listener = tokio::net::TcpListener::bind(("127.0.0.1", port))
         .await

--- a/crates/mpc-xproc-harness/src/main.rs
+++ b/crates/mpc-xproc-harness/src/main.rs
@@ -1,0 +1,461 @@
+//! `mpc-xnode` — one real MPC ceremony node, driven as a separate OS process.
+//!
+//! The cross-process Stage-D harness (`tests/xproc.rs`) spawns several of these
+//! and wires them together over real HTTP + a stdin/stdout JSON control channel
+//! to prove the resumed rolling-ceremony CONTRIBUTION flow works across genuine
+//! process boundaries — the gate before the mainnet un-pin
+//! (`tasks/plan_mpc_rolling_resume.md`).
+//!
+//! Each node holds a real long-lived [`ghost_mpc::CeremonyManager`] over its own
+//! params dir (exactly like the mainnet `ghost-pool` process), and:
+//!   * (contributor) generates a real phase-2 candidate, writes it to the
+//!     SEPARATE serving file `note_spend_params_candidate_<hash>.bin` (NEVER the
+//!     active `note_spend_params_current.bin`), and serves it via the EXACT
+//!     production handler `ghost_verification::api_mpc_params_handler` at
+//!     `GET /api/v1/mpc/params?new_hash=<hex>`;
+//!   * (voter) FETCHES a peer's candidate by hash over real HTTP, parses it with
+//!     the same `ghost_mpc::params::read_parameters_from_bytes` the mainnet fetch
+//!     uses, and runs the real `verify_contribution` (Schnorr + h/l pairing);
+//!   * (all) applies an approved contribution through the sole legitimate writer
+//!     of `current.bin`, `apply_contribution_multi`.
+//!
+//! STARTUP GENESIS-ANCHORED GUARD (the node5 crash-loop reproduction): when
+//! `--expected-head` is supplied, the node hashes its on-disk
+//! `note_spend_params_current.bin` and, if it does not equal the expected BFT
+//! chain head, prints `FATAL ...` and exits non-zero — the exact fail-closed
+//! behaviour that crash-looped node5 when an un-applied candidate had been
+//! written over current.bin. With the fix, a contributor that has only GENERATED
+//! (not applied) leaves current.bin at the head, so this guard passes.
+//!
+//! Control protocol: one JSON object per stdin line -> one JSON object per stdout
+//! line (prefixed `RESP `). Human/diagnostic lines are prefixed `EVENT `.
+
+use std::collections::HashMap;
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use ghost_mpc::contribution::hash_parameters;
+use ghost_mpc::params::{load_parameters, read_parameters_from_bytes};
+use ghost_mpc::{CeremonyManager, CeremonyState, Groth16Params, MpcError};
+use serde_json::{json, Value};
+use tokio::io::{AsyncBufReadExt, BufReader};
+
+/// Parse `--flag value` pairs and bare `--flag` switches from argv.
+struct Args {
+    map: HashMap<String, String>,
+    switches: Vec<String>,
+}
+impl Args {
+    fn parse(argv: &[String]) -> Self {
+        let mut map = HashMap::new();
+        let mut switches = Vec::new();
+        let mut i = 0;
+        while i < argv.len() {
+            let a = &argv[i];
+            if let Some(key) = a.strip_prefix("--") {
+                if i + 1 < argv.len() && !argv[i + 1].starts_with("--") {
+                    map.insert(key.to_string(), argv[i + 1].clone());
+                    i += 2;
+                } else {
+                    switches.push(key.to_string());
+                    i += 1;
+                }
+            } else {
+                i += 1;
+            }
+        }
+        Self { map, switches }
+    }
+    fn get(&self, k: &str) -> Option<&str> {
+        self.map.get(k).map(|s| s.as_str())
+    }
+    fn has(&self, k: &str) -> bool {
+        self.switches.iter().any(|s| s == k)
+    }
+}
+
+fn hex32(s: &str) -> [u8; 32] {
+    let b = hex::decode(s).expect("hex");
+    let mut a = [0u8; 32];
+    a.copy_from_slice(&b);
+    a
+}
+
+/// Lineage hash of the on-disk active head (`note_spend_params_current.bin`).
+fn current_bin_lineage_hash(params_dir: &Path) -> Option<String> {
+    let p = params_dir.join("note_spend_params_current.bin");
+    let params = load_parameters(&p).ok()?;
+    Some(hex::encode(hash_parameters(&params).ok()?))
+}
+
+fn emit_event(msg: &str) {
+    println!("EVENT {msg}");
+    let _ = std::io::stdout().flush();
+}
+fn emit_resp(v: &Value) {
+    println!("RESP {v}");
+    let _ = std::io::stdout().flush();
+}
+
+fn main() {
+    let argv: Vec<String> = std::env::args().skip(1).collect();
+    let mode = argv.first().cloned().unwrap_or_default();
+    match mode.as_str() {
+        "node" => {
+            let rt = tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(2)
+                .enable_all()
+                .build()
+                .unwrap();
+            rt.block_on(run_node(&argv[1..]));
+        }
+        other => {
+            eprintln!("unknown mode: {other:?}; expected `node`");
+            std::process::exit(64);
+        }
+    }
+}
+
+async fn run_node(argv: &[String]) {
+    let args = Args::parse(argv);
+    let home = PathBuf::from(args.get("home").expect("--home"));
+    let params_dir = home.join(".ghost/mpc_params");
+    let head = hex32(args.get("head").expect("--head"));
+    let ceremony_id = hex32(args.get("ceremony-id").expect("--ceremony-id"));
+    let count: u32 = args.get("count").unwrap_or("0").parse().unwrap();
+    let ossified = args.has("ossified");
+    let node_id = args.get("node-id").unwrap_or("xnode").to_string();
+
+    // Rebuild the manager exactly as ghost-pool does at startup: state from the
+    // (simulated) DB singleton, params loaded from disk.
+    let state = CeremonyState {
+        contribution_count: count,
+        current_params_hash: head,
+        is_ossified: ossified,
+        ceremony_id,
+        ..Default::default()
+    };
+    let manager = CeremonyManager::load_or_init(params_dir.clone(), Some(state))
+        .expect("load_or_init");
+    // Force the on-disk current params into memory even at count 0 (a genesis
+    // holder must be able to generate/verify against them).
+    manager.load_current_params().expect("load_current_params");
+
+    // ---- STARTUP GENESIS-ANCHORED CROSS-CHECK (node5 crash-loop guard) -------
+    if let Some(expected) = args.get("expected-head") {
+        if expected != "none" {
+            match current_bin_lineage_hash(&params_dir) {
+                Some(got) if got == expected => {
+                    emit_event(&format!(
+                        "startup-guard OK current.bin={}… == chain-head",
+                        &got[..16]
+                    ));
+                }
+                got => {
+                    // EXACTLY the node5 failure: on-disk head != BFT chain head.
+                    eprintln!(
+                        "FATAL genesis-anchored cross-check: current.bin={:?} != expected head {}…",
+                        got.as_deref().map(|g| &g[..g.len().min(16)]),
+                        &expected[..16]
+                    );
+                    std::process::exit(2);
+                }
+            }
+        }
+    }
+
+    let manager = Arc::new(manager);
+
+    // ---- Optional REAL params-serving HTTP endpoint --------------------------
+    if let Some(port) = args.get("http-port") {
+        let port: u16 = port.parse().unwrap();
+        // The production handler reads $HOME/.ghost/mpc_params; the parent spawns
+        // us with HOME=<home> so it serves THIS node's params dir.
+        std::env::set_var("HOME", &home);
+        spawn_params_server(port, node_id.clone()).await;
+        emit_event(&format!("serving :{port} /api/v1/mpc/params"));
+    }
+
+    // Announce readiness AFTER the guard + server bind so the parent can rely on
+    // it as a synchronisation point.
+    emit_resp(&json!({
+        "ready": true,
+        "node_id": node_id,
+        "count": manager.contribution_count(),
+        "head": hex::encode(manager.current_params_hash()),
+        "current_bin_hash": current_bin_lineage_hash(&params_dir),
+        "ossified": manager.is_ossified(),
+    }));
+
+    // In-memory cache of candidate params this node holds (generated OR fetched),
+    // keyed by lineage hash — the params it will apply on BFT approval.
+    let mut params_cache: HashMap<String, Groth16Params> = HashMap::new();
+
+    let stdin = tokio::io::stdin();
+    let mut lines = BufReader::new(stdin).lines();
+    while let Ok(Some(line)) = lines.next_line().await {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let cmd: Value = match serde_json::from_str(line) {
+            Ok(v) => v,
+            Err(e) => {
+                emit_resp(&json!({"error": format!("bad json: {e}")}));
+                continue;
+            }
+        };
+        let c = cmd.get("cmd").and_then(|v| v.as_str()).unwrap_or("");
+        match c {
+            "inspect" => {
+                emit_resp(&json!({
+                    "count": manager.contribution_count(),
+                    "mgr_head": hex::encode(manager.current_params_hash()),
+                    "current_bin_hash": current_bin_lineage_hash(&params_dir),
+                    "ossified": manager.is_ossified(),
+                }));
+            }
+            "gen_candidate" => {
+                let contributor = cmd
+                    .get("contributor_id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or(&node_id)
+                    .to_string();
+                match manager.generate_contribution(&contributor) {
+                    Ok((params, contrib)) => {
+                        let new_hash = hex::encode(contrib.new_params_hash);
+                        // Serialize + write to the SEPARATE candidate serving file
+                        // (mirrors ghost-pool::write_candidate_note_spend_params;
+                        // NEVER touches current.bin).
+                        let mut buf = Vec::new();
+                        params.write(&mut buf).expect("serialize candidate");
+                        write_candidate(&params_dir, &contrib.new_params_hash, &buf);
+                        params_cache.insert(new_hash.clone(), params);
+                        emit_resp(&json!({
+                            "ok": true,
+                            "position": contrib.position,
+                            "prev_hash": hex::encode(contrib.prev_params_hash),
+                            "new_hash": new_hash,
+                            // current.bin MUST be unchanged by generation.
+                            "current_bin_hash": current_bin_lineage_hash(&params_dir),
+                            "mgr_head": hex::encode(manager.current_params_hash()),
+                            "contribution": serde_json::to_string(&contrib).unwrap(),
+                        }));
+                    }
+                    Err(e) => emit_resp(&json!({"ok": false, "err": err_kind(&e)})),
+                }
+            }
+            "fetch_verify" => {
+                let url = cmd.get("url").and_then(|v| v.as_str()).unwrap().to_string();
+                let new_hash = cmd.get("new_hash").and_then(|v| v.as_str()).unwrap().to_string();
+                let contribution_json =
+                    cmd.get("contribution").and_then(|v| v.as_str()).unwrap().to_string();
+                let resp = do_fetch_verify(&manager, &url, &new_hash, &contribution_json).await;
+                if let Some(p) = resp.1 {
+                    params_cache.insert(new_hash.clone(), p);
+                }
+                emit_resp(&resp.0);
+            }
+            "apply" => {
+                let new_hash = cmd.get("new_hash").and_then(|v| v.as_str()).unwrap().to_string();
+                let contribution_json =
+                    cmd.get("contribution").and_then(|v| v.as_str()).unwrap().to_string();
+                let contrib: ghost_mpc::contribution::MpcContribution =
+                    serde_json::from_str(&contribution_json).unwrap();
+                match params_cache.remove(&new_hash) {
+                    Some(params) => match manager.apply_contribution_multi(params, None, None, &contrib) {
+                        Ok(()) => emit_resp(&json!({
+                            "ok": true,
+                            "count": manager.contribution_count(),
+                            "mgr_head": hex::encode(manager.current_params_hash()),
+                            "current_bin_hash": current_bin_lineage_hash(&params_dir),
+                            "ossified": manager.is_ossified(),
+                        })),
+                        Err(e) => emit_resp(&json!({"ok": false, "err": err_kind(&e)})),
+                    },
+                    None => emit_resp(&json!({
+                        "ok": false,
+                        "err": "no cached params for new_hash (node never fetched/generated it)"
+                    })),
+                }
+            }
+            // Bare fetch (optionally by hash) with NO verify — used by a fresh
+            // post-ossification node to fetch the final params and confirm their
+            // lineage hash, since `verify_contribution` refuses once ossified.
+            "fetch_head" => {
+                let url = cmd.get("url").and_then(|v| v.as_str()).unwrap().to_string();
+                let new_hash = cmd.get("new_hash").and_then(|v| v.as_str()).map(|s| s.to_string());
+                let full = match &new_hash {
+                    Some(h) => format!("{url}?new_hash={h}"),
+                    None => url,
+                };
+                match reqwest::Client::new()
+                    .get(&full)
+                    .timeout(std::time::Duration::from_secs(60))
+                    .send()
+                    .await
+                {
+                    Ok(r) if r.status().is_success() => {
+                        let data = r.bytes().await.unwrap_or_default();
+                        match read_parameters_from_bytes(&data) {
+                            Ok(p) => emit_resp(&json!({
+                                "ok": true,
+                                "fetched_hash": hex::encode(hash_parameters(&p).unwrap()),
+                                "size": data.len(),
+                            })),
+                            Err(e) => emit_resp(&json!({"ok": false, "err": format!("parse: {e}")})),
+                        }
+                    }
+                    Ok(r) => emit_resp(&json!({"ok": false, "err": format!("status {}", r.status())})),
+                    Err(e) => emit_resp(&json!({"ok": false, "err": format!("http: {e}")})),
+                }
+            }
+            "try_generate" => {
+                let contributor = cmd
+                    .get("contributor_id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("late-comer");
+                match manager.generate_contribution(contributor) {
+                    Ok((_p, cnt)) => {
+                        emit_resp(&json!({"ok": true, "position": cnt.position}))
+                    }
+                    Err(e) => emit_resp(&json!({"ok": false, "err": err_kind(&e)})),
+                }
+            }
+            // NEGATIVE CONTROL: reproduce the OLD Bug-1 behaviour — write the
+            // un-applied candidate OVER the active current.bin. A subsequent
+            // restart must then crash-loop (startup guard fails), proving the
+            // guard has teeth and that the fixed path (separate file) avoids it.
+            "simulate_old_bug_overwrite_current" => {
+                let new_hash = cmd.get("new_hash").and_then(|v| v.as_str()).unwrap().to_string();
+                match params_cache.get(&new_hash) {
+                    Some(params) => {
+                        let mut buf = Vec::new();
+                        params.write(&mut buf).unwrap();
+                        let current = params_dir.join("note_spend_params_current.bin");
+                        std::fs::write(&current, &buf).unwrap();
+                        emit_resp(&json!({
+                            "ok": true,
+                            "current_bin_hash": current_bin_lineage_hash(&params_dir),
+                        }));
+                    }
+                    None => emit_resp(&json!({"ok": false, "err": "no cached params"})),
+                }
+            }
+            "shutdown" => {
+                emit_resp(&json!({"ok": true, "bye": true}));
+                std::process::exit(0);
+            }
+            other => emit_resp(&json!({"error": format!("unknown cmd {other:?}")})),
+        }
+    }
+}
+
+/// Mirror of `ghost-pool::write_candidate_note_spend_params`: write the candidate
+/// to its own hash-keyed serving file and purge superseded ones. NEVER current.bin.
+fn write_candidate(params_dir: &Path, new_params_hash: &[u8; 32], serialized: &[u8]) {
+    std::fs::create_dir_all(params_dir).unwrap();
+    let keep = ghost_common::mpc::candidate_note_spend_filename(new_params_hash);
+    if let Ok(entries) = std::fs::read_dir(params_dir) {
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            if name.starts_with(ghost_common::mpc::CANDIDATE_NOTE_SPEND_PREFIX)
+                && name.ends_with(".bin")
+                && name != keep
+            {
+                let _ = std::fs::remove_file(entry.path());
+            }
+        }
+    }
+    std::fs::write(params_dir.join(&keep), serialized).unwrap();
+}
+
+/// Fetch a candidate by hash over real HTTP and run the real cryptographic
+/// verify. Mirrors `ghost-pool::fetch_and_parse_params` (the `?new_hash=` URL
+/// shape + `read_parameters_from_bytes` + hash check) then `verify_contribution`.
+async fn do_fetch_verify(
+    manager: &CeremonyManager,
+    base_url: &str,
+    new_hash: &str,
+    contribution_json: &str,
+) -> (Value, Option<Groth16Params>) {
+    let url = format!("{base_url}?new_hash={new_hash}");
+    let resp = match reqwest::Client::new()
+        .get(&url)
+        .timeout(std::time::Duration::from_secs(60))
+        .send()
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => return (json!({"verify_ok": false, "err": format!("http: {e}")}), None),
+    };
+    if !resp.status().is_success() {
+        return (json!({"verify_ok": false, "err": format!("status {}", resp.status())}), None);
+    }
+    let data = match resp.bytes().await {
+        Ok(b) => b,
+        Err(e) => return (json!({"verify_ok": false, "err": format!("body: {e}")}), None),
+    };
+    if data.len() <= 1000 {
+        return (json!({"verify_ok": false, "err": "params too small"}), None);
+    }
+    let params = match read_parameters_from_bytes(&data) {
+        Ok(p) => p,
+        Err(e) => return (json!({"verify_ok": false, "err": format!("parse: {e}")}), None),
+    };
+    let fetched_hash = match hash_parameters(&params) {
+        Ok(h) => hex::encode(h),
+        Err(e) => return (json!({"verify_ok": false, "err": format!("hash: {e}")}), None),
+    };
+    let contrib: ghost_mpc::contribution::MpcContribution =
+        match serde_json::from_str(contribution_json) {
+            Ok(c) => c,
+            Err(e) => return (json!({"verify_ok": false, "err": format!("contrib json: {e}")}), None),
+        };
+    let verify_ok = matches!(manager.verify_contribution(&params, &contrib), Ok(true));
+    (
+        json!({
+            "verify_ok": verify_ok,
+            "fetched_hash": fetched_hash,
+            "size": data.len(),
+            "served_by_hash": fetched_hash == new_hash,
+        }),
+        Some(params),
+    )
+}
+
+/// Stand up the REAL production params-serving handler on `127.0.0.1:port`.
+async fn spawn_params_server(port: u16, node_id: String) {
+    use ghost_common::types::NodeCapabilities;
+    use ghost_policy::PolicyProfile;
+    use ghost_verification::{api_mpc_params_handler, VerificationState};
+
+    let state = Arc::new(VerificationState::new(
+        node_id,
+        "xproc".to_string(),
+        PolicyProfile::default(),
+        NodeCapabilities::default(),
+    ));
+    // Mount ONLY the real params handler — same code path the mainnet node
+    // serves `/api/v1/mpc/params?new_hash=` through, minus unrelated middleware.
+    let app = axum::Router::new()
+        .route("/api/v1/mpc/params", axum::routing::get(api_mpc_params_handler))
+        .with_state(state);
+    let listener = tokio::net::TcpListener::bind(("127.0.0.1", port))
+        .await
+        .expect("bind params server");
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+}
+
+fn err_kind(e: &MpcError) -> String {
+    match e {
+        MpcError::CeremonyOssified(_) => "CeremonyOssified".to_string(),
+        MpcError::InvalidPosition(a, b) => format!("InvalidPosition({a},{b})"),
+        MpcError::InvalidProof(_) => "InvalidProof".to_string(),
+        other => format!("{other:?}"),
+    }
+}

--- a/crates/mpc-xproc-harness/tests/xproc.rs
+++ b/crates/mpc-xproc-harness/tests/xproc.rs
@@ -1,0 +1,439 @@
+//! Cross-PROCESS MPC rolling-ceremony contribution harness (Stage D / Stage 5).
+//!
+//! This is the GATE before the mainnet un-pin (`tasks/plan_mpc_rolling_resume.md`).
+//! It proves the resumed CONTRIBUTION flow works across genuine, separate OS
+//! processes with real mesh-style HTTP fetching — the exact path the node5
+//! mainnet attempt broke on. The in-process `ghost-mpc` harness
+//! (`tests/mpc_lifecycle.rs`) already proves the crypto + DB lineage at node
+//! level; THIS harness adds the real process boundary the fix is about.
+//!
+//! Topology: one shared genesis (generated once, like fleet node 1) distributed
+//! to a fixed committee of `COMMITTEE` real `mpc-xnode` processes on localhost.
+//! Node C is the contributor + params HTTP server; V1..V3 are voters that FETCH
+//! C's candidate by hash over real HTTP and verify it with real crypto.
+//!
+//! # Run
+//! ```text
+//! cargo test -p mpc-xproc-harness --release --features mpc-test-cap \
+//!     --test xproc -- --nocapture --test-threads=1
+//! ```
+//! (`--release` because it drives real Groth16 phase-2 transforms to the cap;
+//!  `mpc-test-cap` shrinks the cap 101 -> 4 so it finishes in a few minutes.)
+//!
+//! # The five gates (each a mainnet-canary precondition)
+//! 1. genesis inits (count 0); a SEPARATE process generates a candidate and
+//!    SERVES it at `?new_hash=<hash>` while its OWN current.bin is UNCHANGED.
+//! 2. a voter PROCESS fetches the candidate by hash, runs real
+//!    `verify_contribution`, and approves; a >= threshold quorum forms.
+//! 3. on threshold the contribution APPLIES; every node's current.bin converges
+//!    to the candidate — and NOT before apply.
+//! 4. Bug-1 cross-process: the contributor's current.bin never equals the
+//!    un-applied candidate, and a mid-ceremony RESTART does not crash-loop
+//!    (plus a negative control: the OLD overwrite-current behaviour DOES).
+//! 5. drive to the cap -> ossify; a fresh node fetches+confirms the final params
+//!    and CANNOT contribute.
+
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Child, ChildStdin, Command, Stdio};
+
+use ghost_mpc::{CeremonyManager, Groth16Params, MAX_CEREMONY_CONTRIBUTORS};
+use serde_json::{json, Value};
+
+const COMMITTEE: usize = 4; // C + V1 + V2 + V3 -> BFT threshold ceil(4*0.67)=3
+const BASE_PORT: u16 = 8563; // Noise-mesh-adjacent; the fix opened 8563/8443.
+
+// ---------------------------------------------------------------------------
+// Genesis (one shared set, like fleet node 1 generating and peers fetching).
+// ---------------------------------------------------------------------------
+fn generate_genesis_params() -> (Groth16Params, Groth16Params, Groth16Params) {
+    use bellperson::groth16::generate_random_parameters;
+    use blstrs::{Bls12, Scalar as Fr};
+    use ghost_zkp::circuit::{GhostNoteSpendCircuit, GhostUnshieldCircuit, NoteConsolidateCircuit};
+    use rand::rngs::OsRng;
+
+    let note =
+        generate_random_parameters::<Bls12, _, _>(GhostNoteSpendCircuit::<Fr>::dummy(20), &mut OsRng)
+            .expect("genesis note-spend");
+    let consolidate =
+        generate_random_parameters::<Bls12, _, _>(NoteConsolidateCircuit::<Fr>::dummy(20), &mut OsRng)
+            .expect("genesis consolidate");
+    let unshield =
+        generate_random_parameters::<Bls12, _, _>(GhostUnshieldCircuit::<Fr>::dummy(20), &mut OsRng)
+            .expect("genesis unshield");
+    (note, consolidate, unshield)
+}
+
+fn copy_dir_files(src: &Path, dst: &Path) {
+    std::fs::create_dir_all(dst).unwrap();
+    for entry in std::fs::read_dir(src).unwrap().flatten() {
+        let p = entry.path();
+        if p.is_file() {
+            std::fs::copy(&p, dst.join(entry.file_name())).unwrap();
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// One spawned node process, driven over its stdin/stdout JSON control channel.
+// ---------------------------------------------------------------------------
+struct Node {
+    name: String,
+    child: Child,
+    stdin: ChildStdin,
+    stdout: BufReader<std::process::ChildStdout>,
+    port: Option<u16>,
+}
+
+impl Node {
+    /// Read stdout until the next `RESP <json>` line, echoing `EVENT` lines.
+    /// Returns `None` if the process closed stdout (e.g. exited) first.
+    fn read_resp(&mut self) -> Option<Value> {
+        loop {
+            let mut line = String::new();
+            match self.stdout.read_line(&mut line) {
+                Ok(0) => return None, // EOF: process exited
+                Ok(_) => {}
+                Err(_) => return None,
+            }
+            let line = line.trim_end();
+            if let Some(rest) = line.strip_prefix("RESP ") {
+                return Some(serde_json::from_str(rest).expect("resp json"));
+            } else if let Some(rest) = line.strip_prefix("EVENT ") {
+                println!("[{}] {}", self.name, rest);
+            } else if !line.is_empty() {
+                println!("[{}] (raw) {}", self.name, line);
+            }
+        }
+    }
+
+    fn send(&mut self, v: Value) -> Value {
+        writeln!(self.stdin, "{v}").unwrap();
+        self.stdin.flush().unwrap();
+        self.read_resp()
+            .unwrap_or_else(|| panic!("[{}] process died awaiting response to {v}", self.name))
+    }
+
+    fn url(&self) -> String {
+        format!(
+            "http://127.0.0.1:{}/api/v1/mpc/params",
+            self.port.expect("node has no http port")
+        )
+    }
+
+    fn shutdown(&mut self) {
+        let _ = writeln!(self.stdin, "{}", json!({"cmd": "shutdown"}));
+        let _ = self.stdin.flush();
+        let _ = self.child.wait();
+    }
+}
+
+/// Spawn a node process and wait for the startup `RESP {ready:true}` handshake;
+/// returns a fully-owned `Node`, or `None` if the process exited before
+/// readiness (a fail-closed startup guard firing — the node5 crash-loop).
+#[allow(clippy::too_many_arguments)]
+fn start_node(
+    name: &str,
+    home: &Path,
+    head_hex: &str,
+    ceremony_id_hex: &str,
+    count: u32,
+    ossified: bool,
+    http_port: Option<u16>,
+    expected_head: Option<&str>,
+) -> Option<Node> {
+    let bin = env!("CARGO_BIN_EXE_mpc-xnode");
+    let mut cmd = Command::new(bin);
+    cmd.arg("node")
+        .arg("--home")
+        .arg(home)
+        .arg("--head")
+        .arg(head_hex)
+        .arg("--ceremony-id")
+        .arg(ceremony_id_hex)
+        .arg("--count")
+        .arg(count.to_string())
+        .arg("--node-id")
+        .arg(name)
+        .env("HOME", home)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit());
+    if ossified {
+        cmd.arg("--ossified");
+    }
+    if let Some(p) = http_port {
+        cmd.arg("--http-port").arg(p.to_string());
+    }
+    if let Some(e) = expected_head {
+        cmd.arg("--expected-head").arg(e);
+    }
+    let mut child = cmd.spawn().expect("spawn mpc-xnode");
+    let stdin = child.stdin.take().unwrap();
+    let stdout = BufReader::new(child.stdout.take().unwrap());
+    let mut node = Node {
+        name: name.to_string(),
+        child,
+        stdin,
+        stdout,
+        port: http_port,
+    };
+    match node.read_resp() {
+        Some(ready) => {
+            assert_eq!(ready["ready"], json!(true), "[{name}] first RESP must be ready");
+            Some(node)
+        }
+        None => {
+            let _ = node.child.wait();
+            None
+        }
+    }
+}
+
+#[test]
+fn cross_process_contribution_flow() {
+    let cap = MAX_CEREMONY_CONTRIBUTORS;
+    assert!(
+        cap <= 8,
+        "run under --features mpc-test-cap (small cap); got {cap}. \
+         Without it this would need 101 real phase-2 transforms."
+    );
+    let threshold = ghost_mpc::mpc_bft_threshold(COMMITTEE as u32);
+    println!("== cross-process MPC ceremony: cap={cap}, committee={COMMITTEE}, BFT threshold={threshold} ==");
+
+    // ---- Shared genesis (fleet node 1 generates; peers fetch the files) ------
+    let seed_root = tempfile::tempdir().unwrap();
+    let seed_params = seed_root.path().join(".ghost/mpc_params");
+    let seed_mgr = CeremonyManager::new(seed_params.clone());
+    let (g_note, g_consolidate, g_unshield) = generate_genesis_params();
+    seed_mgr
+        .initialize_genesis_multi(g_note, g_consolidate, g_unshield)
+        .expect("genesis init");
+    let anchor_bytes = seed_mgr.current_params_hash();
+    let anchor = hex::encode(anchor_bytes);
+    println!("genesis anchor (ceremony_id) = {}…", &anchor[..16]);
+    assert_ne!(anchor_bytes, [0u8; 32]);
+
+    // Distribute identical genesis to every committee node's params dir.
+    let node_roots: Vec<tempfile::TempDir> = (0..COMMITTEE).map(|_| tempfile::tempdir().unwrap()).collect();
+    let homes: Vec<PathBuf> = node_roots.iter().map(|d| d.path().to_path_buf()).collect();
+    for home in &homes {
+        copy_dir_files(&seed_params, &home.join(".ghost/mpc_params"));
+    }
+
+    // ---- Spawn the committee: node 0 = contributor+server; 1..=voters --------
+    // Every node starts pinned to the genesis anchor (expected-head = anchor).
+    let names: Vec<String> = (0..COMMITTEE)
+        .map(|i| if i == 0 { "C".to_string() } else { format!("V{i}") })
+        .collect();
+    let mut nodes: Vec<Node> = Vec::new();
+    for i in 0..COMMITTEE {
+        let port = if i == 0 { Some(BASE_PORT) } else { None };
+        let n = start_node(
+            &names[i],
+            &homes[i],
+            &anchor,
+            &anchor,
+            0,
+            false,
+            port,
+            Some(&anchor),
+        )
+        .expect("committee node must start clean at genesis");
+        nodes.push(n);
+    }
+    // GATE 1a: genesis initialised, count 0 on every node, current.bin == anchor.
+    for n in nodes.iter_mut() {
+        let s = n.send(json!({"cmd": "inspect"}));
+        assert_eq!(s["count"], json!(0), "genesis count 0");
+        assert_eq!(s["current_bin_hash"], json!(anchor), "on-disk head == anchor");
+        assert_eq!(s["ossified"], json!(false));
+    }
+    println!("GATE 1a PASS: {COMMITTEE} separate processes share genesis; count 0; current.bin == anchor");
+
+    let contributor_url = nodes[0].url();
+    let mut current_head = anchor.clone();
+    let restart_at: u32 = 2.min(cap.max(1));
+
+    for p in 1..=cap {
+        println!("\n---- position {p} ----");
+
+        // ---- (1) CONTRIBUTOR (separate process) generates + serves candidate --
+        let mut gen = nodes[0].send(json!({"cmd": "gen_candidate", "contributor_id": format!("elder-{p}")}));
+        assert_eq!(gen["ok"], json!(true), "gen_candidate ok");
+        assert_eq!(gen["position"], json!(p), "sequential position");
+        assert_eq!(gen["prev_hash"], json!(current_head), "prev chains from head");
+        let mut new_hash = gen["new_hash"].as_str().unwrap().to_string();
+        let mut contribution = gen["contribution"].as_str().unwrap().to_string();
+        assert_ne!(new_hash, current_head, "candidate hash strictly evolves");
+        // GATE 1b: contributor's OWN current.bin is UNCHANGED by generation.
+        assert_eq!(
+            gen["current_bin_hash"], json!(current_head),
+            "GATE 1: generating a candidate MUST NOT move the contributor's current.bin"
+        );
+        println!("GATE 1 PASS: C generated pos {p} candidate {}… ; C.current.bin still {}… (un-applied)", &new_hash[..16], &current_head[..16]);
+
+        // ---- (4) Bug-1 cross-process RESTART mid-ceremony (fixed path) --------
+        if p == restart_at {
+            println!("-- Bug-1: restarting contributor C mid-position (candidate generated, not applied) --");
+            // Kill C hard (it has an un-applied candidate on disk).
+            let _ = nodes[0].child.kill();
+            let _ = nodes[0].child.wait();
+            std::thread::sleep(std::time::Duration::from_millis(500));
+            // Respawn pinned to the APPLIED head (current_head). With the fix,
+            // current.bin is still the applied head, so the guard passes.
+            let restarted = start_node(
+                "C",
+                &homes[0],
+                &current_head,
+                &anchor,
+                p - 1,
+                false,
+                Some(BASE_PORT),
+                Some(&current_head),
+            )
+            .expect("GATE 4: contributor must NOT crash-loop on restart (current.bin == chain head)");
+            nodes[0] = restarted;
+            let s = nodes[0].send(json!({"cmd": "inspect"}));
+            assert_eq!(
+                s["current_bin_hash"], json!(current_head),
+                "GATE 4: after restart current.bin == applied chain head (never the candidate)"
+            );
+            println!("GATE 4 PASS: C restarted cleanly; current.bin == chain head {}… (no crash-loop)", &current_head[..16]);
+            // Regenerate the candidate on the fresh process (cache was lost).
+            gen = nodes[0].send(json!({"cmd": "gen_candidate", "contributor_id": format!("elder-{p}")}));
+            assert_eq!(gen["ok"], json!(true));
+            new_hash = gen["new_hash"].as_str().unwrap().to_string();
+            contribution = gen["contribution"].as_str().unwrap().to_string();
+            assert_eq!(gen["current_bin_hash"], json!(current_head), "still un-applied after regen");
+        }
+
+        // ---- (2) VOTERS (separate processes) FETCH by hash + real verify ------
+        let mut approvals = 0u32;
+        for v in 1..COMMITTEE {
+            let r = nodes[v].send(json!({
+                "cmd": "fetch_verify",
+                "url": contributor_url,
+                "new_hash": new_hash,
+                "contribution": contribution,
+            }));
+            assert_eq!(
+                r["served_by_hash"], json!(true),
+                "voter must receive the candidate served via ?new_hash= (hash matches)"
+            );
+            assert_eq!(r["fetched_hash"], json!(new_hash), "fetched params hash == candidate");
+            assert_eq!(r["verify_ok"], json!(true), "real verify_contribution (Schnorr+pairing) approves");
+            approvals += 1;
+            println!("  [{}] fetched {} bytes via ?new_hash=, verify_ok=true", nodes[v].name, r["size"]);
+        }
+        // The contributor holds valid params it generated -> counts as an approval.
+        approvals += 1;
+        assert!(
+            approvals >= threshold,
+            "GATE 2: {approvals} approvals must meet BFT threshold {threshold}"
+        );
+        println!("GATE 2 PASS: {approvals}/{COMMITTEE} approvals >= threshold {threshold} (voters fetched+verified cross-process)");
+
+        // ---- (3 + 4) NOT before threshold: current.bin still un-applied -------
+        let pre = nodes[0].send(json!({"cmd": "inspect"}));
+        assert_eq!(
+            pre["current_bin_hash"], json!(current_head),
+            "GATE 3/4: before apply the contributor's current.bin is STILL the old head (candidate not adopted)"
+        );
+
+        // ---- (3) APPLY on every node -> convergence ---------------------------
+        for n in nodes.iter_mut() {
+            // Voters already fetched+cached; the contributor holds its generated
+            // params. Contributor also needs the params cached — it does (gen).
+            let a = n.send(json!({"cmd": "apply", "new_hash": new_hash, "contribution": contribution}));
+            assert_eq!(a["ok"], json!(true), "[{}] apply ok", n.name);
+            assert_eq!(a["count"], json!(p), "[{}] count advanced to {p}", n.name);
+            assert_eq!(
+                a["current_bin_hash"], json!(new_hash),
+                "GATE 3: [{}] current.bin converged to the candidate after apply", n.name
+            );
+        }
+        println!("GATE 3 PASS: all {COMMITTEE} nodes' current.bin converged to {}… (count {p})", &new_hash[..16]);
+
+        current_head = new_hash;
+    }
+
+    // ---- (5) Ossification at the cap -----------------------------------------
+    println!("\n---- ossification ----");
+    for n in nodes.iter_mut() {
+        let s = n.send(json!({"cmd": "inspect"}));
+        assert_eq!(s["ossified"], json!(true), "[{}] ossified at cap", n.name);
+        let t = n.send(json!({"cmd": "try_generate", "contributor_id": "late"}));
+        assert_eq!(t["ok"], json!(false));
+        assert_eq!(t["err"], json!("CeremonyOssified"), "[{}] post-cap contribute refused", n.name);
+    }
+    println!("GATE 5a PASS: every node ossified at cap {cap}; further contribution refused (CeremonyOssified)");
+
+    // ---- (5) Fresh node fetches final params + cannot contribute -------------
+    let fresh_root = tempfile::tempdir().unwrap();
+    let fresh_home = fresh_root.path().to_path_buf();
+    // A fresh node "fetches" genesis+the chain to disk (we copy the contributor's
+    // final params dir, standing in for the network sync), then boots ossified.
+    copy_dir_files(&homes[0].join(".ghost/mpc_params"), &fresh_home.join(".ghost/mpc_params"));
+    let mut fresh = start_node(
+        "F",
+        &fresh_home,
+        &current_head,
+        &anchor,
+        cap,
+        true,
+        None,
+        Some(&current_head),
+    )
+    .expect("fresh post-ossification node must boot clean");
+    // It fetches the final params from the still-serving contributor and confirms
+    // the lineage hash equals the ossified head.
+    let f = fresh.send(json!({"cmd": "fetch_head", "url": contributor_url, "new_hash": current_head}));
+    assert_eq!(f["ok"], json!(true), "fresh node fetched final params over HTTP");
+    assert_eq!(
+        f["fetched_hash"], json!(current_head),
+        "GATE 5: fresh node's fetched final params hash == ossified head"
+    );
+    // And it CANNOT contribute.
+    let t = fresh.send(json!({"cmd": "try_generate", "contributor_id": "johnny-come-lately"}));
+    assert_eq!(t["ok"], json!(false));
+    assert_eq!(t["err"], json!("CeremonyOssified"), "fresh node cannot contribute post-ossification");
+    println!("GATE 5b PASS: fresh node fetched final params ({}…) + cannot contribute", &current_head[..16]);
+
+    // ---- (4) NEGATIVE CONTROL: the OLD overwrite-current behaviour crashes ----
+    // Prove the startup guard actually detects the node5 condition, and that the
+    // fixed contributor path (separate candidate file) is what avoids it.
+    println!("\n---- Bug-1 negative control (old behaviour must crash-loop) ----");
+    let d_root = tempfile::tempdir().unwrap();
+    let d_home = d_root.path().to_path_buf();
+    copy_dir_files(&seed_params, &d_home.join(".ghost/mpc_params"));
+    let mut d = start_node("D", &d_home, &anchor, &anchor, 0, false, None, Some(&anchor))
+        .expect("D starts clean at genesis");
+    let dg = d.send(json!({"cmd": "gen_candidate", "contributor_id": "d-elder"}));
+    let d_new_hash = dg["new_hash"].as_str().unwrap().to_string();
+    assert_eq!(dg["current_bin_hash"], json!(anchor), "D fixed path: current.bin still anchor");
+    // Simulate the OLD bug: write the un-applied candidate OVER current.bin.
+    let ob = d.send(json!({"cmd": "simulate_old_bug_overwrite_current", "new_hash": d_new_hash}));
+    assert_eq!(ob["ok"], json!(true));
+    assert_eq!(ob["current_bin_hash"], json!(d_new_hash), "D now has candidate as current.bin (the bug)");
+    d.shutdown();
+    std::thread::sleep(std::time::Duration::from_millis(300));
+    // Restart D pinned to the real chain head (anchor). current.bin != anchor now,
+    // so the genesis-anchored guard MUST fail-closed (exit non-zero, no ready).
+    let crashed = start_node("D", &d_home, &anchor, &anchor, 0, false, None, Some(&anchor));
+    assert!(
+        crashed.is_none(),
+        "GATE 4 negative control: overwriting current.bin with the candidate MUST crash-loop on restart"
+    );
+    println!("GATE 4 negative control PASS: old overwrite-current behaviour fails the startup guard (crash-loop reproduced)");
+
+    // ---- Teardown ------------------------------------------------------------
+    for n in nodes.iter_mut() {
+        n.shutdown();
+    }
+    fresh.shutdown();
+    // keep tempdirs alive until here
+    drop(node_roots);
+    drop(seed_root);
+    println!("\n== ALL GATES PASS (cross-process) ==");
+}

--- a/crates/mpc-xproc-harness/tests/xproc.rs
+++ b/crates/mpc-xproc-harness/tests/xproc.rs
@@ -52,15 +52,21 @@ fn generate_genesis_params() -> (Groth16Params, Groth16Params, Groth16Params) {
     use ghost_zkp::circuit::{GhostNoteSpendCircuit, GhostUnshieldCircuit, NoteConsolidateCircuit};
     use rand::rngs::OsRng;
 
-    let note =
-        generate_random_parameters::<Bls12, _, _>(GhostNoteSpendCircuit::<Fr>::dummy(20), &mut OsRng)
-            .expect("genesis note-spend");
-    let consolidate =
-        generate_random_parameters::<Bls12, _, _>(NoteConsolidateCircuit::<Fr>::dummy(20), &mut OsRng)
-            .expect("genesis consolidate");
-    let unshield =
-        generate_random_parameters::<Bls12, _, _>(GhostUnshieldCircuit::<Fr>::dummy(20), &mut OsRng)
-            .expect("genesis unshield");
+    let note = generate_random_parameters::<Bls12, _, _>(
+        GhostNoteSpendCircuit::<Fr>::dummy(20),
+        &mut OsRng,
+    )
+    .expect("genesis note-spend");
+    let consolidate = generate_random_parameters::<Bls12, _, _>(
+        NoteConsolidateCircuit::<Fr>::dummy(20),
+        &mut OsRng,
+    )
+    .expect("genesis consolidate");
+    let unshield = generate_random_parameters::<Bls12, _, _>(
+        GhostUnshieldCircuit::<Fr>::dummy(20),
+        &mut OsRng,
+    )
+    .expect("genesis unshield");
     (note, consolidate, unshield)
 }
 
@@ -180,7 +186,11 @@ fn start_node(
     };
     match node.read_resp() {
         Some(ready) => {
-            assert_eq!(ready["ready"], json!(true), "[{name}] first RESP must be ready");
+            assert_eq!(
+                ready["ready"],
+                json!(true),
+                "[{name}] first RESP must be ready"
+            );
             Some(node)
         }
         None => {
@@ -215,7 +225,9 @@ fn cross_process_contribution_flow() {
     assert_ne!(anchor_bytes, [0u8; 32]);
 
     // Distribute identical genesis to every committee node's params dir.
-    let node_roots: Vec<tempfile::TempDir> = (0..COMMITTEE).map(|_| tempfile::tempdir().unwrap()).collect();
+    let node_roots: Vec<tempfile::TempDir> = (0..COMMITTEE)
+        .map(|_| tempfile::tempdir().unwrap())
+        .collect();
     let homes: Vec<PathBuf> = node_roots.iter().map(|d| d.path().to_path_buf()).collect();
     for home in &homes {
         copy_dir_files(&seed_params, &home.join(".ghost/mpc_params"));
@@ -224,7 +236,13 @@ fn cross_process_contribution_flow() {
     // ---- Spawn the committee: node 0 = contributor+server; 1..=voters --------
     // Every node starts pinned to the genesis anchor (expected-head = anchor).
     let names: Vec<String> = (0..COMMITTEE)
-        .map(|i| if i == 0 { "C".to_string() } else { format!("V{i}") })
+        .map(|i| {
+            if i == 0 {
+                "C".to_string()
+            } else {
+                format!("V{i}")
+            }
+        })
         .collect();
     let mut nodes: Vec<Node> = Vec::new();
     for i in 0..COMMITTEE {
@@ -246,7 +264,11 @@ fn cross_process_contribution_flow() {
     for n in nodes.iter_mut() {
         let s = n.send(json!({"cmd": "inspect"}));
         assert_eq!(s["count"], json!(0), "genesis count 0");
-        assert_eq!(s["current_bin_hash"], json!(anchor), "on-disk head == anchor");
+        assert_eq!(
+            s["current_bin_hash"],
+            json!(anchor),
+            "on-disk head == anchor"
+        );
         assert_eq!(s["ossified"], json!(false));
     }
     println!("GATE 1a PASS: {COMMITTEE} separate processes share genesis; count 0; current.bin == anchor");
@@ -259,19 +281,29 @@ fn cross_process_contribution_flow() {
         println!("\n---- position {p} ----");
 
         // ---- (1) CONTRIBUTOR (separate process) generates + serves candidate --
-        let mut gen = nodes[0].send(json!({"cmd": "gen_candidate", "contributor_id": format!("elder-{p}")}));
+        let mut gen =
+            nodes[0].send(json!({"cmd": "gen_candidate", "contributor_id": format!("elder-{p}")}));
         assert_eq!(gen["ok"], json!(true), "gen_candidate ok");
         assert_eq!(gen["position"], json!(p), "sequential position");
-        assert_eq!(gen["prev_hash"], json!(current_head), "prev chains from head");
+        assert_eq!(
+            gen["prev_hash"],
+            json!(current_head),
+            "prev chains from head"
+        );
         let mut new_hash = gen["new_hash"].as_str().unwrap().to_string();
         let mut contribution = gen["contribution"].as_str().unwrap().to_string();
         assert_ne!(new_hash, current_head, "candidate hash strictly evolves");
         // GATE 1b: contributor's OWN current.bin is UNCHANGED by generation.
         assert_eq!(
-            gen["current_bin_hash"], json!(current_head),
+            gen["current_bin_hash"],
+            json!(current_head),
             "GATE 1: generating a candidate MUST NOT move the contributor's current.bin"
         );
-        println!("GATE 1 PASS: C generated pos {p} candidate {}… ; C.current.bin still {}… (un-applied)", &new_hash[..16], &current_head[..16]);
+        println!(
+            "GATE 1 PASS: C generated pos {p} candidate {}… ; C.current.bin still {}… (un-applied)",
+            &new_hash[..16],
+            &current_head[..16]
+        );
 
         // ---- (4) Bug-1 cross-process RESTART mid-ceremony (fixed path) --------
         if p == restart_at {
@@ -292,20 +324,31 @@ fn cross_process_contribution_flow() {
                 Some(BASE_PORT),
                 Some(&current_head),
             )
-            .expect("GATE 4: contributor must NOT crash-loop on restart (current.bin == chain head)");
+            .expect(
+                "GATE 4: contributor must NOT crash-loop on restart (current.bin == chain head)",
+            );
             nodes[0] = restarted;
             let s = nodes[0].send(json!({"cmd": "inspect"}));
             assert_eq!(
-                s["current_bin_hash"], json!(current_head),
+                s["current_bin_hash"],
+                json!(current_head),
                 "GATE 4: after restart current.bin == applied chain head (never the candidate)"
             );
-            println!("GATE 4 PASS: C restarted cleanly; current.bin == chain head {}… (no crash-loop)", &current_head[..16]);
+            println!(
+                "GATE 4 PASS: C restarted cleanly; current.bin == chain head {}… (no crash-loop)",
+                &current_head[..16]
+            );
             // Regenerate the candidate on the fresh process (cache was lost).
-            gen = nodes[0].send(json!({"cmd": "gen_candidate", "contributor_id": format!("elder-{p}")}));
+            gen = nodes[0]
+                .send(json!({"cmd": "gen_candidate", "contributor_id": format!("elder-{p}")}));
             assert_eq!(gen["ok"], json!(true));
             new_hash = gen["new_hash"].as_str().unwrap().to_string();
             contribution = gen["contribution"].as_str().unwrap().to_string();
-            assert_eq!(gen["current_bin_hash"], json!(current_head), "still un-applied after regen");
+            assert_eq!(
+                gen["current_bin_hash"],
+                json!(current_head),
+                "still un-applied after regen"
+            );
         }
 
         // ---- (2) VOTERS (separate processes) FETCH by hash + real verify ------
@@ -318,13 +361,25 @@ fn cross_process_contribution_flow() {
                 "contribution": contribution,
             }));
             assert_eq!(
-                r["served_by_hash"], json!(true),
+                r["served_by_hash"],
+                json!(true),
                 "voter must receive the candidate served via ?new_hash= (hash matches)"
             );
-            assert_eq!(r["fetched_hash"], json!(new_hash), "fetched params hash == candidate");
-            assert_eq!(r["verify_ok"], json!(true), "real verify_contribution (Schnorr+pairing) approves");
+            assert_eq!(
+                r["fetched_hash"],
+                json!(new_hash),
+                "fetched params hash == candidate"
+            );
+            assert_eq!(
+                r["verify_ok"],
+                json!(true),
+                "real verify_contribution (Schnorr+pairing) approves"
+            );
             approvals += 1;
-            println!("  [{}] fetched {} bytes via ?new_hash=, verify_ok=true", nodes[v].name, r["size"]);
+            println!(
+                "  [{}] fetched {} bytes via ?new_hash=, verify_ok=true",
+                nodes[v].name, r["size"]
+            );
         }
         // The contributor holds valid params it generated -> counts as an approval.
         approvals += 1;
@@ -345,15 +400,21 @@ fn cross_process_contribution_flow() {
         for n in nodes.iter_mut() {
             // Voters already fetched+cached; the contributor holds its generated
             // params. Contributor also needs the params cached — it does (gen).
-            let a = n.send(json!({"cmd": "apply", "new_hash": new_hash, "contribution": contribution}));
+            let a =
+                n.send(json!({"cmd": "apply", "new_hash": new_hash, "contribution": contribution}));
             assert_eq!(a["ok"], json!(true), "[{}] apply ok", n.name);
             assert_eq!(a["count"], json!(p), "[{}] count advanced to {p}", n.name);
             assert_eq!(
-                a["current_bin_hash"], json!(new_hash),
-                "GATE 3: [{}] current.bin converged to the candidate after apply", n.name
+                a["current_bin_hash"],
+                json!(new_hash),
+                "GATE 3: [{}] current.bin converged to the candidate after apply",
+                n.name
             );
         }
-        println!("GATE 3 PASS: all {COMMITTEE} nodes' current.bin converged to {}… (count {p})", &new_hash[..16]);
+        println!(
+            "GATE 3 PASS: all {COMMITTEE} nodes' current.bin converged to {}… (count {p})",
+            &new_hash[..16]
+        );
 
         current_head = new_hash;
     }
@@ -365,7 +426,12 @@ fn cross_process_contribution_flow() {
         assert_eq!(s["ossified"], json!(true), "[{}] ossified at cap", n.name);
         let t = n.send(json!({"cmd": "try_generate", "contributor_id": "late"}));
         assert_eq!(t["ok"], json!(false));
-        assert_eq!(t["err"], json!("CeremonyOssified"), "[{}] post-cap contribute refused", n.name);
+        assert_eq!(
+            t["err"],
+            json!("CeremonyOssified"),
+            "[{}] post-cap contribute refused",
+            n.name
+        );
     }
     println!("GATE 5a PASS: every node ossified at cap {cap}; further contribution refused (CeremonyOssified)");
 
@@ -374,7 +440,10 @@ fn cross_process_contribution_flow() {
     let fresh_home = fresh_root.path().to_path_buf();
     // A fresh node "fetches" genesis+the chain to disk (we copy the contributor's
     // final params dir, standing in for the network sync), then boots ossified.
-    copy_dir_files(&homes[0].join(".ghost/mpc_params"), &fresh_home.join(".ghost/mpc_params"));
+    copy_dir_files(
+        &homes[0].join(".ghost/mpc_params"),
+        &fresh_home.join(".ghost/mpc_params"),
+    );
     let mut fresh = start_node(
         "F",
         &fresh_home,
@@ -388,17 +457,30 @@ fn cross_process_contribution_flow() {
     .expect("fresh post-ossification node must boot clean");
     // It fetches the final params from the still-serving contributor and confirms
     // the lineage hash equals the ossified head.
-    let f = fresh.send(json!({"cmd": "fetch_head", "url": contributor_url, "new_hash": current_head}));
-    assert_eq!(f["ok"], json!(true), "fresh node fetched final params over HTTP");
+    let f =
+        fresh.send(json!({"cmd": "fetch_head", "url": contributor_url, "new_hash": current_head}));
     assert_eq!(
-        f["fetched_hash"], json!(current_head),
+        f["ok"],
+        json!(true),
+        "fresh node fetched final params over HTTP"
+    );
+    assert_eq!(
+        f["fetched_hash"],
+        json!(current_head),
         "GATE 5: fresh node's fetched final params hash == ossified head"
     );
     // And it CANNOT contribute.
     let t = fresh.send(json!({"cmd": "try_generate", "contributor_id": "johnny-come-lately"}));
     assert_eq!(t["ok"], json!(false));
-    assert_eq!(t["err"], json!("CeremonyOssified"), "fresh node cannot contribute post-ossification");
-    println!("GATE 5b PASS: fresh node fetched final params ({}…) + cannot contribute", &current_head[..16]);
+    assert_eq!(
+        t["err"],
+        json!("CeremonyOssified"),
+        "fresh node cannot contribute post-ossification"
+    );
+    println!(
+        "GATE 5b PASS: fresh node fetched final params ({}…) + cannot contribute",
+        &current_head[..16]
+    );
 
     // ---- (4) NEGATIVE CONTROL: the OLD overwrite-current behaviour crashes ----
     // Prove the startup guard actually detects the node5 condition, and that the
@@ -407,20 +489,46 @@ fn cross_process_contribution_flow() {
     let d_root = tempfile::tempdir().unwrap();
     let d_home = d_root.path().to_path_buf();
     copy_dir_files(&seed_params, &d_home.join(".ghost/mpc_params"));
-    let mut d = start_node("D", &d_home, &anchor, &anchor, 0, false, None, Some(&anchor))
-        .expect("D starts clean at genesis");
+    let mut d = start_node(
+        "D",
+        &d_home,
+        &anchor,
+        &anchor,
+        0,
+        false,
+        None,
+        Some(&anchor),
+    )
+    .expect("D starts clean at genesis");
     let dg = d.send(json!({"cmd": "gen_candidate", "contributor_id": "d-elder"}));
     let d_new_hash = dg["new_hash"].as_str().unwrap().to_string();
-    assert_eq!(dg["current_bin_hash"], json!(anchor), "D fixed path: current.bin still anchor");
+    assert_eq!(
+        dg["current_bin_hash"],
+        json!(anchor),
+        "D fixed path: current.bin still anchor"
+    );
     // Simulate the OLD bug: write the un-applied candidate OVER current.bin.
     let ob = d.send(json!({"cmd": "simulate_old_bug_overwrite_current", "new_hash": d_new_hash}));
     assert_eq!(ob["ok"], json!(true));
-    assert_eq!(ob["current_bin_hash"], json!(d_new_hash), "D now has candidate as current.bin (the bug)");
+    assert_eq!(
+        ob["current_bin_hash"],
+        json!(d_new_hash),
+        "D now has candidate as current.bin (the bug)"
+    );
     d.shutdown();
     std::thread::sleep(std::time::Duration::from_millis(300));
     // Restart D pinned to the real chain head (anchor). current.bin != anchor now,
     // so the genesis-anchored guard MUST fail-closed (exit non-zero, no ready).
-    let crashed = start_node("D", &d_home, &anchor, &anchor, 0, false, None, Some(&anchor));
+    let crashed = start_node(
+        "D",
+        &d_home,
+        &anchor,
+        &anchor,
+        0,
+        false,
+        None,
+        Some(&anchor),
+    );
     assert!(
         crashed.is_none(),
         "GATE 4 negative control: overwriting current.bin with the candidate MUST crash-loop on restart"

--- a/scripts/install-node.sh
+++ b/scripts/install-node.sh
@@ -21,8 +21,21 @@ POOL_TARBALL="bitcoin-ghost-${GHOST_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
 GHOSTD_URL="${GHOSTD_URL:-https://get.bitcoinghost.org/bin/ghostd}"
 GHOSTD_SHA256="bb3a864248cea6ece930eb76fef525a0f5b1fde65976a886935df34e9e95859d"
 RELEASE_KEY_URL="https://get.bitcoinghost.org/ghost-release-key.asc"
-# ZK params are auto-fetched from peers on first run; this is the pinned hash.
-ZK_PARAMS_HASH="BLOCK:fa9db2b79ee55bd181c33943a466aad24e58618c7cf1e2f23daf91462115ce77"
+# ── MPC ceremony: genesis-anchored trust root ────────────────────────────────
+# A fresh community node JOINS a still-rolling MPC ceremony GENESIS-ANCHORED: it
+# trusts the immutable genesis lineage anchor below and accepts whatever params
+# the ceremony has currently rolled to (each contribution is verified to chain
+# back to this anchor) — rather than pinning ONE static position hash. A stale
+# `BLOCK:<hash>` pin makes a late joiner REJECT the ceremony's current params,
+# which is exactly the manual step a fresh node hit before this change.
+#
+# The value below is the mainnet genesis MPC params hash: the IMMUTABLE trust
+# root of the ceremony lineage, hardcoded here exactly like a genesis block hash
+# is baked into a client. It is NEVER fetched from a peer (an untrusted source).
+# The node self-pins automatically once the ceremony ossifies at position 101, so
+# genesis-anchored is the correct startup mode for BOTH the rolling and ossified
+# states — there is deliberately no static ZK_PARAMS_HASH on the join path.
+ZK_GENESIS_PARAMS_HASH="c9c907f688fc11023d2202de44d6826c2b3f320646b70867009696d632515533"
 # Bootstrap peers (the current Elders). The node discovers the rest via gossip.
 SEED_NODES='"83.136.251.162:8555", "85.9.198.212:8555", "213.163.207.46:8555", "95.111.221.169:8555"'
 # assumevalid checkpoint (speeds signature validation; does NOT skip download).
@@ -711,7 +724,7 @@ chown -R ghost:ghost /home/ghost /var/lib/ghost /var/lib/bitcoin
 
 # ─────────────────────────── 7. node identity ────────────────────────────────
 log "Generating node identity"
-sudo -u ghost ZK_PARAMS_PATH=/home/ghost/.ghost/mpc_params ZK_PARAMS_HASH="$ZK_PARAMS_HASH" \
+sudo -u ghost ZK_PARAMS_PATH=/home/ghost/.ghost/mpc_params ZK_GENESIS_PARAMS_HASH="$ZK_GENESIS_PARAMS_HASH" \
   /opt/ghost/bin/ghost-pool --config /etc/ghost/pool.toml --generate-identity 2>&1 | grep -iE "Node ID" || true
 
 # ───────────────────────── 8. sync gate (auto) ───────────────────────────────
@@ -801,12 +814,30 @@ WorkingDirectory=/var/lib/ghost
 ExecStart=/opt/ghost/bin/ghost-pool --config /etc/ghost/pool.toml --tdp-enabled --tdp-port 8442 --stratum-port 3333
 Environment=RUST_LOG=info
 Environment=ZK_PARAMS_PATH=/home/ghost/.ghost/mpc_params
-Environment=ZK_PARAMS_HASH=${ZK_PARAMS_HASH}
 Restart=on-failure
 RestartSec=15
 LimitNOFILE=65536
 [Install]
 WantedBy=multi-user.target
+EOF
+
+# MPC startup mode — GENESIS-ANCHORED (join path), written as a systemd drop-in
+# to match the fleet convention (ghost-pool.service.d/genesis-anchor.conf). A
+# fresh community node joining a still-rolling ceremony must NOT carry a static
+# ZK_PARAMS_HASH pin (a stale pin makes it reject the ceremony's current params);
+# it runs genesis-anchored instead, validating the current params back to the
+# immutable mainnet genesis lineage anchor. `cat >` overwrites on every run, so
+# this is idempotent; the later `systemctl daemon-reload` picks it up.
+mkdir -p /etc/systemd/system/ghost-pool.service.d
+cat > /etc/systemd/system/ghost-pool.service.d/genesis-anchor.conf <<EOF
+[Service]
+# ZK_GENESIS_PARAMS_HASH is the IMMUTABLE mainnet genesis MPC params hash — the
+# ceremony's trust root, baked into the installer exactly like a genesis block
+# hash is baked into a client. It is NEVER fetched from a peer (untrusted). With
+# this set and NO static ZK_PARAMS_HASH, ghost-pool accepts the ceremony's
+# current rolling params (verified to chain back to this anchor) and self-pins
+# once the ceremony ossifies at position 101 — correct for both states.
+Environment=ZK_GENESIS_PARAMS_HASH=${ZK_GENESIS_PARAMS_HASH}
 EOF
 
 # ghost-pay L2 service (also serves the Wraith bond ledger on 8800). Only
@@ -1617,7 +1648,7 @@ fi
 systemctl enable --now ghost-pool-gate >/dev/null 2>&1
 sleep 5
 
-NODE_ID="$(sudo -u ghost ZK_PARAMS_PATH=/home/ghost/.ghost/mpc_params ZK_PARAMS_HASH="$ZK_PARAMS_HASH" /opt/ghost/bin/ghost-pool --config /etc/ghost/pool.toml --show-identity 2>/dev/null | grep -i 'Node ID' | head -1 || true)"
+NODE_ID="$(sudo -u ghost ZK_PARAMS_PATH=/home/ghost/.ghost/mpc_params ZK_GENESIS_PARAMS_HASH="$ZK_GENESIS_PARAMS_HASH" /opt/ghost/bin/ghost-pool --config /etc/ghost/pool.toml --show-identity 2>/dev/null | grep -i 'Node ID' | head -1 || true)"
 cat <<EOF
 
   ✅ Bitcoin Ghost node installed.

--- a/scripts/install-node.sh
+++ b/scripts/install-node.sh
@@ -848,7 +848,9 @@ ufw allow 22/tcp        >/dev/null 2>&1   # ssh FIRST so we don't lock out
 ufw allow 8333/tcp      >/dev/null 2>&1   # bitcoin P2P
 ufw allow 8080/tcp      >/dev/null 2>&1   # ghost API
 ufw allow 8442/tcp      >/dev/null 2>&1   # TDP
-ufw allow 8555:8562/tcp >/dev/null 2>&1   # mesh consensus
+ufw allow 8555:8562/tcp >/dev/null 2>&1   # mesh consensus (ZMQ pub/sub)
+ufw allow 8563/tcp      >/dev/null 2>&1   # Noise mesh (verifications + MPC contribution/vote exchange)
+ufw allow 8443/tcp      >/dev/null 2>&1   # verification HTTPS (peers fetch MPC params + votes)
 # Ghost Pay L2 / Wraith bond ledger (peers issue Ghost Pay verification
 # challenges here, and wallets escrow Wraith bonds here) — only when enabled.
 [[ "$GHOST_PAY" == "true" ]] && ufw allow 8800/tcp >/dev/null 2>&1   # ghost-pay / bond ledger


### PR DESCRIPTION
Fixes the two bugs the live rolling-ceremony un-pin surfaced on mainnet (node5 → position 5):

1. **Contributor overwrote its active `current.bin`** with the un-applied candidate → crash-loop on restart (on-disk candidate != BFT chain head). Fix: the candidate is written to a hash-keyed `note_spend_params_candidate_<hex>.bin` and served via `GET /api/v1/mpc/params?new_hash=<hex>`; `current.bin` is written **only** by the BFT-apply path (`apply_contribution_multi`) + install/self-heal of applied params. Proven by `generate_does_not_advance_current_only_apply_does`.
2. **Installer firewall** missing the Noise (8563) + verification-HTTPS (8443) inbound rules → peers could not fetch a community node’s candidate params. Fix: opened in the base firewall.

**Cross-process proof:** new `mpc-xproc-harness` spawns real separate OS processes using the production `api_mpc_params_handler` + real `verify_contribution` (Schnorr+pairing) + real apply. All 5 gates pass, incl. the Bug-1 restart invariant with a negative control that proves the old behaviour still crash-loops.

Also bumps workspace version to 1.10.10.