### PR TITLE
Release: build + publish ghostd, ghost-pool, ghost-pay together (one version)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,17 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libsqlite3-dev capnproto libcapnp-dev
+          # ghost-pool/ghost-pay (Rust) need libsqlite3 + capnproto (the SV2
+          # stratum-core dep). The Linux job ALSO builds ghostd (the C++ Bitcoin
+          # Core daemon) below, which needs the standard Core build deps: a
+          # compiler + CMake + pkgconf, libevent, boost, and libzmq. WITH_ZMQ is
+          # ON (see the ghostd build step) because ghost-pool subscribes to
+          # ghostd's ZMQ hashblock/sequence feed, so libzmq3-dev is required; the
+          # capnproto/libsqlite3 packages above double as ghostd's IPC
+          # (ENABLE_IPC) and wallet (ENABLE_WALLET) dependencies.
+          sudo apt-get install -y \
+            libsqlite3-dev capnproto libcapnp-dev \
+            build-essential cmake pkgconf python3 libevent-dev libboost-dev libzmq3-dev
 
       # Install system dependencies (macOS) — capnproto for the SV2 stratum-core dep
       - name: Install dependencies (macOS)
@@ -64,6 +74,44 @@ jobs:
             -p ghost-pool -p ghost-cli -p ghost-pay -p ghost-gsp-bin \
             -p translator_sv2 -p pool_sv2 -p jd_client_sv2 -p jd_server_sv2
 
+      # Build ghostd (the C++ Bitcoin Core daemon) so all THREE node binaries
+      # (ghost-pool + ghost-pay + ghostd) ship in ONE signed release at ONE
+      # version and can never drift apart. Linux only — the pool/elder fleet is
+      # Linux, and a Bitcoin Core build is neither needed nor attempted on the
+      # macOS targets.
+      #
+      # CMake derives the client version from the workspace Cargo.toml (watch for
+      # the "Ghost client version (from workspace Cargo.toml)" log line), so the
+      # tag's version is baked into ghostd automatically with no extra wiring.
+      #
+      # WITH_ZMQ=ON is REQUIRED, not optional: ghost-pool subscribes to ghostd's
+      # ZMQ hashblock/sequence feed for new-block and reorg detection, so a
+      # non-ZMQ ghostd would silently break the pool. ENABLE_IPC/ENABLE_WALLET
+      # keep their defaults (ON) to match the fleet's reference binary; their
+      # deps (capnproto, libsqlite3) are already installed above.
+      #
+      # We build only the `ghostd` target and disable tests/bench/gui/tx/util/
+      # wallet-tool to keep the release build tractable (a Core build is ~20-40
+      # min on the 4-core runner). If the runner ever OOMs, cap `-j"$(nproc)"` at
+      # -j2 and/or add -DCMAKE_CXX_FLAGS="--param ggc-min-expand=1 --param
+      # ggc-min-heapsize=32768".
+      - name: Build ghostd (Linux release only)
+        if: matrix.target == 'x86_64-unknown-linux-gnu'
+        run: |
+          cmake -B ghost-core/build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DWITH_ZMQ=ON \
+            -DBUILD_TESTS=OFF \
+            -DBUILD_BENCH=OFF \
+            -DBUILD_GUI=OFF \
+            -DBUILD_FUZZ_BINARY=OFF \
+            -DBUILD_TX=OFF \
+            -DBUILD_UTIL=OFF \
+            -DBUILD_WALLET_TOOL=OFF
+          cmake --build ghost-core/build --target ghostd -j"$(nproc)"
+          # Fail loudly here (not at packaging time) if the daemon didn't build.
+          test -x ghost-core/build/bin/ghostd
+
       # Package binaries
       - name: Package
         shell: bash
@@ -76,6 +124,14 @@ jobs:
               cp "target/${{ matrix.target }}/release/${bin}${{ matrix.suffix }}" dist/
             fi
           done
