### PR TITLE
fix(wallet): default to mainnet + build Linux on glibc 2.35

### DIFF
--- a/.github/workflows/release-wraith.yml
+++ b/.github/workflows/release-wraith.yml
@@ -25,8 +25,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # ubuntu-22.04 (glibc 2.35), NOT ubuntu-latest (2.39): the CLI + GUI
+          # bind the builder's glibc, so building on 24.04 made them refuse to run
+          # on Ubuntu 22.04 / Debian 12. 22.04 lowers the floor to run near-anywhere.
           - triple: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
+            os: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v5

--- a/apps/wraith-wallet/daemon/src/main.rs
+++ b/apps/wraith-wallet/daemon/src/main.rs
@@ -521,7 +521,7 @@ mod server {
         let network = std::env::var(NETWORK_ENV)
             .ok()
             .and_then(|s| parse_network(&s))
-            .unwrap_or(bitcoin::Network::Signet);
+            .unwrap_or(bitcoin::Network::Bitcoin);
         tracing::info!(
             ghost_pay = ?ghost_pay_urls,
             gsp = ?gsp_urls,

--- a/apps/wraith-wallet/daemon/tests/watch_payments_daemon.rs
+++ b/apps/wraith-wallet/daemon/tests/watch_payments_daemon.rs
@@ -201,6 +201,9 @@ async fn spawn_daemon(gsp_url: &str) -> (Child, PathBuf, tempfile::TempDir) {
     let child = Command::new(wraithd_binary())
         .env("WRAITHD_SOCKET", &socket)
         .env("WRAITHD_WALLETS_DIR", &wallets)
+        // This test imports a publicly-known test mnemonic, which the daemon now
+        // (correctly) refuses on the mainnet default. Pin the test to signet.
+        .env("WRAITHD_NETWORK", "signet")
         .env("WRAITHD_GSP", gsp_url)
         // ghost-pay is unused on this test path. Point it at a dead address
         // so the daemon doesn't accidentally hit a real local instance.


### PR DESCRIPTION
Two release-readiness fixes found while inspecting the v1.10.21 draft: (1) `wraithd` defaults to mainnet (was Signet) when `WRAITHD_NETWORK` is unset — the publicly-known-mnemonic guard now correctly fires by default, so the watch-payments contract test is pinned to signet. (2) The Linux release builds on `ubuntu-22.04` (glibc 2.35) instead of `ubuntu-latest` (2.39), which had made the CLI/GUI refuse to run on Ubuntu 22.04 / Debian 12.