### PR TITLE
v1.10.18: gate ghost-pay finalization notify on enabled flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-ghost-tests"
-version = "1.10.17"
+version = "1.10.18"
 dependencies = [
  "bitcoin",
  "chrono",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin_core_sv2"
-version = "1.10.17"
+version = "1.10.18"
 dependencies = [
  "async-channel 1.9.0",
  "bitcoin-capnp-types",
@@ -3083,7 +3083,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-accounting"
-version = "1.10.17"
+version = "1.10.18"
 dependencies = [
  "bitcoin",
  "ghost-common",
@@ -3097,7 +3097,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-buds"
-version = "1.10.17"
+version = "1.10.18"
 dependencies = [
  "bitcoin",
  "ghost-common",
@@ -3111,7 +3111,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-cli"
-version = "1.10.17"
+version = "1.10.18"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3129,7 +3129,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-common"
-version = "1.10.17"
+version = "1.10.18"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -3162,7 +3162,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-consensus"
-version = "1.10.17"
+version = "1.10.18"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3194,7 +3194,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-glyph"
-version = "1.10.17"
+version = "1.10.18"
 dependencies = [
  "hex",
  "serde",
@@ -3205,7 +3205,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-gsp"
-version = "1.10.17"
+version = "1.10.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3267,7 +3267,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-gsp-proto"
-version = "1.10.17"
+version = "1.10.18"
 dependencies = [
  "bitcoin",
  "chrono",
@@ -3284,7 +3284,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-keys"
-version = "1.10.17"
+version = "1.10.18"
 dependencies = [
  "bech32",
  "bitcoin",
@@ -3306,7 +3306,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-locks"
-version = "1.10.17"
+version = "1.10.18"
 dependencies = [
  "bitcoin",
  "getrandom 0.2.17",
@@ -3350,7 +3350,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-pay"
-version = "1.10.17"
+version = "1.10.18"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3398,7 +3398,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-policy"
-version = "1.10.17"
+version = "1.10.18"
 dependencies = [
  "bitcoin",
  "ghost-buds",
@@ -3411,7 +3411,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-pool"
-version = "1.10.17"
+version = "1.10.18"
 dependencies = [
  "anyhow",
  "async-channel 2.5.0",
@@ -3466,7 +3466,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-reaper"
-version = "1.10.17"
+version = "1.10.18"
 dependencies = [
  "bitcoin",
  "hex",
@@ -3478,7 +3478,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-reconciliation"
-version = "1.10.17"
+version = "1.10.18"
 dependencies = [
  "async-trait",
  "bitcoin",
@@ -3504,7 +3504,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-registry"
-version = "1.10.17"
+version = "1.10.18"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -3539,7 +3539,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-setup"
-version = "1.10.17"
+version = "1.10.18"
 dependencies = [
  "clap",
  "dirs 5.0.1",
@@ -3550,7 +3550,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-storage"
-version = "1.10.17"
+version = "1.10.18"
 dependencies = [
  "base64 0.22.1",
  "chacha20poly1305",
@@ -3571,7 +3571,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-tap-core"
-version = "1.10.17"
+version = "1.10.18"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3613,7 +3613,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-tap-desktop"
-version = "1.10.17"
+version = "1.10.18"
 dependencies = [
  "dirs 6.0.0",
  "getrandom 0.2.17",
@@ -3639,7 +3639,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-tap-integration"
-version = "1.10.17"
+version = "1.10.18"
 dependencies = [
  "ghost-gsp-proto",
  "ghost-tap-core",
@@ -3653,7 +3653,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-template"
-version = "1.10.17"
+version = "1.10.18"
 dependencies = [
  "bitcoin",
  "ghost-buds",
@@ -3669,7 +3669,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-verification"
-version = "1.10.17"
+version = "1.10.18"
 dependencies = [
  "axum 0.7.9",
  "bitcoin",
@@ -4642,7 +4642,7 @@ dependencies = [
 
 [[package]]
 name = "jd_client_sv2"
-version = "1.10.17"
+version = "1.10.18"
 dependencies = [
  "async-channel 1.9.0",
  "bitcoin_core_sv2",
@@ -4658,7 +4658,7 @@ dependencies = [
 
 [[package]]
 name = "jd_server_sv2"
-version = "1.10.17"
+version = "1.10.18"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -6181,7 +6181,7 @@ dependencies = [
 
 [[package]]
 name = "pool_sv2"
-version = "1.10.17"
+version = "1.10.18"
 dependencies = [
  "async-channel 1.9.0",
  "bitcoin_core_sv2",
@@ -7905,7 +7905,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stratum-apps"
-version = "1.10.17"
+version = "1.10.18"
 dependencies = [
  "async-channel 1.9.0",
  "axum 0.8.9",
@@ -9118,7 +9118,7 @@ dependencies = [
 
 [[package]]
 name = "translator_sv2"
-version = "1.10.17"
+version = "1.10.18"
 dependencies = [
  "async-channel 1.9.0",
  "clap",
@@ -10449,7 +10449,7 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "wraith-coordinator"
-version = "1.10.17"
+version = "1.10.18"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -10486,7 +10486,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-protocol"
-version = "1.10.17"
+version = "1.10.18"
 dependencies = [
  "bitcoin",
  "getrandom 0.2.17",
@@ -10507,7 +10507,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-cli"
-version = "1.10.17"
+version = "1.10.18"
 dependencies = [
  "clap",
  "clap_complete",
@@ -10520,7 +10520,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-core"
-version = "1.10.17"
+version = "1.10.18"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -10557,7 +10557,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-daemon"
-version = "1.10.17"
+version = "1.10.18"
 dependencies = [
  "axum 0.7.9",
  "base64 0.22.1",
@@ -10582,7 +10582,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-gui"
-version = "1.10.17"
+version = "1.10.18"
 dependencies = [
  "serde",
  "serde_json",
@@ -10596,7 +10596,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-ipc"
-version = "1.10.17"
+version = "1.10.18"
 dependencies = [
  "libc",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ exclude = []
 # Use scripts/build-all-wallets.sh to build all wallet types.
 
 [workspace.package]
-version = "1.10.17"
+version = "1.10.18"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Bitcoin Ghost Team"]

--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -189,6 +189,51 @@ fn cached_contribution_still_valid(cached_count: u32, current_count: u32) -> boo
     current_count == cached_count
 }
 
+/// Local ghost-pay endpoint that accepts L2 checkpoint finalization notices.
+/// ghost-pay serves identity-derived TLS on 8800; the caller uses a client with
+/// `danger_accept_invalid_certs(true)` since this is loopback-only IPC.
+const GHOST_PAY_FINALIZE_URL: &str = "https://127.0.0.1:8800/api/v1/l2/finalize";
+
+/// Notify the local ghost-pay daemon that an L2 checkpoint finalized at `height`.
+///
+/// Retries up to 3 times with exponential backoff (500ms, then 1000ms). On
+/// success returns the zero-based index of the attempt that succeeded (so the
+/// caller can log a plain success vs. a succeeded-after-retry); on total failure
+/// returns the last error string. This is only ever invoked when
+/// [`NodeConfig::ghost_pay_enabled`] is true, so a returned `Err` always means a
+/// genuine problem reaching a ghost-pay that is supposed to be running locally —
+/// worth logging as an error — rather than the "ghost-pay isn't installed" case,
+/// which is now gated out entirely at the call site.
+async fn notify_ghost_pay_finalize(
+    client: &reqwest::Client,
+    endpoint: &str,
+    height: u64,
+    state_root: [u8; 32],
+    nullifiers: &[[u8; 32]],
+) -> Result<u32, String> {
+    let body = serde_json::json!({
+        "height": height,
+        "state_root": hex::encode(state_root),
+        "attestation_count": nullifiers.len(),
+        "included_tx_ids": nullifiers.iter().map(hex::encode).collect::<Vec<_>>(),
+    });
+    let mut last_err = String::new();
+    for attempt in 0..3u32 {
+        if attempt > 0 {
+            tokio::time::sleep(std::time::Duration::from_millis(
+                500 * 2u64.pow(attempt - 1),
+            ))
+            .await;
+        }
+        match client.post(endpoint).json(&body).send().await {
+            Ok(resp) if resp.status().is_success() => return Ok(attempt),
+            Ok(resp) => last_err = format!("HTTP {}", resp.status()),
+            Err(e) => last_err = e.to_string(),
+        }
+    }
+    Err(last_err)
+}
+
 /// The ceremony position this node should target next, accounting for a node
 /// whose adopted head lags the recorded chain tip.
 ///
@@ -3440,7 +3485,15 @@ async fn main() -> Result<()> {
         // call doesn't need cert-chain validation — `danger_accept_invalid_certs`
         // is appropriate for localhost-only IPC. (Not the same code path as the
         // L-29-blocked verification client; that one talks to remote peers.)
-        if config.ghost_pay.is_some() {
+        //
+        // Gate on `ghost_pay_enabled()` — NOT on `ghost_pay.is_some()`. Pool-only
+        // nodes carry a `[ghost_pay]` block (setup emits one with `enabled = false`)
+        // but never run the ghost-pay daemon; wiring the notify there produced a
+        // failed POST + 3 retries + an ERROR on every checkpoint finalization
+        // (~7/min of pure noise). Nodes that DO run ghost-pay set `enabled = true`,
+        // so they still get notified exactly as before, and a genuine notify
+        // failure there still surfaces as an error (a real, log-worthy problem).
+        if config.ghost_pay_enabled() {
             let finalize_client = reqwest::Client::builder()
                 .timeout(std::time::Duration::from_secs(5))
                 .danger_accept_invalid_certs(true)
@@ -3450,56 +3503,42 @@ async fn main() -> Result<()> {
                 move |height: u64, state_root: [u8; 32], nullifiers: Vec<[u8; 32]>| {
                     let client = finalize_client.clone();
                     tokio::spawn(async move {
-                        let body = serde_json::json!({
-                            "height": height,
-                            "state_root": hex::encode(state_root),
-                            "attestation_count": nullifiers.len(),
-                            "included_tx_ids": nullifiers.iter().map(hex::encode).collect::<Vec<_>>(),
-                        });
-                        // Retry up to 3 times with exponential backoff
-                        let mut last_err = String::new();
-                        for attempt in 0..3u32 {
-                            if attempt > 0 {
-                                tokio::time::sleep(std::time::Duration::from_millis(
-                                    500 * 2u64.pow(attempt - 1),
-                                ))
-                                .await;
+                        match notify_ghost_pay_finalize(
+                            &client,
+                            GHOST_PAY_FINALIZE_URL,
+                            height,
+                            state_root,
+                            &nullifiers,
+                        )
+                        .await
+                        {
+                            Ok(0) => {
+                                tracing::debug!(height, "Ghost-pay finalization notified");
                             }
-                            match client
-                                .post("https://127.0.0.1:8800/api/v1/l2/finalize")
-                                .json(&body)
-                                .send()
-                                .await
-                            {
-                                Ok(resp) if resp.status().is_success() => {
-                                    if attempt > 0 {
-                                        tracing::info!(
-                                            height,
-                                            attempt = attempt + 1,
-                                            "Ghost-pay finalization notified (after retry)"
-                                        );
-                                    } else {
-                                        tracing::debug!(height, "Ghost-pay finalization notified");
-                                    }
-                                    return;
-                                }
-                                Ok(resp) => {
-                                    last_err = format!("HTTP {}", resp.status());
-                                }
-                                Err(e) => {
-                                    last_err = e.to_string();
-                                }
+                            Ok(attempt) => {
+                                tracing::info!(
+                                    height,
+                                    attempt = attempt + 1,
+                                    "Ghost-pay finalization notified (after retry)"
+                                );
+                            }
+                            Err(last_err) => {
+                                tracing::error!(
+                                    height,
+                                    error = %last_err,
+                                    "Failed to notify ghost-pay of finalization after 3 attempts"
+                                );
                             }
                         }
-                        tracing::error!(
-                            height,
-                            error = %last_err,
-                            "Failed to notify ghost-pay of finalization after 3 attempts"
-                        );
                     });
                 },
             );
             nullifier_handler.set_finalize_fn(finalize_fn);
+        } else {
+            // Pool-only node: participate in L2 checkpoint consensus/gossip as
+            // normal, just don't try to hand finalizations to a local ghost-pay
+            // that isn't there. Logged once here, never per-checkpoint.
+            info!("ghost-pay not enabled — L2 finalization notifications disabled");
         }
 
         // Initialize validators from MPC elders in DB
@@ -8033,7 +8072,71 @@ fn resolve_signer_path(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ghost_common::config::GhostPayConfig;
     use std::path::Path;
+
+    // ── ghost-pay finalization notify gate ───────────────────────────
+    //
+    // The finalize callback must be wired ONLY when ghost-pay is actually
+    // enabled on this node. Pool-only nodes carry a `[ghost_pay]` block with
+    // `enabled = false` and no local ghost-pay daemon; wiring the notify there
+    // spammed an ERROR (+3 retries) on every checkpoint finalization.
+
+    #[test]
+    fn test_finalize_gate_disabled_without_ghost_pay() {
+        // No [ghost_pay] block at all → no notify wiring.
+        let mut config = NodeConfig::default();
+        assert!(config.ghost_pay.is_none());
+        assert!(!config.ghost_pay_enabled());
+
+        // [ghost_pay] present but disabled (what `setup` writes on a pool-only
+        // node) → still no notify wiring.
+        config.ghost_pay = Some(GhostPayConfig::default());
+        assert!(!config.ghost_pay.as_ref().unwrap().enabled);
+        assert!(
+            !config.ghost_pay_enabled(),
+            "pool-only node must not attempt the ghost-pay finalize notify"
+        );
+    }
+
+    #[test]
+    fn test_finalize_gate_enabled_with_ghost_pay() {
+        // A node running ghost-pay sets enabled = true → notify is wired.
+        let mut config = NodeConfig::default();
+        config.ghost_pay = Some(GhostPayConfig {
+            enabled: true,
+            ..GhostPayConfig::default()
+        });
+        assert!(
+            config.ghost_pay_enabled(),
+            "a ghost-pay node must attempt the finalize notify"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_notify_ghost_pay_finalize_surfaces_genuine_failure() {
+        // On a node WITH ghost-pay enabled but the daemon unreachable, the
+        // notify must still fail loudly (return Err) so the caller logs an
+        // error. 127.0.0.1:1 refuses connections fast, so this doesn't wait on
+        // the full 5s HTTP timeout — only the two backoff sleeps (~1.5s total).
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(5))
+            .danger_accept_invalid_certs(true)
+            .build()
+            .expect("build test client");
+        let result = notify_ghost_pay_finalize(
+            &client,
+            "https://127.0.0.1:1/api/v1/l2/finalize",
+            123,
+            [0u8; 32],
+            &[[1u8; 32], [2u8; 32]],
+        )
+        .await;
+        assert!(
+            result.is_err(),
+            "an unreachable ghost-pay must surface as an error, not be swallowed"
+        );
+    }
 
     // ── ordered_fetch_sources (MPC candidate fetch ordering) ─────────
     //

--- a/crates/ghost-common/src/config.rs
+++ b/crates/ghost-common/src/config.rs
@@ -248,6 +248,19 @@ impl ConfigValidationResult {
 }
 
 impl NodeConfig {
+    /// Whether a local ghost-pay L2 daemon is enabled on this node.
+    ///
+    /// Ghost Pay counts as enabled only when the `[ghost_pay]` block is present
+    /// AND its `enabled` flag is true. Pool-only nodes carry a `[ghost_pay]`
+    /// block (setup emits one by default) but with `enabled = false` and never
+    /// run the ghost-pay daemon, so the block's mere presence must NOT be read
+    /// as "ghost-pay is running here". This mirrors `validate_ghost_pay`, which
+    /// likewise treats `enabled = false` as off, and is the single source of
+    /// truth for whether ghost-pool should talk to a local ghost-pay.
+    pub fn ghost_pay_enabled(&self) -> bool {
+        self.ghost_pay.as_ref().is_some_and(|gp| gp.enabled)
+    }
+
     /// Validate the configuration
     ///
     /// Returns validation result with any errors and warnings found.
@@ -1653,6 +1666,63 @@ mod tests {
         let config = NodeConfig::default();
         assert_eq!(config.network.sv2_port, SV2_STRATUM_PORT);
         assert_eq!(config.bitcoin.network, BitcoinNetwork::Signet);
+    }
+
+    #[test]
+    fn test_ghost_pay_enabled_predicate() {
+        // Pool-only node: no [ghost_pay] block at all → not enabled.
+        let mut config = NodeConfig::default();
+        assert!(config.ghost_pay.is_none());
+        assert!(
+            !config.ghost_pay_enabled(),
+            "absent [ghost_pay] must read as disabled"
+        );
+
+        // Pool-only node: [ghost_pay] block present but enabled = false
+        // (this is exactly what `setup` writes via GhostPayConfig::default()).
+        // The block's presence must NOT be mistaken for a running ghost-pay.
+        config.ghost_pay = Some(GhostPayConfig::default());
+        assert!(!config.ghost_pay.as_ref().unwrap().enabled);
+        assert!(
+            !config.ghost_pay_enabled(),
+            "[ghost_pay] with enabled = false must read as disabled"
+        );
+
+        // Core node: ghost-pay actually enabled.
+        config.ghost_pay = Some(GhostPayConfig {
+            enabled: true,
+            ..GhostPayConfig::default()
+        });
+        assert!(
+            config.ghost_pay_enabled(),
+            "[ghost_pay] with enabled = true must read as enabled"
+        );
+    }
+
+    #[test]
+    fn test_ghost_pay_enabled_from_toml() {
+        // The `enabled` flag round-trips through TOML: a pool-only node writes
+        // `enabled = false`, a core node `enabled = true`. Deserialise the
+        // [ghost_pay] block in isolation to confirm the flag is what the
+        // predicate keys off (NodeConfig sections other than reaper/coordinator
+        // aren't serde(default), so we parse the sub-struct directly).
+        let pool_only: GhostPayConfig = toml::from_str(
+            "enabled = false\nvirtual_block_secs = 10\nepoch_blocks = 2160\nwraith_enabled = true\n",
+        )
+        .unwrap();
+        assert!(!pool_only.enabled);
+
+        let core: GhostPayConfig = toml::from_str(
+            "enabled = true\nvirtual_block_secs = 10\nepoch_blocks = 2160\nwraith_enabled = true\n",
+        )
+        .unwrap();
+        assert!(core.enabled);
+
+        let mut config = NodeConfig::default();
+        config.ghost_pay = Some(pool_only);
+        assert!(!config.ghost_pay_enabled());
+        config.ghost_pay = Some(core);
+        assert!(config.ghost_pay_enabled());
     }
 
     #[test]


### PR DESCRIPTION
Pool-only nodes (5-8, `[ghost_pay] enabled = false`) were POSTing L2-finalization notifications to a ghost-pay daemon that isn't running, retrying 3× + error-logging on every checkpoint (~7 ERRORs/min). Root cause: the notify callback was wired on `config.ghost_pay.is_some()` (block present) rather than the `enabled` flag.

Fix: new `NodeConfig::ghost_pay_enabled()` (the `enabled` boolean is now the single source of truth); the finalize-notify wiring is gated on it, with a single startup log when disabled. Genuine failures on ghost-pay-enabled nodes still surface as errors (retry path extracted + tested against an unreachable port). No fleet config change needed — nodes 5-8 default `enabled=false`, cores 1-4 `enabled=true`.

Deployed + verified live: nodes 5-8 now log 0 notify-failures (was ~223/30min), one-time gate log, otherwise clean. Tests: enabled predicate (None / Some(false) / Some(true)), gate wired/skipped, genuine-failure-still-errors. Build clean under zk-production.