### PR TITLE
feat(wallet): layered help/explainer system

### DIFF
--- a/apps/wraith-wallet/gui/src/App.tsx
+++ b/apps/wraith-wallet/gui/src/App.tsx
@@ -27,6 +27,9 @@ import { ErrorBoundary } from "./components/ErrorBoundary";
 import { Logo } from "./components/Logo";
 import { ThemeToggle } from "./components/ThemeToggle";
 import { ConnectionStatus } from "./components/ConnectionStatus";
+import { HelpTip } from "./components/HelpTip";
+import { FirstRunTour } from "./components/FirstRunTour";
+import { CATEGORY_HELP } from "./lib/help";
 
 type Screen =
   | "wallet"
@@ -114,6 +117,19 @@ export default function App() {
     return localStorage.getItem("wraith.kiosk") === "1";
   });
   const kioskMode = daemonKiosk || guiKiosk;
+
+  // Skippable first-run tour. Shown until the user finishes or skips it
+  // once, then suppressed via a localStorage flag (same convention as
+  // wraith.kiosk / ghost-theme). Never shown in kiosk mode — a locked
+  // till isn't a first-run learning surface. Replayable from Settings.
+  const [showTour, setShowTour] = useState<boolean>(() => {
+    return localStorage.getItem("wraith.tour.seen") !== "1";
+  });
+  const dismissTour = () => {
+    localStorage.setItem("wraith.tour.seen", "1");
+    setShowTour(false);
+  };
+  const replayTour = () => setShowTour(true);
 
   const autoAuthInFlight = useRef<string | null>(null);
 
@@ -273,6 +289,7 @@ export default function App() {
             guiKiosk={guiKiosk}
             daemonKiosk={daemonKiosk}
             onToggleGuiKiosk={toggleGuiKiosk}
+            onReplayTour={replayTour}
           />
         );
     }
