### PR TITLE
v1.10.20: advertise GhostPay capability on enabled flag, not block presence

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ exclude = []
 # Use scripts/build-all-wallets.sh to build all wallet types.
 
 [workspace.package]
-version = "1.10.19"
+version = "1.10.20"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Bitcoin Ghost Team"]

--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -2372,7 +2372,14 @@ async fn main() -> Result<()> {
     // We'll update after registering with the database
     let mut capabilities = NodeCapabilities {
         archive_mode: config.storage.archive_mode,
-        ghost_pay: config.ghost_pay.is_some(),
+        // Advertise GhostPay only when it is actually enabled — NOT on mere
+        // presence of a `[ghost_pay]` block. Pool-only nodes carry a default
+        // (disabled) block; advertising `is_some()` made them claim GhostPay,
+        // so every peer port-probed their (absent) ghost-pay API and logged a
+        // `GhostPay verification failed: Verification timeout` warning. Gating on
+        // `ghost_pay_enabled()` stops the false claim (verification still
+        // correctly denied them the +4 share, but silently now).
+        ghost_pay: config.ghost_pay_enabled(),
         public_mining: is_public_mining, // Derived from mining_mode
         reaper: config.reaper.enabled,
         elder_status: false,

--- a/bins/ghost-pool/src/self_check.rs
+++ b/bins/ghost-pool/src/self_check.rs
@@ -470,12 +470,27 @@ mod tests {
     #[tokio::test]
     async fn ghost_pay_check_failure_carries_remediation_hint() {
         let mut cfg = NodeConfig::default();
-        cfg.ghost_pay = Some(GhostPayConfig::default());
+        // ghost-pay ENABLED (claimed) but not running — the remediation scenario.
+        cfg.ghost_pay = Some(GhostPayConfig {
+            enabled: true,
+            ..Default::default()
+        });
         // 127.0.0.1:8800 almost certainly not bound in test env
         let r = check_ghost_pay(&cfg).await;
         assert!(r.claimed);
         if !r.passed {
             assert!(r.reason.as_ref().unwrap().contains("ghost-pay"));
         }
+    }
+
+    #[tokio::test]
+    async fn ghost_pay_check_disabled_block_is_unclaimed() {
+        // v1.10.20: a present-but-disabled `[ghost_pay]` block must NOT claim the
+        // capability (gate on `enabled`, not mere block presence) — otherwise
+        // pool-only nodes advertise GhostPay and peers waste probes on port 8800.
+        let mut cfg = NodeConfig::default();
+        cfg.ghost_pay = Some(GhostPayConfig::default()); // default enabled = false
+        let r = check_ghost_pay(&cfg).await;
+        assert!(!r.claimed && !r.passed && r.reason.is_none());
     }
 }

--- a/bins/ghost-pool/src/self_check.rs
+++ b/bins/ghost-pool/src/self_check.rs
@@ -240,7 +240,9 @@ fn check_archive(config: &NodeConfig) -> CapabilityCheck {
 }
 
 async fn check_ghost_pay(config: &NodeConfig) -> CapabilityCheck {
-    let claimed = config.ghost_pay.is_some();
+    // Match the capability advertisement: claim GhostPay only when enabled, not
+    // on mere presence of a (possibly disabled) `[ghost_pay]` block.
+    let claimed = config.ghost_pay_enabled();
     let last_checked_unix = now_unix();
     if !claimed {
         return CapabilityCheck {


### PR DESCRIPTION
Final follow-up to the v1.10.18 ghost-pay work. Pool-only nodes carry a default (disabled) `[ghost_pay]` block, so advertising the capability via `config.ghost_pay.is_some()` made them CLAIM GhostPay. Every peer then port-probed their absent ghost-pay API (8800) and logged `GhostPay verification failed: Verification timeout` — ~30-40/node fleet-wide.

Gate both the capability advertisement (`main.rs`) and the self-check (`self_check.rs`) on `config.ghost_pay_enabled()` (the predicate added in v1.10.18). Pool-only nodes stop falsely claiming GhostPay; verification already correctly denied them the +4 share, so this only removes the wasted probes + warning spam. No behaviour change for ghost-pay-enabled cores.