### PR TITLE
feat(dashboard): node-side password recovery

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -193,6 +193,41 @@ User=ghost
 
 When deployed alongside ghost-node, the dashboard is accessible at the node's IP on port 3000. Ensure the ghost-node API is running on port 8080.
 
+## Password recovery
+
+Auth is a single `DASHBOARD_PASSWORD`, read from the dashboard's systemd
+drop-in (`/etc/systemd/system/ghost-dashboard.service.d/override.conf`), and
+the dashboard binds loopback. So a forgotten password can lock the operator
+out — there is **no web-based reset**, because a web endpoint that reset the
+password would be an authentication bypass (anyone who could reach the login
+page could take over the node).
+
+Instead, the recovery credential is **node access itself**: reaching the
+dashboard already implies SSH or local access to the node, and only someone
+with that access should be able to reset the password. Run this on the node,
+as root:
+
+```bash
+sudo scripts/agathion-reset-password.sh
+```
+
+It:
+
+- Generates a strong password (or accepts one via `--password <value>`).
+- Writes it to the systemd drop-in as the `DASHBOARD_PASSWORD=` line,
+  **preserving every other `Environment=` entry**, and creates the drop-in if
+  it does not exist yet.
+- Drops any explicit `DASHBOARD_JWT_SECRET=` so the JWT signing secret
+  re-derives from the new password — this plus the restart invalidates all
+  existing `ghost-session` cookies (old sessions die).
+- Runs `systemctl daemon-reload && systemctl restart ghost-dashboard`.
+- Prints the new password.
+
+The script backs up the drop-in before editing it and is idempotent (re-running
+just sets a fresh password). Useful flags: `--no-restart` (write only),
+`--service <name>` (non-default unit name), `--help`. The login page's "Forgot
+password?" link points operators here.
+
 ## Technology Stack
 
 - **Framework**: Next.js 14 (App Router)

