### PR TITLE
feat(wallet): fix mnemonic modal + Ossification + grouped nav + delete wallet

### DIFF
--- a/apps/wraith-wallet/daemon/src/main.rs
+++ b/apps/wraith-wallet/daemon/src/main.rs
@@ -3007,6 +3007,43 @@ mod server {
                     Response::WalletLocked { name: target }
                 }
             }
+            Request::WalletDelete { name } => {
+                if let Some(refused) = refuse_in_kiosk_mode(state, "wallet delete") {
+                    return Envelope::new(id, refused);
+                }
+                if let Err(e) = validate_wallet_name(&name) {
+                    Response::Error(ErrorResponse { message: e })
+                } else {
+                    let keystore = keystore_path(&state.wallets_dir, &name);
+                    // The per-wallet directory holds the keystore plus any
+                    // saved descriptors; removing it wipes every on-disk
+                    // trace of the wallet.
+                    let wallet_dir = state.wallets_dir.join(&name);
+                    if !keystore.is_file() {
+                        Response::Error(ErrorResponse {
+                            message: format!("no wallet '{name}' at {}", keystore.display()),
+                        })
+                    } else if let Err(e) = std::fs::remove_dir_all(&wallet_dir) {
+                        Response::Error(ErrorResponse {
+                            message: format!("delete '{name}': {e}"),
+                        })
+                    } else {
+                        // Drop the in-memory keystore and clear the active
+                        // pointer / bound GSP session so nothing keeps
+                        // referencing a wallet whose backing is now gone.
+                        state.wallets.write().await.remove(&name);
+                        let mut active = state.active.write().await;
+                        if active.as_deref() == Some(name.as_str()) {
+                            *active = None;
+                        }
+                        let mut session = state.session.write().await;
+                        if session.as_ref().is_some_and(|s| s.wallet_name == name) {
+                            *session = None;
+                        }
+                        Response::WalletDeleted { name }
+                    }
+                }
+            }
             Request::WalletList => {
                 let on_disk = list_on_disk(&state.wallets_dir);
                 let unlocked = state.wallets.read().await;
@@ -4260,6 +4297,10 @@ mod server {
         /// live GSP session, which the IPC integration tests cover; here
         /// we only care that the gate accepts/rejects the right modes.
         fn test_state() -> Arc<DaemonState> {
+            test_state_in(std::env::temp_dir())
+        }
+
+        fn test_state_in(wallets_dir: std::path::PathBuf) -> Arc<DaemonState> {
             Arc::new(DaemonState {
                 started: Instant::now(),
                 chain: Arc::new(RejectChain),
@@ -4269,7 +4310,7 @@ mod server {
                 tor_proxy: None,
                 wraith_coordinator_url: None,
                 kiosk_mode: false,
-                wallets_dir: std::env::temp_dir(),
+                wallets_dir,
                 wallets: RwLock::new(HashMap::new()),
                 active: RwLock::new(None),
                 session: RwLock::new(None),
@@ -4345,6 +4386,74 @@ mod server {
                     "ghostpay must clear the mode gate and reach the session step; got: {err}"
                 );
             }
+        }
+
+        #[tokio::test]
+        async fn wallet_delete_removes_keystore_and_forgets_active() {
+            let dir = tempfile::tempdir().unwrap();
+            let state = test_state_in(dir.path().to_path_buf());
+
+            // Create a wallet through the real dispatch path so the test
+            // exercises the same code the GUI drives.
+            let create = serde_json::to_string(&Envelope::new(
+                1,
+                Request::WalletCreate {
+                    name: "doomed".into(),
+                    passphrase: "hunter2hunter2".into(),
+                },
+            ))
+            .unwrap();
+            let resp = super::dispatch(&create, &state).await;
+            assert!(
+                matches!(resp.payload, Response::WalletCreate(_)),
+                "create should succeed; got {:?}",
+                resp.payload
+            );
+            let wallet_dir = dir.path().join("doomed");
+            let keystore = wallet_dir.join("keystore.bin");
+            assert!(keystore.is_file(), "keystore should exist after create");
+            assert_eq!(state.active.read().await.as_deref(), Some("doomed"));
+
+            // Delete it.
+            let del = serde_json::to_string(&Envelope::new(
+                2,
+                Request::WalletDelete {
+                    name: "doomed".into(),
+                },
+            ))
+            .unwrap();
+            let resp = super::dispatch(&del, &state).await;
+            match resp.payload {
+                Response::WalletDeleted { name } => assert_eq!(name, "doomed"),
+                other => panic!("expected WalletDeleted, got {other:?}"),
+            }
+
+            // On-disk directory gone, in-memory state cleared.
+            assert!(!keystore.exists(), "keystore file must be removed");
+            assert!(!wallet_dir.exists(), "wallet dir must be removed");
+            assert!(state.wallets.read().await.get("doomed").is_none());
+            assert!(state.active.read().await.is_none());
+
+            // No longer surfaced by WalletList.
+            let list =
+                serde_json::to_string(&Envelope::new(3, Request::WalletList)).unwrap();
+            let resp = super::dispatch(&list, &state).await;
+            match resp.payload {
+                Response::WalletList(l) => assert!(
+                    l.wallets.iter().all(|w| w.name != "doomed"),
+                    "deleted wallet must not appear in the list"
+                ),
+                other => panic!("expected WalletList, got {other:?}"),
+            }
+
+            // Deleting a wallet that no longer exists is a clean error,
+            // never a panic.
+            let resp = super::dispatch(&del, &state).await;
+            assert!(
+                matches!(resp.payload, Response::Error(_)),
+                "second delete should error; got {:?}",
+                resp.payload
+            );
         }
     }
 }

--- a/apps/wraith-wallet/gui/src-tauri/src/lib.rs
+++ b/apps/wraith-wallet/gui/src-tauri/src/lib.rs
@@ -184,6 +184,12 @@ async fn wallet_select(name: String) -> Result<serde_json::Value, String> {
 }
 
 #[tauri::command]
+async fn wallet_delete(name: String) -> Result<serde_json::Value, String> {
+    let resp = call_daemon(Request::WalletDelete { name }).await?;
+    to_value(&resp)
+}
+
+#[tauri::command]
 async fn wallet_create(name: String, passphrase: String) -> Result<serde_json::Value, String> {
     let resp = call_daemon(Request::WalletCreate { name, passphrase }).await?;
     to_value(&resp)
@@ -835,6 +841,7 @@ pub fn run() {
             wallet_unlock,
             wallet_lock,
             wallet_select,
+            wallet_delete,
             wallet_create,
             wallet_import,
             wallet_show_mnemonic,

--- a/apps/wraith-wallet/gui/src/App.tsx
+++ b/apps/wraith-wallet/gui/src/App.tsx
@@ -44,20 +44,47 @@ type Screen =
   | "network"
   | "settings";
 
-const NAV: Array<{ id: Screen; label: string }> = [
-  { id: "wallet", label: "Wallet" },
-  { id: "receive", label: "Receive" },
-  { id: "send", label: "Send" },
-  { id: "sign", label: "Sign" },
-  { id: "cosigner", label: "Cosigner" },
-  { id: "mix", label: "Mix" },
-  { id: "glyph", label: "Glyph" },
-  { id: "merchant", label: "Merchant" },
-  { id: "reports", label: "Reports" },
-  { id: "locks", label: "Locks" },
-  { id: "history", label: "History" },
-  { id: "network", label: "Network" },
-  { id: "settings", label: "Settings" },
+// Sidebar navigation grouped into a few plain-language categories.
+// Keep the grouping shallow — end users scan headings, not a flat
+// list of thirteen links. Every existing route is preserved; only
+// the presentation changes.
+const NAV_GROUPS: Array<{
+  heading: string;
+  items: Array<{ id: Screen; label: string }>;
+}> = [
+  {
+    heading: "Wallet",
+    items: [
+      { id: "wallet", label: "Wallet" },
+      { id: "history", label: "History" },
+      { id: "locks", label: "Locks" },
+    ],
+  },
+  {
+    heading: "Payments",
+    items: [
+      { id: "receive", label: "Receive" },
+      { id: "send", label: "Send" },
+      { id: "sign", label: "Sign" },
+      { id: "cosigner", label: "Cosigner" },
+      { id: "mix", label: "Mix" },
+      { id: "glyph", label: "Glyph" },
+    ],
+  },
+  {
+    heading: "Merchant",
+    items: [
+      { id: "merchant", label: "Merchant" },
+      { id: "reports", label: "Reports" },
+    ],
+  },
+  {
+    heading: "System",
+    items: [
+      { id: "network", label: "Network" },
+      { id: "settings", label: "Settings" },
+    ],
+  },
 ];
 
 export default function App() {
@@ -379,14 +406,19 @@ export default function App() {
       {!kioskMode && (
         <aside className="app-sidebar">
           <nav>
-            {NAV.map((item) => (
-              <button
-                key={item.id}
-                className={screen === item.id ? "active" : ""}
-                onClick={() => setScreen(item.id)}
-              >
-                {item.label}
-              </button>
+            {NAV_GROUPS.map((group) => (
+              <div className="nav-group" key={group.heading}>
+                <div className="nav-heading">{group.heading}</div>
+                {group.items.map((item) => (
+                  <button
+                    key={item.id}
+                    className={screen === item.id ? "active" : ""}
+                    onClick={() => setScreen(item.id)}
+                  >
+                    {item.label}
+                  </button>
+                ))}
+              </div>
             ))}
           </nav>
         </aside>

--- a/apps/wraith-wallet/gui/src/lib/tauri.ts
+++ b/apps/wraith-wallet/gui/src/lib/tauri.ts
@@ -331,6 +331,16 @@ export async function walletSelect(name: string): Promise<unknown> {
   return unwrap(resp).payload;
 }
 
+/// Permanently delete a wallet: the daemon removes its on-disk
+/// keystore + data directory and drops it from the unlocked set.
+/// Irreversible — callers must confirm with the user first.
+export async function walletDelete(
+  name: string,
+): Promise<{ name: string }> {
+  const resp = await invoke("wallet_delete", { name });
+  return unwrap<{ name: string }>(resp).payload;
+}
+
 export async function walletGhostId(): Promise<{
   ghost_id: string;
   network: string;

--- a/apps/wraith-wallet/gui/src/screens/Onboarding.tsx
+++ b/apps/wraith-wallet/gui/src/screens/Onboarding.tsx
@@ -28,7 +28,7 @@ type Step =
 ///
 /// Two paths share the shell:
 ///   create:  welcome → name+pass → daemon-create returns mnemonic
-///         →  show full 12 words → user types 3 random ones back
+///         →  show all 24 words → user types 3 random ones back
 ///         →  done
 ///   import:  welcome → name+pass → enter mnemonic → daemon-import
 ///         →  done
@@ -269,7 +269,7 @@ export function Onboarding({ mode, onClose }: OnboardingProps) {
           <>
             <div className="card warn" style={{ margin: 0 }}>
               <p style={{ margin: 0 }}>
-                <strong>Write these 12 words on paper.</strong> Anyone
+                <strong>Write these 24 words on paper.</strong> Anyone
                 with this phrase can spend funds in this wallet. The
                 daemon doesn't keep it in plaintext anywhere — without
                 it, recovery is impossible if the keystore file or its
@@ -277,15 +277,13 @@ export function Onboarding({ mode, onClose }: OnboardingProps) {
               </p>
               <div className="mnemonic-block">
                 {generatedMnemonic
+                  .trim()
                   .split(/\s+/)
                   .map((w, i) => (
-                    <span key={i}>
-                      <span className="muted" style={{ fontSize: 11, marginRight: 4 }}>
-                        {i + 1}.
-                      </span>
-                      {w}
-                      {i < 11 ? "  " : ""}
-                    </span>
+                    <div className="mnemonic-word" key={i}>
+                      <span className="mnemonic-idx">{i + 1}</span>
+                      <span className="mnemonic-text">{w}</span>
+                    </div>
                   ))}
               </div>
               <button

--- a/apps/wraith-wallet/gui/src/screens/Wallet.tsx
+++ b/apps/wraith-wallet/gui/src/screens/Wallet.tsx
@@ -3,6 +3,7 @@ import {
   daemonEnv,
   lightBalance,
   lightHistory,
+  walletDelete,
   walletList,
   walletSelect,
   walletShowMnemonic,
@@ -52,6 +53,14 @@ export function Wallet({ paymentTick = 0 }: WalletProps) {
     | { kind: "unlock" | "show_mnemonic"; wallet: string; error?: string }
     | null
   >(null);
+  /// Delete-confirmation modal. Deleting a wallet erases its keystore
+  /// from disk, so we require the user to type the wallet name back
+  /// before the action is armed.
+  const [deleteModal, setDeleteModal] = useState<{
+    wallet: string;
+    confirm: string;
+    error?: string;
+  } | null>(null);
 
   const refresh = async () => {
     setErr(null);
@@ -141,6 +150,34 @@ export function Wallet({ paymentTick = 0 }: WalletProps) {
     setPassModal({ kind: "unlock", wallet: name });
   };
 
+  const onDelete = (name: string) => {
+    setDeleteModal({ wallet: name, confirm: "" });
+  };
+
+  const onConfirmDelete = async () => {
+    if (!deleteModal) return;
+    if (deleteModal.confirm !== deleteModal.wallet) {
+      setDeleteModal({
+        ...deleteModal,
+        error: "Type the wallet name exactly to confirm.",
+      });
+      return;
+    }
+    setBusy(true);
+    try {
+      await walletDelete(deleteModal.wallet);
+      setDeleteModal(null);
+      await refresh();
+    } catch (e) {
+      setDeleteModal({
+        ...deleteModal,
+        error: (e as Error).message ?? String(e),
+      });
+    } finally {
+      setBusy(false);
+    }
+  };
+
   const onPassSubmit = async (passphrase: string) => {
     if (!passModal) return;
     const { kind, wallet } = passModal;
@@ -215,6 +252,73 @@ export function Wallet({ paymentTick = 0 }: WalletProps) {
         />
       )}
 
+      {deleteModal && (
+        <div className="modal-overlay">
+          <div className="modal-card" onClick={(e) => e.stopPropagation()}>
+            <div className="card-header">
+              <h2 style={{ margin: 0 }}>Delete wallet</h2>
+              <span className="eyebrow eyebrow-dim">irreversible</span>
+            </div>
+            <p style={{ margin: 0 }}>
+              This permanently removes the keystore for{" "}
+              <strong>{deleteModal.wallet}</strong> from disk. If you
+              have not written down its backup phrase,{" "}
+              <strong>any funds in this wallet will be lost forever.</strong>
+            </p>
+            {deleteModal.error && (
+              <div className="pill fail" style={{ alignSelf: "flex-start" }}>
+                {deleteModal.error}
+              </div>
+            )}
+            <div className="col">
+              <label>
+                Type <span className="mono">{deleteModal.wallet}</span> to
+                confirm
+              </label>
+              <input
+                className="mono"
+                value={deleteModal.confirm}
+                onChange={(e) =>
+                  setDeleteModal({
+                    ...deleteModal,
+                    confirm: e.target.value,
+                    error: undefined,
+                  })
+                }
+                disabled={busy}
+                autoFocus
+                onKeyDown={(e) => {
+                  if (
+                    e.key === "Enter" &&
+                    deleteModal.confirm === deleteModal.wallet
+                  )
+                    onConfirmDelete();
+                }}
+              />
+            </div>
+            <div
+              className="row"
+              style={{ justifyContent: "flex-end", gap: 8 }}
+            >
+              <button
+                className="btn-secondary"
+                onClick={() => setDeleteModal(null)}
+                disabled={busy}
+              >
+                Cancel
+              </button>
+              <button
+                className="btn-danger"
+                onClick={onConfirmDelete}
+                disabled={busy || deleteModal.confirm !== deleteModal.wallet}
+              >
+                {busy ? "Deleting…" : "Delete wallet"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
       {err && <div className="card" style={{ borderColor: "var(--fail)" }}>{err}</div>}
 
       {mnemonicReveal && (
@@ -230,27 +334,22 @@ export function Wallet({ paymentTick = 0 }: WalletProps) {
             {`Backup phrase: ${mnemonicReveal.name}`}
           </h2>
           <p style={{ margin: 0 }}>
-            <strong>Write these 12 words down on paper.</strong> Anyone
+            <strong>Write these 24 words down on paper.</strong> Anyone
             with this phrase can spend funds in this wallet. The
             daemon does not keep it in plaintext — without it, fund
             recovery is impossible if the keystore file or its
             passphrase are lost.
           </p>
-          <div
-            className="mono"
-            style={{
-              marginTop: 12,
-              padding: 16,
-              background: "var(--bg-subtle, rgba(0,0,0,0.06))",
-              border: "1px solid var(--border)",
-              borderRadius: 6,
-              wordSpacing: 4,
-              lineHeight: 1.8,
-              fontSize: 16,
-              userSelect: "text",
-            }}
-          >
-            {mnemonicReveal.mnemonic}
+          <div className="mnemonic-block" style={{ marginTop: 12 }}>
+            {mnemonicReveal.mnemonic
+              .trim()
+              .split(/\s+/)
+              .map((w, i) => (
+                <div className="mnemonic-word" key={i}>
+                  <span className="mnemonic-idx">{i + 1}</span>
+                  <span className="mnemonic-text">{w}</span>
+                </div>
+              ))}
           </div>
           <div className="row" style={{ marginTop: 12 }}>
             <button
@@ -412,9 +511,9 @@ export function Wallet({ paymentTick = 0 }: WalletProps) {
             <span style={{ color: "var(--accent)" }}>Bitcoin Ghost</span>.
           </h1>
           <p className="welcome-lead">
-            Self-custodial. Open source. Ossifying. Create a new
-            wallet to receive your first sats, or restore an existing
-            one from its 12-word backup phrase.
+            Self-custodial. Open source. Create a new wallet to
+            receive your first sats, or restore an existing one from
+            its 24-word backup phrase.
           </p>
           <div className="row" style={{ gap: 8, marginTop: 12 }}>
             <button
@@ -504,8 +603,17 @@ export function Wallet({ paymentTick = 0 }: WalletProps) {
                       onClick={() => onShowMnemonic(w.name)}
                       disabled={busy}
                       title="Decrypt and display the BIP-39 backup phrase"
+                      style={{ marginRight: 6 }}
                     >
                       Backup
+                    </button>
+                    <button
+                      className="btn-danger btn-sm"
+                      onClick={() => onDelete(w.name)}
+                      disabled={busy}
+                      title="Permanently delete this wallet from disk"
+                    >
+                      Delete
                     </button>
                   </td>
                 </tr>

--- a/apps/wraith-wallet/gui/src/styles.css
+++ b/apps/wraith-wallet/gui/src/styles.css
@@ -152,6 +152,26 @@ button { cursor: pointer; }
 .app-sidebar nav {
   display: flex; flex-direction: column;
 }
+/* Grouped navigation — a small caps heading precedes each cluster of
+   routes. Groups are separated by vertical rhythm, not rules, to keep
+   the sidebar quiet. */
+.nav-group {
+  display: flex;
+  flex-direction: column;
+}
+.nav-group + .nav-group {
+  margin-top: 18px;
+}
+.nav-heading {
+  padding: 0 24px 6px;
+  font-family: var(--font-sans);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--dim);
+  opacity: 0.7;
+}
 .app-sidebar nav button {
   display: flex; align-items: center; gap: 12px;
   appearance: none; background: transparent; border: 0;
@@ -565,18 +585,44 @@ code {
   overflow: auto;
 }
 
-/* Mnemonic display block — used by Onboarding + backup reveal */
+/* Mnemonic display block — used by Onboarding + backup reveal.
+   A fixed-column grid gives every word its own cell, so the phrase
+   renders identically for 12- and 24-word seeds with no reliance on
+   collapsing whitespace or a hard-coded word count. auto-fill keeps
+   it responsive inside the modal's max-width. */
 .mnemonic-block {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  gap: 6px 14px;
   padding: 16px;
   background: var(--surface);
   border: 1px solid var(--rule-strong);
   border-radius: 6px;
   font-family: var(--font-mono);
   font-size: 15px;
-  line-height: 1.85;
-  word-spacing: 4px;
+  line-height: 1.6;
   user-select: text;
   letter-spacing: 0.01em;
+}
+
+.mnemonic-word {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  white-space: nowrap;
+}
+
+.mnemonic-idx {
+  flex: 0 0 auto;
+  min-width: 1.6em;
+  text-align: right;
+  font-size: 11px;
+  color: var(--dim);
+  user-select: none;
+}
+
+.mnemonic-text {
+  overflow-wrap: anywhere;
 }
 
 /* QR card surrounding */

--- a/apps/wraith-wallet/ipc/src/lib.rs
+++ b/apps/wraith-wallet/ipc/src/lib.rs
@@ -259,6 +259,14 @@ pub enum Request {
     WalletLock {
         name: Option<String>,
     },
+    /// Permanently delete a named wallet: remove its on-disk keystore
+    /// (and per-wallet data directory) and drop it from the daemon's
+    /// unlocked set. Irreversible — the caller MUST confirm with the
+    /// user first, since losing the keystore means losing the funds
+    /// unless the backup phrase was written down.
+    WalletDelete {
+        name: String,
+    },
     /// List all on-disk wallets with unlocked / active status.
     WalletList,
     /// Set the active wallet (must already be unlocked).
@@ -611,6 +619,11 @@ pub enum Response {
     },
     WalletUnlocked,
     WalletLocked {
+        name: String,
+    },
+    /// Reply to [`Request::WalletDelete`]. The wallet's keystore and
+    /// data directory have been removed from disk.
+    WalletDeleted {
         name: String,
     },
     WalletList(WalletListResponse),


### PR DESCRIPTION
Four operator-review fixes: (1) removed the 'Ossification' paragraph on the pre-open wallet page; (2) fixed the mnemonic modal where words 13–24 ran together (hard-coded 12-word layout → proper CSS grid, works for 12/24); (3) grouped the flat left nav into Wallet/Payments/Merchant/System; (4) added a **Delete wallet** action end-to-end (IPC + daemon RPC + Tauri + GUI with type-the-name confirmation + test). Builds + tests green.