### PR TITLE
fix(dashboard): rename product to Ghost Node (Agathion = codename)

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -1,16 +1,16 @@
-# Agathion Node
+# Ghost Node
 
-**Agathion Node** — the familiar spirit that watches your Ghost node. A web-based
+**Ghost Node** — the familiar spirit that watches your Ghost node. A web-based
 dashboard for monitoring and managing Ghost Network nodes, bound to serve and
 report to its keeper (the node operator). Built with Next.js and React.
 
 > **Infrastructure naming:** the on-disk directory is still `dashboard/` and the
 > systemd unit on production nodes is historically named `ghost-dashboard.service`.
 > Those names are kept stable so the deployed fleet keeps working; only the
-> user-facing product identity is "Agathion Node". A future infra rename can
+> user-facing product identity is "Ghost Node". A future infra rename can
 > happen separately.
 
-> **Releases:** Agathion Node is a **separate download** from the node binaries.
+> **Releases:** Ghost Node is a **separate download** from the node binaries.
 > It ships as a Next.js standalone tarball (`agathion-<version>-node.tar.gz`) cut
 > by the `Release Agathion` workflow (tag `agathion-v*`); see the packaged
 > `RUN.md` for how to launch it.

--- a/dashboard/src/app/layout.tsx
+++ b/dashboard/src/app/layout.tsx
@@ -20,8 +20,8 @@ const plexMono = IBM_Plex_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "Agathion Node",
-  description: "Agathion Node — the familiar spirit that watches your Ghost node",
+  title: "Ghost Node",
+  description: "Ghost Node — the familiar spirit that watches your Ghost node",
 };
 
 // Inline script that runs before paint so there's no flash of wrong theme on

--- a/dashboard/src/app/login/page.tsx
+++ b/dashboard/src/app/login/page.tsx
@@ -41,7 +41,7 @@ function LoginForm() {
       <div className="w-full max-w-sm p-8 space-y-6">
         <div className="flex flex-col items-center space-y-2">
           <Ghost size={48} strokeWidth={1.75} style={{ color: "var(--accent)" }} aria-hidden="true" />
-          <h1 className="text-xl font-semibold text-gray-100">Agathion Node</h1>
+          <h1 className="text-xl font-semibold text-gray-100">Ghost Node</h1>
           <p className="text-sm text-gray-400">Your node&apos;s familiar — enter your password</p>
         </div>
 

--- a/dashboard/src/components/dashboard/NodeHeader.tsx
+++ b/dashboard/src/components/dashboard/NodeHeader.tsx
@@ -36,7 +36,7 @@ export function NodeHeader() {
   if (!info) {
     return (
       <header className="mb-8">
-        <h1 className="text-2xl font-bold text-gray-100">Agathion Node</h1>
+        <h1 className="text-2xl font-bold text-gray-100">Ghost Node</h1>
         <p className="text-gray-400">Unable to connect to node</p>
       </header>
     );
@@ -47,7 +47,7 @@ export function NodeHeader() {
   return (
     <header className="mb-8">
       <div className="flex items-center gap-4 mb-2">
-        <h1 className="text-2xl font-bold text-gray-100">Agathion Node</h1>
+        <h1 className="text-2xl font-bold text-gray-100">Ghost Node</h1>
         <Badge variant="success">Online</Badge>
       </div>
 

--- a/dashboard/src/components/ui/GhostBrand.tsx
+++ b/dashboard/src/components/ui/GhostBrand.tsx
@@ -6,7 +6,7 @@ import { Ghost } from "lucide-react";
 interface GhostBrandProps {
   /** Visual scale. `sm` = sidebar header, `md` = top header. */
   size?: "sm" | "md";
-  /** Override the wordmark text. Default "agathion node". */
+  /** Override the wordmark text. Default "ghost node". */
   label?: string;
   /** Where the brand links to. Default `/`. Pass `null` to render unlinked. */
   href?: string | null;
@@ -21,7 +21,7 @@ interface GhostBrandProps {
  */
 export function GhostBrand({
   size = "md",
-  label = "agathion node",
+  label = "ghost node",
   href = "/",
   className = "",
 }: GhostBrandProps) {


### PR DESCRIPTION
Per the naming convention: product is **Ghost Node**, Agathion is the version codename. Renames login heading, title, header, wordmark, README from 'Agathion Node' → 'Ghost Node'. Codename references (Release Agathion workflow, agathion-v* tag) untouched.