### PR TITLE
Website: refresh pages + docs against current code

### DIFF
--- a/ghost-web/core.html
+++ b/ghost-web/core.html
@@ -332,8 +332,8 @@
       <div class="rs-col">
         <div class="rs-head done">shipped</div>
         <ul>
-          <li>Ghost v1.8.0 mainnet observe mode</li>
-          <li>Four-node BFT mesh live</li>
+          <li>Ghost v1.10 mainnet observe mode</li>
+          <li>BFT consensus mesh live and growing</li>
           <li>MPC trusted-setup ceremony complete</li>
           <li>Ghost mining pool</li>
           <li>Ledger-style payout model</li>

--- a/ghost-web/docs/consensus.md
+++ b/ghost-web/docs/consensus.md
@@ -68,6 +68,7 @@ MessageEnvelope {
   sequence:  u64,           // Per-sender sequence number (dedup / replay guard)
   signature: [u8; 64],      // Ed25519 signature over the payload
   payload:   Vec<u8>,       // JSON-serialized message
+  ttl:       u8,            // Hop count for gossip fan-out
 }
 ```
 
@@ -174,7 +175,7 @@ Ghost consensus is designed to resist Byzantine (malicious) nodes:
 | --- | --- |
 | Share Consensus | All honest nodes agree on valid shares if 67% are honest |
 | Payout Consensus | Correct payouts enforced by honest majority |
-| Elder Consensus | Elder list immutable, revocation requires 67% witness |
+| Elder Consensus | Elder list is append-only up to 101 via deterministic Node ID ordering; revocation requires 67% witness and reopens the slot |
 | Liveness | System never deadlocks; honest nodes converge on the same ledger + split |
 
 ### Cryptographic Security
@@ -201,7 +202,7 @@ Ghost consensus is designed to resist Byzantine (malicious) nodes:
 
 **Attack:** Attacker registers many nodes to dominate Elder slots.
 
-**Defense:** Only first 101 nodes become Elders. One-time event at launch. Deterministic ordering by (timestamp, hash) prevents manipulation.
+**Defense:** Every Node ID must carry a **proof-of-work** to be eligible, so minting many identities is expensive. Elder slots are capped at 101 and filled by deterministic Node ID ordering (lowest first) among PoW-valid nodes — registration is rolling rather than a one-time launch event, but the ordering is fixed data so no node can reorder itself ahead of another.
 
 ### Network Partition Attack
 

--- a/ghost-web/docs/deployment.md
+++ b/ghost-web/docs/deployment.md
@@ -268,7 +268,7 @@ LimitNOFILE=65536
 
 # Ensure ZK params are findable
 Environment=ZK_PARAMS_PATH=/home/ghost/.ghost/mpc_params
-Environment=ZK_PARAMS_HASH=<sha256-of-final-ossified-params>
+Environment=ZK_PARAMS_HASH=<sha256-of-the-params-your-cluster-runs>
 
 [Install]
 WantedBy=multi-user.target
@@ -276,7 +276,7 @@ WantedBy=multi-user.target
 
 Two environment variables matter on mainnet:
 
-- `ZK_PARAMS_PATH` — directory containing the ossified MPC ceremony params (`note_spend_vk.bin`, `payout_vk.bin`, `unshield_vk.bin`).
+- `ZK_PARAMS_PATH` — directory containing the current MPC ceremony params and verifying keys (`note_spend_vk.bin`, `payout_vk.bin`, `unshield_vk.bin`). The ceremony is rolling, so these are the current chain head, not necessarily a final ossified set.
 - `ZK_PARAMS_HASH` — SHA256 of the params used to verify the binary loaded the right ones. The release notes for each version include the expected hash.
 
 If the params don't match the hash, ghost-pool refuses to start. This protects against a node accidentally running with stale or test params.
@@ -305,7 +305,7 @@ Before flipping the service on, walk this checklist. Every item must pass:
 **ZK pipeline:**
 
 - [ ] All three VK files present: `note_spend_vk.bin`, `payout_vk.bin`, `unshield_vk.bin`.
-- [ ] MPC ceremony has completed for the cluster you're joining (not test params).
+- [ ] MPC params match the cluster you're joining (the current rolling-ceremony chain head, not test params).
 - [ ] `ZK_PARAMS_HASH` env matches the published hash for your ghost-pool version.
 
 **Database:**

--- a/ghost-web/docs/elder-system.md
+++ b/ghost-web/docs/elder-system.md
@@ -18,20 +18,20 @@ Elders receive a permanent +1 share bonus in the node reward system. This bonus 
 
 ## Selection Process
 
-Elder selection happens automatically during the network launch:
+Elder selection is **rolling** — slots fill continuously as nodes come online, not in a single event at launch:
 
-1. **Node Registration** — You install Ghost Node and it generates your unique 32-byte Node ID. Your node registers with the network.
-2. **Timestamp Recording** — Your registration timestamp is cryptographically signed and broadcast to all nodes.
-3. **Ordering** — Nodes are ordered by (timestamp, hash(node_id)) for deterministic tie-breaking.
-4. **Elder Assignment** — Once 101 nodes have registered, the Elder list is frozen. Positions 1-101 are assigned.
+1. **Node Registration** — You install Ghost Node and it generates a unique 32-byte Node ID. Generating a valid Node ID requires a **proof-of-work** (Sybil resistance — you can't cheaply mint thousands of identities).
+2. **Promotion on registration** — Every time a node registers (or refreshes its health), the network runs an atomic promotion pass: while fewer than 101 Elders exist, eligible non-Elder nodes are promoted to fill the open slots.
+3. **Ordering** — Promotion is by **Node ID ascending** (lowest Node IDs first), and only nodes that submitted a valid proof-of-work are eligible. The ordering is deterministic, so every node computes the same Elder set.
+4. **Elder Assignment** — Positions are assigned in promotion order. Once 101 Elders are held simultaneously, no further promotions happen until a slot reopens (see [Revocation](#revocation)).
 
 ### Deterministic Selection
 
-The selection is fully deterministic — all nodes calculate the same Elder list from the same data. There's no central authority deciding who becomes an Elder.
+The selection is fully deterministic — all nodes derive the same Elder list from the same on-chain-anchored data. There's no central authority deciding who becomes an Elder.
 
-### One-Time Event
+### Rolling, Not One-Shot
 
-Elder selection happens only once, at network launch. Once 101 Elders are assigned, the list is permanent. New nodes cannot become Elders.
+Elder slots are filled as nodes arrive, up to the cap of 101. Today the network holds far fewer than 101 Elders, so any node presenting a valid proof-of-work is promoted immediately; Node ID ordering only breaks ties once more than 101 proof-of-work nodes compete for the remaining slots.
 
 ## Benefits
 
@@ -58,14 +58,15 @@ Elders are visible on the network dashboard with their rank (1-101). It's a perm
 
 To become an Elder, you must:
 
-1. **Register early** — Be one of the first 101 nodes to register
-2. **Stay online** — Maintain uptime after registration
-3. **Run a valid node** — Full sync, passing health checks
+1. **Hold a slot** — Be promoted into one of the 101 slots. Promotion is by Node ID (lowest first) among proof-of-work-valid nodes; while the network is below the cap, any valid node is promoted immediately.
+2. **Present a valid proof-of-work Node ID** — Elder eligibility requires the PoW-stamped Node ID (Sybil resistance).
+3. **Stay online** — Maintain uptime after promotion, or risk revocation (see below).
+4. **Run a valid node** — Full sync, passing health checks.
 
-There's no payment, no application, no approval process. Just be early and run a good node.
+There's no payment, no application, no approval process. Run a valid node while slots remain and you're promoted automatically.
 
 :::callout Current Status
-The Elder Genesis Event has occurred. 4 Elder nodes are currently active (out of 101 maximum). 97 slots remain for new Elders. Check the [Network page](/pool.html) for the latest status.
+Elder registration is open and rolling. The network currently holds well under the 101-Elder cap, so slots remain available for new operators who run a valid node. Check the [Network page](/pool.html) for the live Elder count and registry.
 :::
 
 ## Revocation
@@ -84,14 +85,13 @@ If your Elder node is offline for **7 continuous days**, your Elder status is pe
 4. 67% of active nodes must witness/confirm
 5. Revocation is recorded permanently
 
-### Slots Are Not Refilled
+### Slots Reopen on Revocation
 
-When an Elder is revoked, their slot is **not** given to someone else. The total number of Elders decreases permanently. This means:
+When an Elder is revoked, its slot **reopens**. The promotion pass runs continuously, so the next eligible node (lowest Node ID with a valid proof-of-work) is promoted into the freed slot. The cap stays at 101 — the network doesn't shrink permanently below it while eligible candidates exist.
 
-- Starting with 101 Elders
-- If 5 are revoked → 96 Elders remain
-- Those 96 share the Elder pool among fewer nodes
-- Remaining Elders get slightly more
+- A revoked Elder loses its `is_elder` status and `elder_order`, and is recorded in the retired-nodes table for audit.
+- If eligible non-Elder nodes are waiting, one is promoted into the vacated slot on the next registration pass.
+- If no eligible candidate is online, the slot simply sits open until one registers.
 
 ### Why So Strict?
 
@@ -113,7 +113,7 @@ The dashboard UI sometimes refers to a `ghostnode.dat` label, but the node itsel
 
 ### Can I run multiple Elder nodes?
 
-Technically yes, if you register multiple nodes in the first 101. But each node requires separate infrastructure and must maintain uptime independently.
+Technically yes, if you get multiple nodes promoted while slots remain. But each node requires separate infrastructure, its own proof-of-work Node ID, and must maintain uptime independently.
 
 ### What if I'm offline for 6 days?
 

--- a/ghost-web/docs/ghost-pool.md
+++ b/ghost-web/docs/ghost-pool.md
@@ -124,7 +124,7 @@ The system tolerates up to 33% malicious nodes. Key properties:
 
 - **67% supermajority** required for critical decisions
 - **Cryptographic proofs** prevent share forgery
-- **Median fallback** if no consensus reached
+- **Deterministic recompute, not median** — every validator recomputes the payout split from its own converged ledger and rejects a proposal that doesn't match (there is no "median of proposals" fallback)
 - **Self-healing** through periodic state verification
 
 ## Payout Flow

--- a/ghost-web/docs/mpc.md
+++ b/ghost-web/docs/mpc.md
@@ -85,13 +85,28 @@ Existing contributors (current Elders), upon receipt:
    3. Verify the Schnorr PoK.
    4. Cast MpcVerificationVote (approve / reject + reason).
 
-When ≥67 % of existing contributors approve:
+When the approval threshold is met:
    - Contribution is applied; the candidate is admitted.
    - New params hash becomes the network's current.
    - Candidate's position is permanent.
 ```
 
