### PR TITLE
ci(release): build ghost-pay with zk-production (mainnet guard)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,14 +63,17 @@ jobs:
       # release artifacts here.
       - name: Build
         run: |
-          # CRITICAL: ghost-pool MUST be built with --features zk-production so the
-          # released binary can run on mainnet. Without it, is_production_mode() is
-          # false and ghost-pool aborts at startup ("MAINNET SECURITY: ZK consensus
-          # on mainnet requires trusted setup parameters"), so every curl|bash
-          # install crash-loops. zk-production is a compile-time flag with no
-          # build-time artefacts (params are loaded at runtime), so this is safe.
+          # CRITICAL: BOTH ghost-pool AND ghost-pay must be built with their own
+          # zk-production feature so the released binaries can run on mainnet.
+          # Without it, is_production_mode() is false and the binary aborts at
+          # startup ("MAINNET SECURITY: ZK consensus on mainnet requires trusted
+          # setup parameters"), so every curl|bash install crash-loops. ghost-pay
+          # has a SEPARATE `zk-production` feature (ghost-zkp/zk-production) — it is
+          # NOT enabled transitively by ghost-pool/zk-production, so it must be
+          # listed explicitly. zk-production is a compile-time flag with no
+          # build-time artefacts (params load at runtime), so this is safe.
           cargo build --release --target ${{ matrix.target }} \
-            --features ghost-pool/zk-production \
+            --features ghost-pool/zk-production,ghost-pay/zk-production \
             -p ghost-pool -p ghost-cli -p ghost-pay -p ghost-gsp-bin \
             -p translator_sv2 -p pool_sv2 -p jd_client_sv2 -p jd_server_sv2
 


### PR DESCRIPTION
The release built ghost-pay with only `--features ghost-pool/zk-production`, which does NOT enable ghost-pay's separate `zk-production` feature. So the released ghost-pay binary lacks zk-production and refuses to start on mainnet (the L2 mainnet guard). Hasn't bitten because new installs are pool-only, but it's a latent bug + a drift trap. Add `ghost-pay/zk-production` to the release build features.