### PR TITLE
fix(wallet): retire cosmetic Send privacy modes (truth-in-advertising)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10559,6 +10559,7 @@ dependencies = [
 name = "wraith-wallet-daemon"
 version = "1.10.20"
 dependencies = [
+ "async-trait",
  "axum 0.7.9",
  "base64 0.22.1",
  "bitcoin",

--- a/apps/wraith-wallet/cli/src/main.rs
+++ b/apps/wraith-wallet/cli/src/main.rs
@@ -270,13 +270,14 @@ enum LightCommand {
         #[arg(short, long, default_value_t = 0)]
         offset: u32,
     },
-    /// Send a payment. Mode is one of `ghostpay` (default), `wraith`, or `confidential`.
+    /// Send an instant L2 payment. Mode is `ghostpay` (the only accepted
+    /// value; default). For unlinkable L1 spends use the Mix flow instead.
     Send {
         /// Recipient: a Bitcoin address or a Ghost ID.
         recipient: String,
         /// Amount in satoshis.
         amount_sats: u64,
-        /// Payment mode.
+        /// Payment mode. Only `ghostpay` (instant L2) is supported.
         #[arg(long, default_value = "ghostpay")]
         mode: String,
         /// Optional memo, included with the payment metadata.

--- a/apps/wraith-wallet/daemon/Cargo.toml
+++ b/apps/wraith-wallet/daemon/Cargo.toml
@@ -43,3 +43,5 @@ axum = { workspace = true }
 bitcoin = { workspace = true }
 rand = { workspace = true }
 hex = { workspace = true }
+# Implement the `ChainClient` trait on a test stub for `light_send` gating tests.
+async-trait = { workspace = true }

--- a/apps/wraith-wallet/daemon/src/main.rs
+++ b/apps/wraith-wallet/daemon/src/main.rs
@@ -4099,8 +4099,8 @@ mod unix {
 
         #[test]
         fn parse_payment_mode_rejects_unknown() {
-            let err = super::parse_payment_mode("banana")
-                .expect_err("an unknown mode must be rejected");
+            let err =
+                super::parse_payment_mode("banana").expect_err("an unknown mode must be rejected");
             assert!(
                 err.contains("unknown payment mode"),
                 "unexpected error text: {err}"
@@ -4116,10 +4116,8 @@ mod unix {
         impl ChainClient for RejectChain {
             async fn status(
                 &self,
-            ) -> Result<
-                wraith_wallet_core::chain::ChainStatus,
-                wraith_wallet_core::chain::ChainError,
-            > {
+            ) -> Result<wraith_wallet_core::chain::ChainStatus, wraith_wallet_core::chain::ChainError>
+            {
                 Err(wraith_wallet_core::chain::ChainError::Backend(
                     "test stub".into(),
                 ))
@@ -4165,10 +4163,16 @@ mod unix {
         async fn light_send_refuses_retired_modes_before_any_send() {
             let state = test_state();
             for mode in ["wraith", "confidential"] {
-                let err =
-                    super::light_send(&state, "tghost1qexample".into(), 1000, mode.into(), None, Some(0))
-                        .await
-                        .expect_err("a retired mode must be refused, never silently sent");
+                let err = super::light_send(
+                    &state,
+                    "tghost1qexample".into(),
+                    1000,
+                    mode.into(),
+                    None,
+                    Some(0),
+                )
+                .await
+                .expect_err("a retired mode must be refused, never silently sent");
                 // Must fail at the mode gate — NOT by reaching the session
                 // step. If it reached the session it would return the
                 // "no GSP session" error, which would mean the mode was
@@ -4192,10 +4196,16 @@ mod unix {
             // "no GSP session" error rather than a mode-rejection error.
             let state = test_state();
             for mode in ["ghostpay", ""] {
-                let err =
-                    super::light_send(&state, "tghost1qexample".into(), 1000, mode.into(), None, Some(0))
-                        .await
-                        .expect_err("no session is configured in this unit test");
+                let err = super::light_send(
+                    &state,
+                    "tghost1qexample".into(),
+                    1000,
+                    mode.into(),
+                    None,
+                    Some(0),
+                )
+                .await
+                .expect_err("no session is configured in this unit test");
                 assert!(
                     err.contains("no GSP session"),
                     "ghostpay must clear the mode gate and reach the session step; got: {err}"

--- a/apps/wraith-wallet/daemon/src/main.rs
+++ b/apps/wraith-wallet/daemon/src/main.rs
@@ -882,13 +882,29 @@ mod unix {
     }
 
     fn parse_payment_mode(s: &str) -> Result<PaymentMode, String> {
+        // Send only exposes the instant L2 ledger transfer (`ghostpay`).
+        // The `wraith` and `confidential` modes were retired here because
+        // they never had a real code path in Send — both silently took the
+        // plaintext L2 ledger route, so advertising them was a
+        // truth-in-advertising defect. Unlinkable L1 spends live in the Mix
+        // tab (Wraith CoinJoin); a shielded confidential L2 transfer needs
+        // client-side ZK proving the wallet-core cannot yet produce, so it
+        // is not offered rather than faked. Both are rejected below instead
+        // of silently accepted — a rejected send can never leak as a
+        // plaintext one.
         match s.trim().to_ascii_lowercase().as_str() {
             "" | "ghostpay" | "ghost-pay" | "ghost_pay" => Ok(PaymentMode::GhostPay),
-            "wraith" => Ok(PaymentMode::Wraith),
-            "confidential" => Ok(PaymentMode::Confidential),
-            other => Err(format!(
-                "unknown payment mode '{other}' (try ghostpay, wraith, confidential)"
-            )),
+            "wraith" => Err(
+                "payment mode 'wraith' is not available from Send — unlinkable L1 spends go \
+                 through the Mix tab (Wraith CoinJoin)"
+                    .to_string(),
+            ),
+            "confidential" => Err(
+                "payment mode 'confidential' is not available: shielded L2 transfers require \
+                 client-side ZK proving that is not yet supported"
+                    .to_string(),
+            ),
+            other => Err(format!("unknown payment mode '{other}' (try ghostpay)")),
         }
     }
 
@@ -902,11 +918,11 @@ mod unix {
         memo: Option<String>,
         shroud_override_ms: Option<u64>,
     ) -> Result<LightSentResponse, String> {
-        // The `mode` field on the IPC is parsed for validation /
-        // forward-compat (we may want to differentiate L2 transfer
-        // tiers later) but the wire path is the same one-shot
-        // SendL2Payment for every mode in v1. ghost-pay's L2 ledger
-        // doesn't differentiate.
+        // The `mode` field on the IPC is parsed and validated. Only
+        // `ghostpay` (the instant L2 ledger transfer) is accepted; the
+        // retired `wraith`/`confidential` modes are rejected here so a
+        // stale caller can never fall through to a plaintext send it
+        // did not intend (see `parse_payment_mode`).
         let mode = parse_payment_mode(&mode_str)?;
         let mode_label = format!("{mode}");
 
@@ -4042,6 +4058,149 @@ mod unix {
                 }
             }
             panic!("did not see both 0 and 1 across 1000 samples");
+        }
+
+        // ---- payment-mode gating -------------------------------------
+        //
+        // Send exposes exactly one real mode (`ghostpay`). The former
+        // `wraith`/`confidential` modes were cosmetic — they parsed into
+        // a label but took the same plaintext L2 ledger path — so they
+        // are now refused. These tests lock that in: a retired mode must
+        // never resolve into an accepted send.
+
+        #[test]
+        fn parse_payment_mode_accepts_ghostpay_aliases_and_default() {
+            for s in [
+                "",
+                "ghostpay",
+                "GhostPay",
+                "ghost-pay",
+                "ghost_pay",
+                "  ghostpay  ",
+            ] {
+                assert!(
+                    matches!(super::parse_payment_mode(s), Ok(PaymentMode::GhostPay)),
+                    "{s:?} should resolve to GhostPay"
+                );
+            }
+        }
+
+        #[test]
+        fn parse_payment_mode_rejects_retired_modes() {
+            for s in ["wraith", "Wraith", "confidential", "CONFIDENTIAL"] {
+                let err = super::parse_payment_mode(s)
+                    .expect_err(&format!("retired mode {s:?} must be rejected"));
+                assert!(
+                    err.contains("not available"),
+                    "{s:?} rejection should explain it is unavailable; got: {err}"
+                );
+            }
+        }
+
+        #[test]
+        fn parse_payment_mode_rejects_unknown() {
+            let err = super::parse_payment_mode("banana")
+                .expect_err("an unknown mode must be rejected");
+            assert!(
+                err.contains("unknown payment mode"),
+                "unexpected error text: {err}"
+            );
+        }
+
+        /// Minimal `ChainClient` stub — `light_send` never touches the
+        /// chain (its gating happens before any I/O), so a status-only
+        /// error stub is all we need to satisfy the `DaemonState` field.
+        struct RejectChain;
+
+        #[async_trait::async_trait]
+        impl ChainClient for RejectChain {
+            async fn status(
+                &self,
+            ) -> Result<
+                wraith_wallet_core::chain::ChainStatus,
+                wraith_wallet_core::chain::ChainError,
+            > {
+                Err(wraith_wallet_core::chain::ChainError::Backend(
+                    "test stub".into(),
+                ))
+            }
+        }
+
+        /// A session-less `DaemonState` sufficient to exercise
+        /// `light_send`'s mode gate. Everything past the gate needs a
+        /// live GSP session, which the IPC integration tests cover; here
+        /// we only care that the gate accepts/rejects the right modes.
+        fn test_state() -> Arc<DaemonState> {
+            Arc::new(DaemonState {
+                started: Instant::now(),
+                chain: Arc::new(RejectChain),
+                gsp: GspClient::new("ws://127.0.0.1:0"),
+                ghost_pay_urls: vec!["http://127.0.0.1:0".to_string()],
+                gsp_urls: vec!["ws://127.0.0.1:0".to_string()],
+                tor_proxy: None,
+                wraith_coordinator_url: None,
+                kiosk_mode: false,
+                wallets_dir: std::env::temp_dir(),
+                wallets: RwLock::new(HashMap::new()),
+                active: RwLock::new(None),
+                session: RwLock::new(None),
+                network: bitcoin::Network::Regtest,
+                socket_path: std::env::temp_dir().join("wraithd-modegate-test.sock"),
+                last_activity: std::sync::atomic::AtomicU64::new(0),
+                idle_lock_secs: 0,
+                shroud_max_ms: 0,
+                update_manifest_url: None,
+                http: reqwest::Client::new(),
+                wraith_mixes: RwLock::new(HashMap::new()),
+                prepared_locks: RwLock::new(HashMap::new()),
+                next_recovery_index: AtomicU32::new(0),
+                ghostd_url: None,
+                ghostd_cookie_path: None,
+                ghostd_user: None,
+                ghostd_pass: None,
+            })
+        }
+
+        #[tokio::test]
+        async fn light_send_refuses_retired_modes_before_any_send() {
+            let state = test_state();
+            for mode in ["wraith", "confidential"] {
+                let err =
+                    super::light_send(&state, "tghost1qexample".into(), 1000, mode.into(), None, Some(0))
+                        .await
+                        .expect_err("a retired mode must be refused, never silently sent");
+                // Must fail at the mode gate — NOT by reaching the session
+                // step. If it reached the session it would return the
+                // "no GSP session" error, which would mean the mode was
+                // (wrongly) accepted as sendable.
+                assert!(
+                    !err.contains("no GSP session"),
+                    "mode `{mode}` must be rejected at the gate before the send path; got: {err}"
+                );
+                assert!(
+                    err.contains("not available"),
+                    "mode `{mode}` rejection should explain it is unavailable; got: {err}"
+                );
+            }
+        }
+
+        #[tokio::test]
+        async fn light_send_accepts_ghostpay_past_the_mode_gate() {
+            // ghostpay (and the empty default) must pass the mode gate.
+            // With no session configured the send can't complete, but it
+            // must advance to the session step — proven by the
+            // "no GSP session" error rather than a mode-rejection error.
+            let state = test_state();
+            for mode in ["ghostpay", ""] {
+                let err =
+                    super::light_send(&state, "tghost1qexample".into(), 1000, mode.into(), None, Some(0))
+                        .await
+                        .expect_err("no session is configured in this unit test");
+                assert!(
+                    err.contains("no GSP session"),
+                    "ghostpay must clear the mode gate and reach the session step; got: {err}"
+                );
+            }
         }
     }
 }

--- a/apps/wraith-wallet/gui/src/lib/tauri.ts
+++ b/apps/wraith-wallet/gui/src/lib/tauri.ts
@@ -452,7 +452,11 @@ export async function lightReceive(index = 0): Promise<LightReceiveResponse> {
   return unwrap<LightReceiveResponse>(resp).payload;
 }
 
-export type LightSendMode = "ghostpay" | "wraith" | "confidential";
+// `ghostpay` is the only real Send mode — the instant L2 ledger
+// transfer. The former `wraith`/`confidential` values were cosmetic:
+// they took the same plaintext L2 path, so the daemon now rejects
+// them. Unlinkable L1 spends live in the Mix flow, not Send.
+export type LightSendMode = "ghostpay";
 
 export async function lightSend(
   recipient: string,

--- a/apps/wraith-wallet/gui/src/screens/Send.tsx
+++ b/apps/wraith-wallet/gui/src/screens/Send.tsx
@@ -12,12 +12,18 @@ import {
   type PsbtCreateResponse,
 } from "../lib/tauri";
 
-/// Send "mode" widening — the daemon side has 3 modes
-/// (ghostpay/wraith/confidential), but the GUI also exposes a 4th:
-/// `psbt`, which doesn't go through `lightSend` at all. Instead
-/// it builds an unsigned PSBT and lets the user download / sign
-/// it elsewhere. This keeps the mode-card UX consistent without
+/// Send "mode" widening — the daemon exposes exactly one real send
+/// mode (`ghostpay`, the instant L2 ledger transfer). The GUI adds a
+/// second option, `psbt`, which doesn't go through `lightSend` at all:
+/// it builds an unsigned PSBT and lets the user download / sign it
+/// elsewhere. This keeps the mode-card UX consistent without
 /// pretending PSBT is a daemon send mode.
+///
+/// The former `wraith`/`confidential` cards were removed: neither had
+/// a real Send code path (both silently took the plaintext L2 route),
+/// so offering them was a truth-in-advertising defect. Unlinkable L1
+/// spends live in the Mix tab; a shielded confidential L2 transfer is
+/// post-v1 (needs client-side ZK proving the wallet can't yet do).
 type UiSendMode = LightSendMode | "psbt";
 
 interface SendProps {
@@ -30,28 +36,35 @@ interface ModeOption {
   hint: string;
 }
 
-const MODES: ModeOption[] = [
+const MODES = [
   {
     id: "ghostpay",
     label: "Ghost Pay (instant L2)",
-    hint: "Instant off-chain transfer through the operator. No on-chain tx, no confirmation wait — settles to L1 in batches later.",
-  },
-  {
-    id: "wraith",
-    label: "Wraith (L1 CoinJoin)",
-    hint: "Routes through a Wraith Lite mix round so the on-chain trail is unlinked from the wallet's UTXOs. Slower (waits for the round to fill).",
-  },
-  {
-    id: "confidential",
-    label: "Confidential (L2)",
-    hint: "Zero-knowledge-shielded L2 transfer. Server learns nothing about amount or sender.",
+    hint: "Instant off-chain transfer through the operator. No on-chain tx, no confirmation wait — settles to L1 in batches later. For an unlinkable on-chain spend, use the Mix tab (Wraith CoinJoin).",
   },
   {
     id: "psbt",
     label: "PSBT export (L1)",
     hint: "Builds an unsigned BIP-174 PSBT spending your L1 UTXOs. Sign here, on a hardware wallet, or with cosigners — then broadcast from the Sign tab. Use for cold-storage flows or multisig.",
   },
-];
+] as const satisfies readonly ModeOption[];
+
+// Compile-time guard: Send must offer *exactly* the real modes, no
+// more. The GUI has no unit-test runner — its check is `tsc --noEmit`
+// (the `lint`/`build` scripts) — so this type-level assertion is the
+// stand-in. It fails the build if the set of card ids ever drifts from
+// `UiSendMode` (`ghostpay` | `psbt`): dropping a real mode, or letting
+// a retired one (`wraith`/`confidential`) back in, both break here.
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+type Expect<T extends true> = T;
+// Exported so `noUnusedLocals` doesn't strip it — the export is the
+// only reference it needs; the assertion still runs at compile time.
+export type _ModesAreExactlyTheRealModes = Expect<
+  Equal<(typeof MODES)[number]["id"], UiSendMode>
+>;
 
 /// Recipient prefix → human-readable network/format identifier.
 /// Surfaced to the user as a "we recognise this as X" hint so a
@@ -178,6 +191,17 @@ export function Send({ activeWallet }: SendProps) {
     setRecents(loadRecents(activeWallet));
     setCoinControl(loadCoinControl(activeWallet));
   }, [activeWallet]);
+
+  // Safety net: if `mode` ever holds a value that is no longer a real
+  // mode (e.g. a `wraith`/`confidential` string surviving from an old
+  // build's persisted state), fall back to the safe default so the UI
+  // never sits on a retired mode. Today `mode` isn't persisted, but
+  // this keeps the invariant explicit and future-proof.
+  useEffect(() => {
+    if (mode !== "psbt" && !MODES.some((m) => m.id === mode)) {
+      setMode("ghostpay");
+    }
+  }, [mode]);
 
   // Reload UTXOs whenever we enter PSBT mode (or the wallet changes
   // while already in PSBT mode). One-shot — coin control is a
@@ -428,10 +452,10 @@ export function Send({ activeWallet }: SendProps) {
           <span className="eyebrow">outgoing</span>
           <h1>Send</h1>
           <p className="lead">
-            Three modes: Ghost Pay (instant L2, no on-chain tx),
-            Wraith (L1 CoinJoin), Confidential (ZK-shielded L2).
-            Recipient field accepts both ghost-id and any Bitcoin
-            address.
+            Two ways to send: Ghost Pay (instant L2, no on-chain tx) or
+            PSBT export (unsigned L1 spend to sign yourself). For an
+            unlinkable on-chain spend, use the Mix tab. Recipient field
+            accepts both ghost-id and any Bitcoin address.
           </p>
         </div>
       </div>

--- a/apps/wraith-wallet/ipc/src/lib.rs
+++ b/apps/wraith-wallet/ipc/src/lib.rs
@@ -147,8 +147,11 @@ pub enum Request {
         /// refuses fee >= prev_value_sats.
         fee_sats: u64,
     },
-    /// Prepare + sign + submit an on-chain / L2 payment.
-    /// Mode is one of: "ghostpay" (default), "wraith", "confidential".
+    /// Prepare + sign + submit an L2 payment.
+    /// Mode is `ghostpay` (the instant L2 ledger transfer); it is the
+    /// only accepted value and the default. The legacy `wraith` and
+    /// `confidential` values are rejected — unlinkable L1 spends go
+    /// through the Mix flow, not Send.
     ///
     /// `shroud_max_ms` overrides the daemon's default outbound-broadcast
     /// shroud window for *this one* payment.


### PR DESCRIPTION
The wallet Send screen's `wraith`/`confidential` modes silently took the plaintext L2 path. `parse_payment_mode` now rejects them with a clear error (before any send — no fall-through); GUI trimmed to the real modes (`ghostpay` + `psbt`) with a Mix-tab pointer for unlinkable spends + a compile-time type guard. CLI/IPC help in lockstep. 17+14 daemon tests pass. Real CoinJoin remains in the Mix tab; confidential-in-Send is post-v1 (needs client-side ZK proving that doesn't exist yet).