+The approval threshold is a **67 % supermajority of existing contributors**, with a small bootstrap exception: while there are fewer than four contributors (the earliest positions), the threshold floor is one — the genesis node alone can admit the first couple of contributions so the ceremony can get off the ground. From the fourth contributor onward the full `ceil(count × 67 / 100)` supermajority applies.
+
 Only existing MPC contributors can vote on new ones. Non-Elder nodes observe but don't have a vote.
+
+### Joining mid-ceremony (catch-up)
+
+Because the ceremony is rolling, a node can come online at position 30 — or reconnect after days offline — and must trust a chain that was built without it. It does this by **genesis-anchored verification**, not by trusting whoever it synced from:
+
+1. Fetch the full contribution chain and the retained BFT quorum votes from peers (large params transfer in hash-verified chunks).
+2. Check the positions are a contiguous `1..=N`.
+3. Check position 1's `prev_params_hash` equals the genesis anchor (the genesis params hash, which doubles as the immutable ceremony ID).
+4. Check every link: each position's `prev_params_hash` equals the previous position's `new_params_hash`.
+5. Check the params on disk hash to the head of the chain.
+6. Check each position retained a valid supermajority of signed approval votes.
+
+Catch-up verification runs the same cryptographic checks as live verification but skips the timestamp-freshness window, so a node re-verifying old, already-approved contributions doesn't reject them for being stale. Any mismatch is fail-closed — the node refuses the chain rather than adopt an unverifiable one.
 
 ## Toxic waste handling
 
@@ -148,7 +163,7 @@ After the 101st contribution to a circuit:
 - The verifying key extracted from the final params is what every node uses to validate Ghost Pay shielded transactions forever.
 - Elder positions for that ceremony are frozen — no new Elders can join via that circuit.
 
-The three circuits ossify independently. As of writing, all three slots have completed across the four mainnet VMs (params at `/home/ghost/.ghost/mpc_params/` on each VM).
+The three circuits ossify independently. On mainnet the ceremonies are **still rolling** — none of the three circuits has reached position 101 yet. Contributions accrue as new operators onboard, so the ceremonies sit in their early positions and grow toward the cap. Until a circuit ossifies, every node runs against the *current* (latest) params for that circuit (`*_params_current.bin`), and the versioned chain on disk records each position reached so far. The live position is a runtime value — `SELECT contribution_count FROM mpc_ceremony` on any node — not a compiled-in constant.
 
 ## What goes wrong if the MPC fails
 
@@ -158,7 +173,7 @@ Two failure modes are worth distinguishing:
 
 2. **Liveness failure (no contributors arrive).** The genesis node generates valid params; nobody else contributes. The chain is sound (the 1-of-N argument trivially holds with only one contributor) but the anonymity set of "who could have created this honest setup" is one. This is a privacy concern, not a soundness concern — and it's mitigated as more contributors join.
 
-In practice, Ghost's mainnet completed all three ceremonies during initial bootstrap; the mainnet VMs have ossified params with the full 101-contributor chain.
+In practice, Ghost's mainnet ceremonies are still rolling — they are in their early positions and have not ossified. Each is sound today (the 1-of-N argument holds at every position from genesis onward); the anonymity set of honest contributors simply grows with each new Elder until the chain reaches 101 and freezes.
 
 ## Why this matters
 