@@ -419,7 +436,17 @@ export default function App() {
           <nav>
             {NAV_GROUPS.map((group) => (
               <div className="nav-group" key={group.heading}>
-                <div className="nav-heading">{group.heading}</div>
+                <div className="nav-heading">
+                  <span>{group.heading}</span>
+                  {CATEGORY_HELP[group.heading] && (
+                    <HelpTip
+                      title={group.heading}
+                      label={`About ${group.heading}`}
+                    >
+                      {CATEGORY_HELP[group.heading]}
+                    </HelpTip>
+                  )}
+                </div>
                 {group.items.map((item) => (
                   <button
                     key={item.id}
@@ -438,6 +465,8 @@ export default function App() {
       <main className="app-main">
         <ErrorBoundary key={screen}>{activeScreen()}</ErrorBoundary>
       </main>
+
+      {showTour && !kioskMode && <FirstRunTour onClose={dismissTour} />}
     </div>
   );
 }

--- a/apps/wraith-wallet/gui/src/components/FirstRunTour.tsx
+++ b/apps/wraith-wallet/gui/src/components/FirstRunTour.tsx
@@ -1,0 +1,124 @@
+import { useState } from "react";
+import { Logo } from "./Logo";
+import { CATEGORY_HELP } from "../lib/help";
+
+interface FirstRunTourProps {
+  /// Called when the user finishes or skips. The parent persists the
+  /// "seen" flag and unmounts the tour — see App.tsx `dismissTour`.
+  onClose: () => void;
+}
+
+interface TourStep {
+  eyebrow: string;
+  title: string;
+  body: string;
+}
+
+// A short, linear walk-through of the four nav categories plus the two
+// things a newcomer reaches for first: the connection indicator and
+// sending money. Category copy is pulled straight from CATEGORY_HELP so
+// the tour never contradicts the sidebar "?" text.
+const STEPS: TourStep[] = [
+  {
+    eyebrow: "welcome",
+    title: "Welcome to Ghost Wallet",
+    body: "A quick tour of where everything lives. It takes about a minute, and you can skip it any time — you'll find it again under Settings.",
+  },
+  {
+    eyebrow: "category · 1 of 4",
+    title: "Wallet",
+    body: CATEGORY_HELP.Wallet,
+  },
+  {
+    eyebrow: "category · 2 of 4",
+    title: "Payments",
+    body: CATEGORY_HELP.Payments,
+  },
+  {
+    eyebrow: "category · 3 of 4",
+    title: "Merchant",
+    body: CATEGORY_HELP.Merchant,
+  },
+  {
+    eyebrow: "category · 4 of 4",
+    title: "System",
+    body: CATEGORY_HELP.System,
+  },
+  {
+    eyebrow: "staying connected",
+    title: "Connection status",
+    body: "Look to the top-right of the window. A small indicator there shows whether the wallet is talking to a Ghost node. If it ever reads offline, open Network or Settings to check your connection — nothing can send or receive until it's green.",
+  },
+  {
+    eyebrow: "your first payment",
+    title: "Sending money",
+    body: "Open Payments, then Send. Paste a ghost-id or a Bitcoin address, enter an amount, and choose Ghost Pay for an instant fee-free transfer or on-chain for a normal Bitcoin payment. The little ? on each screen explains the choices as you go.",
+  },
+];
+
+/// First-launch guided tour. A plain modal built on the existing
+/// modal styles — skippable at every step, and shown only until the
+/// user finishes or skips once (the parent stores the flag). Kept
+/// deliberately light: no spotlight/overlay-pointer machinery, just
+/// clear words and a progress rail.
+export function FirstRunTour({ onClose }: FirstRunTourProps) {
+  const [idx, setIdx] = useState(0);
+  const step = STEPS[idx];
+  const isLast = idx === STEPS.length - 1;
+
+  return (
+    <div className="modal-overlay">
+      <div className="modal-card tour-card" onClick={(e) => e.stopPropagation()}>
+        <div className="card-header">
+          <div className="row" style={{ gap: 10, alignItems: "center" }}>
+            <Logo size={22} />
+            <span className="eyebrow eyebrow-dim">{step.eyebrow}</span>
+          </div>
+          <button className="btn-secondary btn-sm" onClick={onClose}>
+            Skip tour
+          </button>
+        </div>
+
+        {/* TODO(design): a small illustrated diagram per step goes here
+            (e.g. an annotated screenshot of the relevant nav category or
+            the connection indicator). Text-only for now by design. */}
+
+        <h2 style={{ margin: 0 }}>{step.title}</h2>
+        <p className="muted" style={{ margin: 0 }}>
+          {step.body}
+        </p>
+
+        <div className="tour-dots" aria-hidden="true">
+          {STEPS.map((_, i) => (
+            <span
+              key={i}
+              className={`tour-dot${i === idx ? " active" : ""}`}
+            />
+          ))}
+        </div>
+
+        <div className="row" style={{ justifyContent: "space-between", gap: 8 }}>
+          <button
+            className="btn-secondary"
+            onClick={() => setIdx((i) => Math.max(0, i - 1))}
+            disabled={idx === 0}
+          >
+            Back
+          </button>
+          {isLast ? (
+            <button className="btn-primary" onClick={onClose}>
+              Get started
+            </button>
+          ) : (
+            <button
+              className="btn-primary"
+              onClick={() => setIdx((i) => Math.min(STEPS.length - 1, i + 1))}
+            >
+              Next →
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/wraith-wallet/gui/src/components/HelpTip.tsx
+++ b/apps/wraith-wallet/gui/src/components/HelpTip.tsx
@@ -1,0 +1,72 @@
+import { useEffect, useId, useRef, useState, type ReactNode } from "react";
+
+interface HelpTipProps {
+  /// Heading shown at the top of the revealed popover.
+  title: string;
+  /// The explanation itself — a string (2–4 plain-language sentences)
+  /// or richer nodes if a caller ever needs them.
+  children: ReactNode;
+  /// Accessible label for the trigger button. Defaults to a generic
+  /// "What's this?" so every instance reads sensibly to a screen reader.
+  label?: string;
+  /// Which side of the trigger the popover opens toward. Defaults to
+  /// "right"; use "left" near the right edge of a screen so it stays
+  /// on-screen.
+  align?: "left" | "right";
+}
+
+/// The one contextual-help affordance used across the wallet: a small
+/// round "?" the user can click to reveal a concise explanation, and
+/// click again (or press Escape, or click away) to dismiss. Purely
+/// presentational and self-contained — no library, no portal — so it
+/// drops in beside any heading or label without extra wiring.
+export function HelpTip({ title, children, label, align = "right" }: HelpTipProps) {
+  const [open, setOpen] = useState(false);
+  const wrapRef = useRef<HTMLSpanElement>(null);
+  const panelId = useId();
+
+  // Dismiss on outside click / Escape while open. Registered only when
+  // open so we don't hold global listeners for every dormant tip.
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("mousedown", onDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  return (
+    <span className="helptip" ref={wrapRef}>
+      <button
+        type="button"
+        className={`helptip-btn${open ? " open" : ""}`}
+        aria-label={label ?? "What's this?"}
+        aria-expanded={open}
+        aria-controls={panelId}
+        onClick={() => setOpen((v) => !v)}
+      >
+        ?
+      </button>
+      {open && (
+        <span
+          id={panelId}
+          role="tooltip"
+          className={`helptip-panel ${align === "left" ? "align-left" : "align-right"}`}
+        >
+          <strong className="helptip-title">{title}</strong>
+          <span className="helptip-body">{children}</span>
+        </span>
+      )}
+    </span>
+  );
+}

--- a/apps/wraith-wallet/gui/src/lib/help.ts
+++ b/apps/wraith-wallet/gui/src/lib/help.ts
@@ -1,0 +1,60 @@
+// Plain-language help copy, kept in one place so the three help
+// layers never drift out of sync:
+//
+//   1. Per-category explainers — the "?" beside each sidebar group
+//      heading reveals CATEGORY_HELP[heading].
+//   2. Contextual "What's this?" tips — the HelpTip affordance on
+//      Send / Locks / Mix / Merchant / the seed step reads HELP_TOPICS.
+//   3. First-run tour — walks the four categories, reusing the same
+//      CATEGORY_HELP text so the tour and the sidebar agree word-for-word.
+//
+// Everything here is beginner-first: no jargon that isn't immediately
+// explained, British spelling, one to four short sentences each.
+
+/// Keyed by the sidebar group heading in App.tsx `NAV_GROUPS`.
+/// One or two sentences: "what this is / what you can do here".
+export const CATEGORY_HELP: Record<string, string> = {
+  Wallet:
+    "Your money and its history live here. Create or restore a wallet, watch your balance and past payments, and time-lock funds so they can only be spent later.",
+  Payments:
+    "Send and receive money here. Pay instantly and fee-free off-chain with Ghost Pay, or make a normal on-chain Bitcoin payment. You can also sign transactions and mix coins for privacy.",
+  Merchant:
+    "Take payments as a shop or stall. Show a customer a QR code, watch it flip to paid, and export tidy sales reports for your records.",
+  System:
+    "Settings and health. Choose which Ghost node the wallet connects to, back up your wallet file, check for updates, and see how the wallet is doing.",
+};
+
+/// Contextual tips surfaced by the HelpTip "?" affordance. Two to four
+/// sentences, jargon-light. `title` shows as the popover heading.
+export interface HelpTopic {
+  title: string;
+  body: string;
+}
+
+export const HELP_TOPICS: Record<string, HelpTopic> = {
+  send: {
+    title: "Ghost Pay (L2) vs on-chain (L1)",
+    body:
+      "Ghost Pay is a Layer 2 (L2) transfer: it settles instantly between Ghost wallets with no network fee, ideal for everyday spending. On-chain is Layer 1 (L1): a normal Bitcoin transaction that anyone can verify on the blockchain, but it pays a miner fee and takes time to confirm. Start with Ghost Pay; switch to on-chain (PSBT) when you're paying a plain Bitcoin address or moving funds off the network.",
+  },
+  locks: {
+    title: "What is a time-lock?",
+    body:
+      "A time-lock puts coins into an output that can't be spent until a chosen future point. It's a self-custody safety tool — think of it as a savings jar you set to open on a certain date. Because the lock uses the same shape as a CoinJoin output, it also blends you in with others for privacy, and you can always recover the funds yourself once the lock matures.",
+  },
+  mix: {
+    title: "What is mixing (CoinJoin)?",
+    body:
+      "Mixing joins your coins with other people's in a single transaction, so an outside observer can't tell which output belongs to whom. This breaks the link between your old coins and your new ones, giving you on-chain privacy. Nobody takes custody of your money during a mix — you always keep control of your own keys.",
+  },
+  merchant: {
+    title: "How taking a payment works",
+    body:
+      "Add up an amount, and the wallet shows the customer a QR code to scan. When their payment lands, the screen flips to PAID on its own — no need to refresh or check manually. Every sale is recorded so you can export a report later from the Reports screen.",
+  },
+  mnemonic: {
+    title: "Why write down your recovery phrase?",
+    body:
+      "These words are the only complete backup of your wallet. If your computer is lost, stolen, or wiped, typing this phrase into any Ghost wallet restores your money in full. Write it on paper and store it somewhere safe and private — never a photo or a cloud note. Anyone who reads it can spend your funds, and nobody, not even us, can recover it for you if it's lost.",
+  },
+};

--- a/apps/wraith-wallet/gui/src/screens/Locks.tsx
+++ b/apps/wraith-wallet/gui/src/screens/Locks.tsx
@@ -11,6 +11,8 @@ import {
   type LocksRecoveredResult,
   type LocksJumpedResult,
 } from "../lib/tauri";
+import { HelpTip } from "../components/HelpTip";
+import { HELP_TOPICS } from "../lib/help";
 
 interface Tier {
   id: string;
@@ -193,7 +195,12 @@ export function Locks() {
       <div className="page-head">
         <div>
           <span className="eyebrow">custody primitive</span>
-          <h1>Ghost Locks</h1>
+          <h1>
+            Ghost Locks{" "}
+            <HelpTip title={HELP_TOPICS.locks.title} label="About time-locks">
+              {HELP_TOPICS.locks.body}
+            </HelpTip>
+          </h1>
           <p className="lead">
             Time-locked taproot outputs that mix you in with every
             other CoinJoin output of the same denomination. Recover

--- a/apps/wraith-wallet/gui/src/screens/Merchant.tsx
+++ b/apps/wraith-wallet/gui/src/screens/Merchant.tsx
@@ -12,6 +12,8 @@ import {
 } from "../lib/tauri";
 import { Numpad } from "../components/Numpad";
 import { ProductCatalog, useProducts, type Product } from "../components/ProductCatalog";
+import { HelpTip } from "../components/HelpTip";
+import { HELP_TOPICS } from "../lib/help";
 import { printReceipt, emailReceipt, receiptPlainText } from "../lib/receipt";
 
 interface MerchantProps {
@@ -524,7 +526,16 @@ export function Merchant({
       <div className="page-head">
         <div>
           <span className="eyebrow">point of sale</span>
-          <h1>Merchant</h1>
+          <h1>
+            Merchant{" "}
+            <HelpTip
+              title={HELP_TOPICS.merchant.title}
+              label="About taking payments"
+              align="left"
+            >
+              {HELP_TOPICS.merchant.body}
+            </HelpTip>
+          </h1>
           <p className="lead">
             Tap products, punch a custom amount, take the payment.
             Customer scans the QR — terminal flips to PAID when the

--- a/apps/wraith-wallet/gui/src/screens/Mix.tsx
+++ b/apps/wraith-wallet/gui/src/screens/Mix.tsx
@@ -10,6 +10,8 @@ import {
   type WraithDiscoverTier,
   type WraithMixCompleted,
 } from "../lib/tauri";
+import { HelpTip } from "../components/HelpTip";
+import { HELP_TOPICS } from "../lib/help";
 
 interface MixProps {
   activeWallet: string | null;
@@ -343,7 +345,12 @@ export function Mix({ activeWallet }: MixProps) {
       <div className="page-head">
         <div>
           <span className="eyebrow">privacy · l1 coinjoin</span>
-          <h1>Wraith mix</h1>
+          <h1>
+            Wraith mix{" "}
+            <HelpTip title={HELP_TOPICS.mix.title} label="About mixing">
+              {HELP_TOPICS.mix.body}
+            </HelpTip>
+          </h1>
           <p className="lead">
             One round, five denom-sized outputs, no input→output
             linkage. The coordinator can't link your input UTXO to

--- a/apps/wraith-wallet/gui/src/screens/Onboarding.tsx
+++ b/apps/wraith-wallet/gui/src/screens/Onboarding.tsx
@@ -1,6 +1,8 @@
 import { useMemo, useState } from "react";
 import { walletCreate, walletImport } from "../lib/tauri";
 import { Logo } from "../components/Logo";
+import { HelpTip } from "../components/HelpTip";
+import { HELP_TOPICS } from "../lib/help";
 
 interface OnboardingProps {
   /// "create" launches the create-new flow; "import" launches the
@@ -269,11 +271,17 @@ export function Onboarding({ mode, onClose }: OnboardingProps) {
           <>
             <div className="card warn" style={{ margin: 0 }}>
               <p style={{ margin: 0 }}>
-                <strong>Write these 24 words on paper.</strong> Anyone
-                with this phrase can spend funds in this wallet. The
-                daemon doesn't keep it in plaintext anywhere — without
-                it, recovery is impossible if the keystore file or its
-                passphrase are lost.
+                <strong>Write these 24 words on paper.</strong>{" "}
+                <HelpTip
+                  title={HELP_TOPICS.mnemonic.title}
+                  label="Why write down the recovery phrase"
+                >
+                  {HELP_TOPICS.mnemonic.body}
+                </HelpTip>{" "}
+                Anyone with this phrase can spend funds in this wallet.
+                The daemon doesn't keep it in plaintext anywhere —
+                without it, recovery is impossible if the keystore file
+                or its passphrase are lost.
               </p>
               <div className="mnemonic-block">
                 {generatedMnemonic

--- a/apps/wraith-wallet/gui/src/screens/Send.tsx
+++ b/apps/wraith-wallet/gui/src/screens/Send.tsx
@@ -11,6 +11,8 @@ import {
   type OutpointRef,
   type PsbtCreateResponse,
 } from "../lib/tauri";
+import { HelpTip } from "../components/HelpTip";
+import { HELP_TOPICS } from "../lib/help";
 
 /// Send "mode" widening — the daemon exposes exactly one real send
 /// mode (`ghostpay`, the instant L2 ledger transfer). The GUI adds a
@@ -464,7 +466,12 @@ export function Send({ activeWallet }: SendProps) {
       <div className="page-head">
         <div>
           <span className="eyebrow">outgoing</span>
-          <h1>Send</h1>
+          <h1>
+            Send{" "}
+            <HelpTip title={HELP_TOPICS.send.title} label="About sending">
+              {HELP_TOPICS.send.body}
+            </HelpTip>
+          </h1>
           <p className="lead">
             Default is <strong>Ghost Pay</strong> — an instant, off-chain
             L2 transfer with no network fee. Need a plain on-chain spend

--- a/apps/wraith-wallet/gui/src/screens/Settings.tsx
+++ b/apps/wraith-wallet/gui/src/screens/Settings.tsx
@@ -30,6 +30,9 @@ interface SettingsProps {
   /// restarts without the env var. The "real" till lock.
   daemonKiosk: boolean;
   onToggleGuiKiosk: (next: boolean) => void;
+  /// Re-open the skippable first-run tour. The "seen" flag lives in
+  /// localStorage; replaying just re-shows the tour without clearing it.
+  onReplayTour: () => void;
 }
 
 /// Read-only inspection of the daemon's environment + endpoints,
@@ -38,7 +41,7 @@ interface SettingsProps {
 /// URLs, idle-lock, shroud window) are set via env vars at
 /// wraithd boot — this screen surfaces what's currently active so
 /// you can confirm what the daemon is using vs what you intended.
-export function Settings({ guiKiosk, daemonKiosk, onToggleGuiKiosk }: SettingsProps) {
+export function Settings({ guiKiosk, daemonKiosk, onToggleGuiKiosk, onReplayTour }: SettingsProps) {
   const [env, setEnv] = useState<DaemonEnvResponse | null>(null);
   const [health, setHealth] = useState<HealthResponse | null>(null);
   const [err, setErr] = useState<string | null>(null);
@@ -726,6 +729,21 @@ export function Settings({ guiKiosk, daemonKiosk, onToggleGuiKiosk }: SettingsPr
               till deployment, also set the daemon lock above.
             </span>
           </div>
+        </div>
+      </div>
+
+      <div className="card">
+        <h2>Help &amp; guidance</h2>
+        <p className="muted" style={{ marginTop: 0, fontSize: 13 }}>
+          New here, or showing someone else the ropes? Replay the short
+          guided tour of the wallet's four sections. You can skip it at
+          any point. Every screen also has a small <strong>?</strong> that
+          explains what it does.
+        </p>
+        <div className="row" style={{ marginTop: 8 }}>
+          <button className="btn-secondary" onClick={onReplayTour}>
+            Show tour
+          </button>
         </div>
       </div>
 

--- a/apps/wraith-wallet/gui/src/styles.css
+++ b/apps/wraith-wallet/gui/src/styles.css
@@ -163,6 +163,9 @@ button { cursor: pointer; }
   margin-top: 18px;
 }
 .nav-heading {
+  display: flex;
+  align-items: center;
+  gap: 6px;
   padding: 0 24px 6px;
   font-family: var(--font-sans);
   font-size: 11px;
@@ -1159,3 +1162,103 @@ code {
 }
 .theme-toggle:hover { color: var(--fg); background: var(--surface); }
 .theme-toggle svg { width: 18px; height: 18px; }
+
+/* ===========================================================
+   HelpTip — the one contextual "?" affordance. A small round
+   trigger that reveals a concise explanation in a popover. Sized
+   independently of its surroundings (fixed 16px) so it reads the
+   same beside a 32px <h1> or an 11px nav heading.
+   =========================================================== */
+
+.helptip {
+  position: relative;
+  display: inline-flex;
+  vertical-align: middle;
+}
+.helptip-btn {
+  appearance: none;
+  cursor: pointer;
+  width: 16px;
+  height: 16px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  border: 1px solid var(--rule-strong);
+  background: transparent;
+  color: var(--dim);
+  font-family: var(--font-sans);
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: 0;
+  text-transform: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  transition: color 120ms, border-color 120ms, background 120ms;
+}
+.helptip-btn:hover,
+.helptip-btn.open {
+  color: var(--bg);
+  background: var(--accent);
+  border-color: var(--accent);
+}
+.helptip-panel {
+  position: absolute;
+  top: calc(100% + 8px);
+  z-index: 60;
+  width: min(300px, 78vw);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 12px 14px;
+  background: var(--bg);
+  border: 1px solid var(--rule-strong);
+  border-radius: 8px;
+  box-shadow: 0 8px 24px color-mix(in srgb, var(--fg) 18%, transparent);
+  cursor: default;
+}
+.helptip-panel.align-right { left: 0; }
+.helptip-panel.align-left { right: 0; }
+.helptip-title {
+  font-family: var(--font-sans);
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0;
+  text-transform: none;
+  color: var(--fg);
+}
+.helptip-body {
+  font-family: var(--font-sans);
+  font-size: 13px;
+  font-weight: 400;
+  line-height: 1.5;
+  letter-spacing: 0;
+  text-transform: none;
+  color: var(--dim);
+}
+
+/* ===========================================================
+   First-run tour — reuses the modal shell; only the progress
+   rail is bespoke.
+   =========================================================== */
+
+.tour-card {
+  width: min(460px, 92vw);
+}
+.tour-dots {
+  display: flex;
+  gap: 7px;
+  align-items: center;
+}
+.tour-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--rule-strong);
+  transition: background 120ms, transform 120ms;
+}
+.tour-dot.active {
+  background: var(--accent);
+  transform: scale(1.25);
+}


### PR DESCRIPTION
Three-layer help so any experience level can use the wallet: (1) per-category '?' explainers on the nav group headings (Wallet/Payments/Merchant/System); (2) a reusable HelpTip '?' popover on Send (L2 vs L1), Locks, Mix, Merchant, and the seed step; (3) a skippable first-run tour (localStorage-persisted, replayable from Settings → 'Show tour'). All copy centralised in lib/help.ts. Rich diagrams left as design TODOs. GUI-only; builds + tests pass.