### PR TITLE
fix(dashboard): authenticate the WebSocket (close JWT-bypass)

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -18,6 +18,11 @@ RUN addgroup --system --gid 1001 nodejs && adduser --system --uid 1001 nextjs
 COPY --from=builder /app/public ./public
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+# Override the generated standalone entry with our custom server, which adds the
+# JWT-authenticated `/api/ws` WebSocket relay on top of the Next request handler.
+# It depends only on the `next` package (already present in the standalone
+# node_modules) plus Node built-ins.
+COPY --from=builder --chown=nextjs:nodejs /app/server.js ./server.js
 USER nextjs
 EXPOSE 3000
 ENV PORT=3000

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -61,9 +61,57 @@ NEXT_PUBLIC_API_URL=http://localhost:8080
 # Production build
 npm run build
 
-# Start production server
+# Start production server (custom Node server — see below)
 npm start
 ```
+
+## WebSocket authentication (custom server)
+
+Real-time updates use a WebSocket. App-Router route handlers cannot upgrade a
+connection, so the dashboard ships a **custom Node server** (`server.js`) that
+wraps Next.js and owns the HTTP `upgrade` event:
+
+- The browser connects to the **same-origin** endpoint `wss?://<host>/api/ws`
+  (never straight to the backend `:8080`).
+- On upgrade, `server.js` validates the `ghost-session` JWT — the *same* cookie
+  the middleware and REST proxy enforce. An unauthenticated upgrade is answered
+  with `401` and never becomes a socket.
+- Only after the token verifies does the server open a socket to the loopback
+  backend `/ws` and pipe frames through (the operator's cookie is stripped
+  before forwarding).
+
+This closes the previous hole where the browser opened a raw, unauthenticated
+socket directly to `ws://<host>:8080/ws`.
+
+### Deployment note (IMPORTANT)
+
+The dashboard entry point is now `server.js`, not `next start`:
+
+- `npm start` runs `NODE_ENV=production node server.js`.
+- With `output: 'standalone'`, the Docker image copies `server.js` over the
+  generated `.next/standalone/server.js`. **Any systemd unit / process manager
+  must launch `node server.js` (from the standalone dir), not `next start`** —
+  `next start` does not run the WS relay and is incompatible with standalone.
+- `HOSTNAME` defaults to `127.0.0.1` (loopback); access remotely via SSH tunnel
+  (`ssh -L 3000:localhost:3000 <node>`).
+
+### Defence-in-depth: backend `:8080`
+
+The node API (`ghost-verification`) listens on `0.0.0.0:8080` because mesh peers
+challenge each other over it, and its `/ws` runs unauthenticated
+(`WsState::new()` → `require_auth:false`). The `/api/ws` relay is therefore the
+**user-auth boundary** for the browser. Operators should still confirm the API
+is not needlessly exposed:
+
+```bash
+# Expect the node API bound as intended (mesh reachability is by design):
+ss -ltnp 'sport = :8080'
+```
+
+Locking `:8080` to loopback would break inter-node verification, so it is left
+as-is; hardening the backend `/ws` (enabling `require_auth` in prod wiring, or
+serving `/ws` on a separate loopback listener) is tracked as a backend follow-up
+and is out of scope for this dashboard change.
 
 ## Pages
 