--- a/ghost-web/docs/recovery.md
+++ b/ghost-web/docs/recovery.md
@@ -10,7 +10,7 @@ The mesh is BFT-tolerant: it survives one node going down without operator inter
 
 ## 1. Single elder offline
 
-**Impact:** Minimal. BFT consensus needs 67% (so 3 of 4 in the standard cluster). Payouts, voting, and L2 checkpoints continue.
+**Impact:** Minimal. BFT consensus needs a 67% supermajority of active elders. Losing a single elder in a healthy mesh stays comfortably above the threshold, so payouts, voting, and L2 checkpoints continue.
 
 **Detect:**
 
@@ -34,9 +34,9 @@ Watch for "connected to peer" lines. If they appear, the node has rejoined the m
 
 **If the elder is offline >24 hours:** investigate hardware/network. If permanent loss, see scenario 2 (replacement).
 
-## 2. Two elders offline simultaneously
+## 2. Enough elders offline to drop below quorum
 
-**Impact:** BFT halts. 2/4 = 50% < 67%. Payouts pause. L2 checkpoints pause. Mining continues but shares accumulate without payout. Network is **safe** — no conflicting decisions can land — but stalled.
+**Impact:** BFT halts. If enough elders go offline that the survivors fall below the 67% supermajority (for example, losing 2 of a 4-elder mesh — 50% < 67%), payouts pause, L2 checkpoints pause, and mining continues but shares accumulate without payout. Network is **safe** — no conflicting decisions can land — but stalled.
 
 **Detect:**
 
@@ -95,7 +95,7 @@ The replacement node uses the same node_id as the lost one, so its Elder slot is
 
 ## 3. Genesis node permanent loss
 
-**Impact:** None ongoing. The genesis node has no special role after the MPC ceremony completed. All elders are equal peers thereafter.
+**Impact:** None ongoing. The genesis node has no special role once it has contributed position 1 of the MPC ceremony — its randomness is already mixed into the chain, and it is an equal peer thereafter. This holds even though the ceremony is still rolling toward ossification: genesis is a bootstrap role, not an ongoing one.
 
 **Recover:** follow scenario 2's hardware-loss procedure.
 
@@ -216,7 +216,7 @@ The blast radius of this scenario is the reason MPC backups should be the most p
 # Count voting timeouts in the last 30 min
 journalctl -u ghost-pool --since "30 min ago" | grep -c "VotingSession timed out"
 
-# Check connected peer count (should be 3 in a 4-node cluster)
+# Check connected peer count (in a full mesh this is total elders minus 1)
 journalctl -u ghost-pool --since "1 min ago" | grep "connected_peers"
 ```
 

--- a/ghost-web/docs/zk.md
+++ b/ghost-web/docs/zk.md
@@ -53,15 +53,15 @@ pub struct GhostNoteSpendCircuit<F: PrimeField> {
 
 (Recipients are addressed by the [Keys](#keys) layer's ECDH stealth-derivation, not by a pubkey field inside the spend circuit.)
 
-The circuit enforces approximately 12 675 constraints proving:
+The circuit enforces several thousand constraints (the test suite bounds the count between 5 000 and 20 000 at depth 20) proving:
 
 1. The spent note's commitment is correctly formed (MiMC Pedersen).
 2. The note ID incorporates its index, epoch, and commitment.
 3. The nullifier is derived from the spending key (proves ownership).
 4. The note exists in the commitment tree (Merkle inclusion at depth 20).
-5. **Balance conservation:** `change = note_value − amount`.
+5. **Balance conservation:** `change = note_value − amount − fee`, where `fee` is the fixed 10-satoshi L2 transfer fee (`L2_TRANSFER_FEE_SATS`).
 6. The change and recipient commitments are correctly formed.
-7. **Range proofs:** `amount ∈ [0, 2⁶⁴)` and `change ∈ [0, 2⁶⁴)` (no negative-amount tricks).
+7. **Range proofs:** `amount ∈ [0, 2⁶⁴)` and `change ∈ [0, 2⁶⁴)` (`BALANCE_BITS = 64`; no negative-amount tricks).
 
 **Public inputs (what the verifier sees):**
 
@@ -99,7 +99,7 @@ pub struct NoteConsolidateCircuit<F: PrimeField> {
 }
 ```
 
