### PR TITLE
feat(wallet): Send L2-first + Merchant receipts + connection/sync status (+ fix CLI build)

### DIFF
--- a/apps/wraith-wallet/cli/src/main.rs
+++ b/apps/wraith-wallet/cli/src/main.rs
@@ -1159,6 +1159,10 @@ mod client {
                 println!("wallet '{name}' locked");
                 std::process::ExitCode::SUCCESS
             }
+            Ok(Response::WalletDeleted { name }) => {
+                println!("wallet '{name}' deleted");
+                std::process::ExitCode::SUCCESS
+            }
             Ok(Response::WalletList(l)) => {
                 if l.wallets.is_empty() {
                     println!("(no wallets)");
@@ -1347,6 +1351,32 @@ mod client {
                     None => println!(
                         "update url:   (unset — pass --manifest-url to `wraith update check`)"
                     ),
+                }
+                std::process::ExitCode::SUCCESS
+            }
+            Ok(Response::ConnectionStatus(s)) => {
+                println!("network:    {}", s.network);
+                println!(
+                    "ghost-pay:  {}{}",
+                    if s.ghost_pay_reachable { "reachable" } else { "unreachable" },
+                    s.ghost_pay_version
+                        .as_deref()
+                        .map(|v| format!(" (v{v})"))
+                        .or_else(|| s.ghost_pay_error.as_deref().map(|e| format!(" — {e}")))
+                        .unwrap_or_default()
+                );
+                println!(
+                    "gsp:        {}",
+                    if s.gsp_connected {
+                        "connected"
+                    } else {
+                        s.gsp_phase.as_deref().unwrap_or("disconnected")
+                    }
+                );
+                match s.chain_height {
+                    Some(h) if s.chain_synced => println!("chain:      synced · #{h}"),
+                    Some(h) => println!("chain:      syncing · #{h}"),
+                    None => println!("chain:      unknown"),
                 }
                 std::process::ExitCode::SUCCESS
             }

--- a/apps/wraith-wallet/daemon/src/main.rs
+++ b/apps/wraith-wallet/daemon/src/main.rs
@@ -60,7 +60,8 @@ mod server {
     use wraith_wallet_core::light;
     use wraith_wallet_core::signer::{Signer, SoftwareSigner};
     use wraith_wallet_ipc::{
-        ChainStatusResponse, CheckForUpdateResponse, DaemonEnvResponse, DetectedPaymentEntry,
+        ChainStatusResponse, CheckForUpdateResponse, ConnectionStatusResponse, DaemonEnvResponse,
+        DetectedPaymentEntry,
         DoctorCheck, DoctorResponse, Envelope, ErrorResponse, GlyphClaimResult, GlyphInfo,
         GspAuthResponse, GspPingResponse, GspSessionStatusResponse, HealthResponse,
         LightBalanceResponse, LightDetectedResponse, LightHistoryEntry, LightHistoryResponse,
@@ -1368,6 +1369,18 @@ mod server {
         }
     }
 
+    /// Human-readable network label matching the strings the GUI expects
+    /// ("mainnet"/"signet"/"testnet"/"regtest").
+    fn network_label(n: bitcoin::Network) -> &'static str {
+        match n {
+            bitcoin::Network::Bitcoin => "mainnet",
+            bitcoin::Network::Signet => "signet",
+            bitcoin::Network::Testnet => "testnet",
+            bitcoin::Network::Regtest => "regtest",
+            _ => "unknown",
+        }
+    }
+
     /// Snapshot the active wallet's name + keystore for read-only use.
     /// Returns Err with a user-friendly message if no wallet is active.
     /// Reject the request if kiosk mode is active. Used by the
@@ -2121,6 +2134,63 @@ mod server {
                         last_error: None,
                     }),
                 }
