### PR TITLE
Autonomous MPC ossification: self-pin the trusted setup at the 101-elder cap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3724,6 +3724,7 @@ dependencies = [
  "rayon",
  "serde",
  "sha2 0.10.9",
+ "tempfile",
  "thiserror 1.0.69",
  "tokio",
  "tracing",

--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -1341,6 +1341,7 @@ fn persist_singleton_from_manager(
         payout_vk_hash: s.payout_vk_hash,
         updated_at: s.updated_at,
         ceremony_id: s.ceremony_id,
+        ossified_file_hash: s.ossified_file_hash,
     };
     if let Err(e) = db.save_mpc_ceremony_state(&db_state) {
         tracing::warn!(error = %e, "MPC adopt: failed to persist ceremony singleton");
@@ -1853,13 +1854,19 @@ async fn sync_mpc_proof_and_votes(
 /// failure it returns an error so the process exits — systemd restarts it and
 /// it retries, recovering automatically the moment a seed becomes reachable.
 /// It NEVER loops forever inside one process and NEVER continues without params.
+///
+/// The `expected` pinned hashes gate every fetched/present blob. Normally this is
+/// `expected_param_hashes()` (from `ZK_PARAMS_HASH`), but the autonomous-ossified
+/// path passes `{ "BLOCK": ossified_file_hash }` sourced from the DB latch so a
+/// fresh joiner self-heals the FINAL params with no env pin at all.
 #[cfg(all(feature = "zk-consensus", feature = "mpc-ceremony"))]
 async fn ensure_mpc_params_present(
     seed_nodes: &[String],
     params_dir: &std::path::Path,
+    expected: &std::collections::HashMap<String, [u8; 32]>,
 ) -> Result<()> {
     let current = params_dir.join("note_spend_params_current.bin");
-    let expected = expected_param_hashes();
+    let expected = expected.clone();
 
     if current.exists() {
         // Present — but DON'T blindly trust it. Validate against the pinned
@@ -3082,7 +3089,75 @@ async fn main() -> Result<()> {
             // verification run in the MPC block below. Neither set on a production
             // node → `select_startup_mode` errors and startup aborts (never
             // unverified).
-            match ghost_zkp::select_startup_mode()? {
+            //
+            // AUTONOMOUS OSSIFICATION takes ABSOLUTE precedence: if the DB
+            // ceremony singleton has ossified (reached the 101 cap) and recorded
+            // the final params file hash, the node self-selects `OssifiedPinned`
+            // from that DB latch REGARDLESS of env vars — no operator re-pin. This
+            // is read fresh from the DB here so it drives the very first decision.
+            let ossified_pin: Option<[u8; 32]> = db
+                .get_mpc_ceremony_state()
+                .ok()
+                .flatten()
+                .filter(|s| s.is_ossified)
+                .and_then(|s| s.ossified_file_hash);
+            match ghost_zkp::select_startup_mode_with_ossification(ossified_pin)? {
+                ghost_zkp::ZkStartupMode::OssifiedPinned { file_hash } => {
+                    // The trusted setup is FINAL. Behaves like StaticPin but the
+                    // pin comes from the DB latch, not an env var (which may be a
+                    // stale intermediate hash). Self-heal missing/corrupt params
+                    // from seeds — verified against the ossified pin — then apply
+                    // the hard fail-closed file-hash check. A tampered or wrong
+                    // params file MUST NOT run.
+                    let params_dir = std::path::PathBuf::from(
+                        std::env::var(ghost_zkp::ZK_PARAMS_PATH_ENV).map_err(|_| {
+                            anyhow::anyhow!(
+                                "OSSIFIED PIN: {} is not set — cannot locate the frozen \
+                                 trusted-setup params directory. Refusing to start (fail-closed).",
+                                ghost_zkp::ZK_PARAMS_PATH_ENV
+                            )
+                        })?,
+                    );
+                    #[cfg(feature = "mpc-ceremony")]
+                    {
+                        let mut expected = std::collections::HashMap::new();
+                        expected.insert("BLOCK".to_string(), file_hash);
+                        ensure_mpc_params_present(
+                            &config.network.seed_nodes,
+                            &params_dir,
+                            &expected,
+                        )
+                        .await?;
+                    }
+                    // FATAL if the on-disk head does not match the ossified pin.
+                    ghost_zkp::verify_ossified_current_params(&params_dir, &file_hash)?;
+                    // Still run the genesis-anchored lineage + retained-quorum
+                    // verification below so the frozen params stay cryptographically
+                    // anchored to the genesis root, not merely file-hash-trusted.
+                    // Anchor = DB-derived genesis lineage hash (position-1
+                    // prev_params_hash); fall back to the env anchor if present.
+                    let anchor = db
+                        .mpc_genesis_ceremony_id()
+                        .ok()
+                        .flatten()
+                        .or_else(|| ghost_zkp::genesis_params_hash().ok().flatten())
+                        .ok_or_else(|| {
+                            anyhow::anyhow!(
+                                "OSSIFIED PIN: cannot derive the genesis lineage anchor (no \
+                                 position-1 contribution and {} unset) — refusing to start so the \
+                                 ossified params are never left unanchored (fail-closed).",
+                                ghost_zkp::ZK_GENESIS_PARAMS_HASH_ENV
+                            )
+                        })?;
+                    zk_rolling_anchor = Some(anchor);
+                    info!(
+                        pin = %hex::encode(&file_hash[..8]),
+                        anchor = %hex::encode(&anchor[..8]),
+                        "ZK consensus in OSSIFIED mode: trusted setup is FINAL — verified against \
+                         the permanent DB pin, still genesis-anchored (no operator action, no env \
+                         re-pin)"
+                    );
+                }
                 ghost_zkp::ZkStartupMode::StaticPin => {
                     // SELF-HEAL: a fresh production node may have the binary but no
                     // MPC ceremony output on disk yet. Fetch + verify the params
@@ -3102,7 +3177,12 @@ async fn main() -> Result<()> {
                         // would let a corrupt-but-present file slip straight into
                         // the hard `load_trusted_params` check below and crash-loop
                         // the node.
-                        ensure_mpc_params_present(&config.network.seed_nodes, &params_dir).await?;
+                        ensure_mpc_params_present(
+                            &config.network.seed_nodes,
+                            &params_dir,
+                            &expected_param_hashes(),
+                        )
+                        .await?;
                     }
                     ghost_zkp::load_trusted_params()?;
                     info!(
@@ -3584,6 +3664,9 @@ async fn main() -> Result<()> {
                 // Stable genesis-derived ceremony_id (NOT current_params_hash).
                 ceremony_id: stable_ceremony_id,
                 pending_commitment_count: 0,
+                // Round-trip the permanent ossification pin from the DB so the
+                // manager stays ossified across restarts (irreversible latch).
+                ossified_file_hash: s.ossified_file_hash,
             }),
         ) {
             Ok(manager) => Arc::new(manager),
@@ -3807,6 +3890,54 @@ async fn main() -> Result<()> {
                     }
                 }
             }
+
+            // AUTONOMOUS OSSIFICATION LATCH (fresh-joiner + safety net).
+            //
+            // The genesis-anchored verification above just PROVED the on-disk head
+            // is the cryptographically-valid chain tip. If that verified chain has
+            // reached the cap, permanently record the ossified params FILE hash
+            // from the on-disk head. This is the step that lets a fresh node which
+            // just SYNCED an already-complete 1..MAX chain self-pin: on its NEXT
+            // startup `ossified_pin` is Some and it auto-selects `OssifiedPinned`
+            // with zero operator action. It is also a safety net for any node that
+            // reached the cap without persisting the pin through the apply path.
+            //
+            // Idempotent + irreversible: `latch_mpc_ossification` never re-pins an
+            // already-latched singleton and the storage layer refuses to clear it.
+            // Non-fatal: a transient hash failure just defers self-pinning to the
+            // next restart — the genesis-anchored verification still fully guards
+            // this node in the meantime.
+            if verified_count >= ghost_mpc::MAX_CEREMONY_CONTRIBUTORS {
+                match ceremony_manager.current_params_file_hash() {
+                    Ok(file_hash) => {
+                        let now = std::time::SystemTime::now()
+                            .duration_since(std::time::UNIX_EPOCH)
+                            .map(|d| d.as_secs())
+                            .unwrap_or(0);
+                        match db.latch_mpc_ossification(&file_hash, now) {
+                            Ok(true) => info!(
+                                count = verified_count,
+                                file_hash = %hex::encode(&file_hash[..8]),
+                                "MPC: autonomously OSSIFIED — recorded permanent params file-hash \
+                                 pin; this node self-pins on next startup (no operator action)"
+                            ),
+                            Ok(false) => {
+                                info!("MPC: ossified pin already latched (permanent) — leaving it")
+                            }
+                            Err(e) => warn!(
+                                error = %e,
+                                "MPC: reached cap but could not latch ossified pin — will retry on \
+                                 next restart (genesis-anchored verification still guards this node)"
+                            ),
+                        }
+                    }
+                    Err(e) => warn!(
+                        error = %e,
+                        "MPC: reached cap but could not hash on-disk head to latch ossified pin — \
+                         will retry on next restart"
+                    ),
+                }
+            }
         }
 
         // Create broadcast callback for MPC handler
@@ -4010,6 +4141,7 @@ async fn main() -> Result<()> {
                                 payout_vk_hash: s.payout_vk_hash,
                                 updated_at: s.updated_at,
                                 ceremony_id: s.ceremony_id,
+                                ossified_file_hash: s.ossified_file_hash,
                             };
                             if let Err(e) = db.save_mpc_ceremony_state(&db_state) {
                                 tracing::warn!(error = %e, "MPC params_callback: failed to persist ceremony singleton");
@@ -8928,7 +9060,7 @@ mod tests {
         std::env::set_var("ZK_PARAMS_HASH", format!("BLOCK:{}", hex::encode(pinned)));
 
         // No seeds → cannot heal → must NOT return Ok while the bad file sits there.
-        let res = ensure_mpc_params_present(&[], dir.path()).await;
+        let res = ensure_mpc_params_present(&[], dir.path(), &expected_param_hashes()).await;
 
         // Restore env before asserting (so a panic cannot leak the override).
         match prev {

--- a/crates/ghost-consensus/src/mpc_handler.rs
+++ b/crates/ghost-consensus/src/mpc_handler.rs
@@ -1246,6 +1246,10 @@ fn persist_singleton(db: &Database, manager: &CeremonyManager) -> GhostResult<()
         payout_vk_hash: s.payout_vk_hash,
         updated_at: s.updated_at,
         ceremony_id: s.ceremony_id,
+        // Carry the autonomous-ossification pin through to the singleton. At the
+        // cap `apply_contribution_multi` records it in the manager state; the
+        // storage-layer latch then makes it permanent.
+        ossified_file_hash: s.ossified_file_hash,
     };
     db.save_mpc_ceremony_state(&db_state)
 }

--- a/crates/ghost-mpc/src/manager.rs
+++ b/crates/ghost-mpc/src/manager.rs
@@ -34,7 +34,8 @@ use crate::contribution::{
 };
 use crate::errors::{MpcError, MpcResult};
 use crate::params::{
-    load_parameters, save_parameters, save_verifying_key, update_current_params, ParameterFiles,
+    hash_params_file, load_parameters, save_parameters, save_verifying_key, update_current_params,
+    ParameterFiles,
 };
 use crate::MAX_CEREMONY_CONTRIBUTORS;
 use bellperson::groth16::{prepare_verifying_key, Parameters, PreparedVerifyingKey};
@@ -68,6 +69,13 @@ pub struct CeremonyState {
     pub ceremony_id: [u8; 32],
     /// CRIT-2 FIX: Number of pending commitments (not yet fulfilled)
     pub pending_commitment_count: u32,
+    /// Autonomous-ossification pin: the raw-file SHA-256 of the final
+    /// `note_spend_params_current.bin`, recorded the instant the ceremony reaches
+    /// [`MAX_CEREMONY_CONTRIBUTORS`]. This is the SAME digest a `ZK_PARAMS_HASH`
+    /// static pin holds (NOT the structured lineage hash). `None` until ossified;
+    /// once set it is permanent. Persisted to `mpc_ceremony.ossified_file_hash`
+    /// and drives the self-activating `OssifiedPinned` startup mode.
+    pub ossified_file_hash: Option<[u8; 32]>,
 }
 
 /// Manager for the MPC ceremony
@@ -713,12 +721,36 @@ impl CeremonyManager {
             "Applied MPC contribution - parameters updated"
         );
 
-        // Check for ossification
+        // Check for ossification. At the cap the trusted setup is FINAL, so
+        // record the deterministic ossified FILE hash — the raw SHA-256 of the
+        // just-written `note_spend_params_current.bin`, the SAME digest a
+        // `ZK_PARAMS_HASH` static pin holds. Every node computes the identical
+        // value from the identical final params, so no coordination is needed;
+        // this pin then drives the self-activating `OssifiedPinned` startup mode.
+        // Fail-CLOSED: if the final file cannot be hashed we refuse to declare a
+        // successful apply of the ceremony-closing contribution rather than
+        // ossify without a recorded pin.
         if contribution.position >= MAX_CEREMONY_CONTRIBUTORS {
+            let file_hash = hash_params_file(&self.files.current_note_spend_params_path())?;
+            state.ossified_file_hash = Some(file_hash);
             self.ossify_internal(&mut state)?;
+            info!(
+                file_hash = %hex::encode(file_hash),
+                "MPC ceremony reached cap — recorded permanent ossified params file hash"
+            );
         }
 
         Ok(())
+    }
+
+    /// Raw-file SHA-256 of the current `note_spend_params_current.bin`.
+    ///
+    /// This is the FILE hash (matching `ghost_zkp::compute_params_file_hash` and
+    /// a `ZK_PARAMS_HASH=BLOCK:<hex>` pin), NOT the structured lineage hash. Used
+    /// to record / re-derive the autonomous ossification pin from the on-disk
+    /// head (e.g. a fresh node that synced an already-complete chain).
+    pub fn current_params_file_hash(&self) -> MpcResult<[u8; 32]> {
+        hash_params_file(&self.files.current_note_spend_params_path())
     }
 
     /// Durably install an already-obtained, hash-verified note-spend parameter
@@ -1307,6 +1339,46 @@ mod tests {
         // Attempting to generate a contribution should fail
         let result = manager.generate_contribution("node1");
         assert!(matches!(result, Err(MpcError::CeremonyOssified(_))));
+    }
+
+    /// Drive a REAL-crypto ceremony to the cap (4 under `mpc-test-cap`) and prove
+    /// autonomous ossification: at the cap the ceremony ossifies AND records the
+    /// permanent file-hash pin equal to SHA-256(current.bin); a further
+    /// contribution is refused (the cap is a hard ceiling).
+    #[cfg(feature = "mpc-test-cap")]
+    #[test]
+    fn test_ceremony_autonomously_ossifies_and_records_file_hash_at_cap() {
+        let (manager, _temp) = create_test_manager();
+        manager.ensure_genesis_initialized().unwrap();
+
+        for i in 0..MAX_CEREMONY_CONTRIBUTORS {
+            assert!(!manager.is_ossified(), "must not ossify before the cap");
+            let (new_params, contribution) =
+                manager.generate_contribution(&format!("node{i}")).unwrap();
+            manager
+                .apply_contribution(new_params, &contribution)
+                .unwrap();
+        }
+
+        // Ossified, with the pin recorded and equal to the raw file hash.
+        assert!(manager.is_ossified(), "ceremony must ossify at the cap");
+        assert_eq!(manager.contribution_count(), MAX_CEREMONY_CONTRIBUTORS);
+        let expected = manager.current_params_file_hash().unwrap();
+        assert_eq!(
+            manager.state().ossified_file_hash,
+            Some(expected),
+            "ossified_file_hash must equal SHA-256(note_spend_params_current.bin)"
+        );
+
+        // The cap is a hard ceiling — a further contribution is refused by the
+        // freeze guard (no MAX+1 contribution ever).
+        assert!(
+            matches!(
+                manager.generate_contribution("node-extra"),
+                Err(MpcError::CeremonyOssified(_))
+            ),
+            "no contribution may be generated past the cap"
+        );
     }
 
     #[test]

--- a/crates/ghost-mpc/tests/mpc_lifecycle.rs
+++ b/crates/ghost-mpc/tests/mpc_lifecycle.rs
@@ -139,6 +139,7 @@ impl Node {
             payout_vk_hash: None,
             updated_at: st.updated_at,
             ceremony_id: st.ceremony_id,
+            ossified_file_hash: None,
         })
         .unwrap();
         Self {
@@ -162,6 +163,7 @@ fn persist_singleton_from_manager(db: &Database, manager: &CeremonyManager) {
         payout_vk_hash: st.payout_vk_hash,
         updated_at: st.updated_at,
         ceremony_id: st.ceremony_id,
+        ossified_file_hash: st.ossified_file_hash,
     })
     .unwrap();
 }

--- a/crates/ghost-storage/src/migrations.rs
+++ b/crates/ghost-storage/src/migrations.rs
@@ -28,7 +28,7 @@ use tracing::{debug, info, warn};
 use ghost_common::error::{GhostError, GhostResult};
 
 /// Current schema version
-const SCHEMA_VERSION: u32 = 39;
+const SCHEMA_VERSION: u32 = 40;
 
 /// Run all pending migrations
 pub fn run_migrations(conn: &Connection) -> GhostResult<()> {
@@ -95,6 +95,7 @@ pub fn run_migrations(conn: &Connection) -> GhostResult<()> {
         (37, migrate_v37),
         (38, migrate_v38),
         (39, migrate_v39),
+        (40, migrate_v40),
     ];
 
     for &(version, migrate_fn) in pre_v10 {
@@ -2054,6 +2055,31 @@ fn migrate_v39(conn: &Connection) -> GhostResult<()> {
     Ok(())
 }
 
+/// Migration v40: autonomous-ossification pin.
+///
+/// Adds a nullable `ossified_file_hash BLOB` column to the `mpc_ceremony`
+/// singleton. When the ceremony reaches `MAX_CEREMONY_CONTRIBUTORS` this column
+/// records the raw-file SHA-256 of the final `note_spend_params_current.bin`
+/// (the SAME digest a `ZK_PARAMS_HASH` static pin holds). Its presence makes a
+/// node self-select the `OssifiedPinned` startup mode with no operator action —
+/// no env re-pin, surviving restarts and fresh joins forever.
+///
+/// Additive and idempotent: no existing row is rewritten (a live ceremony that
+/// has not yet ossified simply gets a NULL column, which reads as "not ossified
+/// yet"). The one-way latch in `save_mpc_ceremony_state` / `latch_mpc_ossification`
+/// is what later populates it, deterministically, on every node.
+fn migrate_v40(conn: &Connection) -> GhostResult<()> {
+    debug!(
+        "Running migration v40: Add mpc_ceremony.ossified_file_hash (autonomous ossification pin)"
+    );
+
+    conn.execute_batch("ALTER TABLE mpc_ceremony ADD COLUMN ossified_file_hash BLOB;")
+        .map_err(|e| GhostError::Migration(e.to_string()))?;
+
+    info!("v40: Added mpc_ceremony.ossified_file_hash column");
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2240,6 +2266,57 @@ mod tests {
         assert!(
             read_singleton(&conn).is_none(),
             "no singleton must be written when mpc_contributions is empty"
+        );
+    }
+
+    // ========================================================================
+    // v40: mpc_ceremony.ossified_file_hash (autonomous ossification pin)
+    // ========================================================================
+
+    #[test]
+    fn test_v40_adds_ossified_file_hash_column() {
+        let conn = Connection::open_in_memory().unwrap();
+        run_migrations(&conn).unwrap();
+        let cols = get_column_names(&conn, "mpc_ceremony");
+        assert!(
+            cols.contains(&"ossified_file_hash".to_string()),
+            "v40 must add ossified_file_hash column; got {cols:?}"
+        );
+    }
+
+    #[test]
+    fn test_v40_applies_on_existing_db_without_data_loss() {
+        // Start at the pre-v39 shape with a populated singleton, then run the
+        // full migration chain (v39 + v40). The column is added and the existing
+        // singleton data is untouched (additive migration).
+        let conn = Connection::open_in_memory().unwrap();
+        setup_pre_v39_mpc(&conn);
+        insert_synthetic_contributions(&conn, 3);
+        conn.execute(
+            "INSERT INTO mpc_ceremony
+                (id, contribution_count, current_params_hash, is_ossified, updated_at)
+             VALUES (1, 3, ?1, 0, 77)",
+            rusqlite::params![&[3u8; 32][..]],
+        )
+        .unwrap();
+
+        run_migrations(&conn).unwrap();
+
+        assert_eq!(get_schema_version(&conn).unwrap(), SCHEMA_VERSION);
+        let cols = get_column_names(&conn, "mpc_ceremony");
+        assert!(cols.contains(&"ossified_file_hash".to_string()));
+        // Existing data preserved; new column defaults to NULL.
+        let (count, ofh): (i64, Option<Vec<u8>>) = conn
+            .query_row(
+                "SELECT contribution_count, ossified_file_hash FROM mpc_ceremony WHERE id = 1",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(count, 3, "existing singleton preserved across v40");
+        assert_eq!(
+            ofh, None,
+            "ossified_file_hash defaults to NULL (not ossified)"
         );
     }
 

--- a/crates/ghost-storage/src/mpc_lineage.rs
+++ b/crates/ghost-storage/src/mpc_lineage.rs
@@ -384,6 +384,10 @@ impl crate::Database {
                     payout_vk_hash: None,
                     updated_at,
                     ceremony_id: *genesis_anchor,
+                    // The file-hash pin is latched separately by the startup path
+                    // (which has the on-disk params to hash); reconcile only
+                    // records the verified lineage head + length here.
+                    ossified_file_hash: None,
                 };
                 self.save_mpc_ceremony_state(&new_state)?;
                 Ok(true)
@@ -773,6 +777,7 @@ mod tests {
             payout_vk_hash: None,
             updated_at: 1,
             ceremony_id: ANCHOR,
+            ossified_file_hash: None,
         })
         .unwrap();
 

--- a/crates/ghost-storage/src/queries.rs
+++ b/crates/ghost-storage/src/queries.rs
@@ -6012,6 +6012,14 @@ pub struct MpcCeremonyState {
     /// the life of the ceremony. `[0u8; 32]` if not yet established (pre-genesis
     /// or a legacy row written before this column existed).
     pub ceremony_id: [u8; 32],
+    /// Autonomous-ossification latch: the raw-file SHA-256 of the FINAL
+    /// `note_spend_params_current.bin`, recorded the moment the ceremony reached
+    /// `MAX_CEREMONY_CONTRIBUTORS`. This is the SAME digest a `ZK_PARAMS_HASH`
+    /// static pin holds — NOT the structured lineage hash. `None` until the
+    /// ceremony ossifies. Once set it is PERMANENT: `save_mpc_ceremony_state`
+    /// refuses to null it (a one-way latch at the storage layer), and it drives
+    /// the self-activating `OssifiedPinned` startup mode with no operator action.
+    pub ossified_file_hash: Option<[u8; 32]>,
 }
 
 /// MPC contribution record
@@ -6063,10 +6071,12 @@ impl Database {
                 Option<Vec<u8>>,
                 i64,
                 Option<Vec<u8>>,
+                Option<Vec<u8>>,
             )> = conn
                 .query_row(
                     "SELECT contribution_count, current_params_hash, is_ossified, ossified_at,
-                            block_vk_hash, payout_vk_hash, updated_at, ceremony_id
+                            block_vk_hash, payout_vk_hash, updated_at, ceremony_id,
+                            ossified_file_hash
                      FROM mpc_ceremony WHERE id = 1",
                     [],
                     |row| {
@@ -6079,6 +6089,7 @@ impl Database {
                             row.get(5)?,
                             row.get(6)?,
                             row.get(7)?,
+                            row.get(8)?,
                         ))
                     },
                 )
@@ -6095,6 +6106,7 @@ impl Database {
                     payout_vk,
                     updated,
                     ceremony_id_bytes,
+                    ossified_file_hash_bytes,
                 )) => {
                     let mut params_hash = [0u8; 32];
                     if hash_bytes.len() == 32 {
@@ -6130,6 +6142,17 @@ impl Database {
                         }
                     });
 
+                    // Ossification latch: nullable for pre-ossified / legacy rows.
+                    let ossified_file_hash = ossified_file_hash_bytes.and_then(|v| {
+                        if v.len() == 32 {
+                            let mut arr = [0u8; 32];
+                            arr.copy_from_slice(&v);
+                            Some(arr)
+                        } else {
+                            None
+                        }
+                    });
+
                     // M-10 FIX: Use safe conversions
                     Ok(Some(MpcCeremonyState {
                         contribution_count: i64_to_u32_count(count, "contribution_count")
@@ -6148,6 +6171,7 @@ impl Database {
                         updated_at: i64_to_u64(updated, "updated_at")
                             .map_err(|e| GhostError::Database(e.to_string()))?,
                         ceremony_id,
+                        ossified_file_hash,
                     }))
                 }
                 None => Ok(None),
@@ -6155,23 +6179,34 @@ impl Database {
         })
     }
 
-    /// Save or update MPC ceremony state
+    /// Save or update MPC ceremony state.
+    ///
+    /// IRREVERSIBLE OSSIFICATION LATCH (storage layer): the `is_ossified`,
+    /// `ossified_at` and `ossified_file_hash` columns are ONE-WAY. Once the row
+    /// is ossified (`is_ossified = 1`) no subsequent save can clear it, and once
+    /// `ossified_at` / `ossified_file_hash` are set they are never overwritten or
+    /// nulled — `excluded` is only adopted where the stored value is still
+    /// absent/false. This makes the ossified pin permanent regardless of what any
+    /// caller passes, so a stale or buggy code path can never un-ossify a node.
     pub fn save_mpc_ceremony_state(&self, state: &MpcCeremonyState) -> GhostResult<()> {
         self.with_connection(|conn| {
             conn.execute(
                 "INSERT INTO mpc_ceremony (id, contribution_count, current_params_hash, is_ossified,
                                           ossified_at, block_vk_hash, payout_vk_hash, updated_at,
-                                          ceremony_id)
-                 VALUES (1, ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+                                          ceremony_id, ossified_file_hash)
+                 VALUES (1, ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
                  ON CONFLICT(id) DO UPDATE SET
                     contribution_count = excluded.contribution_count,
                     current_params_hash = excluded.current_params_hash,
-                    is_ossified = excluded.is_ossified,
-                    ossified_at = excluded.ossified_at,
+                    is_ossified = CASE WHEN mpc_ceremony.is_ossified = 1 THEN 1
+                                       ELSE excluded.is_ossified END,
+                    ossified_at = COALESCE(mpc_ceremony.ossified_at, excluded.ossified_at),
                     block_vk_hash = excluded.block_vk_hash,
                     payout_vk_hash = excluded.payout_vk_hash,
                     updated_at = excluded.updated_at,
-                    ceremony_id = excluded.ceremony_id",
+                    ceremony_id = excluded.ceremony_id,
+                    ossified_file_hash =
+                        COALESCE(mpc_ceremony.ossified_file_hash, excluded.ossified_file_hash)",
                 params![
                     state.contribution_count as i64,
                     &state.current_params_hash[..],
@@ -6181,11 +6216,57 @@ impl Database {
                     state.payout_vk_hash.as_ref().map(|v| &v[..]),
                     state.updated_at as i64,
                     &state.ceremony_id[..],
+                    state.ossified_file_hash.as_ref().map(|v| &v[..]),
                 ],
             )
             .map_err(|e| GhostError::Database(e.to_string()))?;
             Ok(())
         })
+    }
+
+    /// Latch the autonomous-ossification pin: mark the singleton ossified and
+    /// record the FINAL params file hash, PERMANENTLY.
+    ///
+    /// This is the join/adopt/self-heal entry point (a fresh node that syncs an
+    /// already-complete `MAX_CEREMONY_CONTRIBUTORS` chain, or any node that
+    /// reaches the cap and needs the pin recorded). It is a strict one-way latch:
+    /// * if the singleton already carries an `ossified_file_hash`, it is left
+    ///   untouched and `Ok(false)` is returned (idempotent, never re-pins);
+    /// * otherwise `is_ossified` is set, `ossified_file_hash` is recorded, and
+    ///   `ossified_at` is set if not already present. Returns `Ok(true)`.
+    ///
+    /// Fails closed if no singleton exists yet (the caller must have a head to
+    /// pin — ossification cannot be fabricated from nothing).
+    pub fn latch_mpc_ossification(
+        &self,
+        ossified_file_hash: &[u8; 32],
+        ossified_at: u64,
+    ) -> GhostResult<bool> {
+        let existing = self.get_mpc_ceremony_state()?;
+        match existing {
+            Some(state) => {
+                if state.ossified_file_hash.is_some() {
+                    // Already latched — irreversible, never re-pin.
+                    return Ok(false);
+                }
+                let mut new_state = state.clone();
+                new_state.is_ossified = true;
+                new_state.ossified_file_hash = Some(*ossified_file_hash);
+                if new_state.ossified_at.is_none() {
+                    new_state.ossified_at = Some(ossified_at);
+                }
+                if new_state.updated_at < ossified_at {
+                    new_state.updated_at = ossified_at;
+                }
+                self.save_mpc_ceremony_state(&new_state)?;
+                Ok(true)
+            }
+            None => Err(GhostError::Database(
+                "latch_mpc_ossification: no mpc_ceremony singleton to pin — refusing to \
+                 fabricate ossification without a recorded head"
+                    .to_string(),
+            )),
+        }
     }
 
     /// Save an MPC contribution.
@@ -11568,6 +11649,7 @@ mod tests {
             payout_vk_hash: None,
             updated_at: 42,
             ceremony_id: [200u8; 32],
+            ossified_file_hash: None,
         };
         db.save_mpc_ceremony_state(&state).unwrap();
 
@@ -11576,6 +11658,83 @@ mod tests {
         assert_eq!(loaded.current_params_hash, [5u8; 32]);
         assert_eq!(loaded.ceremony_id, [200u8; 32]);
         assert_eq!(loaded.updated_at, 42);
+        assert_eq!(loaded.ossified_file_hash, None);
+    }
+
+    fn mk_state(count: u32) -> MpcCeremonyState {
+        MpcCeremonyState {
+            contribution_count: count,
+            current_params_hash: [count as u8; 32],
+            is_ossified: false,
+            ossified_at: None,
+            block_vk_hash: None,
+            payout_vk_hash: None,
+            updated_at: 1,
+            ceremony_id: [200u8; 32],
+            ossified_file_hash: None,
+        }
+    }
+
+    #[test]
+    fn test_ossified_file_hash_roundtrips() {
+        let db = Database::in_memory().unwrap();
+        let mut s = mk_state(4);
+        s.is_ossified = true;
+        s.ossified_at = Some(123);
+        s.ossified_file_hash = Some([0xAB; 32]);
+        db.save_mpc_ceremony_state(&s).unwrap();
+
+        let loaded = db.get_mpc_ceremony_state().unwrap().unwrap();
+        assert!(loaded.is_ossified);
+        assert_eq!(loaded.ossified_file_hash, Some([0xAB; 32]));
+        assert_eq!(loaded.ossified_at, Some(123));
+    }
+
+    #[test]
+    fn test_latch_mpc_ossification_is_one_way_and_irreversible() {
+        let db = Database::in_memory().unwrap();
+        // Need an existing head to pin.
+        db.save_mpc_ceremony_state(&mk_state(4)).unwrap();
+
+        // First latch records the pin + ossifies.
+        assert!(db.latch_mpc_ossification(&[0x11; 32], 100).unwrap());
+        let s = db.get_mpc_ceremony_state().unwrap().unwrap();
+        assert!(s.is_ossified);
+        assert_eq!(s.ossified_file_hash, Some([0x11; 32]));
+        assert_eq!(s.ossified_at, Some(100));
+
+        // Re-latching with a DIFFERENT hash is a no-op — the pin is permanent.
+        assert!(!db.latch_mpc_ossification(&[0x22; 32], 200).unwrap());
+        let s = db.get_mpc_ceremony_state().unwrap().unwrap();
+        assert_eq!(
+            s.ossified_file_hash,
+            Some([0x11; 32]),
+            "ossified pin must never be re-written"
+        );
+        assert_eq!(s.ossified_at, Some(100), "ossified_at must not change");
+
+        // A stale/rolling save (is_ossified=false, hash=None) can NOT un-ossify:
+        // the storage layer latch preserves both the flag and the pin.
+        let mut rolling = mk_state(3);
+        rolling.is_ossified = false;
+        rolling.ossified_file_hash = None;
+        rolling.ossified_at = None;
+        db.save_mpc_ceremony_state(&rolling).unwrap();
+        let s = db.get_mpc_ceremony_state().unwrap().unwrap();
+        assert!(s.is_ossified, "is_ossified must remain latched true");
+        assert_eq!(
+            s.ossified_file_hash,
+            Some([0x11; 32]),
+            "ossified pin must remain latched after a rolling save"
+        );
+        assert_eq!(s.ossified_at, Some(100), "ossified_at must remain latched");
+    }
+
+    #[test]
+    fn test_latch_mpc_ossification_refuses_without_singleton() {
+        let db = Database::in_memory().unwrap();
+        // No singleton yet — ossification cannot be fabricated from nothing.
+        assert!(db.latch_mpc_ossification(&[0x11; 32], 100).is_err());
     }
 
     #[test]
@@ -11608,6 +11767,7 @@ mod tests {
             payout_vk_hash: None,
             updated_at: 0,
             ceremony_id: [200u8; 32],
+            ossified_file_hash: None,
         })
         .unwrap();
         assert_eq!(db.mpc_contribution_count_authoritative().unwrap(), 3);

--- a/crates/ghost-zkp/Cargo.toml
+++ b/crates/ghost-zkp/Cargo.toml
@@ -73,3 +73,4 @@ ghost-common = { path = "../ghost-common" }
 
 [dev-dependencies]
 tokio = { version = "1.35", features = ["rt-multi-thread", "macros"] }
+tempfile = "3.10"

--- a/crates/ghost-zkp/src/lib.rs
+++ b/crates/ghost-zkp/src/lib.rs
@@ -279,6 +279,16 @@ pub enum ZkStartupMode {
     /// chain + the retained BFT quorum per position (see ghost-storage). Carries
     /// the genesis anchor (a LINEAGE hash) that roots the chain.
     GenesisAnchoredRolling { genesis_anchor: [u8; 32] },
+    /// AUTONOMOUS OSSIFIED PIN: the DB ceremony singleton has ossified (reached
+    /// `MAX_CEREMONY_CONTRIBUTORS`) and recorded the final params FILE hash. This
+    /// mode is selected AUTOMATICALLY from that DB latch — with NO operator action
+    /// and REGARDLESS of env vars — and takes precedence over both `StaticPin` and
+    /// `GenesisAnchoredRolling`. Startup verifies the on-disk current params hash
+    /// to this pin (fail-closed), then STILL runs the genesis-anchored lineage +
+    /// retained-quorum verification once so the frozen params stay cryptographically
+    /// anchored to the genesis root — not merely file-hash-trusted. Carries the
+    /// pinned raw-file SHA-256 (the SAME digest a `ZK_PARAMS_HASH` static pin holds).
+    OssifiedPinned { file_hash: [u8; 32] },
 }
 
 /// Stage C: choose the startup verification mode from the environment.
@@ -312,6 +322,88 @@ pub fn select_startup_mode() -> ZkResult<ZkStartupMode> {
             ZK_GENESIS_PARAMS_HASH_ENV
         ))),
     }