-Approximately 2 500 constraints (the test suite asserts only `> 5 000` total when summed across the four input slots), proving:
+Several thousand constraints (the test suite bounds the count between 5 000 and 50 000 for a four-input tree at depth 20), proving:
 
 1. Each input note's commitment is well-formed.
 2. Each nullifier matches its spending key (no spending notes you don't own).
@@ -118,7 +118,7 @@ The exit ramp from L2 to L1. Proves ownership of a note and burns its entire val
 
 Simpler than note-spend — no change, no recipient commitment, the whole note is being consumed:
 
-Approximately 6 300 constraints, proving:
+A few thousand constraints (the test suite bounds the count between 2 000 and 15 000 at depth 20), proving:
 
 1. The note's commitment is well-formed.
 2. The nullifier matches the spending key.

--- a/ghost-web/downloads.html
+++ b/ghost-web/downloads.html
@@ -5,18 +5,18 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Downloads · Bitcoin Ghost</title>
-  <meta name="description" content="Ghost Tap wallet, Ghost Core node, Ghost Pool software, and Ghost CLI. Signed, reproducible, open source.">
+  <meta name="description" content="Download Bitcoin Ghost: the node package (ghostd, ghost-pool, ghost-pay), the Wraith wallet, and the node dashboard. Signed releases, open source, MIT license.">
   <meta property="og:site_name" content="Bitcoin Ghost">
   <meta property="og:type" content="website">
   <meta property="og:title" content="Downloads · Bitcoin Ghost">
-  <meta property="og:description" content="Ghost Tap wallet, Ghost Core node, Ghost Pool daemon, Ghost CLI. Signed releases, reproducible builds, MIT license.">
+  <meta property="og:description" content="The node package (ghostd, ghost-pool, ghost-pay), the Wraith wallet, and the node dashboard. Signed releases, MIT license.">
   <meta property="og:url" content="https://bitcoinghost.org/downloads.html">
   <meta property="og:image" content="https://bitcoinghost.org/logo.png">
   <meta name="twitter:card" content="summary">
   <meta name="twitter:site" content="@defenwycke">
   <meta name="twitter:creator" content="@defenwycke">
   <meta name="twitter:title" content="Downloads · Bitcoin Ghost">
-  <meta name="twitter:description" content="Ghost Tap wallet, Ghost Core node, Ghost Pool daemon, Ghost CLI. Signed releases, reproducible builds, MIT license.">
+  <meta name="twitter:description" content="The node package (ghostd, ghost-pool, ghost-pay), the Wraith wallet, and the node dashboard. Signed releases, MIT license.">
   <meta name="twitter:image" content="https://bitcoinghost.org/logo.png">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -70,177 +70,58 @@
     <span class="eyebrow">Downloads</span>
     <h1>Ghost software.</h1>
     <p class="lead">
-      Wallet, node, mining pool, CLI. Signed releases,
-      reproducible builds, no telemetry. Everything is free and open source
+      Three things to download: the node package, the Wraith wallet, and the
+      node dashboard. Signed releases, no telemetry, free and open source
       under the MIT license.
     </p>
     <div class="hero-actions">
       <a href="https://github.com/bitcoin-ghost/ghost/releases" class="btn btn-primary">GitHub releases <span class="arrow">→</span></a>
-      <a href="#verify" class="btn btn-ghost">Verify signatures</a>
+      <a href="#verify" class="btn btn-ghost">Verify your download</a>
     </div>
   </div>
 </section>
 
-<!-- ───────── Ghost Tap (end users) ───────── -->
+<!-- ───────── 1 · Node package (binaries) ───────── -->
 <section class="block">
   <div class="container">
-    <div class="section-label">Ghost Tap · wallet + merchant terminal</div>
-    <h2 class="section-title">Self-custodial Ghost wallet.</h2>
-    <p class="section-lead">
-      Ghost Tap is the reference wallet for Bitcoin Ghost. Holds L1 BTC,
-      receives and spends L2 shielded notes, opens Wraith mixing sessions,
-      runs a merchant terminal for in-person Bitcoin payments. Keys live on
-      your device — the wallet never phones home and never shares a balance
-      with a server.
-    </p>
-
-    <div class="core-tiles core-tiles-3">
-      <div class="ct-tile">
-        <div class="k">iOS</div>
-        <div class="v">iPhone · iPad</div>
-        <div class="sub">
-          iOS 16+ · universal · TestFlight while App Store review is pending.
-        </div>
-        <div class="hero-actions" style="margin-top:18px;">
-          <a href="https://github.com/bitcoin-ghost/ghost/releases" class="btn btn-primary">TestFlight <span class="arrow">→</span></a>
-        </div>
-      </div>
-      <div class="ct-tile">
-        <div class="k">Android</div>
-        <div class="v">Phone · Tablet</div>
-        <div class="sub">
-          Android 11+ · Play Store + signed APK (reproducible build).
-        </div>
-        <div class="hero-actions" style="margin-top:18px;">
-          <a href="https://github.com/bitcoin-ghost/ghost/releases" class="btn btn-primary">Play Store <span class="arrow">→</span></a>
-          <a href="https://github.com/bitcoin-ghost/ghost/releases" class="btn btn-ghost">APK</a>
-        </div>
-      </div>
-      <div class="ct-tile">
-        <div class="k">Desktop</div>
-        <div class="v">Linux · macOS · Windows</div>
-        <div class="sub">
-          x86_64 + arm64 builds. Same Rust core as the mobile apps.
-        </div>
-        <div class="hero-actions" style="margin-top:18px;">
-          <a href="https://github.com/bitcoin-ghost/ghost/releases" class="btn btn-primary">Download <span class="arrow">→</span></a>
-        </div>
-      </div>
-    </div>
-
-    <ul class="feature-list pay-green" style="margin-top:44px;">
-      <li>
-        <svg class="gh-bullet" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-          <path d="M9 10h.01"/><path d="M15 10h.01"/>
-          <path d="M12 2a8 8 0 0 0-8 8v12l3-3 2.5 2.5L12 19l2.5 2.5L17 19l3 3V10a8 8 0 0 0-8-8z" fill="none" stroke="currentColor" stroke-width="2" stroke-linejoin="round"/>
-        </svg>
-        <div>
-          <div class="fl-name">L1 + L2 in one wallet <span class="fl-badge">bitcoin + shielded</span></div>
-          <div class="fl-desc">Send and receive regular Bitcoin on L1, plus shielded notes on Ghost Pay's L2. One seed, one backup.</div>
-        </div>
-      </li>
-      <li>
-        <svg class="gh-bullet" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-          <path d="M9 10h.01"/><path d="M15 10h.01"/>
-          <path d="M12 2a8 8 0 0 0-8 8v12l3-3 2.5 2.5L12 19l2.5 2.5L17 19l3 3V10a8 8 0 0 0-8-8z" fill="none" stroke="currentColor" stroke-width="2" stroke-linejoin="round"/>
-        </svg>
-        <div>
-          <div class="fl-name">Merchant mode <span class="fl-badge">point of sale</span></div>
-          <div class="fl-desc">Accept L2 payments with instant confirmation. Generate receipts, export CSV at end of day, auto-sweep to cold storage.</div>
-        </div>
-      </li>
-      <li>
-        <svg class="gh-bullet" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-          <path d="M9 10h.01"/><path d="M15 10h.01"/>
-          <path d="M12 2a8 8 0 0 0-8 8v12l3-3 2.5 2.5L12 19l2.5 2.5L17 19l3 3V10a8 8 0 0 0-8-8z" fill="none" stroke="currentColor" stroke-width="2" stroke-linejoin="round"/>
-        </svg>
-        <div>
-          <div class="fl-name">Wraith mixing <span class="fl-badge">built-in</span></div>
-          <div class="fl-desc">Join a coordinator-free mixing round with one tap. Break the transaction graph whenever you want, no third party involved.</div>
-        </div>
-      </li>
-      <li>
-        <svg class="gh-bullet" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-          <path d="M9 10h.01"/><path d="M15 10h.01"/>
-          <path d="M12 2a8 8 0 0 0-8 8v12l3-3 2.5 2.5L12 19l2.5 2.5L17 19l3 3V10a8 8 0 0 0-8-8z" fill="none" stroke="currentColor" stroke-width="2" stroke-linejoin="round"/>
-        </svg>
-        <div>
-          <div class="fl-name">Self-custodial <span class="fl-badge">your keys</span></div>
-          <div class="fl-desc">BIP39 seed, BIP44 key derivation, encrypted device keychain. No accounts, no KYC, no server balance lookups.</div>
-        </div>
-      </li>
-      <li>
-        <svg class="gh-bullet" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-          <path d="M9 10h.01"/><path d="M15 10h.01"/>
-          <path d="M12 2a8 8 0 0 0-8 8v12l3-3 2.5 2.5L12 19l2.5 2.5L17 19l3 3V10a8 8 0 0 0-8-8z" fill="none" stroke="currentColor" stroke-width="2" stroke-linejoin="round"/>
-        </svg>
-        <div>
-          <div class="fl-name">Light wallet backend <span class="fl-badge">GSP</span></div>
-          <div class="fl-desc">Syncs via the Ghost Silent-payment Protocol — the backend never learns which addresses belong to you.</div>
-        </div>
-      </li>
-      <li>
-        <svg class="gh-bullet" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-          <path d="M9 10h.01"/><path d="M15 10h.01"/>
-          <path d="M12 2a8 8 0 0 0-8 8v12l3-3 2.5 2.5L12 19l2.5 2.5L17 19l3 3V10a8 8 0 0 0-8-8z" fill="none" stroke="currentColor" stroke-width="2" stroke-linejoin="round"/>
-        </svg>
-        <div>
-          <div class="fl-name">Tor by default <span class="fl-badge">no metadata leak</span></div>
-          <div class="fl-desc">Every network request is routed through an in-app Tor client. No exit IP leak, no ISP inference, no clearnet fallback.</div>
-        </div>
-      </li>
-    </ul>
-  </div>
-</section>
-
-<!-- ───────── Ghost Core + Ghost Pool (operators) ───────── -->
-<section class="block">
-  <div class="container">
-    <div class="section-label">Ghost Core + Ghost Pool · node software</div>
+    <div class="section-label">1 · node package · operators</div>
     <h2 class="section-title">Run a Ghost node.</h2>
     <p class="section-lead">
-      Bitcoin Ghost runs the same ghost-core full node as the network,
-      plus the ghost-pool daemon that earns rewards and votes on payouts.
-      Most operators install both — the same server runs mainnet in one
-      process and ghost-pool in another, sharing the on-disk chain.
-      See the <a href="/nodes.html">nodes</a> page for hardware requirements
-      and the full operator guide.
+      The node package is a single signed tarball containing every binary a
+      node runs: <code>ghostd</code> (a clean Bitcoin Core v30 fork),
+      <code>ghost-pool</code> (mining pool + BFT payout consensus), and
+      <code>ghost-pay</code> (the optional L2 daemon). The command-line tools
+      — <code>ghost-cli</code>, <code>ghost-light-wallet-cli</code> and
+      <code>ghost-light-wallet-tui</code> — ship in the same tarball. See the
+      <a href="/nodes.html">nodes</a> page for hardware requirements and the
+      full operator guide.
     </p>
 
     <div class="core-tiles core-tiles-3">
-      <div class="ct-tile">
-        <div class="k">ghost-core</div>
-        <div class="v accent">Full node</div>
-        <div class="sub">
-          Clean Bitcoin Core v30 fork. Validates blocks, serves peers,
-          relays transactions. Same CLI as Bitcoin Core.
+      <div class="ct-tile ct-wide">
+        <div class="k">one-command install</div>
+        <div class="v" style="font-size:15px; line-height:1.7;">
+          <code>curl -sSL https://get.bitcoinghost.org | sudo bash -s -- \</code><br>
+          <code>&nbsp;&nbsp;--payout-address bc1q…</code>
         </div>
-        <div class="hero-actions" style="margin-top:18px;">
-          <a href="https://github.com/bitcoin-ghost/ghost/releases" class="btn btn-primary">Binary <span class="arrow">→</span></a>
-          <a href="https://github.com/bitcoin-ghost/ghost" class="btn btn-ghost">Source</a>
-        </div>
-      </div>
-      <div class="ct-tile">
-        <div class="k">ghost-pool</div>
-        <div class="v accent">Pool daemon</div>
-        <div class="sub">
-          Earns share rewards, handles Stratum, participates in BFT payout
-          consensus with the rest of the mesh. Requires ghost-core running.
-        </div>
-        <div class="hero-actions" style="margin-top:18px;">
-          <a href="https://github.com/bitcoin-ghost/ghost/releases" class="btn btn-primary">Binary <span class="arrow">→</span></a>
-          <a href="https://github.com/bitcoin-ghost/ghost" class="btn btn-ghost">Source</a>
+        <div class="sub" style="margin-top:14px;">
+          Downloads and installs <code>ghostd</code>, <code>ghost-pool</code>
+          and <code>ghost-pay</code> with systemd units. It verifies the GPG
+          release signature before writing any binary. Add <code>--sync fast</code>
+          to load a verified assumeUTXO snapshot (height 910000) instead of a
+          full initial block download.
         </div>
       </div>
       <div class="ct-tile">
-        <div class="k">ghost-pay</div>
-        <div class="v accent">L2 daemon</div>
+        <div class="k">release tarball</div>
+        <div class="v accent">Linux x86_64</div>
         <div class="sub">
-          Optional. Participates in Ghost Pay L2 reconciliation. Required
-          to claim the +4 Ghost Pay capability share.
+          <code>bitcoin-ghost-&lt;version&gt;-x86_64-unknown-linux-gnu.tar.gz</code>
+          from GitHub releases, alongside <code>SHA256SUMS.txt</code> and its
+          signature. Prefer to install by hand? This is the file.
         </div>
         <div class="hero-actions" style="margin-top:18px;">
-          <a href="https://github.com/bitcoin-ghost/ghost/releases" class="btn btn-primary">Binary <span class="arrow">→</span></a>
+          <a href="https://github.com/bitcoin-ghost/ghost/releases" class="btn btn-primary">Releases <span class="arrow">→</span></a>
           <a href="https://github.com/bitcoin-ghost/ghost" class="btn btn-ghost">Source</a>
         </div>
       </div>
@@ -253,8 +134,8 @@
           <path d="M12 2a8 8 0 0 0-8 8v12l3-3 2.5 2.5L12 19l2.5 2.5L17 19l3 3V10a8 8 0 0 0-8-8z" fill="none" stroke="currentColor" stroke-width="2" stroke-linejoin="round"/>
         </svg>
         <div>
-          <div class="fl-name">Linux binaries <span class="fl-badge">x86_64 · arm64</span></div>
-          <div class="fl-desc">Static musl builds, no runtime dependencies. Shipped as <code>.tar.gz</code> and as <code>.deb</code> / <code>.rpm</code> packages for the major distros.</div>
+          <div class="fl-name">Signed binaries <span class="fl-badge">GPG</span></div>
+          <div class="fl-desc">Every release ships a detached signature over <code>SHA256SUMS.txt</code>. The installer refuses to write a binary unless both the signature and the checksum verify — see <a href="#verify">Verify your download</a>.</div>
         </div>
       </li>
       <li>
@@ -264,7 +145,7 @@
         </svg>
         <div>
           <div class="fl-name">systemd units included <span class="fl-badge">one-shot install</span></div>
-          <div class="fl-desc"><code>ghost-core.service</code>, <code>ghost-pool.service</code>, and <code>ghost-pay.service</code> ship inside the tarball. Drop them in <code>/etc/systemd/system</code> and enable.</div>
+          <div class="fl-desc">The installer writes and enables <code>ghostd</code>, <code>ghost-pool</code> and <code>ghost-pay</code> services, plus a sync gate so the pool only starts once the node is ready.</div>
         </div>
       </li>
       <li>
@@ -273,8 +154,8 @@
           <path d="M12 2a8 8 0 0 0-8 8v12l3-3 2.5 2.5L12 19l2.5 2.5L17 19l3 3V10a8 8 0 0 0-8-8z" fill="none" stroke="currentColor" stroke-width="2" stroke-linejoin="round"/>
         </svg>
         <div>
-          <div class="fl-name">Docker images <span class="fl-badge">ghcr.io</span></div>
-          <div class="fl-desc">Signed multi-arch images at <code>ghcr.io/bitcoin-ghost/ghost-core</code>, <code>…/ghost-pool</code>, <code>…/ghost-pay</code>. A reference <code>docker-compose.yml</code> wires the stack together.</div>
+          <div class="fl-name">assumeUTXO fast-sync <span class="fl-badge">--sync fast</span></div>
+          <div class="fl-desc">Load a verified UTXO snapshot at height 910000 and be usable in minutes; the node back-fills and validates history behind it. Full trustless IBD from genesis stays the default.</div>
         </div>
       </li>
       <li>
@@ -283,57 +164,88 @@
           <path d="M12 2a8 8 0 0 0-8 8v12l3-3 2.5 2.5L12 19l2.5 2.5L17 19l3 3V10a8 8 0 0 0-8-8z" fill="none" stroke="currentColor" stroke-width="2" stroke-linejoin="round"/>
         </svg>
         <div>
-          <div class="fl-name">macOS + Windows <span class="fl-badge">personal use</span></div>
-          <div class="fl-desc">Desktop builds for operators who want to run a node on their workstation. Not recommended for production mesh participation — Linux is the supported server target.</div>
+          <div class="fl-name">Build from source <span class="fl-badge">reproduce it</span></div>
+          <div class="fl-desc"><code>git clone https://github.com/bitcoin-ghost/ghost</code>, check out the latest release tag, then <code>cargo build --release --workspace</code>. Binaries land in <code>target/release/</code>. Full build docs are in the repo README.</div>
         </div>
       </li>
     </ul>
   </div>
 </section>
 
-<!-- ───────── Ghost CLI ───────── -->
+<!-- ───────── 2 · Wraith wallet (frontend) ───────── -->
 <section class="block">
   <div class="container">
-    <div class="section-label">Ghost CLI · power users</div>
-    <h2 class="section-title">Command-line tools.</h2>
+    <div class="section-label">2 · Wraith wallet · in development</div>
+    <h2 class="section-title">The Ghost wallet.</h2>
     <p class="section-lead">
-      <code>ghost-cli</code> is a single static binary that talks to
-      ghost-core and ghost-pool over RPC. Generate addresses, inspect
-      blocks, query pool state, manage a light wallet from a terminal.
+      Wraith is the reference desktop wallet for Bitcoin Ghost — L1 BTC plus
+      L2 shielded notes, Silent Payments for stealth receiving, and built-in
+      Wraith CoinJoin mixing for unlinkability. It is
+      <strong>still in development and not yet released</strong>; there is no
+      signed build to download today. Follow along in the repository, and
+      check back here — a signed release will appear on this page and on
+      GitHub releases when it ships.
     </p>
 
     <div class="core-tiles core-tiles-3">
       <div class="ct-tile">
-        <div class="k">ghost-cli</div>
-        <div class="v">RPC client</div>
+        <div class="k">Wraith wallet</div>
+        <div class="v">Desktop <span class="fl-badge">in development</span></div>
         <div class="sub">
-          Node RPC + pool RPC in one binary. Works against local or
-          remote daemons over TLS.
+          Linux · macOS · Windows planned. Self-custodial, Tor by default, no
+          server-side balance lookups.
         </div>
         <div class="hero-actions" style="margin-top:18px;">
-          <a href="https://github.com/bitcoin-ghost/ghost/releases" class="btn btn-primary">Download <span class="arrow">→</span></a>
+          <a href="https://github.com/bitcoin-ghost/ghost" class="btn btn-ghost">Track on GitHub <span class="arrow">→</span></a>
+        </div>
+      </div>
+      <div class="ct-tile ct-wide">
+        <div class="k">what it will do</div>
+        <div class="sub" style="line-height:1.7;">
+          Hold L1 Bitcoin and spend L2 shielded notes from one seed; receive
+          to a Silent Payment address; open a coordinator-free Wraith mixing
+          round to break the transaction graph; sync via the Ghost
+          Silent-payment Protocol so the backend never learns your addresses.
+          See the <a href="/pay.html">pay</a> page for how the L2 works.
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ───────── 3 · Node dashboard (frontend) ───────── -->
+<section class="block">
+  <div class="container">
+    <div class="section-label">3 · node dashboard · operators</div>
+    <h2 class="section-title">Watch and manage your node.</h2>
+    <p class="section-lead">
+      The node dashboard is a small web frontend you run against your own
+      node. It shows hashrate, shares, capabilities, verification results and
+      payouts, and lets you adjust policy, mining mode and reaper settings. It
+      binds to localhost and is password-protected — per-operator by design,
+      with no public endpoint.
+    </p>
+
+    <div class="core-tiles core-tiles-3">
+      <div class="ct-tile ct-wide">
+        <div class="k">run it</div>
+        <div class="sub" style="line-height:1.7;">
+          A Next.js app that talks to your node's local API. Access it at
+          <code>http://localhost:3000</code> on the node, or over an SSH
+          tunnel (<code>ssh -L 3000:localhost:3000 your-node</code>) from
+          elsewhere. Build and run instructions are in the
+          <a href="/docs/#node-dashboard">dashboard docs</a>.
         </div>
       </div>
       <div class="ct-tile">
-        <div class="k">ghost-light-wallet-cli</div>
-        <div class="v">Light wallet</div>
+        <div class="k">node dashboard</div>
+        <div class="v accent">Next.js · localhost</div>
         <div class="sub">
-          Command-line light wallet backed by GSP. Send, receive, check
-          balance — no full node required.
+          Ships in the repository. Password-protected, localhost-bound, no
+          telemetry.
         </div>
         <div class="hero-actions" style="margin-top:18px;">
-          <a href="https://github.com/bitcoin-ghost/ghost/releases" class="btn btn-primary">Download <span class="arrow">→</span></a>
-        </div>
-      </div>
-      <div class="ct-tile">
-        <div class="k">ghost-light-wallet-tui</div>
-        <div class="v">Terminal UI</div>
-        <div class="sub">
-          Full-screen ncurses wallet for servers. Same GSP backend as the
-          CLI, prettier interface.
-        </div>
-        <div class="hero-actions" style="margin-top:18px;">
-          <a href="https://github.com/bitcoin-ghost/ghost/releases" class="btn btn-primary">Download <span class="arrow">→</span></a>
+          <a href="https://github.com/bitcoin-ghost/ghost" class="btn btn-primary">Source <span class="arrow">→</span></a>
         </div>
       </div>
     </div>
@@ -346,9 +258,11 @@
     <div class="section-label">verify your download</div>
     <h2 class="section-title">Check every binary before running it.</h2>
     <p class="section-lead">
-      Every Ghost release is signed. Verify the signature before you install
-      anything — a release you didn't verify is a release you can't trust.
-      Three steps:
+      Every Ghost release is signed with the release key
+      (<code>777FE81F8CC077FD3D08055E852C2B3190F5B928</code>). The one-command
+      installer does these checks for you and aborts on any failure. If you
+      install by hand, do them yourself — a release you didn't verify is a
+      release you can't trust.
     </p>
 
     <ol class="quickstart-steps">
@@ -357,77 +271,43 @@
         <div class="qs-body">
           <div class="qs-title">Import the release key</div>
           <div class="qs-desc">
-            <code>gpg --keyserver keys.openpgp.org --recv-keys 0xDEFENWYCKE</code>
-            — replace with the fingerprint published on the release page. Always
-            cross-check the fingerprint against <a href="https://defenwycke.org">defenwycke.org</a>
-            and the pinned GitHub commit.
+            <code>curl -fsSL https://get.bitcoinghost.org/ghost-release-key.asc | gpg --import</code><br>
+            Confirm the fingerprint is
+            <code>777FE81F8CC077FD3D08055E852C2B3190F5B928</code> before you
+            trust it.
           </div>
         </div>
       </li>
       <li>
         <div class="qs-n">2</div>
         <div class="qs-body">
-          <div class="qs-title">Verify SHA256SUMS.asc</div>
+          <div class="qs-title">Verify the checksums file</div>
           <div class="qs-desc">
-            Download <code>SHA256SUMS</code> and <code>SHA256SUMS.asc</code> from
-            the release. Run <code>gpg --verify SHA256SUMS.asc SHA256SUMS</code>.
-            You should see <code>Good signature from defenwycke</code> and a
-            matching fingerprint.
+            Download <code>SHA256SUMS.txt</code> and
+            <code>SHA256SUMS.txt.asc</code> from the release, then run
+            <code>gpg --verify SHA256SUMS.txt.asc SHA256SUMS.txt</code>. You
+            should see a good signature from the fingerprint above.
           </div>
         </div>
       </li>
       <li>
         <div class="qs-n">3</div>
         <div class="qs-body">
-          <div class="qs-title">Check the binary hash</div>
+          <div class="qs-title">Check the tarball hash</div>
           <div class="qs-desc">
-            Run <code>sha256sum -c SHA256SUMS --ignore-missing</code>. Each
-            downloaded binary must match. If any line says <code>FAILED</code>,
-            stop — delete the binary and report it on the issue tracker.
+            With the tarball in the same directory, run
+            <code>sha256sum -c SHA256SUMS.txt</code>. The line for your file
+            must say <code>OK</code>. If anything says <code>FAILED</code>,
+            stop — delete it and report it on the issue tracker.
           </div>
         </div>
       </li>
     </ol>
 
     <div class="pending-note" style="margin-top:28px;">
-      Builds are reproducible — the release tarball contains a Guix manifest
-      and a build script that produces byte-for-byte identical binaries
-      from the tagged source. Run the build yourself if you don't want to
-      trust defenwycke's machine.
-    </div>
-  </div>
-</section>
-
-<!-- ───────── Source / build ───────── -->
-<section class="block">
-  <div class="container">
-    <div class="section-label">source · reproducible builds</div>
-    <h2 class="section-title">Build it yourself.</h2>
-    <p class="section-lead">
-      Every binary on this page builds from a public git tag. Nothing is
-      compiled on a private machine and pushed as an opaque blob. If you
-      spot a divergence between your build and the signed release, that's
-      a bug — open an issue.
-    </p>
-
-    <div class="core-tiles core-tiles-3">
-      <div class="ct-tile ct-wide">
-        <div class="k">clone + build</div>
-        <div class="v" style="font-size:15px; line-height:1.7;">
-          <code>git clone https://github.com/bitcoin-ghost/ghost</code><br>
-          <code>cd ghost &amp;&amp; git checkout v1.0.0</code><br>
-          <code>cargo build --release --workspace</code>
-        </div>
-        <div class="sub" style="margin-top:14px;">
-          Binaries land in <code>target/release/</code>. Full build
-          instructions, dependencies, and Guix manifest in the repo README.
-        </div>
-      </div>
-    </div>
-
-    <div class="hero-actions" style="margin-top:28px;">
-      <a href="https://github.com/bitcoin-ghost/ghost" class="btn btn-primary">Source on GitHub <span class="arrow">→</span></a>
-      <a href="/docs/" class="btn btn-ghost">Build docs</a>
+      Prefer to trust nothing? Build from source: clone the repo, check out
+      the release tag, run <code>cargo build --release --workspace</code>, and
+      compare your binaries against the signed release.
     </div>
   </div>
 </section>

--- a/ghost-web/index.html
+++ b/ghost-web/index.html
@@ -76,8 +76,8 @@
       A bitcoin node stack built on three layers. Incentivised node. Decentralised mining. Private payments. Open source, running on mainnet today.
     </p>
     <div class="hero-actions">
-      <a href="/get-started.html" class="btn btn-primary">Run a node <span class="arrow">→</span></a>
-      <a href="/protocol.html" class="btn btn-ghost">Read the docs</a>
+      <a href="/nodes.html" class="btn btn-primary">Run a node <span class="arrow">→</span></a>
+      <a href="/docs/" class="btn btn-ghost">Read the docs</a>
     </div>
   </div>
 </section>
@@ -429,12 +429,12 @@
       <div class="row">
         <div class="cell phase now">now</div>
         <div class="cell title">Mainnet testing</div>
-        <div class="cell desc">Observe-only deployment across four production nodes. Hardening the checkpoint pipeline and consensus. Soak tests running continuously.</div>
+        <div class="cell desc">Observe-only deployment across a growing production mesh. Hardening the checkpoint pipeline and consensus. Soak tests running continuously.</div>
       </div>
       <div class="row">
         <div class="cell phase">target</div>
-        <div class="cell title">Mainnet launch · July 2026</div>
-        <div class="cell desc">Full production with elder registration, mining, and Ghost Pay active from block 1.</div>
+        <div class="cell title">Mainnet launch</div>
+        <div class="cell desc">Full production with open elder registration, mining, and Ghost Pay active. Follows completion of the observe-mode soak.</div>
       </div>
     </div>
   </div>
@@ -650,10 +650,25 @@
             hosts[(i > 0 ? s.slice(0, i) : s) || ('id:' + ((n && n.node_id) || ''))] = 1;
           });
           meshCount = Object.keys(hosts).length;