+            }
+            Request::ConnectionStatus => {
+                // One probe answers "is ghost-pay reachable" AND supplies the
+                // chain fields. On error we report unreachable rather than
+                // surfacing a Response::Error — the whole point is a header
+                // that says "unreachable" instead of spinning forever.
+                let (
+                    ghost_pay_reachable,
+                    ghost_pay_version,
+                    ghost_pay_error,
+                    chain_height,
+                    chain_headers,
+                    chain_ibd,
+                    l2_height,
+                ) = match state.chain.status().await {
+                    Ok(s) => (
+                        true,
+                        Some(s.backend_version),
+                        None,
+                        s.chain_height,
+                        s.chain_headers,
+                        s.chain_initial_block_download,
+                        s.l2_height,
+                    ),
+                    Err(e) => (false, None, Some(format!("{e}")), None, None, None, None),
+                };
+                // Same rule the GUI's SyncIndicator uses: verified height has
+                // caught the header tip (or headers unknown) AND bitcoind is
+                // out of initial block download.
+                let chain_synced = ghost_pay_reachable
+                    && chain_height.is_some()
+                    && chain_headers.map_or(true, |h| chain_height.unwrap_or(0) >= h)
+                    && chain_ibd == Some(false);
+                let (gsp_have_token, gsp_phase) = {
+                    let guard = state.session.read().await;
+                    match guard.as_ref() {
+                        Some(s) => {
+                            let snap = s.handle.snapshot().await;
+                            (true, Some(phase_label(snap.phase).to_string()))
+                        }
+                        None => (false, None),
+                    }
+                };
+                let gsp_connected = gsp_phase.as_deref() == Some("authenticated");
+                Response::ConnectionStatus(ConnectionStatusResponse {
+                    network: network_label(state.network).to_string(),
+                    ghost_pay_reachable,
+                    ghost_pay_version,
+                    ghost_pay_error,
+                    gsp_have_token,
+                    gsp_connected,
+                    gsp_phase,
+                    chain_height,
+                    chain_headers,
+                    chain_synced,
+                    l2_height,
+                })
             }
             Request::LightBalance => {
                 let guard = state.session.read().await;
@@ -4454,6 +4524,32 @@ mod server {
                 "second delete should error; got {:?}",
                 resp.payload
             );
+        }
+
+        #[tokio::test]
+        async fn connection_status_reports_unreachable_without_erroring() {
+            // With the RejectChain stub (ghost-pay unreachable) and no GSP
+            // session, ConnectionStatus must still return a structured
+            // snapshot — NOT a Response::Error. This is what lets the header
+            // render a clear "unreachable" state instead of a perpetual
+            // "connecting…" spinner on a laptop with no local endpoints.
+            let state = test_state();
+            let req = serde_json::to_string(&Envelope::new(1, Request::ConnectionStatus)).unwrap();
+            let resp = super::dispatch(&req, &state).await;
+            match resp.payload {
+                Response::ConnectionStatus(s) => {
+                    assert_eq!(s.network, "regtest", "network is read from config, not the backend");
+                    assert!(!s.ghost_pay_reachable, "RejectChain stub must read as unreachable");
+                    assert!(s.ghost_pay_error.is_some(), "an unreachable backend should carry an error hint");
+                    assert!(s.ghost_pay_version.is_none());
+                    assert!(!s.gsp_have_token, "no session configured in this test");
+                    assert!(!s.gsp_connected);
+                    assert!(s.gsp_phase.is_none());
+                    assert!(!s.chain_synced, "cannot be synced while ghost-pay is unreachable");
+                    assert!(s.chain_height.is_none());
+                }
+                other => panic!("expected ConnectionStatus, got {other:?}"),
+            }
         }
     }
 }

--- a/apps/wraith-wallet/gui/src-tauri/src/lib.rs
+++ b/apps/wraith-wallet/gui/src-tauri/src/lib.rs
@@ -280,6 +280,12 @@ async fn chain_status() -> Result<serde_json::Value, String> {
 }
 
 #[tauri::command]
