### PR TITLE
ci(release): strip tag prefix from release titles

### DIFF
--- a/.github/workflows/release-agathion.yml
+++ b/.github/workflows/release-agathion.yml
@@ -266,6 +266,12 @@ jobs:
             --armor --detach-sign --output SHA256SUMS.asc SHA256SUMS
           gpg --verify SHA256SUMS.asc SHA256SUMS
 
+      - name: Clean version label
+        shell: bash
+        # Strip the "agathion-" tag prefix so the title reads
+        # "Agathion Node v1.10.21", not "Agathion Node agathion-v1.10.21".
+        run: echo "REL_VERSION=${GITHUB_REF_NAME#agathion-}" >> "$GITHUB_ENV"
+
       - name: Create draft release
         uses: softprops/action-gh-release@v3
         with:
@@ -274,7 +280,7 @@ jobs:
           # as the node release — no separate offline signing needed.
           draft: true
           generate_release_notes: true
-          name: "Agathion Node ${{ github.ref_name }}"
+          name: "Agathion Node ${{ env.REL_VERSION }}"
           files: |
             SHA256SUMS
             SHA256SUMS.asc

--- a/.github/workflows/release-wraith.yml
+++ b/.github/workflows/release-wraith.yml
@@ -397,6 +397,12 @@ jobs:
             --armor --detach-sign --output SHA256SUMS.asc SHA256SUMS
           gpg --verify SHA256SUMS.asc SHA256SUMS
 
+      - name: Clean version label
+        shell: bash
+        # Strip the "wraith-" tag prefix so the release title reads
+        # "Wraith Wallet v1.10.21", not "Wraith Wallet wraith-v1.10.21".
+        run: echo "REL_VERSION=${GITHUB_REF_NAME#wraith-}" >> "$GITHUB_ENV"
+
       - name: Create draft release
         uses: softprops/action-gh-release@v3
         with:
@@ -405,7 +411,7 @@ jobs:
           # as the node release — no separate offline signing step needed.
           draft: true
           generate_release_notes: true
-          name: "Wraith Wallet ${{ github.ref_name }}"
+          name: "Wraith Wallet ${{ env.REL_VERSION }}"
           files: |
             SHA256SUMS
             SHA256SUMS.asc


### PR DESCRIPTION
Release titles doubled the prefix (`Wraith Wallet wraith-v1.10.21`). Compute a clean `v…` label so future releases title cleanly.