### PR TITLE
v1.10.17: fresh-node onboarding robustness (MPC mesh-gate + L2 checkpoint FK)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -66,15 +66,16 @@ ignore = [
     # TDP coinbase construction — i.e. it is gated on a deliberate Bitcoin Core
     # version migration. Re-evaluate when that migration happens.
     "RUSTSEC-2025-0143",  # capnp (unsound) — unreachable; fix gated on a Bitcoin Core IPC version migration
-    # --- quick-xml DoS (RUSTSEC-2026-0194): reviewed, GUI/macOS-bundling only. ---
-    # Quadratic run time when an XML start tag carries many duplicate attribute
-    # names. quick-xml is pulled ONLY via `plist` (Apple .plist parsing) in the
-    # desktop / macOS app-bundling path — not in any shipped node binary (ghost-pool
-    # / translator_sv2 / pool_sv2 / ghost-pay / ghostd; confirmed via cargo tree).
+    # --- quick-xml DoS (RUSTSEC-2026-0194 + -0195): reviewed, GUI/macOS-bundling only. ---
+    # Two DoS advisories (quadratic run time on duplicate start-tag attributes;
+    # unbounded namespace-declaration allocation in NsReader). quick-xml is pulled
+    # ONLY via `plist` (Apple .plist parsing) in the desktop / macOS app-bundling
+    # path — not in any shipped node binary (ghost-pool / translator_sv2 / pool_sv2
+    # / ghost-pay / ghostd; confirmed via cargo tree — no host-target dependents).
     # `plist` reads local, trusted property lists, never untrusted network input, so
-    # the quadratic-DoS is unreachable in ghost's usage. The fix (quick-xml >= 0.41)
-    # is upstream-gated: the latest `plist` (1.9.0) still pins quick-xml 0.39, so
-    # there is no patched version to adopt. Re-evaluate when `plist` moves to
-    # quick-xml >= 0.41.
+    # the DoS is unreachable in ghost's usage. The fix (quick-xml >= 0.41) is
+    # upstream-gated: the latest `plist` (1.9.0) still pins quick-xml 0.39, so there
+    # is no patched version to adopt. Re-evaluate when `plist` moves to quick-xml >= 0.41.
     "RUSTSEC-2026-0194",  # quick-xml (DoS) — GUI/macOS-bundling only via plist, unreachable; fix upstream-gated
+    "RUSTSEC-2026-0195",  # quick-xml (DoS) — same: GUI/macOS-bundling only via plist, unreachable; fix upstream-gated
 ]

