### PR TITLE
fix(dashboard): data accuracy (verified shares/archive, honest L2 state) + proxy default + login logo

### DIFF
--- a/dashboard/src/app/(dashboard)/page.tsx
+++ b/dashboard/src/app/(dashboard)/page.tsx
@@ -134,6 +134,17 @@ function L2Card() {
   const isSyncing = isRunning && gp?.sync_state !== "synced";
   const height = gp ? `${gp.l2_era ?? 1}:${(gp.virtual_block ?? gp.block_height ?? 0).toLocaleString()}` : "--";
 
+  // Wraith is an optional mixing feature layered on L2. Distinguish the three
+  // real states so the tile never reads a bare "Inactive" (which looks like a
+  // fault) when L2 itself is healthy and only mixing is simply not enabled.
+  const wraithActive = !!(isRunning && gp?.wraith_enabled);
+  const wraithLabel = isLoading ? "..." : wraithActive ? "Active" : isRunning ? "Not enabled" : "Offline";
+  const wraithReason = wraithActive
+    ? "Active sessions"
+    : isRunning
+    ? "Mixing not enabled on this node"
+    : "Requires Ghost Pay";
+
   return (
     <Card className="border-purple-600/30">
       <CardHeader
@@ -175,15 +186,17 @@ function L2Card() {
             <div className="text-xs text-gray-500 mb-1">Wraith <InfoIcon /></div>
             <div className="flex items-center gap-2">
               <StatusDot
-                status={isRunning && gp?.wraith_enabled ? "online" : "offline"}
+                status={wraithActive ? "online" : "offline"}
                 size="sm"
               />
               <span className="text-sm font-mono text-gray-100">
-                {isLoading ? "..." : (isRunning && gp?.wraith_enabled) ? "Active" : "Inactive"}
+                {wraithLabel}
               </span>
             </div>
-            {isRunning && gp?.wraith_enabled && (
-              <div className="text-xs text-purple-400 mt-0.5">Active sessions</div>
+            {!isLoading && (
+              <div className={`text-xs mt-0.5 ${wraithActive ? "text-purple-400" : "text-gray-500"}`}>
+                {wraithReason}
+              </div>
             )}
           </div>
         </Tooltip>

--- a/dashboard/src/app/api/proxy/[...path]/route.ts
+++ b/dashboard/src/app/api/proxy/[...path]/route.ts
@@ -1,10 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createHmac } from "crypto";
 
-const BACKEND_URL = process.env.NEXT_PUBLIC_API_URL;
-if (!BACKEND_URL) {
-  console.error("NEXT_PUBLIC_API_URL environment variable is required");
-}
+// The node's local API is always reachable on loopback:8080. Default to it so a
+// fresh install works with no configuration; honour NEXT_PUBLIC_API_URL when set.
+const BACKEND_URL = process.env.NEXT_PUBLIC_API_URL || "http://127.0.0.1:8080";
 
 function signRequest(body: string): { signature: string; timestamp: string } {
   const key = process.env.INTERNAL_AUTH_KEY;

--- a/dashboard/src/app/login/page.tsx
+++ b/dashboard/src/app/login/page.tsx
@@ -2,7 +2,7 @@
 
 import { Suspense, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { GhostLogo } from "@/components/ui/GhostLogo";
+import { Ghost } from "lucide-react";
 
 function LoginForm() {
   const [password, setPassword] = useState("");
@@ -40,7 +40,7 @@ function LoginForm() {
     <div className="min-h-screen flex items-center justify-center bg-gray-950">
       <div className="w-full max-w-sm p-8 space-y-6">
         <div className="flex flex-col items-center space-y-2">
-          <GhostLogo />
+          <Ghost size={48} strokeWidth={1.75} style={{ color: "var(--accent)" }} aria-hidden="true" />
           <h1 className="text-xl font-semibold text-gray-100">Agathion Node</h1>
           <p className="text-sm text-gray-400">Your node&apos;s familiar — enter your password</p>
         </div>

--- a/dashboard/src/hooks/useRealtimeSync.ts
+++ b/dashboard/src/hooks/useRealtimeSync.ts
@@ -30,7 +30,12 @@ export function useRealtimeSync() {
     onSharesUpdate: (event) => {
       const data = (event as NodeEvent & { type: 'SharesUpdate' }).data;
       if (data) {
-        queryClient.setQueryData(nodeKeys.shares(), data);
+        // The pushed payload carries CLAIMED capabilities. Writing it straight
+        // into the cache would overwrite the verified merge getShares() performs
+        // (see lib/api/node.ts), re-showing archive-on / 15-15. Invalidate so the
+        // query refetches the verified view instead of trusting the raw push.
+        queryClient.invalidateQueries({ queryKey: nodeKeys.shares() });
+        queryClient.invalidateQueries({ queryKey: nodeKeys.health() });
         setShares(data);
       }
     },

--- a/dashboard/src/lib/api/node.ts
+++ b/dashboard/src/lib/api/node.ts
@@ -11,11 +11,35 @@ export async function getNodeStatus(): Promise<NodeStatus> {
 }
 
 export async function getShares(): Promise<SharesInfo> {
-  return fetchApi<SharesInfo>('/api/v1/node/shares');
+  // /api/v1/node/shares reports CLAIMED capabilities (e.g. archive_mode:true,
+  // total:15) which is NOT what the node earns. /health reports the VERIFIED
+  // capabilities the node has actually proved and is paid for. Prefer the
+  // verified view for the capability booleans and total; keep the shares
+  // endpoint for fields it alone provides (uptime, elder slot, est. reward).
+  const [claimed, health] = await Promise.all([
+    fetchApi<SharesInfo>('/api/v1/node/shares'),
+    getHealth().catch(() => null),
+  ]);
+
+  const caps = health?.capabilities;
+  if (!caps) return claimed;
+
+  return {
+    ...claimed,
+    archive_mode: caps.archive_mode ?? claimed.archive_mode,
+    ghost_pay: caps.ghost_pay ?? claimed.ghost_pay,
+    public_mining: caps.public_mining ?? claimed.public_mining,
+    reaper: caps.reaper ?? claimed.reaper,
+    elder: caps.elder_status ?? claimed.elder,
+    total: caps.total_shares ?? claimed.total,
+  };
 }
 
 export async function getHealth(): Promise<HealthStatus> {
-  return fetchApi<HealthStatus>('/health');
+  // /health wraps its payload in a SignedResponse envelope: { response, signed }.
+  // Unwrap so callers see the flat HealthStatus shape (healthy, capabilities, …).
+  const raw = await fetchApi<HealthStatus & { response?: HealthStatus }>('/health');
+  return raw?.response ?? raw;
 }
 
 // Nickname (new)

--- a/dashboard/src/types/api.ts
+++ b/dashboard/src/types/api.ts
@@ -130,11 +130,31 @@ export interface SharesInfo {
   estimated_reward_btc?: number | null;
 }
 
+// VERIFIED node capabilities as reported by /health. Unlike the CLAIMED
+// capabilities on /api/v1/node/shares, these reflect what the node has actually
+// proved via challenge-response and is therefore paid for (5-4-3-2-1 model).
+export interface HealthCapabilities {
+  archive_mode?: boolean;   // +5
+  ghost_pay?: boolean;      // +4
+  public_mining?: boolean;  // +3
+  reaper?: boolean;         // +2
+  elder_status?: boolean;   // +1
+  gsp_enabled?: boolean;
+  total_shares?: number;
+}
+
 export interface HealthStatus {
   status?: string;
   healthy?: boolean;
   uptime_seconds?: number;
   uptime_secs?: number;
+  block_height?: number;
+  peer_count?: number;
+  miner_count?: number;
+  round_id?: number;
+  node_id?: string;
+  version?: string;
+  capabilities?: HealthCapabilities;
 }
 
 export type MempoolProfile =


### PR DESCRIPTION
Fixes the Overview data-accuracy bugs from operator review: **#8** the shares card read *claimed* capabilities (`/api/v1/node/shares`) showing archive-on + 15/15 — now overridden with *verified* values from `/health` (archive off, 10/15); the realtime WS path is hardened to refetch the verified merge rather than trust the claimed push. **#9** the L2 card showed a misleading red 'Wraith Inactive' — `wraith_enabled:false` is genuinely correct (mixing moved to the coordinator binary), so the card now shows three honest states with a reason line. Also: the proxy defaults `BACKEND_URL` to `127.0.0.1:8080` (no more `Invalid URL` with unset env — the real 'no data' fix), and the login-modal logo is the orange Lucide ghost. Build + lint clean; mappings verified against live node reads.