+}
+
+/// AUTONOMOUS OSSIFICATION selector: choose the startup verification mode with
+/// the DB ossification latch taking ABSOLUTE precedence over the environment.
+///
+/// `ossified_file_hash` is the `mpc_ceremony.ossified_file_hash` column: `Some`
+/// exactly when the ceremony has reached `MAX_CEREMONY_CONTRIBUTORS` and the final
+/// params file hash was durably recorded. When present, this returns
+/// [`ZkStartupMode::OssifiedPinned`] REGARDLESS of `ZK_PARAMS_HASH` /
+/// `ZK_GENESIS_PARAMS_HASH` — the trusted setup is final, so no env var (which an
+/// operator may have left pointing at a now-stale intermediate hash) can override
+/// the frozen pin. When absent, selection falls back to [`select_startup_mode`]
+/// (StaticPin / GenesisAnchoredRolling), unchanged.
+///
+/// This is the mechanism that lets a node self-pin at the cap with no operator
+/// action, surviving restarts and fresh joins forever: the DB flag drives it.
+pub fn select_startup_mode_with_ossification(
+    ossified_file_hash: Option<[u8; 32]>,
+) -> ZkResult<ZkStartupMode> {
+    if let Some(file_hash) = ossified_file_hash {
+        return Ok(ZkStartupMode::OssifiedPinned { file_hash });
+    }
+    select_startup_mode()
+}
+
+/// Streaming raw-file SHA-256 (available in every build, unlike the
+/// zk-production-gated [`compute_params_file_hash`]). Matches
+/// `ghost_mpc::params::hash_params_file` and a `ZK_PARAMS_HASH=BLOCK:<hex>` pin.
+fn sha256_file_raw(path: &std::path::Path) -> ZkResult<[u8; 32]> {
+    use sha2::{Digest, Sha256};
+    use std::io::Read;
+    let mut file = std::fs::File::open(path)
+        .map_err(|e| ZkError::InvalidParams(format!("Failed to open params file: {e}")))?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0u8; 8192];
+    loop {
+        let n = file
+            .read(&mut buffer)
+            .map_err(|e| ZkError::InvalidParams(format!("Failed to read params file: {e}")))?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buffer[..n]);
+    }
+    Ok(hasher.finalize().into())
+}
+
+/// FAIL-CLOSED verification for [`ZkStartupMode::OssifiedPinned`]: the on-disk
+/// `note_spend_params_current.bin` in `params_dir` MUST hash to `expected`.
+///
+/// A missing file, an unreadable file, or ANY hash mismatch returns `Err`, so a
+/// tampered or wrong params file can never run under the ossified pin. This is
+/// the ossified analogue of the `ZK_PARAMS_HASH` BLOCK check `load_trusted_params`
+/// performs — same digest, same fail-closed posture — but sourcing the pin from
+/// the DB latch instead of an env var.
+pub fn verify_ossified_current_params(
+    params_dir: &std::path::Path,
+    expected: &[u8; 32],
+) -> ZkResult<()> {
+    let current = params_dir.join("note_spend_params_current.bin");
+    if !current.exists() {
+        return Err(ZkError::InvalidParams(format!(
+            "OSSIFIED PIN: {} is missing — refusing to start (fail-closed). The ceremony has \
+             ossified; the final trusted-setup params must be present and match the recorded pin.",
+            current.display()
+        )));
+    }
+    let actual = sha256_file_raw(&current)?;
+    if &actual != expected {
+        return Err(ZkError::InvalidParams(format!(
+            "OSSIFIED PIN MISMATCH: {} hashes to {} but the permanently-recorded ossified pin is \
+             {}. The trusted-setup params are tampered or wrong — refusing to start (fail-closed).",
+            current.display(),
+            hex::encode(actual),
+            hex::encode(expected)
+        )));
+    }
+    tracing::info!(
+        pin = %hex::encode(expected),
+        "OSSIFIED PIN verified: on-disk trusted-setup params match the permanent ossified file hash"
+    );
+    Ok(())
 }
 
 /// 2.4 HIGH: Compute SHA-256 hash of a parameters file