--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -66,4 +66,15 @@ ignore = [
     # TDP coinbase construction — i.e. it is gated on a deliberate Bitcoin Core
     # version migration. Re-evaluate when that migration happens.
     "RUSTSEC-2025-0143",  # capnp (unsound) — unreachable; fix gated on a Bitcoin Core IPC version migration
+    # --- quick-xml DoS (RUSTSEC-2026-0194): reviewed, GUI/macOS-bundling only. ---
+    # Quadratic run time when an XML start tag carries many duplicate attribute
+    # names. quick-xml is pulled ONLY via `plist` (Apple .plist parsing) in the
+    # desktop / macOS app-bundling path — not in any shipped node binary (ghost-pool
+    # / translator_sv2 / pool_sv2 / ghost-pay / ghostd; confirmed via cargo tree).
+    # `plist` reads local, trusted property lists, never untrusted network input, so
+    # the quadratic-DoS is unreachable in ghost's usage. The fix (quick-xml >= 0.41)
+    # is upstream-gated: the latest `plist` (1.9.0) still pins quick-xml 0.39, so
+    # there is no patched version to adopt. Re-evaluate when `plist` moves to
+    # quick-xml >= 0.41.
+    "RUSTSEC-2026-0194",  # quick-xml (DoS) — GUI/macOS-bundling only via plist, unreachable; fix upstream-gated
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-ghost-tests"
-version = "1.10.16"
+version = "1.10.17"
 dependencies = [
  "bitcoin",
  "chrono",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin_core_sv2"
-version = "1.10.16"
+version = "1.10.17"
 dependencies = [
  "async-channel 1.9.0",
  "bitcoin-capnp-types",
@@ -3083,7 +3083,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-accounting"
-version = "1.10.16"
+version = "1.10.17"
 dependencies = [
  "bitcoin",
  "ghost-common",
@@ -3097,7 +3097,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-buds"
-version = "1.10.16"
+version = "1.10.17"
 dependencies = [
  "bitcoin",
  "ghost-common",
@@ -3111,7 +3111,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-cli"
-version = "1.10.16"
+version = "1.10.17"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3129,7 +3129,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-common"
-version = "1.10.16"
+version = "1.10.17"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -3162,7 +3162,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-consensus"
-version = "1.10.16"
+version = "1.10.17"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3194,7 +3194,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-glyph"
-version = "1.10.16"
+version = "1.10.17"
 dependencies = [
  "hex",
  "serde",
@@ -3205,7 +3205,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-gsp"
-version = "1.10.16"
+version = "1.10.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3267,7 +3267,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-gsp-proto"
-version = "1.10.16"
+version = "1.10.17"
 dependencies = [
  "bitcoin",
  "chrono",
@@ -3284,7 +3284,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-keys"
-version = "1.10.16"
+version = "1.10.17"
 dependencies = [
  "bech32",
  "bitcoin",
@@ -3306,7 +3306,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-locks"
-version = "1.10.16"
+version = "1.10.17"
 dependencies = [
  "bitcoin",
  "getrandom 0.2.17",
@@ -3350,7 +3350,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-pay"
-version = "1.10.16"
+version = "1.10.17"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3398,7 +3398,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-policy"
-version = "1.10.16"
+version = "1.10.17"
 dependencies = [
  "bitcoin",
  "ghost-buds",
@@ -3411,7 +3411,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-pool"
-version = "1.10.16"
+version = "1.10.17"
 dependencies = [
  "anyhow",
  "async-channel 2.5.0",
@@ -3466,7 +3466,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-reaper"
-version = "1.10.16"
+version = "1.10.17"
 dependencies = [
  "bitcoin",
  "hex",
@@ -3478,7 +3478,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-reconciliation"
-version = "1.10.16"
+version = "1.10.17"
 dependencies = [
  "async-trait",
  "bitcoin",
@@ -3504,7 +3504,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-registry"
-version = "1.10.16"
+version = "1.10.17"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -3539,7 +3539,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-setup"
-version = "1.10.16"
+version = "1.10.17"
 dependencies = [
  "clap",
  "dirs 5.0.1",
@@ -3550,7 +3550,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-storage"
-version = "1.10.16"
+version = "1.10.17"
 dependencies = [
  "base64 0.22.1",
  "chacha20poly1305",
@@ -3571,7 +3571,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-tap-core"
-version = "1.10.16"
+version = "1.10.17"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3613,7 +3613,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-tap-desktop"
-version = "1.10.16"
+version = "1.10.17"
 dependencies = [
  "dirs 6.0.0",
  "getrandom 0.2.17",
@@ -3639,7 +3639,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-tap-integration"
-version = "1.10.16"
+version = "1.10.17"
 dependencies = [
  "ghost-gsp-proto",
  "ghost-tap-core",
@@ -3653,7 +3653,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-template"
-version = "1.10.16"
+version = "1.10.17"
 dependencies = [
  "bitcoin",
  "ghost-buds",
@@ -3669,7 +3669,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-verification"
-version = "1.10.16"
+version = "1.10.17"
 dependencies = [
  "axum 0.7.9",
  "bitcoin",
@@ -4642,7 +4642,7 @@ dependencies = [
 
 [[package]]
 name = "jd_client_sv2"
-version = "1.10.16"
+version = "1.10.17"
 dependencies = [
  "async-channel 1.9.0",
  "bitcoin_core_sv2",
@@ -4658,7 +4658,7 @@ dependencies = [
 
 [[package]]
 name = "jd_server_sv2"
-version = "1.10.16"
+version = "1.10.17"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -6181,7 +6181,7 @@ dependencies = [
 
 [[package]]
 name = "pool_sv2"
-version = "1.10.16"
+version = "1.10.17"
 dependencies = [
  "async-channel 1.9.0",
  "bitcoin_core_sv2",
@@ -7905,7 +7905,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stratum-apps"
-version = "1.10.16"
+version = "1.10.17"
 dependencies = [
  "async-channel 1.9.0",
  "axum 0.8.9",
@@ -9118,7 +9118,7 @@ dependencies = [
 
 [[package]]
 name = "translator_sv2"
-version = "1.10.16"
+version = "1.10.17"
 dependencies = [
  "async-channel 1.9.0",
  "clap",
@@ -10449,7 +10449,7 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "wraith-coordinator"
-version = "1.10.16"
+version = "1.10.17"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -10486,7 +10486,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-protocol"
-version = "1.10.16"
+version = "1.10.17"
 dependencies = [
  "bitcoin",
  "getrandom 0.2.17",
@@ -10507,7 +10507,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-cli"
-version = "1.10.16"
+version = "1.10.17"
 dependencies = [
  "clap",
  "clap_complete",
@@ -10520,7 +10520,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-core"
-version = "1.10.16"
+version = "1.10.17"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -10557,7 +10557,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-daemon"
-version = "1.10.16"
+version = "1.10.17"
 dependencies = [
  "axum 0.7.9",
  "base64 0.22.1",
@@ -10582,7 +10582,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-gui"
-version = "1.10.16"
+version = "1.10.17"
 dependencies = [
  "serde",
  "serde_json",
@@ -10596,7 +10596,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-ipc"
-version = "1.10.16"
+version = "1.10.17"
 dependencies = [
  "libc",
  "proptest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,9 +152,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.101"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arbitrary"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ exclude = []
 # Use scripts/build-all-wallets.sh to build all wallet types.
 
 [workspace.package]
-version = "1.10.16"
+version = "1.10.17"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Bitcoin Ghost Team"]

--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -131,6 +131,12 @@ const RECORD_WINDOWS: [(&str, i64); 4] = [
 ///
 /// 15 attempts with a randomised 60-90s delay ⇒ 14 sleeps × ~75s ≈ 17.5 min.
 /// These are consensus-affecting timings and are deliberately NOT env-tunable.
+///
+/// This is NO LONGER a terminal cap: a node that genuinely wants to be an elder
+/// keeps retrying indefinitely (with escalating backoff) rather than declaring
+/// "Node will not be an elder" after this many rounds. This constant now only
+/// marks the boundary between the fast converge window (fixed 60-90s delay) and
+/// the slow long-tail (exponential backoff up to `MPC_CONTRIBUTION_BACKOFF_MAX_SECS`).
 const MPC_CONTRIBUTION_MAX_ATTEMPTS: u32 = 15;
 /// Minimum per-attempt retry delay — enough for a voter to fetch the candidate,
 /// run the Groth16 verify, gossip its vote, reach quorum, apply and propagate
@@ -139,6 +145,30 @@ const MPC_CONTRIBUTION_RETRY_DELAY_MIN_SECS: u64 = 60;
 /// Maximum per-attempt retry delay. The delay is randomised in
 /// `[MIN, MAX]` to avoid a thundering herd when several nodes retry at once.
 const MPC_CONTRIBUTION_RETRY_DELAY_MAX_SECS: u64 = 90;
+/// Upper bound (seconds) on the escalating inter-round backoff once a node has
+/// spent its initial `MPC_CONTRIBUTION_MAX_ATTEMPTS` fast rounds without being
+/// voted in. A node that wants to be an elder NEVER permanently gives up (the
+/// node7/node8 onboarding bug that needed a manual restart); it keeps retrying
+/// and re-checking mesh readiness, but throttles to at most one round every few
+/// minutes so it does not hammer the mesh forever.
+#[cfg(feature = "mpc-ceremony")]
+const MPC_CONTRIBUTION_BACKOFF_MAX_SECS: u64 = 300;
+
+/// Freshness window (seconds) for counting an elder peer as "connected" in the
+/// MPC mesh-registration readiness gate. Health pings arrive every ~10s, so 60s
+/// tolerates a few missed pings without admitting long-dead peers.
+#[cfg(feature = "mpc-ceremony")]
+const MPC_READINESS_ELDER_FRESHNESS_SECS: u64 = 60;
+/// Poll interval (seconds) while waiting for mesh registration before the first
+/// contribution attempt. The gate sleeps between polls — it never busy-loops.
+#[cfg(feature = "mpc-ceremony")]
+const MPC_READINESS_POLL_SECS: u64 = 10;
+/// Overall ceiling (seconds) on the pre-contribution mesh-registration wait.
+/// Fail-safe: after this the node proceeds to attempt anyway. The contribution
+/// loop itself re-checks readiness every round, so a node that is still not
+/// meshed simply keeps retrying (with backoff) rather than blocking here forever.
+#[cfg(feature = "mpc-ceremony")]
+const MPC_READINESS_MAX_WAIT_SECS: u64 = 600;
 
 /// Decide whether a cached MPC contribution candidate is still valid to
 /// rebroadcast unchanged on the next retry.
@@ -182,6 +212,91 @@ fn cached_contribution_still_valid(cached_count: u32, current_count: u32) -> boo
 #[cfg(feature = "mpc-ceremony")]
 fn mpc_next_contribution_position(authoritative_count: u32, max_position: u32) -> u32 {
     authoritative_count.max(max_position) + 1
+}
+
+/// Pure readiness predicate for the MPC mesh-registration gate.
+///
+/// A freshly joined node must NOT start broadcasting its ceremony candidate
+/// until enough elders have DISCOVERED it (learned its address via mesh
+/// discovery + health-ping propagation) that they can actually fetch its
+/// candidate parameters and vote on them. Start too early and the voters cannot
+/// resolve the new node's address, every vote abstains, and — under the old
+/// fixed 15-attempt cap — the node wrongly concluded it "will not be an elder"
+/// and needed a manual `ghost-pool` restart to re-trigger the loop once the mesh
+/// had caught up (the node7/node8 onboarding bug this gate eliminates).
+///
+/// "Ready" iff BOTH hold:
+///   * our own candidate-serving HTTP endpoint is up (`endpoint_up`) — voters
+///     fetch `/api/v1/mpc/params?new_hash=…` from it, so it must be listening; and
+///   * we have live (recent health-ping) connectivity with at least
+///     `quorum` elders — the same BFT quorum the voters need to APPROVE the
+///     contribution. Receiving their pings proves they have discovered us and
+///     know our address, i.e. the reverse fetch path can succeed.
+#[cfg(feature = "mpc-ceremony")]
+fn mpc_contribution_ready(connected_elders: u32, quorum: u32, endpoint_up: bool) -> bool {
+    endpoint_up && connected_elders >= quorum
+}
+
+/// Inter-round backoff (seconds) for the indefinite MPC contribution retry loop.
+///
+/// For the first `MPC_CONTRIBUTION_MAX_ATTEMPTS` rounds the ceremony is still in
+/// its fast converge window, so this returns the upper bound of the tuned 60-90s
+/// delay (`MPC_CONTRIBUTION_RETRY_DELAY_MAX_SECS`) — the post-attempt delay site
+/// applies its own random jitter within `[MIN, MAX]`, while the readiness-wait
+/// site uses this value directly. Beyond the fast window the delay escalates
+/// exponentially and SATURATES at `MPC_CONTRIBUTION_BACKOFF_MAX_SECS`, so a node
+/// that cannot yet get voted in keeps retrying forever (never the old permanent
+/// "will not be an elder" giveup) without hammering the mesh.
+#[cfg(feature = "mpc-ceremony")]
+fn mpc_retry_backoff_secs(attempt: u32) -> u64 {
+    if attempt <= MPC_CONTRIBUTION_MAX_ATTEMPTS {
+        MPC_CONTRIBUTION_RETRY_DELAY_MAX_SECS
+    } else {
+        // over ∈ {1,2,…}; cap the shift so 1<<over cannot overflow.
+        let over = (attempt - MPC_CONTRIBUTION_MAX_ATTEMPTS).min(6);
+        MPC_CONTRIBUTION_RETRY_DELAY_MAX_SECS
+            .saturating_mul(1u64 << over)
+            .min(MPC_CONTRIBUTION_BACKOFF_MAX_SECS)
+    }
+}
+
+/// Count peers that are currently LIVE elders: they advertised `elder_status`
+/// in their most recent health ping AND that ping arrived within
+/// `freshness_secs` of `now`. `now` is passed explicitly so the count is
+/// deterministic under test.
+///
+/// NOTE: this reads `capabilities.elder_status` (refreshed on every health ping
+/// via `PeerManager::update_health_metrics`), NOT the `Peer::is_elder` field —
+/// the latter is only ever set true in unit tests and stays false in production,
+/// so counting it would always yield zero on a real mesh.
+#[cfg(feature = "mpc-ceremony")]
+fn count_connected_elders(
+    peers: &[ghost_consensus::peer::Peer],
+    now: u64,
+    freshness_secs: u64,
+) -> u32 {
+    let cutoff = now.saturating_sub(freshness_secs);
+    peers
+        .iter()
+        .filter(|p| p.capabilities.elder_status && p.last_seen >= cutoff)
+        .count() as u32
+}
+
+/// Probe our own candidate-serving HTTP endpoint — the same `:{http_port}` from
+/// which voters fetch `/api/v1/mpc/params`. Returns true once it answers, so the
+/// readiness gate never lets us advertise a candidate the voters could not
+/// actually fetch back from us. Binds to loopback (the listener is `0.0.0.0`).
+#[cfg(feature = "mpc-ceremony")]
+async fn local_mpc_endpoint_up(http_port: u16) -> bool {
+    let url = format!("http://127.0.0.1:{}/api/v1/mpc/status", http_port);
+    matches!(
+        reqwest::Client::new()
+            .get(&url)
+            .timeout(std::time::Duration::from_secs(5))
+            .send()
+            .await,
+        Ok(resp) if resp.status().is_success()
+    )
 }
 
 /// Build this node's best (rarest) valid share per records window from the
@@ -4236,6 +4351,9 @@ async fn main() -> Result<()> {
         let args_genesis_password = args.genesis_password.clone();
         let genesis_password = config.pool.genesis_password.clone();
         let seed_nodes_for_mpc = config.network.seed_nodes.clone();
+        // Local HTTP port for the mesh-registration readiness probe (voters fetch
+        // our candidate from `:{http_port}/api/v1/mpc/params`).
+        let http_port_for_mpc = config.network.http_port;
 
         tokio::spawn(async move {
             // Wait a bit for network to stabilize
@@ -4324,6 +4442,76 @@ async fn main() -> Result<()> {
                 return;
             }
 
+            // === MESH-REGISTRATION READINESS GATE ===
+            // Before starting (and counting) contribution attempts, WAIT until
+            // the mesh has registered this node — i.e. enough elders have
+            // discovered it that they can fetch its candidate and vote on it.
+            // A fresh node that broadcast its candidate before the voters knew
+            // its address had every vote abstain, exhausted the fixed attempt
+            // cap, and wrongly gave up ("Node will not be an elder") — needing a
+            // manual restart once the mesh had caught up (the node7/node8 bug).
+            //
+            // Skipped for the genesis-bootstrap case: a genesis node with an
+            // empty ceremony creates position 1 itself and has no other elders to
+            // connect to, so gating it would pointlessly stall ceremony formation.
+            {
+                let bootstrap_genesis = is_genesis_node
+                    && db_for_mpc
+                        .mpc_contribution_count_authoritative()
+                        .unwrap_or(0)
+                        == 0;
+                if !bootstrap_genesis {
+                    let deadline = std::time::Instant::now()
+                        + std::time::Duration::from_secs(MPC_READINESS_MAX_WAIT_SECS);
+                    loop {
+                        // Already voted in while we waited: fall through to the
+                        // loop below (its is_mpc_elder branch adopts + returns).
+                        if db_for_mpc.is_mpc_elder(&node_id_hex).unwrap_or(false) {
+                            break;
+                        }
+                        let contributor_count = db_for_mpc
+                            .mpc_contribution_count_authoritative()
+                            .unwrap_or(0);
+                        let quorum = ghost_mpc::mpc_bft_threshold(contributor_count);
+                        let now = chrono::Utc::now().timestamp() as u64;
+                        let connected_elders = count_connected_elders(
+                            &mesh_for_mpc_startup.peers().get_all_peers(),
+                            now,
+                            MPC_READINESS_ELDER_FRESHNESS_SECS,
+                        );
+                        let endpoint_up = local_mpc_endpoint_up(http_port_for_mpc).await;
+                        if mpc_contribution_ready(connected_elders, quorum, endpoint_up) {
+                            info!(
+                                connected_elders,
+                                quorum, "MPC: mesh registration complete — beginning contribution"
+                            );
+                            break;
+                        }
+                        if std::time::Instant::now() >= deadline {
+                            warn!(
+                                connected_elders,
+                                quorum,
+                                endpoint_up,
+                                "MPC: mesh-registration wait ceiling reached — proceeding to \
+                                 contribute anyway (the loop re-checks readiness every round)"
+                            );
+                            break;
+                        }
+                        info!(
+                            connected_elders,
+                            quorum,
+                            endpoint_up,
+                            "MPC: waiting for mesh registration before contributing — connected to \
+                             {}/{} elders",
+                            connected_elders,
+                            quorum
+                        );
+                        tokio::time::sleep(std::time::Duration::from_secs(MPC_READINESS_POLL_SECS))
+                            .await;
+                    }
+                }
+            }
+
             // Retry loop: attempt contribution up to MPC_CONTRIBUTION_MAX_ATTEMPTS
             // times with a randomised 60-90s interval (~15-20 min total window).
             // This handles race conditions where multiple nodes try the same position
@@ -4336,7 +4524,28 @@ async fn main() -> Result<()> {
             // accumulate votes for one hash toward quorum (no "moving target").
             let mut cached_msg: Option<(ghost_consensus::message::MpcContributionMessage, u32)> =
                 None;
-            for attempt in 1..=MPC_CONTRIBUTION_MAX_ATTEMPTS {
+            // INDEFINITE retry: a node that wants to be an elder never permanently
+            // gives up. The first MPC_CONTRIBUTION_MAX_ATTEMPTS rounds use the tuned
+            // 60-90s converge window; beyond that the inter-round delay backs off
+            // (up to MPC_CONTRIBUTION_BACKOFF_MAX_SECS) so a still-unregistered node
+            // keeps retrying without hammering the mesh. The ONLY exits are: voted
+            // in (is_mpc_elder success → return) or the ceremony ossifies (clean
+            // break). Each round re-checks mesh readiness so a node that lost its
+            // elder connectivity waits rather than broadcasting into the void.
+            let mut attempt: u32 = 0;
+            loop {
+                attempt += 1;
+
+                // Clean exit if the ceremony ossified (101 contributors reached)
+                // while we were retrying — nothing more to contribute.
+                if ceremony_manager_for_startup.is_ossified() {
+                    info!(
+                        attempt,
+                        "MPC: ceremony ossified while retrying — stopping contribution attempts"
+                    );
+                    break;
+                }
+
                 // Re-check if we became an elder (e.g., via P2P sync of our own contribution)
                 if db_for_mpc.is_mpc_elder(&node_id_hex).unwrap_or(false) {
                     let position = db_for_mpc
@@ -4378,6 +4587,51 @@ async fn main() -> Result<()> {
                     );
                     tokio::time::sleep(tokio::time::Duration::from_secs(10)).await;
                     continue;
+                }
+
+                // Re-check mesh registration each round (skipped for the
+                // genesis-bootstrap case, which has no other elders). If we are no
+                // longer connected to a BFT quorum of elders — or our own
+                // candidate-serving endpoint went away — broadcasting a candidate
+                // now would just abstain-vote into the void. Wait (with the same
+                // escalating backoff as a failed attempt) and re-check instead of
+                // burning a round. This is what stops a node from ever wrongly
+                // concluding it "will not be an elder" while the mesh catches up.
+                {
+                    let bootstrap_genesis = is_genesis_node
+                        && db_for_mpc
+                            .mpc_contribution_count_authoritative()
+                            .unwrap_or(0)
+                            == 0;
+                    if !bootstrap_genesis {
+                        let contributor_count = db_for_mpc
+                            .mpc_contribution_count_authoritative()
+                            .unwrap_or(0);
+                        let quorum = ghost_mpc::mpc_bft_threshold(contributor_count);
+                        let now = chrono::Utc::now().timestamp() as u64;
+                        let connected_elders = count_connected_elders(
+                            &mesh_for_mpc_startup.peers().get_all_peers(),
+                            now,
+                            MPC_READINESS_ELDER_FRESHNESS_SECS,
+                        );
+                        let endpoint_up = local_mpc_endpoint_up(http_port_for_mpc).await;
+                        if !mpc_contribution_ready(connected_elders, quorum, endpoint_up) {
+                            let delay_secs = mpc_retry_backoff_secs(attempt);
+                            warn!(
+                                attempt,
+                                connected_elders,
+                                quorum,
+                                endpoint_up,
+                                delay_secs,
+                                "MPC: not adequately meshed to contribute (connected to {}/{} \
+                                 elders) — waiting before re-checking (no permanent giveup)",
+                                connected_elders,
+                                quorum
+                            );
+                            tokio::time::sleep(std::time::Duration::from_secs(delay_secs)).await;
+                            continue;
+                        }
+                    }
                 }
 
                 // Ensure we have parameters loaded.
@@ -4950,17 +5204,23 @@ async fn main() -> Result<()> {
                     }
                 }
 
-                // Wait a randomised 60-90s before retry: long enough for voters to
-                // fetch + Groth16-verify + vote + reach quorum + apply + propagate
-                // back, and randomised to prevent races where multiple nodes fight
-                // for the same position simultaneously.
-                if attempt < MPC_CONTRIBUTION_MAX_ATTEMPTS {
-                    let delay_secs = {
+                // Wait before the next round, then sync contributors + conditionally
+                // refetch. ALWAYS runs now (the loop is indefinite): during the fast
+                // converge window the delay is a randomised 60-90s — long enough for
+                // voters to fetch + Groth16-verify + vote + reach quorum + apply +
+                // propagate back, and randomised to prevent races where multiple
+                // nodes fight for the same position simultaneously; beyond the fast
+                // window it escalates to a capped backoff so a not-yet-voted-in node
+                // keeps retrying without hammering the mesh.
+                {
+                    let delay_secs = if attempt < MPC_CONTRIBUTION_MAX_ATTEMPTS {
                         use rand::Rng;
                         rand::thread_rng().gen_range(
                             MPC_CONTRIBUTION_RETRY_DELAY_MIN_SECS
                                 ..=MPC_CONTRIBUTION_RETRY_DELAY_MAX_SECS,
                         )
+                    } else {
+                        mpc_retry_backoff_secs(attempt)
                     };
                     info!(
                         attempt,
@@ -5240,7 +5500,13 @@ async fn main() -> Result<()> {
                 }
             }
 
-            // Final check after all attempts
+            // The loop only exits by BREAK (ceremony ossified) — the elder-success
+            // path returns from inside it. So reaching here means the ceremony
+            // ossified. If we were nonetheless voted in on the same tick we broke,
+            // finalise elder state; otherwise the ceremony filled before we could
+            // register. Either way this is a legitimate terminal state, NOT the old
+            // misleading "gave up after N attempts / will not be an elder" — until
+            // ossification a node that wants to be an elder retries indefinitely.
             if db_for_mpc.is_mpc_elder(&node_id_hex).unwrap_or(false) {
                 let position = db_for_mpc
                     .get_mpc_elder_position(&node_id_hex)
@@ -5253,9 +5519,9 @@ async fn main() -> Result<()> {
                 round_manager_for_mpc
                     .update_node_capabilities(identity_for_mpc.node_id(), updated_caps);
             } else {
-                warn!(
-                    attempts = MPC_CONTRIBUTION_MAX_ATTEMPTS,
-                    "MPC: Failed to contribute after all attempts. Node will not be an elder."
+                info!(
+                    "MPC: ceremony ossified before this node was voted in — it will not be an \
+                     elder in this ceremony (retried until ossification; no premature giveup)"
                 );
             }
         });
@@ -8283,6 +8549,113 @@ mod tests {
         // a phantom advance past the head.
         assert_eq!(mpc_next_contribution_position(0, 0), 1);
         assert_eq!(mpc_next_contribution_position(3, 3), 4);
+    }
+
+    /// Build a peer that advertises elder status with an explicit `last_seen`.
+    #[cfg(feature = "mpc-ceremony")]
+    fn elder_peer(tag: u8, last_seen: u64) -> ghost_consensus::peer::Peer {
+        let mut p = ghost_consensus::peer::Peer::new([tag; 32], format!("10.0.0.{tag}:8555"));
+        p.capabilities = NodeCapabilities {
+            elder_status: true,
+            ..NodeCapabilities::default()
+        };
+        p.last_seen = last_seen;
+        p
+    }
+
+    /// The mesh-registration readiness predicate: ready iff our candidate-serving
+    /// endpoint is up AND we are connected to at least a BFT quorum of elders.
+    /// This is the gate that stops the node7/node8 "broadcast before the voters
+    /// know my address → abstain → give up" bug.
+    #[cfg(feature = "mpc-ceremony")]
+    #[test]
+    fn mpc_contribution_ready_below_at_and_above_threshold() {
+        // Below quorum: NOT ready even with the endpoint up.
+        assert!(!mpc_contribution_ready(2, 3, true));
+        // Exactly at quorum with the endpoint up: ready.
+        assert!(mpc_contribution_ready(3, 3, true));
+        // Above quorum: ready.
+        assert!(mpc_contribution_ready(4, 3, true));
+        // Endpoint down is never ready, regardless of elder count.
+        assert!(!mpc_contribution_ready(4, 3, false));
+        // Bootstrap quorum of 1 needs exactly one connected elder.
+        assert!(!mpc_contribution_ready(0, 1, true));
+        assert!(mpc_contribution_ready(1, 1, true));
+    }
+
+    /// `count_connected_elders` counts only peers that BOTH advertise elder
+    /// status AND were seen within the freshness window; a `now`-relative cutoff
+    /// keeps it deterministic.
+    #[cfg(feature = "mpc-ceremony")]
+    #[test]
+    fn count_connected_elders_filters_stale_and_non_elders() {
+        let now = 10_000u64;
+        let fresh = now - 30; // within a 60s window
+        let stale = now - 120; // outside it
+
+        let mut non_elder = ghost_consensus::peer::Peer::new([9u8; 32], "10.0.0.9:8555".into());
+        non_elder.last_seen = fresh; // recent but NOT an elder
+        non_elder.capabilities = NodeCapabilities::default();
+
+        let peers = vec![
+            elder_peer(1, fresh), // counts
+            elder_peer(2, fresh), // counts
+            elder_peer(3, stale), // too old — excluded
+            non_elder,            // not an elder — excluded
+        ];
+
+        assert_eq!(count_connected_elders(&peers, now, 60), 2);
+        // Widen the window and the stale elder is admitted too.
+        assert_eq!(count_connected_elders(&peers, now, 300), 3);
+        // No peers → zero (a fresh node that nobody has discovered yet).
+        assert_eq!(count_connected_elders(&[], now, 60), 0);
+    }
+
+    /// The retry loop NEVER permanently gives up: for a node that is not yet
+    /// registered (`connected_elders < quorum`) the readiness predicate stays
+    /// false for every round, and the inter-round backoff stays a FINITE, bounded
+    /// delay no matter how many rounds elapse — so the node keeps re-checking
+    /// forever instead of hitting the old fixed 15-attempt "will not be an elder"
+    /// terminal state.
+    #[cfg(feature = "mpc-ceremony")]
+    #[test]
+    fn retry_backoff_is_indefinite_and_capped() {
+        // Fast converge window: the tuned upper bound (jitter added at the call site).
+        assert_eq!(
+            mpc_retry_backoff_secs(1),
+            MPC_CONTRIBUTION_RETRY_DELAY_MAX_SECS
+        );
+        assert_eq!(
+            mpc_retry_backoff_secs(MPC_CONTRIBUTION_MAX_ATTEMPTS),
+            MPC_CONTRIBUTION_RETRY_DELAY_MAX_SECS
+        );
+
+        // Beyond the fast window the delay escalates monotonically, then saturates
+        // at the cap — and is ALWAYS finite (never a "stop" sentinel), even for an
+        // absurd round count. This is the essence of "no permanent giveup".
+        let first_over = mpc_retry_backoff_secs(MPC_CONTRIBUTION_MAX_ATTEMPTS + 1);
+        assert!(first_over > MPC_CONTRIBUTION_RETRY_DELAY_MAX_SECS);
+        assert!(first_over <= MPC_CONTRIBUTION_BACKOFF_MAX_SECS);
+        for attempt in [MPC_CONTRIBUTION_MAX_ATTEMPTS + 5, 1_000, 100_000, u32::MAX] {
+            let d = mpc_retry_backoff_secs(attempt);
+            assert!(
+                d >= first_over,
+                "backoff must not shrink back below the first step"
+            );
+            assert_eq!(
+                d, MPC_CONTRIBUTION_BACKOFF_MAX_SECS,
+                "backoff must saturate at the cap, not overflow or reset"
+            );
+        }
+
+        // A still-unregistered node is never "ready", for any round — contrast the
+        // OLD behaviour, which stopped trying after MPC_CONTRIBUTION_MAX_ATTEMPTS.
+        for attempt in [1u32, MPC_CONTRIBUTION_MAX_ATTEMPTS, 10_000] {
+            assert!(
+                !mpc_contribution_ready(1, 3, true),
+                "unregistered node stays not-ready at round {attempt}, so the loop keeps retrying"
+            );
+        }
     }
 
     /// node6 reproduction: singleton at 1 while the chain tip advanced to a FOREIGN

--- a/crates/ghost-consensus/src/epoch_manager.rs
+++ b/crates/ghost-consensus/src/epoch_manager.rs
@@ -779,17 +779,26 @@ impl EpochManager {
             notes_migrated,
         )?;
 
-        // Insert new epoch record before any l2_notes reference it
-        // Initial root computed after tree build; use placeholder, update below
-        self.db.insert_l2_epoch(&ghost_storage::L2EpochRecord {
-            epoch: new_epoch,
-            start_height: boundary_height,
-            end_height: None,
-            initial_root: [0u8; 32], // placeholder, updated after tree build
-            final_root: None,
-            notes_migrated: 0,
-            status: "active".to_string(),
-        })?;
+        // Insert new epoch record before any l2_notes reference it.
+        // Initial root computed after tree build; use placeholder, update below.
+        //
+        // The row may already exist if it was materialised by a tree-sync
+        // payload (a joining node can receive the peer's authoritative epoch
+        // record before it locally replays this boundary). In that case leave
+        // the existing row untouched — the peer's data is authoritative and a
+        // plain INSERT would trip the PRIMARY KEY constraint.
+        let epoch_row_exists = self.db.get_l2_epoch(new_epoch)?.is_some();
+        if !epoch_row_exists {
+            self.db.insert_l2_epoch(&ghost_storage::L2EpochRecord {
+                epoch: new_epoch,
+                start_height: boundary_height,
+                end_height: None,
+                initial_root: [0u8; 32], // placeholder, updated after tree build
+                final_root: None,
+                notes_migrated: 0,
+                status: "active".to_string(),
+            })?;
+        }
 
         // 5. Build new tree from unspent notes (deterministic order)
         let mut new_tree = CommitmentTree::new(self.config.tree_depth);
@@ -805,9 +814,12 @@ impl EpochManager {
             .root()
             .map_err(|e| GhostError::Internal(format!("Failed to compute new root: {}", e)))?;
 
-        // Update epoch record with actual initial root
-        self.db
-            .update_l2_epoch_initial_root(new_epoch, &new_initial_root)?;
+        // Update epoch record with actual initial root (only for a freshly
+        // inserted row — do not overwrite an authoritative synced record).
+        if !epoch_row_exists {
+            self.db
+                .update_l2_epoch_initial_root(new_epoch, &new_initial_root)?;
+        }
 
         // 6. Swap trees and move nullifiers to transition set for cross-epoch protection
         *self.commitment_tree.write() = new_tree;

--- a/crates/ghost-consensus/src/message.rs
+++ b/crates/ghost-consensus/src/message.rs
@@ -1526,10 +1526,48 @@ pub struct L2TreeSyncResponse {
     /// Current commitment root for verification
     #[serde(with = "ghost_common::serde_hex::bytes32")]
     pub commitment_root: [u8; 32],
+    /// Epoch records for every epoch referenced by the checkpoints above.
+    ///
+    /// Sent so a joining node can materialise the parent `l2_epochs` rows
+    /// BEFORE persisting checkpoints that reference them, satisfying the
+    /// `l2_checkpoints.epoch -> l2_epochs.epoch` foreign-key trigger even when
+    /// the batch begins past an epoch boundary (e.g. early checkpoints were
+    /// pruned, or a prior boundary batch was dropped). Without this, a fresh
+    /// node relied on locally re-deriving epoch rows by replaying every
+    /// boundary in sequence — any gap left the epoch row missing and every
+    /// sync round re-failed the FK. `#[serde(default)]` keeps wire-compat with
+    /// peers that predate this field.
+    #[serde(default)]
+    pub epochs: Vec<L2EpochSync>,
     /// Whether there are more checkpoints to sync
     pub has_more: bool,
     /// Timestamp
     pub timestamp: u64,
+}
+
+/// L2: Epoch metadata carried inside a tree-sync response.
+///
+/// Mirrors `ghost_storage::L2EpochRecord` on the wire (hex-encoded roots) so a
+/// joining node can upsert the parent epoch row for each synced checkpoint.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct L2EpochSync {
+    /// Epoch number
+    pub epoch: u64,
+    /// First checkpoint height of this epoch
+    pub start_height: u64,
+    /// Last checkpoint height of this epoch (None while active)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub end_height: Option<u64>,
+    /// Commitment root at epoch start
+    #[serde(with = "ghost_common::serde_hex::bytes32")]
+    pub initial_root: [u8; 32],
+    /// Commitment root at epoch end (None while active)
+    #[serde(default, with = "ghost_common::serde_hex::option_bytes32")]
+    pub final_root: Option<[u8; 32]>,
+    /// Number of notes migrated into this epoch at compaction
+    pub notes_migrated: u64,
+    /// Lifecycle status ("active" | "archived")
+    pub status: String,
 }
 
 /// L2: Note gap request — sent when tree sync replay didn't fix root mismatch.

--- a/crates/ghost-consensus/src/nullifier_route_handler.rs
+++ b/crates/ghost-consensus/src/nullifier_route_handler.rs
@@ -30,7 +30,7 @@ use ghost_zkp::{
 use crate::epoch_manager::{EpochManager, PROPOSER_GRACE_SECS};
 use crate::mesh::MessageHandler;
 use crate::message::{
-    L2CheckpointBlockMessage, L2CheckpointVoteMessage, L2ConfidentialTransferMessage,
+    L2CheckpointBlockMessage, L2CheckpointVoteMessage, L2ConfidentialTransferMessage, L2EpochSync,
     L2NoteGapRequest, L2NoteGapResponse, L2Transaction, L2TransferBroadcastMessage,
     L2TransferConfirmationMessage, L2TreeSyncRequest, L2TreeSyncResponse, MessageEnvelope,
     MessageType, ShieldCommitment,
@@ -1566,6 +1566,42 @@ impl NullifierRouteHandler {
             }
         }
 
+        // Attach the parent epoch record for every epoch referenced by the
+        // checkpoints being sent. The requesting node upserts these BEFORE
+        // persisting the checkpoints so the l2_checkpoints.epoch -> l2_epochs
+        // FK is satisfied even when this batch starts past an epoch boundary
+        // (the requester may never have replayed the boundary transition that
+        // would otherwise create the epoch row locally).
+        let mut epochs: Vec<L2EpochSync> = Vec::new();
+        let mut seen_epochs = std::collections::HashSet::new();
+        for block in &checkpoint_blocks {
+            if !seen_epochs.insert(block.epoch) {
+                continue;
+            }
+            match self.db.get_l2_epoch(block.epoch) {
+                Ok(Some(rec)) => epochs.push(L2EpochSync {
+                    epoch: rec.epoch,
+                    start_height: rec.start_height,
+                    end_height: rec.end_height,
+                    initial_root: rec.initial_root,
+                    final_root: rec.final_root,
+                    notes_migrated: rec.notes_migrated,
+                    status: rec.status,
+                }),
+                Ok(None) => {
+                    // Our own checkpoint references an epoch we don't have —
+                    // should not happen, but don't fail the whole sync.
+                    warn!(
+                        epoch = block.epoch,
+                        "Tree sync: local epoch record missing for checkpoint being sent"
+                    );
+                }
+                Err(e) => {
+                    warn!(epoch = block.epoch, error = %e, "Tree sync: failed to load epoch record");
+                }
+            }
+        }
+
         // Use checkpoint_base_root (last finalized canonical root) instead of current_root()
         // which includes pending shields. This gives the requesting node a stable target
         // to verify against after replaying the checkpoints.
@@ -1576,6 +1612,7 @@ impl NullifierRouteHandler {
             checkpoints: checkpoint_blocks,
             current_epoch: self.epoch_manager.current_epoch(),
             commitment_root: canonical_root,
+            epochs,
             has_more,
             timestamp: chrono::Utc::now().timestamp_millis() as u64,
         };
@@ -1653,9 +1690,50 @@ impl NullifierRouteHandler {
             }
         }
 
+        // Materialise the parent epoch rows BEFORE replaying any checkpoint.
+        // Checkpoints foreign-key l2_checkpoints.epoch -> l2_epochs.epoch; a
+        // fresh node that starts syncing past an epoch boundary (pruned early
+        // checkpoints, or a dropped boundary batch) never replayed the local
+        // transition that would create those epoch rows. Upserting the peer's
+        // authoritative epoch records here satisfies the FK legitimately
+        // instead of tripping the trigger on every sync round.
+        for epoch in &response.epochs {
+            let record = ghost_storage::L2EpochRecord {
+                epoch: epoch.epoch,
+                start_height: epoch.start_height,
+                end_height: epoch.end_height,
+                initial_root: epoch.initial_root,
+                final_root: epoch.final_root,
+                notes_migrated: epoch.notes_migrated,
+                status: epoch.status.clone(),
+            };
+            self.db.upsert_l2_epoch(&record)?;
+        }
+
         // Replay checkpoint blocks in order
+        let mut last_applied_root: Option<[u8; 32]> = None;
         for block in &response.checkpoints {
             let height = block.height;
+
+            // Defence in depth: if a checkpoint's parent epoch is still absent
+            // (e.g. a peer predating the `epochs` field, or a malformed batch),
+            // DEFER rather than force the insert and trip the FK trigger every
+            // round. Stop at the first unsatisfiable checkpoint — later ones in
+            // the batch would cascade — and return cleanly so the mesh does not
+            // log a handler error. The next sync round (from an upgraded peer)
+            // supplies the epoch and replay resumes from here.
+            match self.db.get_l2_epoch(block.epoch) {
+                Ok(Some(_)) => {}
+                Ok(None) => {
+                    warn!(
+                        height,
+                        epoch = block.epoch,
+                        "Tree sync: deferring checkpoint — parent epoch not yet available"
+                    );
+                    break;
+                }
+                Err(e) => return Err(e),
+            }
 
             // Apply shield commitments first (they may be needed for tx roots)
             for sc in &block.shield_commitments {
@@ -1721,11 +1799,14 @@ impl NullifierRouteHandler {
                 state.finalized = true;
                 state.checkpoint_hash = canonical_root;
             }
+
+            last_applied_root = Some(canonical_root);
         }
 
-        // Update checkpoint base root to the last replayed checkpoint's canonical root
-        if let Some(last) = response.checkpoints.last() {
-            *self.checkpoint_base_root.write() = last.new_commitment_root;
+        // Update checkpoint base root to the last checkpoint we actually applied
+        // (not response.checkpoints.last(), which may have been deferred above).
+        if let Some(root) = last_applied_root {
+            *self.checkpoint_base_root.write() = root;
         }
 
         // Pagination follow-up: if peer has more checkpoints, request next batch
@@ -2971,6 +3052,153 @@ mod tests {
         // The late proposal should not produce a vote (already finalized returns early)
         // or if it does, the finalized flag should block supersede
         let _ = vote_result; // Result doesn't matter as long as state is preserved
+    }
+
+    /// Regression (l2-checkpoint-epoch-fk): a freshly-joined node whose
+    /// `l2_epochs` only contains genesis (epoch 0) receives a tree-sync batch
+    /// whose checkpoints reference a higher epoch it never replayed the
+    /// boundary for. The parent epoch rows now travel in the response, so the
+    /// checkpoint persists and the `l2_checkpoints.epoch -> l2_epochs.epoch` FK
+    /// is satisfied — no FK-violation error, no infinite re-attempt loop. When
+    /// the epoch is absent from the payload (a peer predating the field), the
+    /// checkpoint is DEFERRED rather than force-inserted, and the FK trigger is
+    /// still enforced against a genuinely orphan checkpoint.
+    #[test]
+    fn test_tree_sync_materialises_missing_epoch() {
+        use ghost_common::identity::NodeIdentity;
+
+        // Proposer identity — signs the checkpoint so the joining node accepts it.
+        let proposer = NodeIdentity::generate();
+        let proposer_id = proposer.node_id();
+
+        // Checkpoint for epoch 5 at a non-boundary height (epoch_length = 100).
+        let mut block = L2CheckpointBlockMessage {
+            height: 550,
+            epoch: 5,
+            prev_commitment_root: [0u8; 32],
+            new_commitment_root: [0xAB; 32],
+            transactions: vec![],
+            shield_commitments: vec![],
+            active_node_count: 1,
+            proposer: proposer_id,
+            proposer_signature: [0u8; 64],
+            timestamp: 0,
+            epoch_transition: None,
+        };
+        block.proposer_signature = proposer.sign(&block.to_signable_bytes());
+
+        let epoch5 = L2EpochSync {
+            epoch: 5,
+            start_height: 500,
+            end_height: None,
+            initial_root: [0x11; 32],
+            final_root: None,
+            notes_migrated: 0,
+            status: "active".to_string(),
+        };
+
+        // Fresh joining node: only genesis epoch 0 present.
+        let make_node = || {
+            let identity = NodeIdentity::generate();
+            let db = Arc::new(Database::in_memory().expect("in-memory db"));
+            let config = EpochManagerConfig {
+                epoch_length: 100,
+                transition_window: 10,
+                tree_depth: 4,
+                max_valid_roots: 16,
+            };
+            let epoch_mgr = Arc::new(EpochManager::new(db.clone(), config));
+            epoch_mgr.initialize_genesis().unwrap();
+            let handler = NullifierRouteHandler::with_defaults(
+                identity.node_id(),
+                epoch_mgr.clone(),
+                db.clone(),
+            );
+            handler.set_sign_fn(Arc::new(move |msg: &[u8]| identity.sign(msg)));
+            (db, handler)
+        };
+
+        // --- Case 1: epoch supplied in payload -> checkpoint persists, no error ---
+        let (db_ok, handler_ok) = make_node();
+        assert!(
+            db_ok.get_l2_epoch(5).unwrap().is_none(),
+            "epoch 5 should be absent before sync"
+        );
+        let response = L2TreeSyncResponse {
+            responding_node: proposer_id,
+            checkpoints: vec![block.clone()],
+            current_epoch: 5,
+            commitment_root: block.new_commitment_root,
+            epochs: vec![epoch5.clone()],
+            has_more: false,
+            timestamp: 0,
+        };
+        // Must NOT return a FK-violation error (that is the bug being fixed).
+        handler_ok
+            .handle_tree_sync_response(&response)
+            .expect("sync carrying the parent epoch must succeed");
+        assert!(
+            db_ok.get_l2_epoch(5).unwrap().is_some(),
+            "epoch 5 must be materialised from the payload"
+        );
+        let cps = db_ok.get_l2_checkpoints_from_height(550, 10).unwrap();
+        assert_eq!(cps.len(), 1, "checkpoint must be persisted");
+        assert_eq!(cps[0].epoch, 5);
+
+        // Replaying the SAME response again must remain error-free and idempotent
+        // (no FK violation, no PK conflict on the epoch upsert) — proves there is
+        // no re-attempt error loop across sync rounds.
+        handler_ok
+            .handle_tree_sync_response(&response)
+            .expect("re-replay must stay error-free");
+        assert_eq!(
+            db_ok.get_l2_checkpoints_from_height(550, 10).unwrap().len(),
+            1,
+            "re-replay must not duplicate the checkpoint"
+        );
+
+        // --- Case 2: epoch missing from payload -> deferred, not force-inserted ---
+        let (db_defer, handler_defer) = make_node();
+        let response_no_epoch = L2TreeSyncResponse {
+            responding_node: proposer_id,
+            checkpoints: vec![block.clone()],
+            current_epoch: 5,
+            commitment_root: block.new_commitment_root,
+            epochs: vec![], // peer predating the `epochs` field
+            has_more: false,
+            timestamp: 0,
+        };
+        // No FK-violation error surfaces (returns Ok), so the mesh logs no
+        // "Handler error" and the round does not spam — it defers instead.
+        handler_defer
+            .handle_tree_sync_response(&response_no_epoch)
+            .expect("must defer cleanly rather than error");
+        assert!(
+            db_defer.get_l2_epoch(5).unwrap().is_none(),
+            "epoch must not be fabricated when the peer did not supply it"
+        );
+        assert!(
+            db_defer
+                .get_l2_checkpoints_from_height(550, 10)
+                .unwrap()
+                .is_empty(),
+            "orphan checkpoint must be deferred, not persisted"
+        );
+
+        // --- FK still enforced: a genuinely orphan checkpoint is rejected ---
+        let orphan = ghost_storage::L2CheckpointRecord {
+            height: 550,
+            epoch: 5,
+            commitment_root: [0xAB; 32],
+            tx_count: 0,
+            proposer_id: hex::encode(proposer_id),
+            active_node_count: 1,
+            block_data: vec![],
+        };
+        assert!(
+            db_defer.upsert_l2_checkpoint(&orphan).is_err(),
+            "FK trigger must still reject a checkpoint with no parent epoch"
+        );
     }
 
     /// Test that a transfer with an invalid (wrong) commitment root is rejected

--- a/crates/ghost-storage/src/queries.rs
+++ b/crates/ghost-storage/src/queries.rs
@@ -8610,6 +8610,41 @@ impl Database {
         })
     }
 
+    /// Idempotently insert or update an L2 epoch, keyed by `epoch`.
+    ///
+    /// Used when applying epoch records received during tree-sync: a joining
+    /// node must materialise the parent `l2_epochs` row before persisting any
+    /// checkpoint that references it (FK: `l2_checkpoints.epoch`). The peer's
+    /// record is authoritative, so on conflict every field is replaced. Unlike
+    /// `insert_l2_epoch`, this never fails when the row already exists (e.g. the
+    /// genesis epoch 0, or an epoch re-sent across paginated batches).
+    pub fn upsert_l2_epoch(&self, record: &L2EpochRecord) -> GhostResult<()> {
+        self.with_connection(|conn| {
+            conn.execute(
+                "INSERT INTO l2_epochs (epoch, start_height, end_height, initial_root, final_root, notes_migrated, status)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+                 ON CONFLICT(epoch) DO UPDATE SET
+                     start_height = excluded.start_height,
+                     end_height = excluded.end_height,
+                     initial_root = excluded.initial_root,
+                     final_root = excluded.final_root,
+                     notes_migrated = excluded.notes_migrated,
+                     status = excluded.status",
+                params![
+                    record.epoch as i64,
+                    record.start_height as i64,
+                    record.end_height.map(|h| h as i64),
+                    record.initial_root.as_slice(),
+                    record.final_root.as_ref().map(|r| r.as_slice()),
+                    record.notes_migrated as i64,
+                    record.status,
+                ],
+            )
+            .map_err(|e| GhostError::Database(e.to_string()))?;
+            Ok(())
+        })
+    }
+
     /// Get the current (active) L2 epoch
     pub fn get_active_l2_epoch(&self) -> GhostResult<Option<L2EpochRecord>> {
         self.with_connection(|conn| {
@@ -11819,5 +11854,59 @@ mod tests {
             db.save_mpc_contribution(&mk_contribution(pos)).unwrap();
         }
         assert_eq!(db.get_mpc_max_contribution_position().unwrap(), Some(4));
+    }
+
+    /// `upsert_l2_epoch` materialises a missing epoch row and is idempotent, so
+    /// a tree-sync replay can satisfy the `l2_checkpoints.epoch -> l2_epochs`
+    /// FK without ever hitting a PRIMARY KEY conflict on re-application. The FK
+    /// trigger is still enforced for a checkpoint whose epoch was not upserted.
+    #[test]
+    fn test_upsert_l2_epoch_idempotent_and_fk_enforced() {
+        let db = Database::in_memory().expect("create in-memory db");
+
+        // A checkpoint for an epoch with no parent row is rejected by the FK trigger.
+        let checkpoint = |epoch: u64| L2CheckpointRecord {
+            height: 550,
+            epoch,
+            commitment_root: [0xAB; 32],
+            tx_count: 0,
+            proposer_id: "node".to_string(),
+            active_node_count: 1,
+            block_data: vec![],
+        };
+        assert!(
+            db.upsert_l2_checkpoint(&checkpoint(7)).is_err(),
+            "checkpoint with no parent epoch must be rejected"
+        );
+
+        // Materialise epoch 7, then the same checkpoint inserts cleanly.
+        let epoch = L2EpochRecord {
+            epoch: 7,
+            start_height: 700,
+            end_height: None,
+            initial_root: [0x11; 32],
+            final_root: None,
+            notes_migrated: 0,
+            status: "active".to_string(),
+        };
+        db.upsert_l2_epoch(&epoch).expect("first upsert inserts");
+        db.upsert_l2_checkpoint(&checkpoint(7))
+            .expect("checkpoint persists once parent epoch exists");
+
+        // Re-upserting the same epoch (e.g. re-sent across sync batches) must
+        // not conflict, and may carry updated authoritative fields.
+        let archived = L2EpochRecord {
+            end_height: Some(800),
+            final_root: Some([0x22; 32]),
+            notes_migrated: 3,
+            status: "archived".to_string(),
+            ..epoch.clone()
+        };
+        db.upsert_l2_epoch(&archived)
+            .expect("re-upsert must be idempotent");
+        let loaded = db.get_l2_epoch(7).unwrap().expect("epoch present");
+        assert_eq!(loaded.status, "archived");
+        assert_eq!(loaded.end_height, Some(800));
+        assert_eq!(loaded.final_root, Some([0x22; 32]));
     }
 }


### PR DESCRIPTION
Two fixes for fresh-node onboarding, both hit live by node7/node8, now deployed fleet-wide (v1.10.17) and verified.

**MPC contribution mesh-gate** (`bins/ghost-pool/src/main.rs`): a joining node no longer broadcasts its contribution until a BFT quorum of elders can reach it (fresh health-ping connectivity + own candidate endpoint up), and it retries indefinitely with capped backoff instead of permanently giving up after 15 attempts. Kills the 'node will not be an elder' + manual-restart requirement that hit node7 and node8.

**L2 checkpoint FK** (`ghost-consensus` epoch_manager/message/nullifier_route_handler + `ghost-storage` queries): tree-sync now ships parent `l2_epochs` records alongside checkpoints and upserts them before the checkpoint insert, fixing the `l2_checkpoints.epoch -> l2_epochs.epoch` FK-violation spam (~686/hr) on freshly-joined nodes. FK constraint kept; clean deferral fallback. **Verified: 0 FK violations on node8 since deploy, epochs backfilling.**

Tests: gate readiness predicate + indefinite-backoff + connected-elder counting; L2 epoch-upsert idempotency/FK-enforcement + tree-sync epoch materialisation. Green under `--features zk-production`/`zk-consensus`, `-j2`.