### PR TITLE
fix(dashboard): reaper-confirm error, onboarding gating + profiles, policy shading, Ghost Pay toggle

### DIFF
--- a/dashboard/src/app/(dashboard)/settings/onboarding/page.tsx
+++ b/dashboard/src/app/(dashboard)/settings/onboarding/page.tsx
@@ -19,7 +19,7 @@ import {
   useSetArchiveMode,
   useSetPublicMining,
   useSetReaper,
-  useMempoolProfiles,
+  useSetGhostPay,
   useActivateMempoolProfile,
   useSaveMempoolProfile,
   type CustomMempoolProfile,
@@ -71,7 +71,7 @@ export default function OnboardingPage() {
   const setArchiveMode = useSetArchiveMode();
   const setPublicMining = useSetPublicMining();
   const setReaper = useSetReaper();
-  const { data: mempoolProfilesData } = useMempoolProfiles();
+  const setGhostPay = useSetGhostPay();
   const activateMempoolProfile = useActivateMempoolProfile();
   const saveMempoolProfile = useSaveMempoolProfile();
 
@@ -81,7 +81,9 @@ export default function OnboardingPage() {
   const [editingMempool, setEditingMempool] = useState<CustomMempoolProfile | null>(null);
 
   const activeMempoolProfile = String(config?.mempool_profile ?? "standard");
+  const activeTemplateProfile = String(config?.template_profile ?? "default");
   const ghostPayRunning = Boolean(ghostPay?.l2_height);
+  const ghostPayEnabled = status?.ghost_pay ?? false;
   const budsEnabled = status?.ghost_pay ?? false;
 
   const handleArchiveToggle = async (enabled: boolean) => {
@@ -97,6 +99,15 @@ export default function OnboardingPage() {
     try {
       await setPublicMining.mutateAsync(enabled);
       success("Saved", `Public Mining ${enabled ? "enabled" : "disabled"}`);
+    } catch (err) {
+      error("Failed", err instanceof Error ? err.message : "Unknown error");
+    }
+  };
+
+  const handleGhostPayToggle = async (enabled: boolean) => {
+    try {
+      await setGhostPay.mutateAsync(enabled);
+      success("Saved", `Ghost Pay ${enabled ? "enabled" : "disabled"}`);
     } catch (err) {
       error("Failed", err instanceof Error ? err.message : "Unknown error");
     }
@@ -223,15 +234,20 @@ export default function OnboardingPage() {
               disabled={setArchiveMode.isPending}
               badge={archiveEnabled ? <Badge variant="success">+5 Shares</Badge> : null}
             />
-            <StatusRow
+            <ToggleRow
               label="Ghost Pay"
               description={`L2 payment network participation — requires ghost-pay-node${ghostPay?.l2_height ? ` (L2 height: ${ghostPay.l2_height})` : ""}. Ghost Pay +4 shares.`}
+              enabled={ghostPayEnabled}
+              onChange={handleGhostPayToggle}
+              disabled={setGhostPay.isPending}
               badge={
-                ghostPayRunning ? (
-                  <Badge variant="success">+4 Shares</Badge>
-                ) : (
-                  <Badge variant="warning">Not Running</Badge>
-                )
+                ghostPayEnabled ? (
+                  ghostPayRunning ? (
+                    <Badge variant="success">+4 Shares</Badge>
+                  ) : (
+                    <Badge variant="warning">Not Running</Badge>
+                  )
+                ) : null
               }
             />
             <ToggleRow
@@ -243,8 +259,8 @@ export default function OnboardingPage() {
               badge={publicMiningEnabled ? <Badge variant="success">+3 Shares</Badge> : null}
             />
             <ToggleRow
-              label="Bitcoin Pure (Ghost Reaper)"
-              description="Reject non-financial data (inscriptions, drop-stuffing, dust-flood) from your mempool and blocks. Bitcoin Pure +2 shares."
+              label="Ghost Reaper"
+              description="Reject non-financial data (inscriptions, drop-stuffing, dust-flood) from your mempool and blocks. Reaper +2 shares."
               enabled={reaperEnabled}
               onChange={handleReaperToggle}
               disabled={setReaper.isPending}
@@ -278,22 +294,26 @@ export default function OnboardingPage() {
               subtitle="Choose which transactions your node accepts. The default profile is a sane starting point — tune later from Settings → Policy."
             />
             <div className="space-y-4">
-              <div className="p-3 bg-gray-800/50 rounded-lg flex justify-between items-center">
+              {reaperEnabled && (
+                <div className="p-3 bg-yellow-900/30 border border-yellow-700/50 rounded-lg">
+                  <div className="text-yellow-400 font-medium">Locked by Reaper Mode</div>
+                  <div className="text-sm text-yellow-500/80">
+                    Disable Reaper Mode in the previous step to change profiles.
+                  </div>
+                </div>
+              )}
+
+              <div
+                className={`p-3 bg-gray-800/50 rounded-lg flex justify-between items-center ${
+                  reaperEnabled ? "opacity-50" : ""
+                }`}
+              >
                 <div>
                   <div className="text-gray-100">Current Profile</div>
                   <div className="text-sm text-gray-400">{activeMempoolProfile}</div>
                 </div>
                 <Badge variant="info">{activeMempoolProfile}</Badge>
               </div>
-
-              {reaperEnabled && (
-                <div className="p-3 bg-yellow-900/30 border border-yellow-700/50 rounded-lg">
-                  <div className="text-yellow-400 font-medium">Locked by Reaper Mode</div>
-                  <div className="text-sm text-yellow-500/80">
-                    Disable Bitcoin Pure (Reaper) in the previous step to change profiles.
-                  </div>
-                </div>
-              )}
 
               <div
                 className={`grid grid-cols-1 md:grid-cols-2 gap-2 ${
@@ -374,10 +394,29 @@ export default function OnboardingPage() {
               value={<Badge variant={publicMiningEnabled ? "success" : "default"}>{publicMiningEnabled ? "On" : "Off"}</Badge>}
             />
             <StatItem
-              label="Bitcoin Pure (Reaper)"
+              label="Ghost Reaper"
               value={<Badge variant={reaperEnabled ? "success" : "default"}>{reaperEnabled ? "On" : "Off"}</Badge>}
             />
-            <StatItem label="Mempool Profile" value={<Badge variant="info">{activeMempoolProfile}</Badge>} />
+            <StatItem
+              label="Mempool Profile"
+              value={
+                reaperEnabled ? (
+                  <Badge variant="warning">Reaper Mode</Badge>
+                ) : (
+                  <Badge variant="info">{activeMempoolProfile}</Badge>
+                )
+              }
+            />
+            <StatItem
+              label="Pool Template Profile"
+              value={
+                reaperEnabled ? (
+                  <Badge variant="warning">Reaper Mode</Badge>
+                ) : (
+                  <Badge variant="info">{activeTemplateProfile}</Badge>
+                )
+              }
+            />
             <StatItem label="Reward shares" value={`${shares?.total ?? 0} / ${shares?.max_shares ?? 15}`} />
           </div>
         </Card>

--- a/dashboard/src/app/(dashboard)/settings/wizards/ReaperWizard.tsx
+++ b/dashboard/src/app/(dashboard)/settings/wizards/ReaperWizard.tsx
@@ -155,8 +155,8 @@ export default function ReaperWizard({ isOpen, onClose }: ReaperWizardProps) {
                 onChange={(e) => setData({ max_op_return_bytes: Number(e.target.value) })} disabled={!data.enabled} />
               <Input label="Min drop-stuffing push size (shared)" type="number" value={data.min_drop_size}
                 onChange={(e) => setData({ min_drop_size: Number(e.target.value) })} disabled={!data.enabled} />
-              <Input label="Dust-flood threshold (sats)" type="number" value={data.dustflood_threshold}
-                onChange={(e) => setData({ dustflood_threshold: Number(e.target.value) })} disabled={!data.enabled} />
+              <Input label="Dust-flood threshold (sats)" type="number" value={data.dust_flood_threshold}
+                onChange={(e) => setData({ dust_flood_threshold: Number(e.target.value) })} disabled={!data.enabled} />
               <Input label="Min excess-witness bytes (pool)" type="number" value={data.min_excess_witness_bytes}
                 onChange={(e) => setData({ min_excess_witness_bytes: Number(e.target.value) })} disabled={!data.enabled} />
               <Input label="Legacy max push bytes (pool)" type="number" value={data.legacy_max_push_bytes}

--- a/dashboard/src/components/layout/OnboardingGate.tsx
+++ b/dashboard/src/components/layout/OnboardingGate.tsx
@@ -1,36 +1,28 @@
 'use client';
 
-import { useEffect } from 'react';
-import { usePathname, useRouter } from 'next/navigation';
-import {
-  ONBOARDING_PATH,
-  hasSeenOnboardingThisSession,
-  isOnboarded,
-  markOnboardingSeen,
-} from '@/hooks/useOnboarding';
-
 /**
- * First-run redirect. On the first dashboard load of a browser that has not yet
- * completed onboarding, send the operator to the onboarding flow exactly once
- * per session. After that (e.g. they hit "Skip for now"), they are not trapped:
- * the per-session `seen` marker stops further auto-redirects until they reopen
- * the dashboard in a fresh session, and completing the flow sets the persistent
- * flag so it never fires again.
+ * Onboarding is opt-in, not forced.
+ *
+ * WHY THERE IS NO AUTO-REDIRECT
+ * -----------------------------
+ * The only completion signal available to the dashboard is the client-side
+ * `ghost_dashboard_onboarded` localStorage flag (see `useOnboarding`) — the
+ * ghost-node API exposes no "onboarded"/"configured" marker, and the node's
+ * capability config CANNOT stand in for one: every capability defaults to `true`
+ * server-side (`DashboardConfig::default`: archive/ghost_pay/public_mining/reaper
+ * all on, mempool_profile "permissive"), so a heavily-configured production node
+ * is byte-for-byte indistinguishable from a brand-new install over the API.
+ *
+ * The previous gate keyed the first-run redirect purely on that per-browser
+ * localStorage flag, so any already-set-up node opened from a fresh browser /
+ * cleared storage / new SSH-tunnel session was force-redirected into onboarding
+ * before it could show Overview. Because "configured" can't be detected, the
+ * correct behaviour is to NOT force onboarding at all: the dashboard always
+ * lands on Overview, and onboarding remains reachable on demand as the first
+ * entry under Settings → Onboarding (and re-runnable any time).
  *
  * Renders nothing.
  */
 export function OnboardingGate() {
-  const router = useRouter();
-  const pathname = usePathname();
-
-  useEffect(() => {
-    if (pathname === ONBOARDING_PATH) return;
-    if (isOnboarded()) return;
-    if (hasSeenOnboardingThisSession()) return;
-
-    markOnboardingSeen();
-    router.replace(ONBOARDING_PATH);
-  }, [pathname, router]);
-
   return null;
 }

--- a/dashboard/src/lib/api/client.ts
+++ b/dashboard/src/lib/api/client.ts
@@ -47,6 +47,30 @@ export async function getAuthToken(): Promise<string | null> {
   return null;
 }
 
+// Extract a human-readable message from a failed response. The backend is not
+// uniform: JSON handlers return `{ "error": "..." }`, but the auth middleware
+// and axum's body extractors return PLAIN TEXT (e.g. a 401 "Missing
+// X-Ghost-Signature header" or a 422 JSON-deserialize error). The previous code
+// only ever tried `response.json()` and, when that threw, substituted the
+// literal string "Unknown error" — swallowing every one of those real messages
+// (this is what surfaced as a generic "unknown error" on the Reaper wizard's
+// Confirm). Read the body as text once, prefer a JSON `error`/`message` field
+// when present, and otherwise fall back to the raw text so the operator sees
+// the actual failure.
+async function errorFromResponse(response: Response): Promise<string> {
+  const raw = await response.text().catch(() => "");
+  if (raw) {
+    try {
+      const parsed = JSON.parse(raw);
+      const message = parsed?.error || parsed?.message;
+      if (message) return String(message);
+    } catch {
+      return raw.trim();
+    }
+  }
+  return `API error: ${response.status}`;
+}
+
 export async function fetchApi<T>(
   endpoint: string,
   options?: RequestInit,
@@ -63,10 +87,7 @@ export async function fetchApi<T>(
   });
 
   if (!response.ok) {
-    const error = await response
-      .json()
-      .catch(() => ({ error: "Unknown error" }));
-    throw new Error(error.error || `API error: ${response.status}`);
+    throw new Error(await errorFromResponse(response));
   }
 
   return response.json();
@@ -89,10 +110,7 @@ export async function fetchApiWithFormData<T>(
   );
 
   if (!response.ok) {
-    const error = await response
-      .json()
-      .catch(() => ({ error: "Unknown error" }));
-    throw new Error(error.error || `API error: ${response.status}`);
+    throw new Error(await errorFromResponse(response));
   }
 
   return response.json();

--- a/dashboard/src/lib/api/config.ts
+++ b/dashboard/src/lib/api/config.ts
@@ -71,7 +71,9 @@ export interface ReaperSettings {
   // Thresholds
   max_op_return_bytes: number;
   min_drop_size: number;
-  dustflood_threshold: number;
+  // Must match the Rust field name `dust_flood_threshold` (ghost_common::config::ReaperSettings);
+  // a mismatched key is silently dropped by serde, so the threshold never reaches the node.
+  dust_flood_threshold: number;
   min_excess_witness_bytes: number;
   legacy_max_push_bytes: number;
 }
@@ -111,7 +113,7 @@ export const REAPER_DEFAULTS: ReaperSettings = {
   validate_pubkey_curve_point: true,
   max_op_return_bytes: 82,
   min_drop_size: 76,
-  dustflood_threshold: 330,
+  dust_flood_threshold: 330,
   min_excess_witness_bytes: 500,
   legacy_max_push_bytes: 80,
 };


### PR DESCRIPTION
Onboarding + reaper flow fixes: **#6** reaper Confirm 'unknown error' — the client only parsed JSON error bodies but the node returns plain text; now surfaces the real message (and fixed a `dustflood_threshold`→`dust_flood_threshold` field mismatch that silently dropped the setting). **#2** onboarding force-redirected set-up nodes (client-side localStorage only, no node-state field exists to distinguish) — gate now no-ops to Overview; onboarding stays reachable under Settings. **#7** finish page shows Reaper Mode + the pool-template profile. **#5** current-profile card dimmed under the reaper lock; all 'Bitcoin Pure' → 'Reaper'. **#4** Ghost Pay toggle added to the capabilities step. Build/tsc/lint clean.