--- a/dashboard/eslint.config.mjs
+++ b/dashboard/eslint.config.mjs
@@ -5,6 +5,15 @@ import nextTs from "eslint-config-next/typescript";
 const eslintConfig = defineConfig([
   ...nextVitals,
   ...nextTs,
+  // The custom Node server and its test harness are plain CommonJS modules that
+  // run outside the Next/browser bundle, so the ESM-only `require` ban does not
+  // apply to them.
+  {
+    files: ["server.js", "tests/**/*.js"],
+    rules: {
+      "@typescript-eslint/no-require-imports": "off",
+    },
+  },
   // Override default ignores of eslint-config-next.
   globalIgnores([
     // Default ignores of eslint-config-next:

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -3,10 +3,11 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "node server.js",
     "build": "next build",
-    "start": "next start",
-    "lint": "eslint"
+    "start": "NODE_ENV=production node server.js",
+    "lint": "eslint",
+    "test": "node --test --test-force-exit tests/*.test.js"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.90.16",

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -1,0 +1,259 @@
+// Custom Next.js server for the Ghost Node Dashboard.
+//
+// Why this file exists
+// --------------------
+// App-Router route handlers cannot upgrade a connection to a WebSocket, so
+// there is no way to authenticate a WS purely inside `src/app`. The browser
+// used to open a raw socket straight to the backend (`ws://<host>:8080/ws`),
+// bypassing the JWT that gates every REST call — anyone who could reach the
+// node's :8080 got the live event/log stream unauthenticated.
+//
+// This server wraps Next.js and takes over the HTTP `upgrade` event. Upgrades
+// to the same-origin path `/api/ws` are authenticated with the SAME
+// `ghost-session` JWT the middleware/REST proxy use; only after the token
+// verifies do we open a socket to the loopback backend and pipe frames
+// through. An unauthenticated upgrade is answered with `401` and never becomes
+// a socket. Everything else is served by Next unchanged.
+//
+// The WS relay is a transparent TCP tunnel: once auth passes we forward the
+// client's original upgrade request (with the path rewritten to `/ws` and the
+// cookie stripped) to the backend and pipe the two sockets. The backend
+// computes `Sec-WebSocket-Accept` from the client's key and its `101` flows
+// straight back, so no frame parsing (and no `ws` dependency) is needed.
+
+"use strict";
+
+const http = require("http");
+const net = require("net");
+const crypto = require("crypto");
+
+const WS_PATH = "/api/ws";
+
+// ---------------------------------------------------------------------------
+// JWT verification — a plain-Node mirror of `src/lib/jwt.ts`.
+//
+// This deliberately re-implements the verifier instead of importing the TS
+// module: this file is a hand-written entry point that runs before/outside the
+// Next bundle (and inside the standalone output, where `src/` is not present),
+// so it can only depend on Node built-ins. `tests/ws-auth.test.js` pins the two
+// implementations together — a token minted by `jwt.ts` MUST verify here, and
+// vice versa — so they cannot silently drift.
+// ---------------------------------------------------------------------------
+
+const JWT_HEADER_B64U = Buffer.from(
+  JSON.stringify({ alg: "HS256", typ: "JWT" }),
+).toString("base64url");
+
+/** Derive a stable signing secret from the dashboard password (matches jwt.ts). */
+function deriveJwtSecret(password) {
+  return crypto
+    .createHmac("sha256", Buffer.from(password, "utf8"))
+    .update("ghost-dashboard-jwt-v1")
+    .digest("base64url");
+}
+
+/** Resolve the signing secret from env, deriving from DASHBOARD_PASSWORD as a fallback. */
+function resolveJwtSecret() {
+  const explicit = process.env.DASHBOARD_JWT_SECRET;
+  if (explicit && explicit.length >= 32) return explicit;
+  const password = process.env.DASHBOARD_PASSWORD;
+  if (!password) return null;
+  return deriveJwtSecret(password);
+}
+
+/** Verify an HS256 JWT. Returns the payload on success, else null. */
+function verifySession(token, secret) {
+  if (!token || !secret) return null;
+  const parts = token.split(".");
+  if (parts.length !== 3) return null;
+  const [h, p, s] = parts;
+  if (h !== JWT_HEADER_B64U) return null; // reject non-HS256 / mis-typed
+  const signingInput = `${h}.${p}`;
+  const expected = crypto
+    .createHmac("sha256", Buffer.from(secret, "utf8"))
+    .update(signingInput)
+    .digest();
+  let got;
+  try {
+    got = Buffer.from(s, "base64url");
+  } catch {
+    return null;
+  }
+  if (got.length !== expected.length || !crypto.timingSafeEqual(got, expected)) {
+    return null;
+  }
+  let payload;
+  try {
+    payload = JSON.parse(Buffer.from(p, "base64url").toString("utf8"));
+  } catch {
+    return null;
+  }
+  if (
+    typeof payload.exp !== "number" ||
+    payload.exp < Math.floor(Date.now() / 1000)
+  ) {
+    return null;
+  }
+  return payload;
+}
+
+/** Extract a named cookie value from a raw Cookie header. */
+function readCookie(cookieHeader, name) {
+  if (!cookieHeader) return null;
+  for (const part of cookieHeader.split(";")) {
+    const eq = part.indexOf("=");
+    if (eq === -1) continue;
+    if (part.slice(0, eq).trim() === name) {
+      return part.slice(eq + 1).trim();
+    }
+  }
+  return null;
+}
+
+/**
+ * Decide whether an upgrade request is allowed to reach the backend stream.
+ * Pure and synchronous so it is trivially testable.
+ */
+function authorizeUpgrade(req) {
+  const token = readCookie(req.headers.cookie, "ghost-session");
+  const secret = resolveJwtSecret();
+  return verifySession(token, secret) !== null;
+}
+
+// ---------------------------------------------------------------------------
+// Backend target (loopback by default).
+// ---------------------------------------------------------------------------
+
+/** Parse NEXT_PUBLIC_API_URL into {host, port}, defaulting to loopback:8080. */
+function backendTarget() {
+  const raw = process.env.NEXT_PUBLIC_API_URL || "http://127.0.0.1:8080";
+  try {
+    const u = new URL(raw);
+    return {
+      host: u.hostname || "127.0.0.1",
+      port: Number(u.port) || (u.protocol === "https:" ? 443 : 80),
+    };
+  } catch {
+    return { host: "127.0.0.1", port: 8080 };
+  }
+}
+
+/** Answer a rejected upgrade with a real HTTP status, then close the socket. */
+function rejectUpgrade(socket, status, message) {
+  if (socket.writable) {
+    socket.write(
+      `HTTP/1.1 ${status} ${message}\r\n` +
+        "Connection: close\r\n" +
+        "Content-Length: 0\r\n" +
+        "\r\n",
+    );
+  }
+  socket.destroy();
+}
+
+/** Serialise the (rewritten) upgrade request line + headers for the backend. */
+function buildBackendRequest(req, target) {
+  const qIndex = (req.url || "").indexOf("?");
+  const search = qIndex === -1 ? "" : req.url.slice(qIndex);
+  const headers = { ...req.headers };
+  // Never leak the operator's session cookie to the backend, and rewrite Host.
+  delete headers.cookie;
+  headers.host = `${target.host}:${target.port}`;
+
+  let raw = `GET /ws${search} HTTP/1.1\r\n`;
+  for (const [k, v] of Object.entries(headers)) {
+    if (Array.isArray(v)) {
+      for (const item of v) raw += `${k}: ${item}\r\n`;
+    } else if (v !== undefined) {
+      raw += `${k}: ${v}\r\n`;
+    }
+  }
+  raw += "\r\n";
+  return raw;
+}
+
+/**
+ * Authenticate an `upgrade` event and, if allowed, transparently proxy it to
+ * the backend `/ws`. Returns true if this handler owns the request (i.e. it was
+ * for WS_PATH), false to let the caller delegate (e.g. dev HMR).
+ */
+function handleUpgrade(req, socket, head, target = backendTarget()) {
+  const pathname = (req.url || "").split("?")[0];
+  if (pathname !== WS_PATH) return false;
+
+  socket.on("error", () => socket.destroy());
+
+  if (!authorizeUpgrade(req)) {
+    rejectUpgrade(socket, 401, "Unauthorized");
+    return true;
+  }
+
+  const backend = net.connect(target.port, target.host);
+  backend.on("connect", () => {
+    backend.write(buildBackendRequest(req, target));
+    if (head && head.length) backend.write(head);
+    // Transparent byte pipe in both directions from here on.
+    socket.pipe(backend);
+    backend.pipe(socket);
+  });
+  backend.on("error", () => {
+    rejectUpgrade(socket, 502, "Bad Gateway");
+  });
+  socket.on("close", () => backend.destroy());
+  return true;
+}
+
+module.exports = {
+  WS_PATH,
+  JWT_HEADER_B64U,
+  deriveJwtSecret,
+  resolveJwtSecret,
+  verifySession,
+  readCookie,
+  authorizeUpgrade,
+  backendTarget,
+  handleUpgrade,
+};
+
+// ---------------------------------------------------------------------------
+// Entry point — only runs when executed directly (`node server.js`), so tests
+// can require the helpers above without booting Next.
+// ---------------------------------------------------------------------------
+
+if (require.main === module) {
+  const next = require("next");
+  const dev = process.env.NODE_ENV !== "production";
+  const hostname = process.env.HOSTNAME || "127.0.0.1";
+  const port = Number(process.env.PORT) || 3000;
+
+  const app = next({ dev, dir: __dirname, hostname, port });
+  const handle = app.getRequestHandler();
+
+  app.prepare().then(() => {
+    // Must be fetched after prepare(); used to hand dev HMR upgrades back to Next.
+    const upgradeHandle =
+      typeof app.getUpgradeHandler === "function"
+        ? app.getUpgradeHandler()
+        : null;
+    const server = http.createServer((req, res) => handle(req, res));
+
+    server.on("upgrade", (req, socket, head) => {
+      let owned = false;
+      try {
+        owned = handleUpgrade(req, socket, head);
+      } catch {
+        rejectUpgrade(socket, 500, "Internal Server Error");
+        return;
+      }
+      if (owned) return;
+      // Not our endpoint: let Next handle its own upgrades (HMR in dev);
+      // reject anything else so no other unauthenticated upgrade slips by.
+      if (upgradeHandle) upgradeHandle(req, socket, head);
+      else socket.destroy();
+    });
+
+    server.listen(port, hostname, () => {
+      console.log(`> Dashboard ready on http://${hostname}:${port}`);
+    });
+  });
+}

--- a/dashboard/src/hooks/useWebSocket.ts
+++ b/dashboard/src/hooks/useWebSocket.ts
@@ -2,17 +2,7 @@
 
 import { useEffect, useRef, useState, useCallback } from "react";
 import type { NodeEvent } from "@/types/api";
-
-// Dynamically compute WebSocket URL from window location
-function getWsUrl(): string {
-  if (typeof window !== "undefined") {
-    const { protocol, hostname } = window.location;
-    const wsProtocol = protocol === "https:" ? "wss:" : "ws:";
-    return `${wsProtocol}//${hostname}:8080/ws`;
-  }
-  const base = process.env.NEXT_PUBLIC_API_URL || "";
-  return base.replace(/^http/, "ws") + "/ws";
-}
+import { getWsUrl, isSessionExpired, redirectToLogin } from "@/lib/api/ws";
 
 type ConnectionState = "connecting" | "connected" | "disconnected" | "error";
 
@@ -37,6 +27,11 @@ export function useWebSocket(options: UseWebSocketOptions = {}) {
   const reconnectTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const mountedRef = useRef(true);
   const reconnectDelayRef = useRef(INITIAL_RECONNECT_DELAY);
+  // Whether the CURRENT socket ever reached OPEN. A close before open means the
+  // handshake was rejected (e.g. a 401 from the auth relay), which the browser
+  // cannot surface directly — so we probe the session instead of hot-looping.
+  const openedRef = useRef(false);
+  const authDeadRef = useRef(false);
 
   // Store callbacks in refs so connect() doesn't depend on them
   const callbacksRef = useRef(options);
@@ -44,16 +39,19 @@ export function useWebSocket(options: UseWebSocketOptions = {}) {
 
   const connect = useCallback(() => {
     if (typeof window === "undefined") return;
+    if (authDeadRef.current) return; // session is gone; stop trying until reload
     if (wsRef.current?.readyState === WebSocket.OPEN || wsRef.current?.readyState === WebSocket.CONNECTING) return;
 
     setConnectionState("connecting");
 
     try {
+      openedRef.current = false;
       const ws = new WebSocket(getWsUrl());
       wsRef.current = ws;
 
       ws.onopen = () => {
         if (mountedRef.current) {
+          openedRef.current = true;
           setConnectionState("connected");
           reconnectDelayRef.current = INITIAL_RECONNECT_DELAY;
         }
@@ -86,20 +84,39 @@ export function useWebSocket(options: UseWebSocketOptions = {}) {
         }
       };
 
+      const scheduleReconnect = () => {
+        const delay = reconnectDelayRef.current;
+        reconnectDelayRef.current = Math.min(delay * 2, MAX_RECONNECT_DELAY);
+        reconnectTimeoutRef.current = setTimeout(() => {
+          if (mountedRef.current) connect();
+        }, delay);
+      };
+
       ws.onclose = () => {
         if (!mountedRef.current) return;
 
+        const wasOpen = openedRef.current;
         setConnectionState("disconnected");
         wsRef.current = null;
 
-        if (autoReconnect) {
-          const delay = reconnectDelayRef.current;
-          reconnectDelayRef.current = Math.min(delay * 2, MAX_RECONNECT_DELAY);
-          reconnectTimeoutRef.current = setTimeout(() => {
-            if (mountedRef.current) {
-              connect();
+        if (!autoReconnect) return;
+
+        if (!wasOpen) {
+          // Handshake never completed. Could be a dead session (relay 401) or a
+          // transient backend outage — ask the auth layer which it is before
+          // deciding to reconnect, so an expired session doesn't hot-loop.
+          isSessionExpired().then((expired) => {
+            if (!mountedRef.current) return;
+            if (expired) {
+              authDeadRef.current = true;
+              setConnectionState("error");
+              redirectToLogin();
+            } else {
+              scheduleReconnect();
             }
-          }, delay);
+          });
+        } else {
+          scheduleReconnect();
         }
       };
 

--- a/dashboard/src/lib/api/client.ts
+++ b/dashboard/src/lib/api/client.ts
@@ -3,6 +3,8 @@
 // All API calls go through Next.js API proxy routes (/api/proxy/...)
 // which handle HMAC signing for internal endpoints server-side.
 
+import { getWsUrl } from "./ws";
+
 const FETCH_TIMEOUT = 5000;
 
 /// Get the API base URL for proxied requests
@@ -11,15 +13,6 @@ function getProxyBase(): string {
     return window.location.origin;
   }
   return "http://localhost:3000";
-}
-
-/// Get the direct backend URL (for WebSocket only)
-function getBackendWsUrl(): string {
-  if (typeof window !== "undefined") {
-    const { hostname } = window.location;
-    return `ws://${hostname}:8080`;
-  }
-  return "ws://localhost:8080";
 }
 
 // Legacy exports for compatibility
@@ -105,10 +98,9 @@ export async function fetchApiWithFormData<T>(
   return response.json();
 }
 
-// WebSocket connection (direct to backend — not proxied)
+// WebSocket connection — routed through the same-origin, JWT-authenticated
+// `/api/ws` relay (see server.js), NOT straight to the backend :8080.
 export function createWebSocket(): WebSocket | null {
   if (typeof window === "undefined") return null;
-
-  const wsUrl = getBackendWsUrl() + "/ws";
-  return new WebSocket(wsUrl);
+  return new WebSocket(getWsUrl());
 }

--- a/dashboard/src/lib/api/ws.ts
+++ b/dashboard/src/lib/api/ws.ts
@@ -1,0 +1,56 @@
+// Shared client helpers for the authenticated dashboard WebSocket.
+//
+// The browser connects to the SAME-ORIGIN endpoint `/api/ws` (served by the
+// custom Node server in `server.js`), never straight to the backend :8080.
+// That endpoint validates the `ghost-session` JWT on the HTTP upgrade before
+// relaying to the loopback backend, so the WS is gated by the same session as
+// every REST call.
+
+/**
+ * Same-origin WebSocket URL. Preserves `wss:` on HTTPS pages and inherits the
+ * page host/port, so it works over the SSH tunnel (`localhost:3000`) and any
+ * reverse proxy without extra config.
+ */
+export function getWsUrl(): string {
+  if (typeof window !== "undefined") {
+    const { protocol, host } = window.location;
+    const wsProto = protocol === "https:" ? "wss:" : "ws:";
+    return `${wsProto}//${host}/api/ws`;
+  }
+  return "ws://localhost:3000/api/ws";
+}
+
+let redirecting = false;
+
+/**
+ * Probe whether the session is actually dead. A failed WS handshake cannot
+ * expose its HTTP status to the browser (the spec hides it), so when a socket
+ * closes without ever opening we ask the auth layer directly: POST
+ * `/api/auth/refresh` returns 401 iff the `ghost-session` cookie is missing or
+ * expired (and slides it otherwise). Returns true only on a definite 401 — a
+ * network error is treated as "not an auth problem" so a transiently-down
+ * backend doesn't bounce the operator to /login.
+ */
+export async function isSessionExpired(): Promise<boolean> {
+  try {
+    const res = await fetch("/api/auth/refresh", {
+      method: "POST",
+      cache: "no-store",
+    });
+    return res.status === 401;
+  } catch {
+    return false;
+  }
+}
+
+/** Redirect to the login page once, preserving the current path for return. */
+export function redirectToLogin(): void {
+  if (redirecting || typeof window === "undefined") return;
+  redirecting = true;
+  const here = window.location.pathname + window.location.search;
+  const target =
+    here && here !== "/"
+      ? `/login?redirect=${encodeURIComponent(here)}`
+      : "/login";
+  window.location.assign(target);
+}

--- a/dashboard/tests/ws-auth.test.js
+++ b/dashboard/tests/ws-auth.test.js
@@ -1,0 +1,238 @@
+"use strict";
+
+// End-to-end tests for the authenticated WebSocket relay in ../server.js.
+//
+// These exercise the REAL upgrade handler and REAL JWT verification against a
+// mock backend WS server, over real TCP sockets — no mocking of the security
+// boundary. Run with: `npm test` (node --test).
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const http = require("node:http");
+const net = require("node:net");
+const crypto = require("node:crypto");
+
+// Deterministic signing secret for the whole suite (>= 32 chars so
+// resolveJwtSecret uses it verbatim instead of deriving from a password).
+const SECRET = "test-secret-abcdefghijklmnopqrstuvwxyz-0123456789";
+process.env.DASHBOARD_JWT_SECRET = SECRET;
+delete process.env.DASHBOARD_PASSWORD;
+
+const server = require("../server.js");
+
+// --- helpers ---------------------------------------------------------------
+
+/** Mint an HS256 JWT the same way src/lib/jwt.ts (and server.js) expect. */
+function mintToken(secret, { sub = "operator", ttl = 3600, exp } = {}) {
+  const now = Math.floor(Date.now() / 1000);
+  const payload = { sub, iat: now, exp: exp ?? now + ttl };
+  const payloadB64 = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  const signingInput = `${server.JWT_HEADER_B64U}.${payloadB64}`;
+  const sig = crypto
+    .createHmac("sha256", Buffer.from(secret, "utf8"))
+    .update(signingInput)
+    .digest("base64url");
+  return `${signingInput}.${sig}`;
+}
+
+/** Minimal WS backend: completes the handshake and pushes one text frame. */
+function startMockBackend() {
+  let connections = 0;
+  const srv = http.createServer((_req, res) => {
+    res.writeHead(426);
+    res.end();
+  });
+  srv.on("upgrade", (req, socket) => {
+    connections += 1;
+    const key = req.headers["sec-websocket-key"];
+    const accept = crypto
+      .createHash("sha1")
+      .update(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
+      .digest("base64");
+    socket.write(
+      "HTTP/1.1 101 Switching Protocols\r\n" +
+        "Upgrade: websocket\r\n" +
+        "Connection: Upgrade\r\n" +
+        `Sec-WebSocket-Accept: ${accept}\r\n\r\n`,
+    );
+    const payload = Buffer.from('{"type":"Ping"}');
+    // FIN + text opcode, unmasked (server->client), length < 126.
+    socket.write(Buffer.concat([Buffer.from([0x81, payload.length]), payload]));
+  });
+  return new Promise((resolve) => {
+    srv.listen(0, "127.0.0.1", () =>
+      resolve({
+        srv,
+        port: srv.address().port,
+        get connections() {
+          return connections;
+        },
+      }),
+    );
+  });
+}
+
+/** The relay under test: a bare HTTP server wired to server.handleUpgrade. */
+function startRelay(backendPort) {
+  const srv = http.createServer((_req, res) => {
+    res.writeHead(404);
+    res.end();
+  });
+  srv.on("upgrade", (req, socket, head) => {
+    server.handleUpgrade(req, socket, head, {
+      host: "127.0.0.1",
+      port: backendPort,
+    });
+  });
+  return new Promise((resolve) => {
+    srv.listen(0, "127.0.0.1", () =>
+      resolve({ srv, port: srv.address().port }),
+    );
+  });
+}
+
+/**
+ * Perform a raw WS upgrade against the relay. Resolves with the HTTP status
+ * code and, on a 101, the decoded payload of the first text frame received.
+ */
+function rawUpgrade(port, { cookie } = {}) {
+  return new Promise((resolve, reject) => {
+    const sock = net.connect(port, "127.0.0.1");
+    const key = crypto.randomBytes(16).toString("base64");
+    let buf = Buffer.alloc(0);
+    let settled = false;
+
+    const done = (val) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      sock.destroy();
+      resolve(val);
+    };
+    const timer = setTimeout(() => done({ status: 0, timedOut: true }), 2000);
+
+    sock.on("connect", () => {
+      let req =
+        "GET /api/ws HTTP/1.1\r\n" +
+        `Host: 127.0.0.1:${port}\r\n` +
+        "Upgrade: websocket\r\n" +
+        "Connection: Upgrade\r\n" +
+        `Sec-WebSocket-Key: ${key}\r\n` +
+        "Sec-WebSocket-Version: 13\r\n";
+      if (cookie) req += `Cookie: ${cookie}\r\n`;
+      req += "\r\n";
+      sock.write(req);
+    });
+
+    sock.on("data", (chunk) => {
+      buf = Buffer.concat([buf, chunk]);
+      const sep = buf.indexOf("\r\n\r\n");
+      if (sep === -1) return;
+      const head = buf.slice(0, sep).toString("latin1");
+      const status = Number(head.split(" ")[1]);
+      if (status !== 101) {
+        return done({ status });
+      }
+      // Decode the first (unmasked, short) text frame from the body, if present.
+      const body = buf.slice(sep + 4);
+      if (body.length < 2) return; // wait for the frame
+      const len = body[1] & 0x7f;
+      if (body.length < 2 + len) return;
+      const message = body.slice(2, 2 + len).toString("utf8");
+      done({ status: 101, message });
+    });
+
+    sock.on("error", reject);
+  });
+}
+
+// --- JWT parity / unit checks ---------------------------------------------
+
+test("JWT header encoding matches the HS256/JWT constant", () => {
+  const expected = Buffer.from(
+    JSON.stringify({ alg: "HS256", typ: "JWT" }),
+  ).toString("base64url");
+  assert.equal(server.JWT_HEADER_B64U, expected);
+});
+
+test("verifySession accepts a valid token and rejects bad ones", () => {
+  const good = mintToken(SECRET);
+  assert.ok(server.verifySession(good, SECRET), "valid token should verify");
+
+  // Wrong secret.
+  assert.equal(server.verifySession(good, "another-secret-x".repeat(3)), null);
+  // Tampered signature.
+  assert.equal(server.verifySession(good.slice(0, -2) + "xy", SECRET), null);
+  // Expired.
+  const expired = mintToken(SECRET, { exp: Math.floor(Date.now() / 1000) - 10 });
+  assert.equal(server.verifySession(expired, SECRET), null);
+  // Malformed.
+  assert.equal(server.verifySession("not.a.jwt", SECRET), null);
+  assert.equal(server.verifySession("", SECRET), null);
+});
+
+test("resolveJwtSecret prefers explicit secret, else derives from password", () => {
+  assert.equal(server.resolveJwtSecret(), SECRET);
+
+  const saved = process.env.DASHBOARD_JWT_SECRET;
+  delete process.env.DASHBOARD_JWT_SECRET;
+  process.env.DASHBOARD_PASSWORD = "hunter2";
+  assert.equal(server.resolveJwtSecret(), server.deriveJwtSecret("hunter2"));
+
+  delete process.env.DASHBOARD_PASSWORD;
+  assert.equal(server.resolveJwtSecret(), null, "no secret -> locked (null)");
+
+  process.env.DASHBOARD_JWT_SECRET = saved; // restore for later tests
+});
+
+test("readCookie extracts the named cookie", () => {
+  assert.equal(
+    server.readCookie("a=1; ghost-session=TOKEN; b=2", "ghost-session"),
+    "TOKEN",
+  );
+  assert.equal(server.readCookie("", "ghost-session"), null);
+  assert.equal(server.readCookie(undefined, "ghost-session"), null);
+});
+
+// --- end-to-end relay behaviour -------------------------------------------
+
+test("upgrade WITHOUT a valid session -> 401, no backend socket", async () => {
+  const backend = await startMockBackend();
+  const relay = await startRelay(backend.port);
+  try {
+    const noCookie = await rawUpgrade(relay.port);
+    assert.equal(noCookie.status, 401, "missing cookie must be rejected");
+
+    const badCookie = await rawUpgrade(relay.port, {
+      cookie: "ghost-session=forged.invalid.token",
+    });
+    assert.equal(badCookie.status, 401, "forged token must be rejected");
+
+    const expired = await rawUpgrade(relay.port, {
+      cookie: `ghost-session=${mintToken(SECRET, { exp: Math.floor(Date.now() / 1000) - 10 })}`,
+    });
+    assert.equal(expired.status, 401, "expired token must be rejected");
+
+    // No unauthorized attempt reached the backend.
+    assert.equal(backend.connections, 0, "backend must see zero connections");
+  } finally {
+    backend.srv.close();
+    relay.srv.close();
+  }
+});
+
+test("upgrade WITH a valid session -> 101 and relays a message", async () => {
+  const backend = await startMockBackend();
+  const relay = await startRelay(backend.port);
+  try {
+    const res = await rawUpgrade(relay.port, {
+      cookie: `ghost-session=${mintToken(SECRET)}`,
+    });
+    assert.equal(res.status, 101, "valid session must complete the handshake");
+    assert.equal(res.message, '{"type":"Ping"}', "backend frame must relay");
+    assert.equal(backend.connections, 1, "exactly one backend connection");
+  } finally {
+    backend.srv.close();
+    relay.srv.close();
+  }
+});


### PR DESCRIPTION
The dashboard WS connected directly to the backend `:8080/ws`, bypassing the JWT-gated proxy (the backend runs `/ws` in public mode). Added a custom Node server (`server.js`) that validates the `ghost-session` JWT on the WS upgrade and only then relays to the loopback backend — unauthenticated upgrades get 401. Verified against the standalone deploy artifact (401 no/forged/expired cookie, 101 valid JWT). Deploy note: dashboard must launch via `node server.js`. Backend `:8080` LAN-hardening is a separate backend follow-up.