+          // Persist the last good reading so a transient all-seed failure never
+          // reverts the tile to a misleading fixed number.
+          try { localStorage.setItem('ghost-mesh-count-v1', String(meshCount)); } catch (e) {}
         }
         if (nodesEl) {
-          if (meshCount != null) nodesEl.textContent = String(meshCount);
-          else nodesEl.innerHTML = online + '<span class="unit"> / ' + VMS.length + '</span>';
+          // The live mesh size (self + connected peers from any one seed,
+          // deduped by host) — it grows automatically as nodes join and is
+          // NEVER a hard-coded figure. If every seed is briefly unreachable,
+          // fall back to the last count we saw; only show "—" if we've never
+          // had a reading. We deliberately do NOT render "reachable / 4" here:
+          // the mesh is not four nodes, and the seed list is only an entry
+          // point, not the network size.
+          if (meshCount != null) {
+            nodesEl.textContent = String(meshCount);
+          } else {
+            var cachedMesh = null;
+            try { cachedMesh = localStorage.getItem('ghost-mesh-count-v1'); } catch (e) {}
+            nodesEl.textContent = (cachedMesh != null) ? cachedMesh : '—';
+          }
         }
         if (heightEl) heightEl.textContent = height ? height.toLocaleString() : '—';
         console.debug('[index] refresh ok · ' + online + '/' + VMS.length + ' seeds · ' + (meshCount != null ? meshCount + ' mesh nodes · ' : '') + hash.toFixed(2) + ' TH/s · ' + rawMiners + ' miners');