@@ -878,5 +970,69 @@ mod startup_mode_tests {
         let _s = EnvScrub::new();
         // Neither pin present → never an unverified mode; selection errors.
         assert!(select_startup_mode().is_err());
+    }
+
+    #[test]
+    fn test_ossified_pin_overrides_static_pin_env() {
+        let _g = ENV_LOCK.lock().unwrap();
+        let _s = EnvScrub::new();
+        // Operator left a STALE static pin in the env — the DB ossification latch
+        // must take absolute precedence and select OssifiedPinned with the DB hash.
+        std::env::set_var(ZK_PARAMS_HASH_ENV, "BLOCK:00");
+        let db_pin = [0xEE; 32];
+        assert_eq!(
+            select_startup_mode_with_ossification(Some(db_pin)).unwrap(),
+            ZkStartupMode::OssifiedPinned { file_hash: db_pin }
+        );
+    }
+
+    #[test]
+    fn test_ossified_pin_overrides_genesis_anchor_env() {
+        let _g = ENV_LOCK.lock().unwrap();
+        let _s = EnvScrub::new();
+        std::env::set_var(ZK_GENESIS_PARAMS_HASH_ENV, ANCHOR_HEX);
+        let db_pin = [0x11; 32];
+        assert_eq!(
+            select_startup_mode_with_ossification(Some(db_pin)).unwrap(),
+            ZkStartupMode::OssifiedPinned { file_hash: db_pin }
+        );
+    }
+
+    #[test]
+    fn test_ossified_pin_absent_falls_back_to_env_mode() {
+        let _g = ENV_LOCK.lock().unwrap();
+        let _s = EnvScrub::new();
+        std::env::set_var(ZK_GENESIS_PARAMS_HASH_ENV, ANCHOR_HEX);
+        // No DB latch → behave exactly like select_startup_mode (rolling here).
+        assert_eq!(
+            select_startup_mode_with_ossification(None).unwrap(),
+            ZkStartupMode::GenesisAnchoredRolling {
+                genesis_anchor: anchor_bytes()
+            }
+        );
+        // And with NOTHING configured, absence still refuses (never unverified).
+        std::env::remove_var(ZK_GENESIS_PARAMS_HASH_ENV);
+        assert!(select_startup_mode_with_ossification(None).is_err());
+    }
+
+    #[test]
+    fn test_verify_ossified_params_pass_and_tamper_fail() {
+        use sha2::{Digest, Sha256};
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("note_spend_params_current.bin");
+        let bytes = b"final ossified trusted-setup parameters blob";
+        std::fs::write(&path, bytes).unwrap();
+        let expected: [u8; 32] = Sha256::digest(bytes).into();
+
+        // Matching file → OK.
+        assert!(verify_ossified_current_params(dir.path(), &expected).is_ok());
+
+        // Tampered file (same path, different bytes) → FAIL closed.
+        std::fs::write(&path, b"tampered params blob of a different length!!").unwrap();
+        assert!(verify_ossified_current_params(dir.path(), &expected).is_err());
+
+        // Missing file → FAIL closed.
+        std::fs::remove_file(&path).unwrap();
+        assert!(verify_ossified_current_params(dir.path(), &expected).is_err());
     }
 }


