### PR TITLE
fix(api): report the node's actual network, not hardcoded signet

### DIFF
--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -5702,6 +5702,10 @@ async fn main() -> Result<()> {
         capabilities,
     );
 
+    // Report the node's real configured chain on the status/info endpoints
+    // (dashboard + wallets) instead of the historical hardcoded "signet".
+    verification_state = verification_state.with_network(config.bitcoin.network);
+
     // VER-6: When a peer challenges this node's stratum capability, our
     // handler probes the stratum endpoint to confirm reachability. Without
     // this, the handler falls back to 127.0.0.1, which only proves loopback

--- a/crates/ghost-common/src/config.rs
+++ b/crates/ghost-common/src/config.rs
@@ -1002,6 +1002,17 @@ impl MiningMode {
 }
 
 impl BitcoinNetwork {
+    /// Canonical lowercase network name, matching the serde representation and
+    /// the names used by the `bitcoin` crate, ghostd (`chain`), and pool.toml.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            BitcoinNetwork::Mainnet => "mainnet",
+            BitcoinNetwork::Signet => "signet",
+            BitcoinNetwork::Testnet => "testnet",
+            BitcoinNetwork::Regtest => "regtest",
+        }
+    }
+
     /// Convert to the `bitcoin` crate's `Network` type for address validation
     pub fn to_bitcoin_network(&self) -> bitcoin::Network {
         match self {

--- a/crates/ghost-verification/src/routes.rs
+++ b/crates/ghost-verification/src/routes.rs
@@ -1422,7 +1422,7 @@ async fn api_node_status_handler(State(state): State<Arc<VerificationState>>) ->
         "online": health.healthy,
         "node_id": health.node_id,
         "version": health.version,
-        "network": "signet",
+        "network": state.network.as_str(),
         "sync_height": health.block_height,
         "block_height": health.block_height,
         "round_id": health.round_id,
@@ -1514,7 +1514,7 @@ async fn api_node_info_handler(State(state): State<Arc<VerificationState>>) -> i
         "sync_height": health.block_height,
         "block_height": health.block_height,
         "round_id": health.round_id,
-        "network": "signet",
+        "network": state.network.as_str(),
         "is_synced": true,
         "peer_count": health.peer_count,
         "miner_count": health.miner_count,
@@ -3180,7 +3180,7 @@ async fn api_ghostpay_status_handler(
         "enabled": gp.sync_state != "disabled",
         "node_id": health.node_id,
         "protocol_version": 1,
-        "network": "signet",
+        "network": state.network.as_str(),
         "l2_era": gp.epoch,
         "virtual_block": gp.virtual_block,
         "l2_height": gp.virtual_block,
@@ -4723,7 +4723,7 @@ async fn api_config_full_handler(State(state): State<Arc<VerificationState>>) ->
         "template_profile": config.template_profile,
         "prune_profile": config.prune_profile,
         "operator_window": 100,
-        "network": "signet",
+        "network": state.network.as_str(),
         "stratum_sv2_port": 4444,
         "stratum_sv1_port": 3333,
         "http_port": 8080,
@@ -7573,6 +7573,67 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    /// Regression: status/info endpoints must report the node's configured
+    /// network, not a hardcoded value. Production nodes run mainnet; the old
+    /// code always returned "signet", misleading the dashboard and wallets.
+    #[tokio::test]
+    async fn test_status_reports_configured_network() {
+        use ghost_common::config::BitcoinNetwork;
+        use ghost_common::types::NodeCapabilities;
+        use ghost_policy::PolicyProfile;
+
+        async fn network_field(state: Arc<crate::server::VerificationState>) -> String {
+            let app = super::create_router(state);
+            let response = app
+                .oneshot(
+                    Request::builder()
+                        .method("GET")
+                        .uri("/api/v1/node/status")
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            let bytes = axum::body::to_bytes(response.into_body(), 10 * 1024 * 1024)
+                .await
+                .unwrap();
+            let data: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+            data["network"].as_str().unwrap().to_string()
+        }
+
+        let make_state = |network| {
+            Arc::new(
+                crate::server::VerificationState::new(
+                    "test_node".to_string(),
+                    "1.0.0".to_string(),
+                    PolicyProfile::default(),
+                    NodeCapabilities::default(),
+                )
+                .with_network(network),
+            )
+        };
+
+        assert_eq!(
+            network_field(make_state(BitcoinNetwork::Mainnet)).await,
+            "mainnet",
+            "mainnet-configured node must report mainnet"
+        );
+        assert_eq!(
+            network_field(make_state(BitcoinNetwork::Regtest)).await,
+            "regtest"
+        );
+
+        // Default (no with_network) preserves the historical signet value.
+        let default_state = Arc::new(crate::server::VerificationState::new(
+            "test_node".to_string(),
+            "1.0.0".to_string(),
+            PolicyProfile::default(),
+            NodeCapabilities::default(),
+        ));
+        assert_eq!(network_field(default_state).await, "signet");
     }
 
     /// CRIT-6: Test that config POST without auth returns 401

--- a/crates/ghost-verification/src/server.rs
+++ b/crates/ghost-verification/src/server.rs
@@ -910,6 +910,10 @@ pub struct VerificationState {
     pub node_id: String,
     /// Software version
     pub version: String,
+    /// Configured Bitcoin network (mainnet/signet/testnet/regtest).
+    /// Reported by the public status/info endpoints so the dashboard and
+    /// wallets see the node's real chain instead of a hardcoded default.
+    pub network: ghost_common::config::BitcoinNetwork,
     /// Node identity for signing responses
     identity: Option<Arc<NodeIdentity>>,
     /// Policy engine
@@ -1149,6 +1153,9 @@ impl VerificationState {
         Self {
             node_id,
             version,
+            // Defaults to Signet (the historical hardcoded value); production
+            // ghost-pool overrides this via `with_network` from pool.toml.
+            network: ghost_common::config::BitcoinNetwork::Signet,
             identity: None,
             policy_engine: parking_lot::Mutex::new(PolicyEngine::new(policy_profile)),
             capabilities,
@@ -1466,6 +1473,12 @@ impl VerificationState {
     pub fn with_full_node_config(mut self, config: FullNodeConfig, path: PathBuf) -> Self {
         self.full_node_config = Some(parking_lot::RwLock::new(config));
         self.full_node_config_path = Some(path);
+        self
+    }
+
+    /// Set the configured Bitcoin network reported by the status/info endpoints.
+    pub fn with_network(mut self, network: ghost_common::config::BitcoinNetwork) -> Self {
+        self.network = network;
         self
     }
 


### PR DESCRIPTION
Four API handlers (`/api/v1/node/status`, `/node/info`, `/ghostpay/status`, `/config/full`) hardcoded `"network": "signet"`, so mainnet production nodes reported 'signet' to the dashboard + wallets. Now sourced from `VerificationState.network` (wired from `config.bitcoin.network`, via a new `BitcoinNetwork::as_str()`). Defaults to Signet for GSP-only/test states (unchanged). 127 tests pass incl. a new mainnet/regtest/default regression test. **Needs a ghost-pool redeploy to take visible effect** — cosmetic (everything is already on mainnet).