--- a/ghost-web/miners.html
+++ b/ghost-web/miners.html
@@ -9,14 +9,14 @@
   <meta property="og:site_name" content="Bitcoin Ghost">
   <meta property="og:type" content="website">
   <meta property="og:title" content="Point your hashrate · Bitcoin Ghost">
-  <meta property="og:description" content="Mine to Ghost Pool. Sovereign payouts straight to your address, BFT-voted coinbase, zero custody, zero pool fee.">
+  <meta property="og:description" content="Mine to Ghost Pool. Sovereign payouts straight to your address, BFT-voted coinbase, zero custody, 1% pool fee.">
   <meta property="og:url" content="https://bitcoinghost.org/miners.html">
   <meta property="og:image" content="https://bitcoinghost.org/logo.png">
   <meta name="twitter:card" content="summary">
   <meta name="twitter:site" content="@defenwycke">
   <meta name="twitter:creator" content="@defenwycke">
   <meta name="twitter:title" content="Point your hashrate · Bitcoin Ghost">
-  <meta name="twitter:description" content="Mine to Ghost Pool. Sovereign payouts straight to your address, BFT-voted coinbase, zero custody, zero pool fee.">
+  <meta name="twitter:description" content="Mine to Ghost Pool. Sovereign payouts straight to your address, BFT-voted coinbase, zero custody, 1% pool fee.">
   <meta name="twitter:image" content="https://bitcoinghost.org/logo.png">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/ghost-web/nodes.html