### PR DESCRIPTION
## Summary

Makes the MPC rolling ceremony **autonomously self-pin (ossify) at the 101-elder cap** with zero operator action. When the trusted setup reaches `MAX_CEREMONY_CONTRIBUTORS` (101 in production, 4 under `mpc-test-cap`), every node permanently locks the final parameters — no env re-pin, no systemd edit, no command — and this survives restarts and fresh joins forever.

This closes the last piece of the rolling-ceremony work: the setup can now complete and freeze itself without anyone being present to "re-pin" it.

## How it works

- **Schema v40** (`migrations.rs`): adds nullable `mpc_ceremony.ossified_file_hash BLOB` (additive, idempotent).
- **Deterministic record at the cap** (`manager.rs`): when the final contribution applies, each node computes `hash_params_file(note_spend_params_current.bin)` — the raw-file SHA-256, the same digest a `ZK_PARAMS_HASH=BLOCK` pin uses (not the lineage hash) — and records it. Every node derives the identical value from the identical final params, so no coordination is needed.
- **Self-activating `OssifiedPinned` startup mode** (`ghost-zkp/lib.rs`, `ghost-pool/main.rs`): when the DB latch is set, startup selects this mode **regardless of `ZK_PARAMS_HASH` / `ZK_GENESIS_PARAMS_HASH`**, taking precedence over both. It verifies `current.bin` against the recorded hash (**fatal on mismatch/missing**), self-heals missing params from seeds against the pin, and still runs the genesis-anchored lineage + retained-quorum verification once — so the params stay cryptographically anchored, not merely file-trusted.
- **Irreversible one-way latch** (`queries.rs`): the singleton UPSERT can never clear ossification once set (`is_ossified = CASE WHEN existing=1 THEN 1 ELSE excluded`, hash/timestamp `COALESCE`d). A stale rolling write cannot un-ossify.
- **Fresh joiners self-pin**: a node that syncs a completed 1..101 chain records the pin from its verified head, and on its next boot selects `OssifiedPinned` automatically.
- The existing freeze guard already rejects further contributions on `is_ossified`; the cap blocks a 102nd.

## Testing

- `test_ceremony_autonomously_ossifies_and_records_file_hash_at_cap` — drives real crypto to the cap, asserts `is_ossified` + `ossified_file_hash == SHA-256(current.bin)` + a further contribution rejected.
- `test_latch_mpc_ossification_is_one_way_and_irreversible`, ossified-rejects-operations/commitments, `OssifiedPinned` env-override + pass/tamper/missing gates, and `v40` migration on an existing DB — all green.
- `cargo build -p ghost-pool --features ghost-pool/zk-production` clean; ghost-pool / ghost-mpc (`--features mpc-test-cap`) / ghost-consensus / ghost-zkp / ghost-storage suites pass; fmt clean; no new clippy warnings.

## Deployment note

This is dormant until the ceremony reaches the cap (currently at position 7–8 of 101), so it is safe to merge and deploy well ahead of time. It must be running on the fleet before position 101 is reached so the self-pin fires cleanly.