--- a/dashboard/scripts/agathion-reset-password.sh
+++ b/dashboard/scripts/agathion-reset-password.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# agathion-reset-password.sh — Recover from a forgotten Agathion Node dashboard password.
+#
+# The dashboard authenticates with a single DASHBOARD_PASSWORD, read from a
+# systemd drop-in, and binds loopback only. A forgotten password therefore
+# locks the operator out with no web-based recovery — by design, because a web
+# reset endpoint would be an auth bypass. The recovery credential is instead
+# *node access itself*: whoever can run this script as root on the node is,
+# definitionally, the operator, so it is safe to let them set a new password.
+#
+# This script:
+#   1. Generates a strong password (or accepts one via --password).
+#   2. Writes it to the dashboard's systemd drop-in
+#      (/etc/systemd/system/ghost-dashboard.service.d/override.conf) as the
+#      DASHBOARD_PASSWORD= line, preserving every other Environment= entry.
+#   3. Drops any explicit DASHBOARD_JWT_SECRET= line so the signing secret
+#      re-derives from the new password — this, plus the restart, invalidates
+#      every existing ghost-session cookie (old sessions die).
+#   4. Runs `systemctl daemon-reload && systemctl restart <service>`.
+#   5. Prints the new password.
+#
+# It is idempotent (re-running simply sets a fresh password), backs up the
+# drop-in before touching it, and requires root.
+#
+# Usage:
+#   sudo scripts/agathion-reset-password.sh                 # generate a password
+#   sudo scripts/agathion-reset-password.sh --password 'xy' # set a specific one
+#   sudo scripts/agathion-reset-password.sh --no-restart    # write only, no restart
+#   sudo scripts/agathion-reset-password.sh --service my-dashboard.service
+#
+set -euo pipefail
+
+SERVICE="ghost-dashboard.service"
+NEW_PASSWORD=""
+DO_RESTART=1
+
+usage() {
+    cat <<'EOF'
+Reset the Agathion Node dashboard password (run on the node as root).
+
+Options:
+  -p, --password <value>   Use this password instead of generating one.
+      --service <name>     systemd unit to update (default: ghost-dashboard.service).
+      --no-restart         Write the drop-in but do not daemon-reload/restart.
+  -h, --help               Show this help.
+
+The new password is printed on success. Store it somewhere safe.
+EOF
+}
+
+die() {
+    echo "error: $*" >&2
+    exit 1
+}
+
+# ---------------------------------------------------------------------------
+# Parse arguments
+# ---------------------------------------------------------------------------
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -p|--password)
+            [[ $# -ge 2 ]] || die "$1 requires a value"
+            NEW_PASSWORD="$2"
+            shift 2
+            ;;
+        --service)
+            [[ $# -ge 2 ]] || die "$1 requires a value"
+            SERVICE="$2"
+            shift 2
+            ;;
+        --no-restart)
+            DO_RESTART=0
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            die "unknown argument: $1 (see --help)"
+            ;;
+    esac
+done
+
+# Normalise the service name so both `foo` and `foo.service` work.
+[[ "$SERVICE" == *.service ]] || SERVICE="${SERVICE}.service"
+
+# ---------------------------------------------------------------------------
+# Preconditions
+# ---------------------------------------------------------------------------
+[[ "$(id -u)" -eq 0 ]] || die "must run as root (try: sudo $0)"
+
+DROPIN_DIR="/etc/systemd/system/${SERVICE}.d"
+OVERRIDE="${DROPIN_DIR}/override.conf"
+
+# ---------------------------------------------------------------------------
+# Resolve the new password
+# ---------------------------------------------------------------------------
+if [[ -z "$NEW_PASSWORD" ]]; then
+    command -v openssl >/dev/null 2>&1 || die "openssl not found; pass --password instead"
+    # 24 random bytes -> 32 base64 chars (~144 bits). base64's alphabet
+    # (A-Za-z0-9+/=) contains no characters that need escaping in a
+    # double-quoted systemd Environment= value.
+    NEW_PASSWORD="$(openssl rand -base64 24)"
+    GENERATED=1
+else
+    GENERATED=0
+fi
+
+[[ -n "$NEW_PASSWORD" ]] || die "password is empty"
+# Reject characters we cannot safely place in a double-quoted Environment=
+# value. This never rejects a generated password; it only guards operator
+# input against silently corrupting the drop-in.
+case "$NEW_PASSWORD" in
+    *'"'*|*'\'*)
+        die 'password must not contain a double-quote (") or backslash (\)'
+        ;;
+esac
+if [[ "$NEW_PASSWORD" == *$'\n'* ]]; then
+    die "password must not contain a newline"
+fi
+
+ENV_LINE="Environment=\"DASHBOARD_PASSWORD=${NEW_PASSWORD}\""
+
+# ---------------------------------------------------------------------------
+# Build the new drop-in contents
+# ---------------------------------------------------------------------------
+mkdir -p "$DROPIN_DIR"
+
+TMP="$(mktemp "${DROPIN_DIR}/override.conf.new.XXXXXX")"
+# Ensure the temp file is cleaned up on any early exit.
+trap 'rm -f "$TMP"' EXIT
+
+if [[ -f "$OVERRIDE" ]] && grep -q '^\[Service\]' "$OVERRIDE"; then
+    # Existing, well-formed drop-in: back it up, then rebuild it preserving
+    # every line except the managed DASHBOARD_PASSWORD / DASHBOARD_JWT_SECRET
+    # entries, inserting the fresh password line right after [Service].
+    BACKUP="${OVERRIDE}.bak.$(date +%Y%m%d-%H%M%S)"
+    cp -p "$OVERRIDE" "$BACKUP"
+    echo "backed up existing drop-in -> $BACKUP" >&2
+
+    awk -v newline="$ENV_LINE" '
+        # Drop any previously managed lines (any quoting style).
+        /^[[:space:]]*Environment=.*DASHBOARD_PASSWORD=/ { next }
+        /^[[:space:]]*Environment=.*DASHBOARD_JWT_SECRET=/ { next }
+        { print }
+        /^\[Service\]/ && inserted == 0 { print newline; inserted = 1 }
+    ' "$OVERRIDE" > "$TMP"
+else
+    # No drop-in yet (the common lock-out case), or a malformed one without a
+    # [Service] section: write a clean, minimal drop-in from scratch. Back up
+    # any pre-existing (malformed) file first so nothing is lost.
+    if [[ -f "$OVERRIDE" ]]; then
+        BACKUP="${OVERRIDE}.bak.$(date +%Y%m%d-%H%M%S)"
+        cp -p "$OVERRIDE" "$BACKUP"
+        echo "backed up existing drop-in -> $BACKUP" >&2
+    fi
+    {
+        echo "[Service]"
+        echo "$ENV_LINE"
+    } > "$TMP"
+fi
+
+# Lock down and move into place atomically. The drop-in holds the password in
+# clear, so it must stay root-only.
+chown root:root "$TMP"
+chmod 600 "$TMP"
+mv -f "$TMP" "$OVERRIDE"
+trap - EXIT
+echo "wrote $OVERRIDE" >&2
+
+# ---------------------------------------------------------------------------
+# Apply
+# ---------------------------------------------------------------------------
+if [[ "$DO_RESTART" -eq 1 ]]; then
+    if command -v systemctl >/dev/null 2>&1; then
+        systemctl daemon-reload
+        systemctl restart "$SERVICE"
+        echo "restarted $SERVICE" >&2
+    else
+        echo "warning: systemctl not found; skipped reload/restart" >&2
+    fi
+else
+    echo "skipped daemon-reload/restart (--no-restart); run:" >&2
+    echo "  systemctl daemon-reload && systemctl restart $SERVICE" >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+echo
+echo "==================================================================="
+if [[ "$GENERATED" -eq 1 ]]; then
+    echo " New Agathion Node dashboard password (generated):"
+else
+    echo " New Agathion Node dashboard password (as provided):"
+fi
+echo
+echo "     $NEW_PASSWORD"
+echo
+echo " Store it in your password manager. All existing dashboard"
+echo " sessions have been invalidated; log in again at /login."
+echo "==================================================================="

--- a/dashboard/src/app/login/page.tsx
+++ b/dashboard/src/app/login/page.tsx
@@ -65,6 +65,26 @@ function LoginForm() {
             {loading ? "Signing in..." : "Sign In"}
           </button>
         </form>
+
+        <details className="text-sm text-gray-400">
+          <summary className="cursor-pointer text-gray-500 hover:text-gray-300 transition-colors select-none">
+            Forgot password?
+          </summary>
+          <div className="mt-3 space-y-2 rounded-lg border border-gray-800 bg-gray-900/60 p-4">
+            <p>
+              There is no web reset — that would let anyone who can reach this
+              page bypass the password. Recovery requires access to the node
+              itself. On the node (over SSH or locally), run as root:
+            </p>
+            <pre className="overflow-x-auto rounded bg-gray-950 px-3 py-2 text-xs text-gray-300">
+              <code>sudo scripts/agathion-reset-password.sh</code>
+            </pre>
+            <p>
+              It sets a fresh password, prints it, and restarts the dashboard.
+              Then sign in here with the new password.
+            </p>
+          </div>
+        </details>
       </div>
     </div>
   );

--- a/ghost-web/docs/node-dashboard.md
+++ b/ghost-web/docs/node-dashboard.md
@@ -243,6 +243,25 @@ $ sudo systemctl restart ghost-dashboard
 Existing `ghost-session` cookies remain valid until they expire — restart
 forces a fresh login because the JWT secret is process-scoped.
 
+### Recover a forgotten password
+
+Because the dashboard binds loopback and auth is a single `DASHBOARD_PASSWORD`,
+a *forgotten* password would lock the operator out — and there is deliberately
+no web-based reset (that would be an authentication bypass). Recovery instead
+relies on **node access**, which reaching the dashboard already implies. On the
+node, as root, run the bundled helper:
+
+```bash
+$ sudo scripts/agathion-reset-password.sh
+```
+
+It generates (or accepts, via `--password`) a strong password, writes it to the
+`override.conf` drop-in above while preserving other `Environment=` entries,
+drops any explicit `DASHBOARD_JWT_SECRET` so old sessions die, runs
+`daemon-reload` + `restart`, and prints the new password. The login page's
+"Forgot password?" link points operators to this command. See the dashboard
+README ("Password recovery") for details.
+
 ### Best Practices
 
 1. Use SSH key authentication (no passwords) for the SSH tunnel.


### PR DESCRIPTION
Adds `scripts/agathion-reset-password.sh` (run as root on the node: generates a strong password, rewrites the systemd `DASHBOARD_PASSWORD` override preserving other env, re-derives the JWT secret to kill old sessions, restarts — backed up + idempotent) and a 'Forgot password?' explainer on the login page. No web reset (that'd be an auth bypass); node access is the recovery credential. Addresses the operator lockout concern.