+++ b/ghost-web/nodes.html
@@ -84,10 +84,11 @@
     <div class="section-label">what makes a ghost node</div>
     <h2 class="section-title">Bitcoin Core, plus everything Ghost adds.</h2>
     <p class="section-lead">
-      A Ghost node runs alongside your Bitcoin Core daemon. It adds a
-      mesh layer, an incentive layer, and a privacy layer on top of
-      stock Bitcoin — every feature below is built into the Ghost
-      binary, every one toggles in config.
+      A Ghost node runs <code>ghostd</code> — a clean Bitcoin Core v30 fork —
+      with <code>ghost-pool</code> and <code>ghost-pay</code> alongside it on
+      the same box. It adds a mesh layer, an incentive layer, and a privacy
+      layer on top of a full Bitcoin node — every feature below is built into
+      the Ghost binaries, every one toggles in config.
     </p>
 
     <ul class="feature-list node-core-pink">
@@ -292,10 +293,10 @@
     <div class="section-label">hardware</div>
     <h2 class="section-title">What you need.</h2>
     <p class="section-lead">
-      Ghost runs alongside Bitcoin Core on the same box. Minimum
-      specs scale with the capabilities you opt into — a pruned
-      Bitcoin-only node is far cheaper than a full-archive node with
-      Pay enabled.
+      Ghost runs its own Bitcoin full node (<code>ghostd</code>) plus the
+      pool and Pay daemons on the same box. Minimum specs scale with the
+      capabilities you opt into — a pruned Bitcoin-only node is far cheaper
+      than a full-archive node with Pay enabled.
     </p>
 
     <div class="hw-table-wrap">
