### PR TITLE
fix(dashboard): Swarm shows mesh peers online from gossip, not a failed poll

### DIFF
--- a/crates/ghost-verification/src/routes.rs
+++ b/crates/ghost-verification/src/routes.rs
@@ -3226,39 +3226,166 @@ async fn api_buds_capabilities_handler(
 }
 
 /// API v1 Swarm handler - for multi-node management
+/// Capability shares (0-15) from the individual capability booleans.
+/// Mirrors `NodeCapabilities::total_shares()` for the mesh-gossiped flags
+/// (Archive +5, Ghost Pay +4, Public Mining +3, Reaper +2, Elder +1).
+fn mesh_capability_shares(
+    archive: bool,
+    ghost_pay: bool,
+    public_mining: bool,
+    reaper: bool,
+    elder: bool,
+) -> u32 {
+    (archive as u32) * 5
+        + (ghost_pay as u32) * 4
+        + (public_mining as u32) * 3
+        + (reaper as u32) * 2
+        + (elder as u32)
+}
+
+/// Display name for a mesh node: the host portion of its advertised address,
+/// falling back to a short node-id label when no address has been gossiped yet.
+fn mesh_node_name(address: &str, node_id: &str) -> String {
+    let host = address.split(':').next().unwrap_or("").trim();
+    if !host.is_empty() {
+        host.to_string()
+    } else {
+        format!("node-{}", &node_id[..node_id.len().min(8)])
+    }
+}
+
+/// API v1 Swarm handler — the fleet view consumed by the dashboard Swarm page.
+///
+/// Auto-discovered mesh peers are reported with their REAL, health-ping-gossiped
+/// state (online/capabilities/hashrate/miner count) that this node already holds
+/// in the in-memory `PeerManager` — the exact source `/api/v1/pool/mesh-nodes`
+/// uses. Previously this handler returned each peer stripped down to its mesh
+/// address (`:8555`) with no `online` flag, so the dashboard rendered every mesh
+/// peer as "Offline" with zeroed stats even though the mesh reports them healthy.
+///
+/// Fields that are NOT gossiped per peer (uptime %, mesh peer count, L1/L2 chain
+/// heights, node balance) are deliberately OMITTED rather than sent as `0`, so
+/// the dashboard can render them as "—" instead of a misleading zero. Each node
+/// carries `"source": "mesh"` so the frontend can distinguish auto-discovered
+/// peers (never poll-able from here, so never "offline" just because their
+/// loopback dashboard API is unreachable) from any manually-added swarm node.
 async fn api_swarm_handler(State(state): State<Arc<VerificationState>>) -> impl IntoResponse {
     let health = state.get_health().await;
 
-    // Query database for connected peers
-    let (nodes, total) = if let Some(ref db) = state.database {
-        let peers = db.get_active_peers(50).unwrap_or_default();
-        let nodes_json: Vec<_> = peers
-            .iter()
-            .map(|p| {
-                serde_json::json!({
-                    "node_id": p.node_id.clone().unwrap_or_else(|| "unknown".to_string()),
-                    "address": format!("{}:{}", p.address, p.port),
-                    "last_seen": p.last_seen,
-                    "is_self": false
-                })
-            })
-            .collect();
-        let total = nodes_json.len() + 1; // +1 for self
-        (nodes_json, total)
-    } else {
-        (vec![], 1)
+    // Self node's public address (operator-configured host + HTTP port) and
+    // display name, read from the dashboard config in a single lock.
+    let (self_address, self_name) = {
+        let config = state.dashboard_config.read();
+        let addr = match config.stratum_host.clone() {
+            Some(host) if host.contains(':') => host,
+            Some(host) => format!("{host}:{}", config.http_port.unwrap_or(8080)),
+            None => String::new(),
+        };
+        let name = config
+            .node_name
+            .clone()
+            .filter(|n| !n.trim().is_empty())
+            .unwrap_or_else(|| mesh_node_name(&addr, &health.node_id));
+        (addr, name)
     };
+
+    let self_caps = &health.capabilities;
+    let self_hashrate = state.local_hashrate().unwrap_or(0.0);
+    let self_shares = mesh_capability_shares(
+        self_caps.archive_mode,
+        self_caps.ghost_pay,
+        self_caps.public_mining,
+        self_caps.reaper,
+        self_caps.elder_status,
+    );
+
+    let self_node = serde_json::json!({
+        "node_id": health.node_id.clone(),
+        "name": self_name.clone(),
+        "address": self_address.clone(),
+        // Self is serving this request, so it is online by definition.
+        "online": health.healthy,
+        "is_self": true,
+        "source": "mesh",
+        "version": health.version.clone(),
+        "hashrate_th": self_hashrate,
+        "miner_count": health.miner_count,
+        "shares": self_shares,
+        "max_shares": 15,
+        "archive_mode": self_caps.archive_mode,
+        "ghost_pay": self_caps.ghost_pay,
+        "public_mining": self_caps.public_mining,
+        "reaper": self_caps.reaper,
+        "elder": self_caps.elder_status,
+    });
+
+    let mut nodes = vec![self_node];
+    // Dedup by node_id; self is already in, so skip any peer that re-reports
+    // this node's id (e.g. a same-host placeholder).
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    seen.insert(health.node_id.clone());
+
+    let mut online_nodes: u32 = if health.healthy { 1 } else { 0 };
+    let mut combined_hashrate = self_hashrate;
+    let mut combined_shares = self_shares;
+
+    for peer in state.mesh_nodes() {
+        if !seen.insert(peer.node_id.clone()) {
+            continue;
+        }
+        let shares = mesh_capability_shares(
+            peer.cap_archive,
+            peer.cap_ghost_pay,
+            peer.cap_public_mining,
+            peer.cap_reaper,
+            peer.cap_elder,
+        );
+        if peer.healthy {
+            online_nodes += 1;
+        }
+        combined_hashrate += peer.hashrate_th;
+        combined_shares += shares;
+        nodes.push(serde_json::json!({
+            "node_id": peer.node_id,
+            "name": mesh_node_name(&peer.address, &peer.node_id),
+            "address": peer.address,
+            "online": peer.healthy,
+            "is_self": false,
+            "source": "mesh",
+            "hashrate_th": peer.hashrate_th,
+            "miner_count": peer.miner_count,
+            "shares": shares,
+            "max_shares": 15,
+            "archive_mode": peer.cap_archive,
+            "ghost_pay": peer.cap_ghost_pay,
+            "public_mining": peer.cap_public_mining,
+            "reaper": peer.cap_reaper,
+            "elder": peer.cap_elder,
+        }));
+    }
+
+    let total_nodes = nodes.len() as u32;
 
     Json(serde_json::json!({
         "enabled": true,
-        "node_id": health.node_id,
+        "node_id": health.node_id.clone(),
         "self": {
             "node_id": health.node_id,
+            "name": self_name,
+            "address": self_address,
             "version": health.version,
-            "capabilities": health.capabilities
+            "capabilities": health.capabilities,
         },
         "nodes": nodes,
-        "total": total
+        "total": total_nodes,
+        "stats": {
+            "total_nodes": total_nodes,
+            "online_nodes": online_nodes,
+            "offline_nodes": total_nodes.saturating_sub(online_nodes),
+            "combined_hashrate_th": combined_hashrate,
+            "combined_shares": combined_shares,
+            "max_combined_shares": total_nodes * 15,
+        },
     }))
 }
 
@@ -8129,6 +8256,35 @@ mod tests {
         assert_eq!(v["miner_count"], 0);
         assert_eq!(v["healthy"], false);
         assert!(v["capabilities"].is_object());
+    }
+
+    #[test]
+    fn test_mesh_capability_shares() {
+        // Full stack: 5 + 4 + 3 + 2 + 1 = 15.
+        assert_eq!(mesh_capability_shares(true, true, true, true, true), 15);
+        // None: 0.
+        assert_eq!(mesh_capability_shares(false, false, false, false, false), 0);
+        // Ghost Pay (+4) + Public Mining (+3) + Reaper (+2) + Elder (+1) = 10,
+        // matching the observed production self-node total.
+        assert_eq!(mesh_capability_shares(false, true, true, true, true), 10);
+        // Individual weights.
+        assert_eq!(mesh_capability_shares(true, false, false, false, false), 5);
+        assert_eq!(mesh_capability_shares(false, false, false, false, true), 1);
+    }
+
+    #[test]
+    fn test_mesh_node_name_uses_host() {
+        // Host portion of an advertised address.
+        assert_eq!(
+            mesh_node_name("83.136.251.162:8559", "abcdef0123456789"),
+            "83.136.251.162"
+        );
+        // No port.
+        assert_eq!(mesh_node_name("myhost", "abcdef0123456789"), "myhost");
+        // No address gossiped yet -> short node-id label.
+        assert_eq!(mesh_node_name("", "abcdef0123456789"), "node-abcdef01");
+        // Address that is only a port marker (":8555") also degrades to the id.
+        assert_eq!(mesh_node_name(":8555", "abcdef0123456789"), "node-abcdef01");
     }
 
     /// Stage C task 3 — sync endpoint round-trip:

--- a/dashboard/src/app/(dashboard)/swarm/page.tsx
+++ b/dashboard/src/app/(dashboard)/swarm/page.tsx
@@ -42,6 +42,21 @@ function formatHashrate(th: number): string {
   return `${th.toFixed(0)} TH/s`;
 }
 
+// Em-dash placeholder for values a mesh peer does not gossip (uptime %, mesh
+// peer count, L1/L2 heights, balance). These are genuinely unknown from here,
+// so we render "—" rather than a misleading 0.
+const NO_VALUE = "—";
+
+function orDash<T>(value: T | null | undefined, fmt: (v: T) => string): string {
+  return value === null || value === undefined ? NO_VALUE : fmt(value);
+}
+
+// An auto-discovered consensus mesh peer: status is sourced from health-ping
+// gossip, so it is authoritative and cannot be polled/removed from here.
+function isMeshNode(node: SwarmNode): boolean {
+  return node.source === "mesh" && !node.is_self;
+}
+
 function getAlertIcon(severity: "info" | "warning" | "error"): string {
   switch (severity) {
     case "error":
@@ -173,7 +188,11 @@ export default function SwarmPage() {
   };
 
   const handleRefreshAll = async (showToast = true) => {
-    const remoteNodes = nodes.filter(n => n.address !== "localhost");
+    // Only manually-added remote nodes are polled via their dashboard API.
+    // Mesh peers are gossip-sourced (useSwarm refetches them every 10s), so
+    // there is nothing to poll — and their loopback dashboards are unreachable
+    // from here anyway.
+    const remoteNodes = nodes.filter(n => n.address !== "localhost" && !isMeshNode(n));
 
     if (isRefreshing) return;
     setIsRefreshing(true);
@@ -225,8 +244,8 @@ export default function SwarmPage() {
 
   // Auto-refresh all nodes every 30 seconds
   useEffect(() => {
-    // Only set up interval once we have remote nodes
-    const remoteNodes = nodes.filter(n => n.address !== "localhost");
+    // Only poll manually-added remote nodes; mesh peers are gossip-sourced.
+    const remoteNodes = nodes.filter(n => n.address !== "localhost" && !isMeshNode(n));
     if (remoteNodes.length === 0) return;
 
     const doRefresh = async () => {
@@ -389,10 +408,14 @@ export default function SwarmPage() {
               <div className="p-3 bg-gray-800/50 rounded-lg">
                 <div className="text-xs text-gray-500 uppercase tracking-wide mb-1">Connection Address</div>
                 <div className="font-mono text-sm text-gray-100 mb-2 select-all">
-                  http://&lt;your-ip&gt;:8080
+                  {swarmData?.self?.address
+                    ? `http://${swarmData.self.address}`
+                    : "http://<your-ip>:8080"}
                 </div>
                 <p className="text-xs text-gray-500">
-                  Replace &lt;your-ip&gt; with your public IP or hostname. Other nodes can add this address to their swarm.
+                  {swarmData?.self?.address
+                    ? "Other nodes can add this address to their swarm."
+                    : "Template — replace <your-ip> with your public IP or hostname, then other nodes can add this address to their swarm."}
                 </p>
               </div>
             </div>
@@ -430,6 +453,11 @@ export default function SwarmPage() {
                     <Badge variant={node.online ? "success" : "error"} className="text-xs">
                       {node.online ? "Online" : "Offline"}
                     </Badge>
+                    {isMeshNode(node) && (
+                      <Badge variant="info" className="text-xs">
+                        Mesh
+                      </Badge>
+                    )}
                     {staleNodeIds.has(node.node_id) && (
                       <Badge variant="warning" className="text-xs">
                         Stale
@@ -451,19 +479,19 @@ export default function SwarmPage() {
                 <div className="grid grid-cols-2 gap-2 text-xs mb-3">
                   <div>
                     <span className="text-gray-500">L1:</span>{" "}
-                    <span className="text-gray-300">{(node.l1_height ?? 0).toLocaleString()}</span>
+                    <span className="text-gray-300">{orDash(node.l1_height, (v) => v.toLocaleString())}</span>
                   </div>
                   <div>
                     <span className="text-gray-500">L2:</span>{" "}
-                    <span className="text-gray-300">{(node.l2_height ?? 0).toLocaleString()}</span>
+                    <span className="text-gray-300">{orDash(node.l2_height, (v) => v.toLocaleString())}</span>
                   </div>
                   <div>
                     <span className="text-gray-500">Peers:</span>{" "}
-                    <span className="text-gray-300">{node.peer_count ?? 0}</span>
+                    <span className="text-gray-300">{orDash(node.peer_count, (v) => String(v))}</span>
                   </div>
                   <div>
                     <span className="text-gray-500">Shares:</span>{" "}
-                    <span className="text-gray-300">{node.shares ?? 0}/{node.max_shares ?? 0}</span>
+                    <span className="text-gray-300">{node.shares ?? 0}/{node.max_shares ?? 15}</span>
                   </div>
                 </div>
 
@@ -479,12 +507,12 @@ export default function SwarmPage() {
                   <Button variant="ghost" size="sm" onClick={() => handleEditClick(node)} className="text-xs px-2">
                     Edit
                   </Button>
-                  {node.address !== "localhost" && (
+                  {node.address !== "localhost" && !isMeshNode(node) && (
                     <Button variant="ghost" size="sm" onClick={() => handleRefreshNode(node)} className="text-xs px-2">
                       Refresh
                     </Button>
                   )}
-                  {node.address !== "localhost" && (
+                  {node.address !== "localhost" && !isMeshNode(node) && (
                     <Button variant="danger" size="sm" onClick={() => handleRemoveNode(node)} className="text-xs px-2">
                       Remove
                     </Button>
@@ -512,6 +540,9 @@ export default function SwarmPage() {
                         <Badge variant={node.online ? "success" : "error"}>
                           {node.online ? "Online" : "Offline"}
                         </Badge>
+                        {isMeshNode(node) && (
+                          <Badge variant="info">Mesh</Badge>
+                        )}
                         {staleNodeIds.has(node.node_id) && (
                           <Badge variant="warning">Stale</Badge>
                         )}
@@ -528,10 +559,10 @@ export default function SwarmPage() {
                   </div>
                   <div className="text-right">
                     <div className="text-lg font-bold text-gray-100">
-                      {formatBtc(node.balance_btc ?? 0)} BTC
+                      {orDash(node.balance_btc, (v) => `${formatBtc(v)} BTC`)}
                     </div>
                     <div className="text-sm text-gray-400">
-                      {node.shares ?? 0}/{node.max_shares ?? 0} shares
+                      {node.shares ?? 0}/{node.max_shares ?? 15} shares
                     </div>
                   </div>
                 </div>
@@ -541,27 +572,29 @@ export default function SwarmPage() {
                     <span className="text-gray-500">Uptime</span>
                     <div
                       className={`font-medium ${
-                        (node.uptime_percent ?? 0) >= 95
-                          ? "text-green-400"
-                          : (node.uptime_percent ?? 0) >= 90
-                            ? "text-yellow-400"
-                            : "text-red-400"
+                        node.uptime_percent === undefined || node.uptime_percent === null
+                          ? "text-gray-400"
+                          : node.uptime_percent >= 95
+                            ? "text-green-400"
+                            : node.uptime_percent >= 90
+                              ? "text-yellow-400"
+                              : "text-red-400"
                       }`}
                     >
-                      {formatUptime(node.uptime_percent ?? 0)}
+                      {orDash(node.uptime_percent, formatUptime)}
                     </div>
                   </div>
                   <div>
                     <span className="text-gray-500">Peers</span>
-                    <div className="text-gray-100">{node.peer_count ?? 0}</div>
+                    <div className="text-gray-100">{orDash(node.peer_count, (v) => String(v))}</div>
                   </div>
                   <div>
                     <span className="text-gray-500">L1 Height</span>
-                    <div className="text-gray-100 font-mono">{(node.l1_height ?? 0).toLocaleString()}</div>
+                    <div className="text-gray-100 font-mono">{orDash(node.l1_height, (v) => v.toLocaleString())}</div>
                   </div>
                   <div>
                     <span className="text-gray-500">L2 Height</span>
-                    <div className="text-gray-100 font-mono">{(node.l2_height ?? 0).toLocaleString()}</div>
+                    <div className="text-gray-100 font-mono">{orDash(node.l2_height, (v) => v.toLocaleString())}</div>
                   </div>
                 </div>
 
@@ -591,7 +624,7 @@ export default function SwarmPage() {
                   >
                     Restart
                   </Button>
-                  {node.address !== "localhost" && (
+                  {node.address !== "localhost" && !isMeshNode(node) && (
                     <Button
                       variant="ghost"
                       size="sm"
@@ -601,7 +634,7 @@ export default function SwarmPage() {
                       Refresh
                     </Button>
                   )}
-                  {node.address !== "localhost" && (
+                  {node.address !== "localhost" && !isMeshNode(node) && (
                     <Button
                       variant="danger"
                       size="sm"

--- a/dashboard/src/types/api.ts
+++ b/dashboard/src/types/api.ts
@@ -684,6 +684,11 @@ export interface SwarmNode {
   is_self?: boolean;
   version?: string;
   last_seen?: number;
+  // Origin of this entry: "mesh" = auto-discovered consensus peer whose status
+  // comes from health-ping gossip (never poll-able from here, so never shown
+  // "offline" merely because its dashboard API is unreachable); "manual" (or
+  // undefined) = an operator-added node polled via its own dashboard API.
+  source?: "mesh" | "manual";
   // Capability fields
   shares?: number;
   max_shares?: number;
@@ -692,6 +697,7 @@ export interface SwarmNode {
   balance_btc?: number;
   l1_height?: number;
   l2_height?: number;
+  miner_count?: number;
   archive_mode?: boolean;
   ghost_pay?: boolean;
   public_mining?: boolean;


### PR DESCRIPTION
Swarm page showed the auto-discovered consensus mesh peers as Offline/0 because `api_swarm_handler` returned them with no `online`/stats fields (frontend defaulted to Offline). node1 already holds each peer's real state in PeerManager (healthy, capabilities, hashrate — same as /api/v1/pool/mesh-nodes). Rewrote the handler to source from `mesh_nodes()` (real online/capabilities/hashrate/shares, ungossiped fields omitted as '—' not 0) + frontend renders a Mesh badge, stops polling/removing gossip peers, and populates the self address. Distinguishes mesh vs manually-added nodes. 131+3 tests pass. Backend half needs the ghost-pool redeploy.