+
+          # ghostd (C++) is built only on the Linux target (step above). Stage it
+          # into the SAME dist/ so it lands inside the linux tarball alongside
+          # ghost-pool + ghost-pay and is covered — with zero extra signing logic
+          # — by the existing SHA256SUMS + GPG signature over the tarball.
+          if [ -f "ghost-core/build/bin/ghostd" ]; then
+            cp "ghost-core/build/bin/ghostd" dist/
+          fi
 
           # Create archive only if dist has files
           cd dist

--- a/scripts/ghost-auto-update.sh
+++ b/scripts/ghost-auto-update.sh
@@ -5,15 +5,17 @@
 # Runs as root from `ghost-auto-update.timer` (every 6h, randomised). It is a
 # strict no-op unless the operator has opted in via /etc/ghost/auto-update.conf
 # (AUTO_UPDATE=true). When opted in, it resolves the latest published release,
-# and — ONLY if it is newer than what is installed — downloads the release
-# tarball + ghostd, verifies the detached GPG signature against the pinned
-# release key AND the ghostd SHA256 against the freshly-fetched install.sh,
-# backs up the current binaries, swaps them with a stop→verify-inactive→swap→
-# start sequence, health-checks, and rolls back on any failure.
+# and — ONLY if it is newer than what is installed — downloads the signed
+# release tarball (which now bundles ghostd alongside ghost-pool/ghost-pay),
+# verifies the detached GPG signature against the pinned release key and the
+# tarball's SHA256, backs up the current binaries, swaps them with a
+# stop→verify-inactive→swap→start sequence, health-checks, and rolls back on any
+# failure.
 #
-# SUPPLY-CHAIN-CRITICAL: a binary is NEVER written unless BOTH the GPG signature
-# and the ghostd checksum verify. The verification logic mirrors the first-run
-# installer (scripts/install-node.sh) exactly.
+# SUPPLY-CHAIN-CRITICAL: a binary is NEVER written unless the GPG signature over
+# the tarball verifies. ghostd rides that SAME signature (it lives inside the
+# tarball now), so there is no longer a separate ghostd checksum side-channel.
+# The verification logic mirrors the first-run installer (scripts/install-node.sh).
 #
 # This file is the canonical source. scripts/install-node.sh installs a verbatim
 # copy at /opt/ghost/bin/ghost-auto-update.sh.
@@ -28,7 +30,8 @@ set -euo pipefail
 GPG_KEY_FP="${GHOST_GPG_KEY_FP:-777FE81F8CC077FD3D08055E852C2B3190F5B928}"
 RELEASE_KEY_URL="${GHOST_RELEASE_KEY_URL:-https://get.bitcoinghost.org/ghost-release-key.asc}"
 INSTALL_SH_URL="${GHOST_INSTALL_SH_URL:-https://get.bitcoinghost.org/install.sh}"
-GHOSTD_URL="${GHOSTD_URL:-https://get.bitcoinghost.org/bin/ghostd}"
+# NOTE: ghostd is no longer fetched from a standalone URL — it ships inside the
+# signed release tarball (below), so the old GHOSTD_URL side-channel is gone.
 # Release tarball base. When GHOST_RELEASE_BASE is set it is used verbatim;
 # otherwise it is constructed per-version from the GitHub releases download URL.
 RELEASE_BASE_OVERRIDE="${GHOST_RELEASE_BASE:-}"