@@ -364,15 +365,15 @@
       <li>
         <div class="qs-n">1</div>
         <div class="qs-body">
-          <div class="qs-title">Install Bitcoin Ghost</div>
-          <div class="qs-desc">Download the binary from the <a href="/downloads.html">downloads page</a>, verify the signature, and run <code>ghost-pool --help</code> to confirm.</div>
+          <div class="qs-title">Run the installer</div>
+          <div class="qs-desc">One command installs <code>ghostd</code>, <code>ghost-pool</code> and <code>ghost-pay</code> with signed binaries and systemd units:<br><code>curl -sSL https://get.bitcoinghost.org | sudo bash -s -- --payout-address bc1q…</code><br>The script verifies the GPG release signature before writing anything. Prefer to do it by hand? Grab the tarball from the <a href="/downloads.html">downloads page</a> and verify it yourself.</div>
         </div>
       </li>
       <li>
         <div class="qs-n">2</div>
         <div class="qs-body">
-          <div class="qs-title">Point at Bitcoin Core</div>
-          <div class="qs-desc">Ghost talks to your existing Bitcoin Core daemon via RPC + ZMQ. Add an RPC user and open the two ZMQ ports (<code>hashblock</code>, <code>hashtx</code>) in <code>bitcoin.conf</code>.</div>
+          <div class="qs-title">Choose your sync</div>
+          <div class="qs-desc">Full initial block download (the default) validates every block from genesis — fully trustless. In a hurry? <code>--sync fast</code> loads a verified assumeUTXO snapshot at height 910000 and back-fills history behind it, so the node is usable in minutes rather than days.</div>
         </div>
       </li>
       <li>

--- a/ghost-web/pay.html
+++ b/ghost-web/pay.html
@@ -275,6 +275,7 @@
         <div class="rs-head active">active</div>
         <ul>
           <li>Ghost Tap wallet (iOS / Android / desktop)</li>
+          <li>Ghost Glyph readable addresses</li>
           <li>Live Pay dashboard on bitcoinghost.org</li>
           <li>Settlement batching to reconciliation_state</li>
           <li>Merchant terminal (Ghost Tap merchant mode)</li>
@@ -283,7 +284,6 @@
       <div class="rs-col">
         <div class="rs-head next">next</div>
         <ul>
-          <li>Ghost Glyph readable addresses</li>
           <li>GSP light-wallet backend v2</li>
           <li>Multi-recipient payments in one L2 tx</li>
           <li>Post-quantum signature support</li>

--- a/ghost-web/security.html
+++ b/ghost-web/security.html
@@ -251,6 +251,13 @@
     </ol>
 
     <div class="pending-note">
+      A full-stack security audit (findings GHOST-01 through GHOST-13) is
+      complete — every finding is fixed in the shipping binaries, backed by a
+      multi-node adversarial test harness. The write-up lives in
+      <code>docs/</code> in the <a href="https://github.com/bitcoin-ghost/ghost">source repository</a>.
+    </div>
+
+    <div class="pending-note">
       After ossification (target: 5+ years from mainnet launch) the codebase
       freezes and this process ends. At that point security reports are still
       welcome on GitHub, but fixes only land if the community agrees on a


### PR DESCRIPTION
Corrects stale content across the public site + docs, verified against the codebase. Pages: dynamic mesh node-count fallback fix (was showing `/4`), 1% pool fee in miners social-meta (was 'zero'), dead-link repoints, version/roadmap de-stale, Ghost Glyph marked active, downloads-page restructure (node package + Wraith wallet + dashboard) with correct PGP-verify steps. Docs: MPC ceremony corrected to rolling-in-progress + mid-ceremony catch-up, rolling elder registration + PoW ordering + slot reopen, PoW Sybil defence, removed incorrect median fallback. Deployed to the live site (backups kept). See `tasks/web-audit-report.md` + `tasks/docs-audit-report.md` for the full edit lists + suggested additions + items flagged for review.