### PR TITLE
fix(api): report node's configured wraith_enabled, not ghost-pay's host flag

### DIFF
--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -5706,6 +5706,11 @@ async fn main() -> Result<()> {
     // (dashboard + wallets) instead of the historical hardcoded "signet".
     verification_state = verification_state.with_network(config.bitcoin.network);
 
+    // Report the operator's Wraith-mixing choice from `[ghost_pay] wraith_enabled`
+    // on the ghostpay status endpoint, so the dashboard's L2 card reflects the
+    // node's actual setting rather than ghost-pay's internal "hosts mixing" flag.
+    verification_state = verification_state.with_wraith_enabled(config.wraith_enabled());
+
     // VER-6: When a peer challenges this node's stratum capability, our
     // handler probes the stratum endpoint to confirm reachability. Without
     // this, the handler falls back to 127.0.0.1, which only proves loopback

--- a/crates/ghost-common/src/config.rs
+++ b/crates/ghost-common/src/config.rs
@@ -261,6 +261,17 @@ impl NodeConfig {
         self.ghost_pay.as_ref().is_some_and(|gp| gp.enabled)
     }
 
+    /// Whether the operator enabled Wraith mixing on this node.
+    ///
+    /// Sourced from the `[ghost_pay] wraith_enabled` setting — the operator's
+    /// on/off choice. This is what the public status endpoints must surface,
+    /// as opposed to ghost-pay's internal "does this process host CoinJoin
+    /// sessions" signal (always false since mixing moved to wraith-coordinator).
+    /// Reads as false when no `[ghost_pay]` block is present.
+    pub fn wraith_enabled(&self) -> bool {
+        self.ghost_pay.as_ref().is_some_and(|gp| gp.wraith_enabled)
+    }
+
     /// Validate the configuration
     ///
     /// Returns validation result with any errors and warnings found.
@@ -1707,6 +1718,36 @@ mod tests {
         assert!(
             config.ghost_pay_enabled(),
             "[ghost_pay] with enabled = true must read as enabled"
+        );
+    }
+
+    #[test]
+    fn test_wraith_enabled_predicate() {
+        // No [ghost_pay] block → Wraith reads as off.
+        let mut config = NodeConfig::default();
+        assert!(config.ghost_pay.is_none());
+        assert!(
+            !config.wraith_enabled(),
+            "absent [ghost_pay] must read wraith as disabled"
+        );
+
+        // Operator disabled Wraith explicitly.
+        config.ghost_pay = Some(GhostPayConfig {
+            wraith_enabled: false,
+            ..GhostPayConfig::default()
+        });
+        assert!(!config.wraith_enabled());
+
+        // Operator enabled Wraith → predicate reflects the choice regardless of
+        // whether ghost-pay's `enabled` flag is set (it's a separate signal).
+        config.ghost_pay = Some(GhostPayConfig {
+            enabled: false,
+            wraith_enabled: true,
+            ..GhostPayConfig::default()
+        });
+        assert!(
+            config.wraith_enabled(),
+            "[ghost_pay] wraith_enabled = true must read as enabled"
         );
     }
 

--- a/crates/ghost-verification/src/routes.rs
+++ b/crates/ghost-verification/src/routes.rs
@@ -3189,7 +3189,15 @@ async fn api_ghostpay_status_handler(
         "peer_count": health.peer_count,
         "uptime_secs": health.uptime_secs,
         "sync_state": gp.sync_state,
-        "wraith_enabled": gp.wraith_enabled,
+        // Operator's Wraith setting from config — the user-facing "is Wraith
+        // enabled on this node" flag the dashboard's L2 card reads. Sourced
+        // from `[ghost_pay] wraith_enabled`, NOT ghost-pay's internal host flag
+        // (`gp.wraith_enabled`), which is always false since mixing moved to
+        // the wraith-coordinator binary and would misreport the operator's choice.
+        "wraith_enabled": state.wraith_enabled,
+        // Retained internal signal: whether the ghost-pay process itself hosts
+        // CoinJoin sessions (always false post-wraith-coordinator split).
+        "ghostpay_hosts_mixing": gp.wraith_enabled,
         "total_balances": 0
     }))
 }
@@ -7634,6 +7642,88 @@ mod tests {
             NodeCapabilities::default(),
         ));
         assert_eq!(network_field(default_state).await, "signet");