@@ -224,7 +227,7 @@ main() {
   log "auto-update enabled${DRY_RUN:+ }$([[ "$DRY_RUN" == "true" ]] && echo '(dry-run)')"
 
   # 2. Resolve installed + latest versions.
-  local installed latest install_sh ghostd_sha
+  local installed latest install_sh
   installed="$(read_installed_version || true)"
   [[ -n "$installed" ]] || { err "could not determine installed version"; write_status "error" "installed version unknown"; exit 1; }
 
@@ -232,9 +235,7 @@ main() {
   [[ -n "$install_sh" ]] || { err "could not fetch install.sh from $INSTALL_SH_URL"; write_status "error" "install.sh unreachable"; exit 1; }
   latest="$(echo "$install_sh" | grep -m1 -oE 'GHOST_VERSION="?v?[0-9]+\.[0-9]+\.[0-9]+"?' | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
   [[ "$latest" == v* ]] || latest="v${latest}"
-  ghostd_sha="$(echo "$install_sh" | grep -m1 -oE 'GHOSTD_SHA256="?[0-9a-fA-F]{64}"?' | grep -oE '[0-9a-fA-F]{64}' | head -1 || true)"
   [[ -n "$latest" && "$latest" != "v" ]] || { err "could not parse latest version from install.sh"; write_status "error" "version parse failed"; exit 1; }
-  [[ -n "$ghostd_sha" ]] || { err "could not parse GHOSTD_SHA256 from install.sh"; write_status "error" "ghostd sha parse failed"; exit 1; }
 
   log "installed=$installed latest=$latest"
   if ! is_newer "$installed" "$latest"; then
@@ -256,18 +257,17 @@ main() {
   gnupg="$tmp/gnupg"; mkdir -m700 "$gnupg"
   export GNUPGHOME="$gnupg"
 
-  log "downloading $tarball + signature + ghostd"
+  log "downloading $tarball + signature (ghostd is inside the tarball)"
   curl -fsSL --max-time 600 "${release_base}/${tarball}"            -o "$tmp/$tarball"          || { err "download tarball failed"; write_status "error" "tarball download failed" "$latest"; exit 1; }
   curl -fsSL --max-time 60  "${release_base}/SHA256SUMS.txt"        -o "$tmp/SHA256SUMS.txt"    || { err "download SHA256SUMS.txt failed"; write_status "error" "checksums download failed" "$latest"; exit 1; }
   curl -fsSL --max-time 60  "${release_base}/SHA256SUMS.txt.asc"    -o "$tmp/SHA256SUMS.txt.asc" || { err "download signature failed"; write_status "error" "signature download failed" "$latest"; exit 1; }
-  curl -fsSL --max-time 600 "$GHOSTD_URL"                           -o "$tmp/ghostd"           || { err "download ghostd failed"; write_status "error" "ghostd download failed" "$latest"; exit 1; }
 
   # ══════════════════════════════════════════════════════════════════════════
   # 4. MANDATORY VERIFICATION GATE — no binary is touched unless this passes.
   #    (a) detached GPG signature over SHA256SUMS.txt is VALID *and* the signer
   #        is EXACTLY the pinned release-key fingerprint;
-  #    (b) the release tarball's SHA256 matches SHA256SUMS.txt;
-  #    (c) ghostd's SHA256 matches the value in the freshly-fetched install.sh.
+  #    (b) the release tarball's SHA256 matches SHA256SUMS.txt (this transitively
+  #        covers ghostd, which now lives inside the tarball).
   #    ANY failure → loud abort, binaries untouched, non-zero exit.
   # ══════════════════════════════════════════════════════════════════════════
   curl -fsSL --max-time 60 "$RELEASE_KEY_URL" 2>/dev/null | gpg --quiet --import 2>/dev/null || true
@@ -293,26 +293,21 @@ main() {
     exit 1
   fi
 
-  if ( cd "$tmp" && echo "${ghostd_sha}  ghostd" | sha256sum -c - >/dev/null 2>&1 ); then
-    log "VERIFY ok: ghostd checksum matches install.sh (${ghostd_sha})"
-  else
-    err "VERIFY FAILED: ghostd SHA256 mismatch against install.sh — ABORTING, no binary touched."
-    write_status "verify-failed" "ghostd checksum mismatch for $latest" "$latest"
-    exit 1
-  fi
-
-  # 5. Unpack the verified tarball and locate the binaries it carries.
+  # 5. Unpack the verified tarball and locate the binaries it carries (ghostd is
+  #    now bundled in the tarball, so it is covered by the checks above).
   tar -xzf "$tmp/$tarball" -C "$tmp"
-  local new_pool new_pay new_cli
+  local new_pool new_pay new_cli new_ghostd
   new_pool="$(find "$tmp" -name ghost-pool -type f | head -1 || true)"
   new_pay="$(find "$tmp" -name ghost-pay -type f | head -1 || true)"
   new_cli="$(find "$tmp" -name ghost-cli -type f | head -1 || true)"
+  new_ghostd="$(find "$tmp" -name ghostd -type f | head -1 || true)"
   [[ -n "$new_pool" ]] || { err "verified tarball did not contain ghost-pool"; write_status "error" "tarball missing ghost-pool" "$latest"; exit 1; }
+  [[ -n "$new_ghostd" ]] || { err "verified tarball did not contain ghostd (release predates the unified build?)"; write_status "error" "tarball missing ghostd" "$latest"; exit 1; }
 
   # Build the swap plan: (dest <- src), only for binaries currently installed
   # (so we never introduce ghost-pay onto a node that opted out of it).
   local -a SWAP_DEST=() SWAP_SRC=()
-  SWAP_DEST+=("$BIN_DIR/ghostd");     SWAP_SRC+=("$tmp/ghostd")
+  SWAP_DEST+=("$BIN_DIR/ghostd");     SWAP_SRC+=("$new_ghostd")
   SWAP_DEST+=("$BIN_DIR/ghost-pool"); SWAP_SRC+=("$new_pool")
   if [[ -x "$BIN_DIR/ghost-pay" && -n "$new_pay" ]]; then
     SWAP_DEST+=("$BIN_DIR/ghost-pay"); SWAP_SRC+=("$new_pay")

--- a/scripts/install-node.sh
+++ b/scripts/install-node.sh
@@ -24,8 +24,13 @@ GHOST_VERSION="${GHOST_VERSION:-v1.10.16}"
 GPG_KEY_FP="777FE81F8CC077FD3D08055E852C2B3190F5B928"
 RELEASE_BASE="https://github.com/bitcoin-ghost/ghost/releases/download/${GHOST_VERSION}"
 POOL_TARBALL="bitcoin-ghost-${GHOST_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
-GHOSTD_URL="${GHOSTD_URL:-https://get.bitcoinghost.org/bin/ghostd}"
-GHOSTD_SHA256="bb3a864248cea6ece930eb76fef525a0f5b1fde65976a886935df34e9e95859d"
+# ghostd now ships INSIDE the signed release tarball (same SHA256SUMS + GPG chain
+# as ghost-pool/ghost-pay), so it can never drift from the release version and
+# needs no separate checksum pin — its integrity rides the tarball signature we
+# already verify below. GHOSTD_URL is an OPTIONAL, unverified escape hatch (empty
+# by default) for transition/testing only; leave it unset in production so ghostd
+# comes out of the verified tarball.
+GHOSTD_URL="${GHOSTD_URL:-}"
 RELEASE_KEY_URL="https://get.bitcoinghost.org/ghost-release-key.asc"
 # ── MPC ceremony: genesis-anchored trust root ────────────────────────────────
 # A fresh community node JOINS a still-rolling MPC ceremony GENESIS-ANCHORED: it
@@ -501,10 +506,20 @@ install -m755 -o root -g root "$(find . -name ghost-pool -type f | head -1)" /op
 if [[ "$GHOST_PAY" == "true" ]]; then
   install -m755 -o root -g root "$(find . -name ghost-pay -type f | head -1)" /opt/ghost/bin/ghost-pay
 fi
-# ghostd (pinned checksum)
-curl -fsSL "$GHOSTD_URL" -o ghostd || err "Could not download ghostd from ${GHOSTD_URL}."
-echo "${GHOSTD_SHA256}  ghostd" | sha256sum -c - || err "ghostd checksum verification FAILED."
-install -m755 -o root -g root ghostd /opt/ghost/bin/ghostd
+# ghostd ships in the SAME signed tarball we just GPG- + checksum-verified, so it
+# is installed straight from the extracted tree exactly like ghost-pool — its
+# integrity is covered by the release signature, with no separate download or
+# checksum pin to rot. GHOSTD_URL, if the operator explicitly set it, is an
+# unverified override for transition/testing.
+if [[ -n "$GHOSTD_URL" ]]; then
+  log "Fetching ghostd from override URL ${GHOSTD_URL} (UNVERIFIED override path)"
+  curl -fsSL "$GHOSTD_URL" -o ghostd || err "Could not download ghostd from ${GHOSTD_URL}."
+  install -m755 -o root -g root ghostd /opt/ghost/bin/ghostd
+else
+  GHOSTD_BIN="$(find . -name ghostd -type f | head -1)"
+  [[ -n "$GHOSTD_BIN" ]] || err "ghostd was not found in ${POOL_TARBALL}. This installer requires a release that bundles ghostd (the first unified build onward). Upgrade GHOST_VERSION, or set GHOSTD_URL to override."
+  install -m755 -o root -g root "$GHOSTD_BIN" /opt/ghost/bin/ghostd
+fi
 cd /
 
 # ─────────────────────────── 4. fresh secrets ────────────────────────────────
@@ -989,15 +1004,17 @@ cat > /opt/ghost/bin/ghost-auto-update.sh <<'GHOST_AUTOUPDATE_SH_EOF'
 # Runs as root from `ghost-auto-update.timer` (every 6h, randomised). It is a
 # strict no-op unless the operator has opted in via /etc/ghost/auto-update.conf
 # (AUTO_UPDATE=true). When opted in, it resolves the latest published release,
-# and — ONLY if it is newer than what is installed — downloads the release
-# tarball + ghostd, verifies the detached GPG signature against the pinned
-# release key AND the ghostd SHA256 against the freshly-fetched install.sh,
-# backs up the current binaries, swaps them with a stop→verify-inactive→swap→
-# start sequence, health-checks, and rolls back on any failure.
+# and — ONLY if it is newer than what is installed — downloads the signed
+# release tarball (which now bundles ghostd alongside ghost-pool/ghost-pay),
+# verifies the detached GPG signature against the pinned release key and the
+# tarball's SHA256, backs up the current binaries, swaps them with a
+# stop→verify-inactive→swap→start sequence, health-checks, and rolls back on any
+# failure.
 #
-# SUPPLY-CHAIN-CRITICAL: a binary is NEVER written unless BOTH the GPG signature
-# and the ghostd checksum verify. The verification logic mirrors the first-run
-# installer (scripts/install-node.sh) exactly.
+# SUPPLY-CHAIN-CRITICAL: a binary is NEVER written unless the GPG signature over
+# the tarball verifies. ghostd rides that SAME signature (it lives inside the
+# tarball now), so there is no longer a separate ghostd checksum side-channel.
+# The verification logic mirrors the first-run installer (scripts/install-node.sh).
 #
 # This file is the canonical source. scripts/install-node.sh installs a verbatim
 # copy at /opt/ghost/bin/ghost-auto-update.sh.
@@ -1012,7 +1029,8 @@ set -euo pipefail
 GPG_KEY_FP="${GHOST_GPG_KEY_FP:-777FE81F8CC077FD3D08055E852C2B3190F5B928}"
 RELEASE_KEY_URL="${GHOST_RELEASE_KEY_URL:-https://get.bitcoinghost.org/ghost-release-key.asc}"
 INSTALL_SH_URL="${GHOST_INSTALL_SH_URL:-https://get.bitcoinghost.org/install.sh}"
-GHOSTD_URL="${GHOSTD_URL:-https://get.bitcoinghost.org/bin/ghostd}"
+# NOTE: ghostd is no longer fetched from a standalone URL — it ships inside the
+# signed release tarball (below), so the old GHOSTD_URL side-channel is gone.
 # Release tarball base. When GHOST_RELEASE_BASE is set it is used verbatim;
 # otherwise it is constructed per-version from the GitHub releases download URL.
 RELEASE_BASE_OVERRIDE="${GHOST_RELEASE_BASE:-}"
@@ -1208,7 +1226,7 @@ main() {
   log "auto-update enabled${DRY_RUN:+ }$([[ "$DRY_RUN" == "true" ]] && echo '(dry-run)')"
 
   # 2. Resolve installed + latest versions.
-  local installed latest install_sh ghostd_sha
+  local installed latest install_sh
   installed="$(read_installed_version || true)"
   [[ -n "$installed" ]] || { err "could not determine installed version"; write_status "error" "installed version unknown"; exit 1; }
 
@@ -1216,9 +1234,7 @@ main() {
   [[ -n "$install_sh" ]] || { err "could not fetch install.sh from $INSTALL_SH_URL"; write_status "error" "install.sh unreachable"; exit 1; }
   latest="$(echo "$install_sh" | grep -m1 -oE 'GHOST_VERSION="?v?[0-9]+\.[0-9]+\.[0-9]+"?' | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
   [[ "$latest" == v* ]] || latest="v${latest}"
-  ghostd_sha="$(echo "$install_sh" | grep -m1 -oE 'GHOSTD_SHA256="?[0-9a-fA-F]{64}"?' | grep -oE '[0-9a-fA-F]{64}' | head -1 || true)"
   [[ -n "$latest" && "$latest" != "v" ]] || { err "could not parse latest version from install.sh"; write_status "error" "version parse failed"; exit 1; }
-  [[ -n "$ghostd_sha" ]] || { err "could not parse GHOSTD_SHA256 from install.sh"; write_status "error" "ghostd sha parse failed"; exit 1; }
 
   log "installed=$installed latest=$latest"
   if ! is_newer "$installed" "$latest"; then
@@ -1240,18 +1256,17 @@ main() {
   gnupg="$tmp/gnupg"; mkdir -m700 "$gnupg"
   export GNUPGHOME="$gnupg"
 
-  log "downloading $tarball + signature + ghostd"
+  log "downloading $tarball + signature (ghostd is inside the tarball)"
   curl -fsSL --max-time 600 "${release_base}/${tarball}"            -o "$tmp/$tarball"          || { err "download tarball failed"; write_status "error" "tarball download failed" "$latest"; exit 1; }
   curl -fsSL --max-time 60  "${release_base}/SHA256SUMS.txt"        -o "$tmp/SHA256SUMS.txt"    || { err "download SHA256SUMS.txt failed"; write_status "error" "checksums download failed" "$latest"; exit 1; }
   curl -fsSL --max-time 60  "${release_base}/SHA256SUMS.txt.asc"    -o "$tmp/SHA256SUMS.txt.asc" || { err "download signature failed"; write_status "error" "signature download failed" "$latest"; exit 1; }
-  curl -fsSL --max-time 600 "$GHOSTD_URL"                           -o "$tmp/ghostd"           || { err "download ghostd failed"; write_status "error" "ghostd download failed" "$latest"; exit 1; }
 
   # ══════════════════════════════════════════════════════════════════════════
   # 4. MANDATORY VERIFICATION GATE — no binary is touched unless this passes.
   #    (a) detached GPG signature over SHA256SUMS.txt is VALID *and* the signer
   #        is EXACTLY the pinned release-key fingerprint;
-  #    (b) the release tarball's SHA256 matches SHA256SUMS.txt;
-  #    (c) ghostd's SHA256 matches the value in the freshly-fetched install.sh.
+  #    (b) the release tarball's SHA256 matches SHA256SUMS.txt (this transitively
+  #        covers ghostd, which now lives inside the tarball).
   #    ANY failure → loud abort, binaries untouched, non-zero exit.
   # ══════════════════════════════════════════════════════════════════════════
   curl -fsSL --max-time 60 "$RELEASE_KEY_URL" 2>/dev/null | gpg --quiet --import 2>/dev/null || true
@@ -1277,26 +1292,21 @@ main() {
     exit 1
   fi
 
-  if ( cd "$tmp" && echo "${ghostd_sha}  ghostd" | sha256sum -c - >/dev/null 2>&1 ); then
-    log "VERIFY ok: ghostd checksum matches install.sh (${ghostd_sha})"
-  else
-    err "VERIFY FAILED: ghostd SHA256 mismatch against install.sh — ABORTING, no binary touched."
-    write_status "verify-failed" "ghostd checksum mismatch for $latest" "$latest"
-    exit 1
-  fi
-
-  # 5. Unpack the verified tarball and locate the binaries it carries.
+  # 5. Unpack the verified tarball and locate the binaries it carries (ghostd is
+  #    now bundled in the tarball, so it is covered by the checks above).
   tar -xzf "$tmp/$tarball" -C "$tmp"
-  local new_pool new_pay new_cli
+  local new_pool new_pay new_cli new_ghostd
   new_pool="$(find "$tmp" -name ghost-pool -type f | head -1 || true)"
   new_pay="$(find "$tmp" -name ghost-pay -type f | head -1 || true)"
   new_cli="$(find "$tmp" -name ghost-cli -type f | head -1 || true)"
+  new_ghostd="$(find "$tmp" -name ghostd -type f | head -1 || true)"
   [[ -n "$new_pool" ]] || { err "verified tarball did not contain ghost-pool"; write_status "error" "tarball missing ghost-pool" "$latest"; exit 1; }
+  [[ -n "$new_ghostd" ]] || { err "verified tarball did not contain ghostd (release predates the unified build?)"; write_status "error" "tarball missing ghostd" "$latest"; exit 1; }
 
   # Build the swap plan: (dest <- src), only for binaries currently installed
   # (so we never introduce ghost-pay onto a node that opted out of it).
   local -a SWAP_DEST=() SWAP_SRC=()
-  SWAP_DEST+=("$BIN_DIR/ghostd");     SWAP_SRC+=("$tmp/ghostd")
+  SWAP_DEST+=("$BIN_DIR/ghostd");     SWAP_SRC+=("$new_ghostd")
   SWAP_DEST+=("$BIN_DIR/ghost-pool"); SWAP_SRC+=("$new_pool")
   if [[ -x "$BIN_DIR/ghost-pay" && -n "$new_pay" ]]; then
     SWAP_DEST+=("$BIN_DIR/ghost-pay"); SWAP_SRC+=("$new_pay")


### PR DESCRIPTION
## Summary

Makes a tagged release build and publish **all three node binaries together at one version** — `ghostd` (C++ daemon), `ghost-pool`, and `ghost-pay` — closing the drift that let the fleet run ghost-pool `1.10.16` while ghostd + ghost-pay stayed at `1.10.6`.

## Why

All three already share one version in source (`[workspace.package] version`; ghost-core CMake parses that same `Cargo.toml`). But the release pipeline only built the Rust binaries into the signed tarball — **ghostd was built + hosted out-of-band** (`get.bitcoinghost.org/bin/ghostd`, hardcoded `GHOSTD_SHA256` pin). So releases bumped pool + pay while ghostd silently rotted, and the installer's ghostd came from an unversioned side-channel.

## Changes

- **`.github/workflows/release.yml`**: on the Linux release target, install the Bitcoin Core build deps and build `ghostd` (`cmake … -DWITH_ZMQ=ON` — ghost-pool depends on ghostd's ZMQ hashblock/sequence feed for new-block + reorg detection; tests/bench/gui/etc. off), then stage it into the same `dist/` so it lands in the signed `bitcoin-ghost-<tag>-x86_64-unknown-linux-gnu.tar.gz` under the existing SHA256SUMS + GPG signing.
- **`scripts/install-node.sh`**: install ghostd from the GPG-verified release tarball (like ghost-pool), and **remove the hardcoded `GHOSTD_SHA256` pin**; `GHOSTD_URL` becomes an optional override rather than the default path. ghostd integrity now rides the release signature.
- **`scripts/ghost-auto-update.sh`** (+ its embedded copy in the installer): take ghostd from the verified tarball too, dropping the dead side-channel download.

## Notes

- Takes full effect on the **next tagged release** — the workflow can't be exercised pre-tag. Watch the first release to confirm ghostd lands in the tarball and the installer picks it up.
- The ghostd build adds ~20-40 min to release CI (OOM fallbacks documented inline: cap `-j2` / ggc flags).
- The `-DWITH_ZMQ=ON` flag is load-bearing: a non-ZMQ ghostd silently breaks the pool. Confirmed live — the fleet's ghostd advertises ZMQ notifiers and ghost-pool subscribes to them.
- Aligning the running fleet's ghost-pay to the current version is deliberately left to the first unified release deploy (rather than a standalone L2 redeploy), so all three roll together.