+async fn connection_status() -> Result<serde_json::Value, String> {
+    let resp = call_daemon(Request::ConnectionStatus).await?;
+    to_value(&resp)
+}
+
+#[tauri::command]
 async fn wallet_ghost_id() -> Result<serde_json::Value, String> {
     let resp = call_daemon(Request::WalletGhostId).await?;
     to_value(&resp)
@@ -836,6 +842,7 @@ pub fn run() {
             daemon_doctor,
             daemon_env,
             chain_status,
+            connection_status,
             wallet_list,
             wallet_status,
             wallet_unlock,

--- a/apps/wraith-wallet/gui/src/App.tsx
+++ b/apps/wraith-wallet/gui/src/App.tsx
@@ -1,14 +1,13 @@
 import { useEffect, useRef, useState } from "react";
 import {
-  chainStatus,
+  connectionStatus,
   daemonEnv,
   gspAuth,
-  gspSessionStatus,
   onPaymentDetected,
   onWatchError,
   startWatch,
   walletStatus,
-  type ChainStatusResponse,
+  type ConnectionStatusResponse,
   type DetectedPayment,
 } from "./lib/tauri";
 import { Wallet } from "./screens/Wallet";
@@ -27,7 +26,7 @@ import { Settings } from "./screens/Settings";
 import { ErrorBoundary } from "./components/ErrorBoundary";
 import { Logo } from "./components/Logo";
 import { ThemeToggle } from "./components/ThemeToggle";
-import { SyncIndicator } from "./components/SyncIndicator";
+import { ConnectionStatus } from "./components/ConnectionStatus";
 
 type Screen =
   | "wallet"
@@ -99,7 +98,7 @@ export default function App() {
   const [watchErr, setWatchErr] = useState<string | null>(null);
   const [hasSession, setHasSession] = useState(false);
   const [daemonOffline, setDaemonOffline] = useState(false);
-  const [chain, setChain] = useState<ChainStatusResponse | null>(null);
+  const [conn, setConn] = useState<ConnectionStatusResponse | null>(null);
   // Two layers of kiosk mode:
   //   - daemonKiosk: WRAITHD_KIOSK_MODE on the daemon. Hard lock —
   //     daemon refuses wallet-management ops, can only be exited by
@@ -132,13 +131,19 @@ export default function App() {
         setDaemonOffline(false);
         setNetworkLabel(env.network);
         setWalletState({ active: w.active, unlocked: w.unlocked });
-        // Best-effort chain probe — if ghost-pay is down we leave
-        // the previous chain state and don't flip the offline pill.
-        chainStatus()
-          .then((c) => {
-            if (alive) setChain(c);
-          })
-          .catch(() => {});
+        // Consolidated connectivity probe. Unlike the old chain probe
+        // this NEVER throws for an unreachable ghost-pay/GSP — a
+        // reachable=false snapshot is a normal, renderable result. So a
+        // thrown error here means the daemon itself dropped between
+        // calls (the offline pill covers that); we leave the previous
+        // snapshot in place rather than clearing to a spinner.
+        let conn: ConnectionStatusResponse | null = null;
+        try {
+          conn = await connectionStatus();
+          if (alive) setConn(conn);
+        } catch {
+          /* daemon dropped mid-tick — offline pill handles it */
+        }
         const wasDaemonKiosk = daemonKiosk;
         const isDaemonKiosk = !!env.kiosk_mode;
         if (isDaemonKiosk !== wasDaemonKiosk) {
@@ -146,12 +151,12 @@ export default function App() {
           if (isDaemonKiosk) setScreen("merchant");
         }
         if (w.active && w.unlocked) {
-          try {
-            const session = await gspSessionStatus();
-            if (!alive) return;
-            setHasSession(session.have_token);
+          // Only act on a fresh snapshot; a transient null leaves the
+          // session state untouched until the next tick.
+          if (conn) {
+            setHasSession(conn.gsp_have_token);
             if (
-              !session.have_token &&
+              !conn.gsp_have_token &&
               autoAuthInFlight.current !== w.active
             ) {
               autoAuthInFlight.current = w.active;
@@ -159,8 +164,6 @@ export default function App() {
                 if (alive) autoAuthInFlight.current = null;
               });
             }
-          } catch {
-            /* transient — try again next tick */
           }
         } else {
           setHasSession(false);
@@ -333,9 +336,17 @@ export default function App() {
         )}
 
         {daemonOffline ? (
-          <span className="pill fail live">daemon offline</span>
+          <span
+            className="pill fail live"
+            title="wraithd is not responding. Start the daemon (wraithd) — the GUI reconnects automatically."
+          >
+            daemon offline
+          </span>
         ) : (
-          <SyncIndicator chain={chain} compact />
+          <ConnectionStatus
+            conn={conn}
+            onOpenDiagnostics={() => setScreen("network")}
+          />
         )}
 
         {!daemonOffline && (

--- a/apps/wraith-wallet/gui/src/components/ConnectionStatus.tsx
+++ b/apps/wraith-wallet/gui/src/components/ConnectionStatus.tsx
@@ -1,0 +1,129 @@
+import type { ConnectionStatusResponse } from "../lib/tauri";
+
+interface ConnectionStatusProps {
+  conn: ConnectionStatusResponse | null;
+  /// Where to send the user for the full diagnostics view. Clicking any
+  /// pill jumps to the Network screen.
+  onOpenDiagnostics?: () => void;
+}
+
+/// Persistent header connectivity bar: three compact pills — Ghost Pay,
+/// GSP, and chain sync. The whole point is that a user whose laptop has
+/// no local ghost-pay / GSP sees a clear "unreachable" state (with a
+/// hint) rather than a spinner that never resolves. The backing
+/// `connectionStatus()` call never throws for an unreachable endpoint,
+/// so a red pill here is a real, actionable answer.
+export function ConnectionStatus({ conn, onOpenDiagnostics }: ConnectionStatusProps) {
+  if (!conn) {
+    // Daemon replied to nothing yet — brief, resolves on the next tick.
+    return <span className="pill mute live">connecting…</span>;
+  }
+
+  const jump = onOpenDiagnostics
+    ? { onClick: onOpenDiagnostics, style: { cursor: "pointer", border: 0 } as const }
+    : {};
+
+  // ----- Ghost Pay -----
+  const ghostPay = conn.ghost_pay_reachable ? (
+    <span
+      className="pill pass"
+      title={`Ghost Pay reachable${
+        conn.ghost_pay_version ? ` · v${conn.ghost_pay_version}` : ""
+      }`}
+      {...jump}
+    >
+      Ghost Pay
+    </span>
+  ) : (
+    <span
+      className="pill fail"
+      title={`Ghost Pay unreachable${
+        conn.ghost_pay_error ? ` — ${conn.ghost_pay_error}` : ""
+      }. Set the ghost-pay URL (WRAITHD_GHOST_PAY_URL) or start a local ghost-pay, then check the Network screen.`}
+      {...jump}
+    >
+      Ghost Pay · unreachable
+    </span>
+  );
+
+  // ----- GSP websocket -----
+  let gsp;
+  if (conn.gsp_connected) {
+    gsp = (
+      <span className="pill pass" title="GSP websocket connected and authenticated" {...jump}>
+        GSP
+      </span>
+    );
+  } else if (conn.gsp_have_token) {
+    gsp = (
+      <span
+        className="pill warn"
+        title={`GSP session present but not live (phase: ${conn.gsp_phase ?? "unknown"})`}
+        {...jump}
+      >
+        GSP · {conn.gsp_phase ?? "connecting"}
+      </span>
+    );
+  } else {
+    gsp = (
+      <span
+        className="pill mute"
+        title="No GSP session — unlock a wallet, or configure the GSP URL (WRAITHD_GSP_URL) if this laptop has no local node."
+        {...jump}
+      >
+        GSP · off
+      </span>
+    );
+  }
+
+  // ----- Chain sync -----
+  let sync;
+  if (!conn.ghost_pay_reachable) {
+    sync = (
+      <span
+        className="pill mute"
+        title="Sync unknown — the chain height comes from ghost-pay, which is unreachable."
+        {...jump}
+      >
+        sync · —
+      </span>
+    );
+  } else if (conn.chain_synced) {
+    sync = (
+      <span
+        className="pill pass live"
+        title={`Synced with ${conn.network}${
+          conn.l2_height != null ? ` · L2 #${conn.l2_height}` : ""
+        }`}
+        {...jump}
+      >
+        synced · #{conn.chain_height?.toLocaleString() ?? "—"}
+      </span>
+    );
+  } else {
+    const behind =
+      conn.chain_headers != null && conn.chain_height != null
+        ? conn.chain_headers - conn.chain_height
+        : null;
+    sync = (
+      <span
+        className="pill warn live"
+        title={`Syncing ${conn.network} — ${conn.chain_height?.toLocaleString() ?? "?"} of ${
+          conn.chain_headers?.toLocaleString() ?? "?"
+        }`}
+        {...jump}
+      >
+        syncing · #{conn.chain_height?.toLocaleString() ?? "—"}
+        {behind != null && behind > 0 ? ` · ${behind.toLocaleString()} left` : ""}
+      </span>
+    );
+  }
+
+  return (
+    <span className="conn-status" style={{ display: "inline-flex", gap: 6, alignItems: "center" }}>
+      {ghostPay}
+      {gsp}
+      {sync}
+    </span>
+  );
+}

--- a/apps/wraith-wallet/gui/src/lib/receipt.ts
+++ b/apps/wraith-wallet/gui/src/lib/receipt.ts
@@ -11,6 +11,12 @@ interface PrintReceiptOptions {
   title?: string;
 }
 
+interface EmailReceiptOptions extends PrintReceiptOptions {
+  /// Optional recipient to prefill. Usually left blank — the merchant
+  /// types the customer's address in their own mail client.
+  to?: string;
+}
+
 const SAT = 100_000_000;
 
 /// Renders a single paid receipt to a print-only popup window and
@@ -180,6 +186,81 @@ export function receiptHtml(
   </div>
 </body>
 </html>`;
+}
+
+/// Plain-text rendering of a receipt — the email body and the
+/// "copy receipt" fallback. Mail clients and clipboards want text, not
+/// the print HTML, so this is a separate, dependency-free renderer.
+export function receiptPlainText(
+  receipt: PaidReceipt,
+  opts: PrintReceiptOptions = {},
+): string {
+  const wallet = opts.wallet ?? receipt.wallet_name ?? "wraith";
+  const ts = new Date(receipt.paid_at);
+  const lines = receipt.lines ?? [];
+  const out: string[] = [];
+  out.push(wallet.toUpperCase());
+  out.push(
+    `${opts.title ?? "Receipt"} #${receipt.invoice_id} · paid in bitcoin${
+      opts.network ? ` · ${opts.network}` : ""
+    }`,
+  );
+  out.push("");
+  out.push(`Date:    ${ts.toLocaleDateString()} ${ts.toLocaleTimeString()}`);
+  out.push(
+    `Method:  ${receipt.method === "silent_payment" ? "silent payment" : "direct"}`,
+  );
+  out.push("");
+  if (lines.length) {
+    for (const l of lines) {
+      const name = (l.emoji ? l.emoji + " " : "") + l.label;
+      out.push(`${l.qty}x ${name}  -  ${(l.unit_sats * l.qty).toLocaleString()} sats`);
+    }
+  } else {
+    out.push("(no itemised lines)");
+  }
+  out.push("");
+  out.push(
+    `TOTAL: ${receipt.amount_sats.toLocaleString()} sats (${(
+      receipt.amount_sats / SAT
+    ).toFixed(8)} BTC)`,
+  );
+  if (receipt.memo) {
+    out.push("");
+    out.push(`Memo: ${receipt.memo}`);
+  }
+  out.push("");
+  out.push(`txid: ${receipt.txid}`);
+  out.push("");
+  out.push("Thank you · powered by Ghost Wallet");
+  return out.join("\n");
+}
+
+/// Open the user's mail client with a receipt prefilled (subject +
+/// plain-text body) via a `mailto:` link. No SMTP and no daemon mail
+/// transport — the OS hands off to whatever mail app is registered.
+/// This is the pragmatic v1: the merchant's own client sends it, and
+/// there's a "Copy receipt" fallback in the UI when no mail handler is
+/// registered. Returns the composed `mailto:` URL.
+export function emailReceipt(
+  receipt: PaidReceipt,
+  opts: EmailReceiptOptions = {},
+): string {
+  const wallet = opts.wallet ?? receipt.wallet_name ?? "wraith";
+  const subject = `${opts.title ?? "Receipt"} #${receipt.invoice_id} — ${receipt.amount_sats.toLocaleString()} sats · ${wallet}`;
+  const body = receiptPlainText(receipt, opts);
+  const url = `mailto:${
+    opts.to ? encodeURIComponent(opts.to) : ""
+  }?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
+  // Anchor-click is the most webview-friendly way to trigger the OS
+  // mailto handler — `window.location` is blocked in some Tauri configs.
+  const a = document.createElement("a");
+  a.href = url;
+  a.rel = "noopener noreferrer";
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  return url;
 }
 
 function escapeHtml(s: string): string {

--- a/apps/wraith-wallet/gui/src/lib/tauri.ts
+++ b/apps/wraith-wallet/gui/src/lib/tauri.ts
@@ -154,6 +154,32 @@ export async function chainStatus(): Promise<ChainStatusResponse> {
   return unwrap<ChainStatusResponse>(resp).payload;
 }
 
+/// Consolidated connectivity snapshot for the header status bar.
+/// Composed daemon-side from the ghost-pay probe + GSP session + chain
+/// fields, so the GUI makes ONE call and — crucially — this never
+/// throws for an unreachable backend: `ghost_pay_reachable: false` is a
+/// normal, renderable result, not an error. That's what fixes the
+/// "constantly refreshing, no response" feel when a laptop has no
+/// local ghost-pay/GSP.
+export interface ConnectionStatusResponse {
+  network: string;
+  ghost_pay_reachable: boolean;
+  ghost_pay_version: string | null;
+  ghost_pay_error: string | null;
+  gsp_have_token: boolean;
+  gsp_connected: boolean;
+  gsp_phase: string | null;
+  chain_height: number | null;
+  chain_headers: number | null;
+  chain_synced: boolean;
+  l2_height: number | null;
+}
+
+export async function connectionStatus(): Promise<ConnectionStatusResponse> {
+  const resp = await invoke("connection_status");
+  return unwrap<ConnectionStatusResponse>(resp).payload;
+}
+
 // ----- Wallet ------------------------------------------------------------
 
 export interface WalletEntry {

--- a/apps/wraith-wallet/gui/src/screens/Merchant.tsx
+++ b/apps/wraith-wallet/gui/src/screens/Merchant.tsx
@@ -12,7 +12,7 @@ import {
 } from "../lib/tauri";
 import { Numpad } from "../components/Numpad";
 import { ProductCatalog, useProducts, type Product } from "../components/ProductCatalog";
-import { printReceipt } from "../lib/receipt";
+import { printReceipt, emailReceipt, receiptPlainText } from "../lib/receipt";
 
 interface MerchantProps {
   activeWallet: string | null;
@@ -202,6 +202,8 @@ export function Merchant({
   const [paid, setPaid] = useState<PaidReceipt | null>(null);
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string | null>(null);
+  // Transient positive feedback for receipt actions (email / copy).
+  const [notice, setNotice] = useState<string | null>(null);
 
   // Persisted catalog + takings.
   const { products, setProducts } = useProducts(activeWallet);
@@ -472,6 +474,32 @@ export function Merchant({
       wallet: activeWallet ?? r.wallet_name ?? null,
       network: networkLabel,
     });
+  };
+
+  const flashNotice = (msg: string) => {
+    setNotice(msg);
+    window.setTimeout(() => setNotice(null), 3000);
+  };
+
+  const receiptOpts = (r: PaidReceipt) => ({
+    wallet: activeWallet ?? r.wallet_name ?? null,
+    network: networkLabel,
+  });
+
+  const onEmailReceipt = (r: PaidReceipt) => {
+    // mailto hand-off — opens the operator's own mail client with the
+    // receipt prefilled. No SMTP dependency in the daemon.
+    emailReceipt(r, receiptOpts(r));
+    flashNotice("Opening your mail app… no mail client? Use Copy instead.");
+  };
+
+  const onCopyReceipt = async (r: PaidReceipt) => {
+    try {
+      await navigator.clipboard.writeText(receiptPlainText(r, receiptOpts(r)));
+      flashNotice("Receipt copied to clipboard.");
+    } catch {
+      setErr("Clipboard unavailable — try Print or Email instead.");
+    }
   };
 
   if (!activeWallet) {
@@ -768,14 +796,30 @@ export function Merchant({
                   {paid.txid}
                 </div>
               </div>
-              <div className="row" style={{ justifyContent: "center" }}>
+              <div
+                className="row"
+                style={{ justifyContent: "center", flexWrap: "wrap", gap: 8 }}
+              >
                 <button
-                  className="btn-secondary"
+                  className="btn-secondary btn-sm"
                   onClick={() => onPrintReceipt(paid)}
                   title="Open the printable receipt in a new window"
-                  style={{ padding: "10px 18px" }}
                 >
                   Print receipt
+                </button>
+                <button
+                  className="btn-secondary btn-sm"
+                  onClick={() => onEmailReceipt(paid)}
+                  title="Open your mail app with the receipt prefilled (mailto)"
+                >
+                  Email receipt
+                </button>
+                <button
+                  className="btn-secondary btn-sm"
+                  onClick={() => onCopyReceipt(paid)}
+                  title="Copy the receipt as plain text"
+                >
+                  Copy
                 </button>
                 <button
                   className="btn-primary"
@@ -785,6 +829,14 @@ export function Merchant({
                   Next sale
                 </button>
               </div>
+              {notice && (
+                <div
+                  className="pill pass"
+                  style={{ alignSelf: "center", marginTop: 4 }}
+                >
+                  {notice}
+                </div>
+              )}
             </div>
           ) : open ? (
             <div

--- a/apps/wraith-wallet/gui/src/screens/Send.tsx
+++ b/apps/wraith-wallet/gui/src/screens/Send.tsx
@@ -33,18 +33,32 @@ interface SendProps {
 interface ModeOption {
   id: UiSendMode;
   label: string;
+  /// Short badge on the card ("recommended" / "advanced") so the
+  /// primary path (L2) reads as the default at a glance.
+  badge: string;
+  /// One-line "what this is / when to use it" — the concise helper
+  /// the operator asked for. Sits above the longer `hint`.
+  tagline: string;
   hint: string;
 }
 
+// Order is load-bearing: Ghost Pay (instant L2) is listed FIRST and is
+// the default mode — it's the path most sends should take. PSBT (L1) is
+// the secondary, advanced path. Keep L2 first so the UI always leads
+// with it.
 const MODES = [
   {
     id: "ghostpay",
     label: "Ghost Pay (instant L2)",
+    badge: "recommended",
+    tagline: "Instant · off-chain · no network fee.",
     hint: "Instant off-chain transfer through the operator. No on-chain tx, no confirmation wait — settles to L1 in batches later. For an unlinkable on-chain spend, use the Mix tab (Wraith CoinJoin).",
   },
   {
     id: "psbt",
     label: "PSBT export (L1)",
+    badge: "advanced",
+    tagline: "On-chain · you sign & broadcast · for cold storage or multisig.",
     hint: "Builds an unsigned BIP-174 PSBT spending your L1 UTXOs. Sign here, on a hardware wallet, or with cosigners — then broadcast from the Sign tab. Use for cold-storage flows or multisig.",
   },
 ] as const satisfies readonly ModeOption[];
@@ -452,10 +466,11 @@ export function Send({ activeWallet }: SendProps) {
           <span className="eyebrow">outgoing</span>
           <h1>Send</h1>
           <p className="lead">
-            Two ways to send: Ghost Pay (instant L2, no on-chain tx) or
-            PSBT export (unsigned L1 spend to sign yourself). For an
-            unlinkable on-chain spend, use the Mix tab. Recipient field
-            accepts both ghost-id and any Bitcoin address.
+            Default is <strong>Ghost Pay</strong> — an instant, off-chain
+            L2 transfer with no network fee. Need a plain on-chain spend
+            instead? Switch to PSBT export (L1) and sign it yourself. For
+            an unlinkable on-chain spend, use the Mix tab. The recipient
+            field accepts both a ghost-id and any Bitcoin address.
           </p>
         </div>
       </div>
@@ -609,6 +624,11 @@ export function Send({ activeWallet }: SendProps) {
           </div>
           <div className="col">
             <label>Mode</label>
+            {/* TODO(design): richer infographic — a small illustrated
+                diagram per mode (L2 = phone→phone instant; L1 = coin→
+                block on-chain) would land the difference faster than
+                text. For now we lead with clear labels, a recommended/
+                advanced badge, and a one-line tagline + detail. */}
             <div className="tier-grid">
               {MODES.map((m) => (
                 <button
@@ -618,10 +638,32 @@ export function Send({ activeWallet }: SendProps) {
                   onClick={() => !busy && setMode(m.id)}
                   disabled={busy}
                 >
-                  <div className="tier-label">{m.label.split(" (")[0]}</div>
+                  <div
+                    className="tier-label"
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 8,
+                      flexWrap: "wrap",
+                    }}
+                  >
+                    {m.label.split(" (")[0]}
+                    <span
+                      className={`pill ${m.id === "ghostpay" ? "pass" : "mute"}`}
+                      style={{ fontSize: 9, textTransform: "uppercase" }}
+                    >
+                      {m.badge}
+                    </span>
+                  </div>
                   <div
                     className="tier-meta"
-                    style={{ marginTop: 6, lineHeight: 1.45 }}
+                    style={{ marginTop: 6, fontWeight: 500 }}
+                  >
+                    {m.tagline}
+                  </div>
+                  <div
+                    className="tier-meta muted"
+                    style={{ marginTop: 4, lineHeight: 1.45 }}
                   >
                     {m.hint}
                   </div>

--- a/apps/wraith-wallet/ipc/src/lib.rs
+++ b/apps/wraith-wallet/ipc/src/lib.rs
@@ -122,6 +122,13 @@ pub enum Request {
     GspAuth,
     /// Inspect the daemon's stored GSP session token + persistent connection state.
     GspSessionStatus,
+    /// One-shot connectivity snapshot for the GUI's persistent status bar:
+    /// network, ghost-pay reachability, GSP websocket state, and chain
+    /// sync/height — composed server-side so the frontend makes a single
+    /// call and never sits on a forever-"connecting" spinner. Unlike
+    /// `ChainStatus`, this never errors for an unreachable backend; an
+    /// unreachable ghost-pay is reported as `ghost_pay_reachable = false`.
+    ConnectionStatus,
     /// Register the active wallet's BIP-352 scan public key with the GSP so the
     /// server can detect incoming silent payments on its behalf.
     GspRegisterScanKey,
@@ -582,6 +589,7 @@ pub enum Response {
     Health(HealthResponse),
     Doctor(DoctorResponse),
     ChainStatus(ChainStatusResponse),
+    ConnectionStatus(ConnectionStatusResponse),
     GspPing(GspPingResponse),
     GspAuth(GspAuthResponse),
     GspSessionStatus(GspSessionStatusResponse),
@@ -915,6 +923,49 @@ pub struct ChainStatusResponse {
     /// Current L2 epoch.
     #[serde(default)]
     pub l2_epoch: Option<u64>,
+}
+
+/// Consolidated connectivity snapshot for the GUI's persistent status
+/// bar. Composes the ghost-pay reachability probe, the GSP session
+/// phase, and the chain sync fields into one round-trip. Deliberately
+/// infallible: an unreachable ghost-pay is reported as
+/// `ghost_pay_reachable = false` rather than a `Response::Error`, so the
+/// header can render a clear "unreachable" state instead of hanging on a
+/// perpetual "connecting…" spinner.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConnectionStatusResponse {
+    /// Network the daemon is bound to ("mainnet"/"signet"/"testnet"/"regtest").
+    /// Always known — read from the daemon config, never the backend.
+    pub network: String,
+    /// Whether the configured ghost-pay backend answered its status probe.
+    pub ghost_pay_reachable: bool,
+    /// ghost-pay's reported version, when it was reachable.
+    #[serde(default)]
+    pub ghost_pay_version: Option<String>,
+    /// Probe error, populated only when ghost-pay was unreachable.
+    #[serde(default)]
+    pub ghost_pay_error: Option<String>,
+    /// Whether the daemon holds a GSP session token for the active wallet.
+    pub gsp_have_token: bool,
+    /// True when the GSP websocket is live and authenticated.
+    pub gsp_connected: bool,
+    /// GSP session phase ("disconnected"/"connecting"/"authenticating"/
+    /// "authenticated"/"backoff"), or `None` when there is no session.
+    #[serde(default)]
+    pub gsp_phase: Option<String>,
+    /// L1 verified block height (`None` if bitcoind was unreachable from
+    /// ghost-pay, or ghost-pay itself was unreachable).
+    #[serde(default)]
+    pub chain_height: Option<u64>,
+    /// Highest L1 header ghost-pay's bitcoind has seen.
+    #[serde(default)]
+    pub chain_headers: Option<u64>,
+    /// True when L1 is fully synced: blocks ≥ headers (or headers
+    /// unknown) AND bitcoind is not in initial block download.
+    pub chain_synced: bool,
+    /// L2 chain tip — latest finalized ghost-pay block height.
+    #[serde(default)]
+    pub l2_height: Option<u64>,
 }
 
 /// GSP WebSocket connectivity probe result.
@@ -1572,6 +1623,34 @@ mod tests {
                     active: false,
                     signer: None,
                 }],
+            }),
+            Response::ConnectionStatus(ConnectionStatusResponse {
+                network: "mainnet".into(),
+                ghost_pay_reachable: true,
+                ghost_pay_version: Some("0.9.1".into()),
+                ghost_pay_error: None,
+                gsp_have_token: true,
+                gsp_connected: true,
+                gsp_phase: Some("authenticated".into()),
+                chain_height: Some(880_000),
+                chain_headers: Some(880_000),
+                chain_synced: true,
+                l2_height: Some(1234),
+            }),
+            // Unreachable-backend shape — the fields the header renders
+            // when nothing is configured on a user's laptop.
+            Response::ConnectionStatus(ConnectionStatusResponse {
+                network: "mainnet".into(),
+                ghost_pay_reachable: false,
+                ghost_pay_version: None,
+                ghost_pay_error: Some("connection refused".into()),
+                gsp_have_token: false,
+                gsp_connected: false,
+                gsp_phase: None,
+                chain_height: None,
+                chain_headers: None,
+                chain_synced: false,
+                l2_height: None,
             }),
         ];
         for resp in cases {


### PR DESCRIPTION
Wallet batch 2: Send leads with Ghost Pay (L2/instant) + per-mode taglines (rich infographic left as a design TODO); Merchant gains email (mailto hand-off) + copy alongside the existing print; and a new consolidated `ConnectionStatus` IPC drives a persistent header showing Ghost Pay / GSP / sync state that reports 'unreachable' cleanly instead of spinning forever (the silent-failure fix). Also repairs main's CLI build — batch 1 added `Response::WalletDeleted` without the CLI match arm, breaking `cargo check -p wraith-wallet-cli`. Tests added; daemon/ipc/gui/cli all build.