+    }
+
+    /// Regression: the ghostpay status endpoint's `wraith_enabled` must reflect
+    /// the operator's `[ghost_pay] wraith_enabled` config choice, not ghost-pay's
+    /// internal "hosts CoinJoin sessions" flag (always false since mixing moved
+    /// to wraith-coordinator). Nodes with wraith_enabled = true were reporting
+    /// false, so the dashboard L2 card showed Wraith "Not enabled" when it was.
+    #[tokio::test]
+    async fn test_ghostpay_status_reports_configured_wraith() {
+        use ghost_common::types::NodeCapabilities;
+        use ghost_policy::PolicyProfile;
+
+        async fn wraith_field(state: Arc<crate::server::VerificationState>) -> serde_json::Value {
+            let app = super::create_router(state);
+            let response = app
+                .oneshot(
+                    Request::builder()
+                        .method("GET")
+                        .uri("/api/v1/ghostpay/status")
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            let bytes = axum::body::to_bytes(response.into_body(), 10 * 1024 * 1024)
+                .await
+                .unwrap();
+            serde_json::from_slice(&bytes).unwrap()
+        }
+
+        let make_state = |wraith_enabled| {
+            let state = crate::server::VerificationState::new(
+                "test_node".to_string(),
+                "1.0.0".to_string(),
+                PolicyProfile::default(),
+                NodeCapabilities::default(),
+            )
+            .with_wraith_enabled(wraith_enabled);
+            // Force the fast in-process path (no ghostpay handler wired in tests)
+            // so the handler does not fall through to the 8800 network probe.
+            state.dashboard_config.write().ghost_pay = false;
+            Arc::new(state)
+        };
+
+        // Operator enabled Wraith → status must report true.
+        let enabled = wraith_field(make_state(true)).await;
+        assert_eq!(
+            enabled["wraith_enabled"].as_bool(),
+            Some(true),
+            "config wraith_enabled = true must surface as wraith_enabled: true"
+        );
+        // The internal host-mixing signal stays distinct and false.
+        assert_eq!(
+            enabled["ghostpay_hosts_mixing"].as_bool(),
+            Some(false),
+            "ghost-pay no longer hosts mixing; host flag must stay false"
+        );
+
+        // Operator disabled Wraith → status must report false.
+        let disabled = wraith_field(make_state(false)).await;
+        assert_eq!(
+            disabled["wraith_enabled"].as_bool(),
+            Some(false),
+            "config wraith_enabled = false must surface as wraith_enabled: false"
+        );
+
+        // Default (no with_wraith_enabled) preserves the historical off value.
+        let default_state = {
+            let state = crate::server::VerificationState::new(
+                "test_node".to_string(),
+                "1.0.0".to_string(),
+                PolicyProfile::default(),
+                NodeCapabilities::default(),
+            );
+            state.dashboard_config.write().ghost_pay = false;
+            Arc::new(state)
+        };
+        assert_eq!(
+            wraith_field(default_state).await["wraith_enabled"].as_bool(),
+            Some(false)
+        );
     }
 
     /// CRIT-6: Test that config POST without auth returns 401

--- a/crates/ghost-verification/src/server.rs
+++ b/crates/ghost-verification/src/server.rs
@@ -914,6 +914,11 @@ pub struct VerificationState {
     /// Reported by the public status/info endpoints so the dashboard and
     /// wallets see the node's real chain instead of a hardcoded default.
     pub network: ghost_common::config::BitcoinNetwork,
+    /// Operator's Wraith-mixing on/off choice, from `[ghost_pay] wraith_enabled`.
+    /// Reported by the public status endpoints so the dashboard reflects the
+    /// node's actual setting — NOT ghost-pay's internal "hosts CoinJoin sessions"
+    /// signal, which is always false since mixing moved to wraith-coordinator.
+    pub wraith_enabled: bool,
     /// Node identity for signing responses
     identity: Option<Arc<NodeIdentity>>,
     /// Policy engine
@@ -1156,6 +1161,9 @@ impl VerificationState {
             // Defaults to Signet (the historical hardcoded value); production
             // ghost-pool overrides this via `with_network` from pool.toml.
             network: ghost_common::config::BitcoinNetwork::Signet,
+            // Defaults to off; production ghost-pool overrides this via
+            // `with_wraith_enabled` from the `[ghost_pay]` config block.
+            wraith_enabled: false,
             identity: None,
             policy_engine: parking_lot::Mutex::new(PolicyEngine::new(policy_profile)),
             capabilities,
@@ -1479,6 +1487,12 @@ impl VerificationState {
     /// Set the configured Bitcoin network reported by the status/info endpoints.
     pub fn with_network(mut self, network: ghost_common::config::BitcoinNetwork) -> Self {
         self.network = network;
+        self
+    }
+
+    /// Set the operator's Wraith-mixing setting reported by the status endpoints.
+    pub fn with_wraith_enabled(mut self, wraith_enabled: bool) -> Self {
+        self.wraith_enabled = wraith_enabled;
         self
     }
 


### PR DESCRIPTION
`ghostpay/status` returned `wraith_enabled:false` (ghost-pay's internal 'do I host CoinJoin' flag, hardcoded false since mixing moved to the coordinator) while the node config has `wraith_enabled=true` — so the dashboard showed Wraith 'Not enabled' when it's on. Now sources the operator's config value via `VerificationState.wraith_enabled` (mirrors the #171 network-reporting fix). Ghost-pay's process flag kept separately as `ghostpay_hosts_mixing`. 128 tests pass + regression test. Needs the next ghost-pool redeploy to show.