### PR TITLE
fix(dashboard): Ghost Pool hashrate tile + tooltip overflow + Ghost Haze Active/Off

### DIFF
--- a/dashboard/src/app/(dashboard)/page.tsx
+++ b/dashboard/src/app/(dashboard)/page.tsx
@@ -19,7 +19,8 @@ import { formatHashrate } from "@/components/ui/DataTable";
 const TOOLTIPS = {
   block_height: "The current block height of the Bitcoin blockchain your node has synced to. During Initial Block Download (IBD), this shows sync progress.",
   l1_peers: "Number of Ghost mesh peers your node is directly connected to via P2P.",
-  l1_hashrate: "Combined mining hashrate of miners connected to YOUR node's stratum port. This is your pool's hashrate, not the total Ghost network.",
+  l1_hashrate: "Combined mining hashrate of miners connected to YOUR node's stratum port only. This is just your node, not the whole Ghost pool or the Bitcoin network.",
+  pool_hashrate: "Combined mining hashrate of every miner across the entire Ghost pool — all nodes in the mesh aggregated together. This is the whole Ghost pool, not just your node or the Bitcoin network.",
   network_hashrate: "Estimated total hashrate of the Bitcoin network, derived from current difficulty. This is the global network, not just Ghost.",
   l2_height: "The current block height of the Ghost Pay L2 network. Format: era:block. During IBD, shows syncing state.",
   l2_peers: "Number of Ghost Pay L2 peers your node is connected to.",
@@ -108,11 +109,19 @@ function L1Card() {
             </div>
           </div>
         </Tooltip>
+        <Tooltip content={TOOLTIPS.pool_hashrate}>
+          <div className="p-3 bg-orange-900/10 rounded-lg">
+            <div className="text-xs text-gray-500 mb-1">Ghost Pool Hashrate <InfoIcon /></div>
+            <div className="text-lg font-mono font-semibold text-gray-100">
+              {isLoading ? "..." : mining ? formatHashrate((mining.hashrate_th ?? 0) * 1e12) : "0 H/s"}
+            </div>
+          </div>
+        </Tooltip>
         <Tooltip content={TOOLTIPS.l1_hashrate}>
           <div className="p-3 bg-orange-900/10 rounded-lg">
             <div className="text-xs text-gray-500 mb-1">Your Hashrate <InfoIcon /></div>
             <div className="text-lg font-mono font-semibold text-gray-100">
-              {isLoading ? "..." : mining ? formatHashrate((mining.hashrate_th ?? 0) * 1e12) : "0 H/s"}
+              {isLoading ? "..." : mining ? formatHashrate((mining.local_hashrate_th ?? 0) * 1e12) : "0 H/s"}
             </div>
           </div>
         </Tooltip>
@@ -332,8 +341,11 @@ function PrivacySection() {
   const { data: shroud } = useShroudStatus();
   const { data: gp } = useGhostPayStatus();
 
+  // Any non-standard haze storage mode (stripping "hazed" or "full_archive")
+  // counts as Active; "standard" (default node) is Off. Kept as a clean binary
+  // Active/Off so the tile matches its siblings (single line, no wrapping).
   const hazeActive = haze?.mode === "hazed" || haze?.mode === "full_archive";
-  const hazeLabel = haze?.mode === "hazed" ? "Hazed" : haze?.mode === "full_archive" ? "Full Archive" : haze?.mode === "standard" ? "Off" : haze ? "Off" : "Loading...";
+  const hazeLabel = !haze ? "Loading..." : hazeActive ? "Active" : "Off";
 
   const shroudActive = shroud?.enabled ?? false;
   const shroudLabel = shroud ? (shroudActive ? "Active" : "Off") : "Loading...";

--- a/dashboard/src/components/ui/Tooltip.tsx
+++ b/dashboard/src/components/ui/Tooltip.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ReactNode } from 'react';
+import { CSSProperties, ReactNode, useCallback, useRef, useState } from 'react';
 import { useUIStore } from '@/stores';
 
 interface TooltipProps {
@@ -10,41 +10,115 @@ interface TooltipProps {
 }
 
 const positionClasses = {
-  top: 'bottom-full left-1/2 -translate-x-1/2 mb-2',
-  bottom: 'top-full left-1/2 -translate-x-1/2 mt-2',
-  left: 'right-full top-1/2 -translate-y-1/2 mr-2',
-  right: 'left-full top-1/2 -translate-y-1/2 ml-2',
+  top: 'bottom-full left-1/2 mb-2',
+  bottom: 'top-full left-1/2 mt-2',
+  left: 'right-full top-1/2 mr-2',
+  right: 'left-full top-1/2 ml-2',
 };
 
 const arrowClasses = {
-  top: 'top-full left-1/2 -translate-x-1/2 border-t-gray-700 border-x-transparent border-b-transparent',
-  bottom: 'bottom-full left-1/2 -translate-x-1/2 border-b-gray-700 border-x-transparent border-t-transparent',
-  left: 'left-full top-1/2 -translate-y-1/2 border-l-gray-700 border-y-transparent border-r-transparent',
-  right: 'right-full top-1/2 -translate-y-1/2 border-r-gray-700 border-y-transparent border-l-transparent',
+  top: 'top-full left-1/2 border-t-gray-700 border-x-transparent border-b-transparent',
+  bottom: 'bottom-full left-1/2 border-b-gray-700 border-x-transparent border-t-transparent',
+  left: 'left-full top-1/2 border-l-gray-700 border-y-transparent border-r-transparent',
+  right: 'right-full top-1/2 border-r-gray-700 border-y-transparent border-l-transparent',
 };
+
+// Gap kept between the tooltip box and the viewport edge.
+const MARGIN = 8;
 
 export function Tooltip({ content, children, position = 'top' }: TooltipProps) {
   const tooltipsEnabled = useUIStore((s) => s.tooltipsEnabled);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const tipRef = useRef<HTMLDivElement>(null);
+  const [effective, setEffective] = useState(position);
+  const [shift, setShift] = useState(0);
+
+  // Measure on show and nudge the tooltip so it never leaves the viewport:
+  // top/bottom clamp horizontally (and flip vertically if there is no room),
+  // left/right clamp vertically (and flip horizontally). The arrow is
+  // counter-shifted so it keeps pointing at the trigger.
+  const reposition = useCallback(() => {
+    const wrapper = wrapperRef.current;
+    const tip = tipRef.current;
+    if (!wrapper || !tip) return;
+
+    const w = wrapper.getBoundingClientRect();
+    const tw = tip.offsetWidth;
+    const th = tip.offsetHeight;
+    const vw = window.innerWidth;
+    const vh = window.innerHeight;
+
+    let pos = position;
+
+    if (position === 'top' || position === 'bottom') {
+      // Flip vertically if the preferred side has no room.
+      if (position === 'top' && w.top - th - MARGIN < 0 && w.bottom + th + MARGIN <= vh) {
+        pos = 'bottom';
+      } else if (position === 'bottom' && w.bottom + th + MARGIN > vh && w.top - th - MARGIN >= 0) {
+        pos = 'top';
+      }
+      // Horizontal clamp: tooltip is centred on the trigger.
+      const centerX = w.left + w.width / 2;
+      const left = centerX - tw / 2;
+      const right = centerX + tw / 2;
+      let s = 0;
+      if (left < MARGIN) s = MARGIN - left;
+      else if (right > vw - MARGIN) s = vw - MARGIN - right;
+      setShift(s);
+    } else {
+      // Flip horizontally if the preferred side has no room.
+      if (position === 'left' && w.left - tw - MARGIN < 0 && w.right + tw + MARGIN <= vw) {
+        pos = 'right';
+      } else if (position === 'right' && w.right + tw + MARGIN > vw && w.left - tw - MARGIN >= 0) {
+        pos = 'left';
+      }
+      // Vertical clamp: tooltip is centred on the trigger.
+      const centerY = w.top + w.height / 2;
+      const top = centerY - th / 2;
+      const bottom = centerY + th / 2;
+      let s = 0;
+      if (top < MARGIN) s = MARGIN - top;
+      else if (bottom > vh - MARGIN) s = vh - MARGIN - bottom;
+      setShift(s);
+    }
+
+    setEffective(pos);
+  }, [position]);
 
   if (!tooltipsEnabled) {
     return <>{children}</>;
   }
 
+  const horizontal = effective === 'top' || effective === 'bottom';
+  const boxStyle: CSSProperties = horizontal
+    ? { transform: `translateX(calc(-50% + ${shift}px))` }
+    : { transform: `translateY(calc(-50% + ${shift}px))` };
+  const arrowStyle: CSSProperties = horizontal
+    ? { transform: `translateX(calc(-50% - ${shift}px))` }
+    : { transform: `translateY(calc(-50% - ${shift}px))` };
+
   return (
-    <div className="relative group/tooltip">
+    <div
+      ref={wrapperRef}
+      className="relative group/tooltip"
+      onMouseEnter={reposition}
+      onFocusCapture={reposition}
+    >
       {children}
       <div
+        ref={tipRef}
+        style={boxStyle}
         className={`
           absolute z-50 pointer-events-none
           opacity-0 group-hover/tooltip:opacity-100
           transition-opacity duration-150
-          ${positionClasses[position]}
+          ${positionClasses[effective]}
         `}
       >
-        <div className="bg-gray-800 border border-gray-700 text-gray-200 text-xs rounded-lg px-3 py-2 w-72 shadow-lg whitespace-normal">
+        <div className="bg-gray-800 border border-gray-700 text-gray-200 text-xs rounded-lg px-3 py-2 w-72 max-w-[calc(100vw-1rem)] shadow-lg whitespace-normal">
           {content}
         </div>
-        <div className={`absolute w-0 h-0 border-4 ${arrowClasses[position]}`} />
+        <div className={`absolute w-0 h-0 border-4 ${arrowClasses[effective]}`} style={arrowStyle} />
       </div>
     </div>
   );

--- a/dashboard/src/types/api.ts
+++ b/dashboard/src/types/api.ts
@@ -206,6 +206,9 @@ export interface MiningStatus {
   private_mining?: boolean;
   public_mining?: boolean;
   hashrate_th?: number;
+  local_hashrate_th?: number;
+  local_connected_miners?: number;
+  mesh_active_miners?: number;
   connected_miners?: number;
   shares_submitted?: number;
   shares_accepted?: number;


### PR DESCRIPTION
Overview review fixes: adds a **Ghost Pool Hashrate** tile (mesh-aggregated `hashrate_th`) and repoints **Your Hashrate** at `local_hashrate_th` (it was wrongly showing the pool total); makes tooltips viewport-aware so they don't clip off the right edge; and the Privacy Status **Ghost Haze** tile now shows a clean single-line Active/Off instead of the wrapping 'Full Archive'. Build/tsc/lint clean.