### PR TITLE
fix(auto-update): resolve latest release from GitHub API

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,14 +63,17 @@ jobs:
       # release artifacts here.
       - name: Build
         run: |
-          # CRITICAL: ghost-pool MUST be built with --features zk-production so the
-          # released binary can run on mainnet. Without it, is_production_mode() is
-          # false and ghost-pool aborts at startup ("MAINNET SECURITY: ZK consensus
-          # on mainnet requires trusted setup parameters"), so every curl|bash
-          # install crash-loops. zk-production is a compile-time flag with no
-          # build-time artefacts (params are loaded at runtime), so this is safe.
+          # CRITICAL: BOTH ghost-pool AND ghost-pay must be built with their own
+          # zk-production feature so the released binaries can run on mainnet.
+          # Without it, is_production_mode() is false and the binary aborts at
+          # startup ("MAINNET SECURITY: ZK consensus on mainnet requires trusted
+          # setup parameters"), so every curl|bash install crash-loops. ghost-pay
+          # has a SEPARATE `zk-production` feature (ghost-zkp/zk-production) — it is
+          # NOT enabled transitively by ghost-pool/zk-production, so it must be
+          # listed explicitly. zk-production is a compile-time flag with no
+          # build-time artefacts (params load at runtime), so this is safe.
           cargo build --release --target ${{ matrix.target }} \
-            --features ghost-pool/zk-production \
+            --features ghost-pool/zk-production,ghost-pay/zk-production \
             -p ghost-pool -p ghost-cli -p ghost-pay -p ghost-gsp-bin \
             -p translator_sv2 -p pool_sv2 -p jd_client_sv2 -p jd_server_sv2
 

--- a/scripts/ghost-auto-update.sh
+++ b/scripts/ghost-auto-update.sh
@@ -30,6 +30,10 @@ set -euo pipefail
 GPG_KEY_FP="${GHOST_GPG_KEY_FP:-777FE81F8CC077FD3D08055E852C2B3190F5B928}"
 RELEASE_KEY_URL="${GHOST_RELEASE_KEY_URL:-https://get.bitcoinghost.org/ghost-release-key.asc}"
 INSTALL_SH_URL="${GHOST_INSTALL_SH_URL:-https://get.bitcoinghost.org/install.sh}"
+# Latest-release source of truth. install.sh auto-tracks this same API, so we
+# resolve the newest version straight from it rather than scraping install.sh
+# (whose GHOST_VERSION is now a dynamic ${...} expansion with no literal version).
+RELEASES_API_URL="${GHOST_RELEASES_API_URL:-https://api.github.com/repos/bitcoin-ghost/ghost/releases/latest}"
 # NOTE: ghostd is no longer fetched from a standalone URL — it ships inside the
 # signed release tarball (below), so the old GHOSTD_URL side-channel is gone.
 # Release tarball base. When GHOST_RELEASE_BASE is set it is used verbatim;
@@ -231,11 +235,11 @@ main() {
   installed="$(read_installed_version || true)"
   [[ -n "$installed" ]] || { err "could not determine installed version"; write_status "error" "installed version unknown"; exit 1; }
 
-  install_sh="$(curl -fsSL --max-time 30 "$INSTALL_SH_URL" 2>/dev/null || true)"
-  [[ -n "$install_sh" ]] || { err "could not fetch install.sh from $INSTALL_SH_URL"; write_status "error" "install.sh unreachable"; exit 1; }
-  latest="$(echo "$install_sh" | grep -m1 -oE 'GHOST_VERSION="?v?[0-9]+\.[0-9]+\.[0-9]+"?' | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
+  # Resolve the latest published release directly from the GitHub releases API
+  # (the same source install.sh auto-tracks). Robust to install.sh's format.
+  latest="$(curl -fsSL --max-time 30 "$RELEASES_API_URL" 2>/dev/null | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' | head -1 || true)"
+  [[ -n "$latest" ]] || { err "could not resolve latest release from $RELEASES_API_URL"; write_status "error" "latest version unresolved"; exit 1; }
   [[ "$latest" == v* ]] || latest="v${latest}"
-  [[ -n "$latest" && "$latest" != "v" ]] || { err "could not parse latest version from install.sh"; write_status "error" "version parse failed"; exit 1; }
 
   log "installed=$installed latest=$latest"
   if ! is_newer "$installed" "$latest"; then

--- a/scripts/install-node.sh
+++ b/scripts/install-node.sh
@@ -1039,6 +1039,10 @@ set -euo pipefail
 GPG_KEY_FP="${GHOST_GPG_KEY_FP:-777FE81F8CC077FD3D08055E852C2B3190F5B928}"
 RELEASE_KEY_URL="${GHOST_RELEASE_KEY_URL:-https://get.bitcoinghost.org/ghost-release-key.asc}"
 INSTALL_SH_URL="${GHOST_INSTALL_SH_URL:-https://get.bitcoinghost.org/install.sh}"
+# Latest-release source of truth. install.sh auto-tracks this same API, so we
+# resolve the newest version straight from it rather than scraping install.sh
+# (whose GHOST_VERSION is now a dynamic ${...} expansion with no literal version).
+RELEASES_API_URL="${GHOST_RELEASES_API_URL:-https://api.github.com/repos/bitcoin-ghost/ghost/releases/latest}"
 # NOTE: ghostd is no longer fetched from a standalone URL — it ships inside the
 # signed release tarball (below), so the old GHOSTD_URL side-channel is gone.
 # Release tarball base. When GHOST_RELEASE_BASE is set it is used verbatim;
@@ -1240,11 +1244,11 @@ main() {
   installed="$(read_installed_version || true)"
   [[ -n "$installed" ]] || { err "could not determine installed version"; write_status "error" "installed version unknown"; exit 1; }
 
-  install_sh="$(curl -fsSL --max-time 30 "$INSTALL_SH_URL" 2>/dev/null || true)"
-  [[ -n "$install_sh" ]] || { err "could not fetch install.sh from $INSTALL_SH_URL"; write_status "error" "install.sh unreachable"; exit 1; }
-  latest="$(echo "$install_sh" | grep -m1 -oE 'GHOST_VERSION="?v?[0-9]+\.[0-9]+\.[0-9]+"?' | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
+  # Resolve the latest published release directly from the GitHub releases API
+  # (the same source install.sh auto-tracks). Robust to install.sh's format.
+  latest="$(curl -fsSL --max-time 30 "$RELEASES_API_URL" 2>/dev/null | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' | head -1 || true)"
+  [[ -n "$latest" ]] || { err "could not resolve latest release from $RELEASES_API_URL"; write_status "error" "latest version unresolved"; exit 1; }
   [[ "$latest" == v* ]] || latest="v${latest}"
-  [[ -n "$latest" && "$latest" != "v" ]] || { err "could not parse latest version from install.sh"; write_status "error" "version parse failed"; exit 1; }
 
   log "installed=$installed latest=$latest"
   if ! is_newer "$installed" "$latest"; then


### PR DESCRIPTION
The auto-updater scraped a literal `GHOST_VERSION` from install.sh, but install.sh now auto-tracks the release dynamically (`${GHOST_VERSION:-$(curl API)}`), so there's no literal version -> `version parse failed` -> every auto-update + drift-detection silently errored. Resolve the newest tag directly from the releases API instead. Fixed in the canonical `scripts/ghost-auto-update.sh` + the installer's embedded copy. Already redeployed to the fleet + verified (elder detection now reports `up-to-date`).