### PR TITLE
feat(pool): best-hash returns real per-window miner shares, not the chain tip

### DIFF
--- a/crates/ghost-storage/src/models.rs
+++ b/crates/ghost-storage/src/models.rs
@@ -60,6 +60,10 @@ pub struct BestShare {
     pub timestamp: i64,
     /// Claimed share difficulty at submission time.
     pub difficulty: f64,
+    /// Block height of the round the share belongs to, resolved via the
+    /// share's `round_id` against the `rounds` table. `None` when the round
+    /// row is absent (e.g. a share recorded before its round was persisted).
+    pub block_height: Option<u64>,
 }
 
 /// Round record

--- a/crates/ghost-storage/src/queries.rs
+++ b/crates/ghost-storage/src/queries.rs
@@ -600,27 +600,67 @@ impl Database {
                     // Only real `address.worker` miners so the best share is
                     // attributed to the miner, not its bare hex(SHA256(id))
                     // gossip-ledger twin (see get_leaderboard_best_hash).
-                    "SELECT share_hash, miner_id, timestamp, difficulty
-                     FROM shares
-                     WHERE timestamp >= ?1 AND valid = 1 AND instr(miner_id, '.') > 0
-                     ORDER BY share_hash ASC
+                    // LEFT JOIN rounds resolves the share's block height from
+                    // its round_id (NULL if the round row isn't persisted).
+                    "SELECT s.share_hash, s.miner_id, s.timestamp, s.difficulty, r.block_height
+                     FROM shares s
+                     LEFT JOIN rounds r ON r.round_id = s.round_id
+                     WHERE s.timestamp >= ?1 AND s.valid = 1 AND instr(s.miner_id, '.') > 0
+                     ORDER BY s.share_hash ASC
                      LIMIT 1",
                 )
                 .map_err(|e| GhostError::Database(e.to_string()))?;
 
             let row = stmt
-                .query_row(params![since_ts], |row| {
-                    Ok(crate::models::BestShare {
-                        share_hash: row.get(0)?,
-                        miner_id: row.get(1)?,
-                        timestamp: row.get(2)?,
-                        difficulty: row.get(3)?,
-                    })
-                })
+                .query_row(params![since_ts], Self::map_best_share)
                 .optional()
                 .map_err(|e| GhostError::Database(e.to_string()))?;
 
             Ok(row)
+        })
+    }
+
+    /// Find the best (lowest-value hex, most-leading-zeros) valid share in a
+    /// specific round. Backs the "current round" best-hash window, which is
+    /// scoped by `round_id` rather than a timestamp cutoff so it tracks the
+    /// live round exactly. Returns `None` if the round has no real-miner
+    /// shares yet.
+    pub fn get_best_share_in_round(
+        &self,
+        round_id: u64,
+    ) -> GhostResult<Option<crate::models::BestShare>> {
+        self.with_connection(|conn| {
+            let mut stmt = conn
+                .prepare(
+                    // Same real-miner filter as get_best_share_since; scoped
+                    // to a single round instead of a time window.
+                    "SELECT s.share_hash, s.miner_id, s.timestamp, s.difficulty, r.block_height
+                     FROM shares s
+                     LEFT JOIN rounds r ON r.round_id = s.round_id
+                     WHERE s.round_id = ?1 AND s.valid = 1 AND instr(s.miner_id, '.') > 0
+                     ORDER BY s.share_hash ASC
+                     LIMIT 1",
+                )
+                .map_err(|e| GhostError::Database(e.to_string()))?;
+
+            let row = stmt
+                .query_row(params![round_id], Self::map_best_share)
+                .optional()
+                .map_err(|e| GhostError::Database(e.to_string()))?;
+
+            Ok(row)
+        })
+    }
+
+    /// Row mapper shared by the best-share queries: columns must be
+    /// `(share_hash, miner_id, timestamp, difficulty, block_height)`.
+    fn map_best_share(row: &rusqlite::Row) -> rusqlite::Result<crate::models::BestShare> {
+        Ok(crate::models::BestShare {
+            share_hash: row.get(0)?,
+            miner_id: row.get(1)?,
+            timestamp: row.get(2)?,
+            difficulty: row.get(3)?,
+            block_height: row.get::<_, Option<i64>>(4)?.map(|h| h as u64),
         })
     }
 
@@ -10500,6 +10540,97 @@ mod tests {
             .expect("recent");
         assert_eq!(recent.len(), 1, "quasar feed must exclude the gossip twin");
         assert_eq!(recent[0].0, "bc1qexampleaddr.bitaxe3");
+    }
+
+    #[test]
+    fn test_best_share_per_window_and_round_scoping() {
+        // Backs the /api/v1/mining/best-hash per-window records. Each window
+        // must resolve the rarest real-miner share within it (not the chain
+        // tip), attach the round's block height, and scope "current round"
+        // strictly by round_id.
+        let db = Database::in_memory().expect("create in-memory db");
+        let now_s = chrono::Utc::now().timestamp();
+
+        let round = |round_id: u64, block_height: u64| RoundRecord {
+            round_id,
+            block_height,
+            block_hash: None,
+            start_time: now_s - 100_000,
+            end_time: None,
+            total_shares: 0,
+            total_work: 0.0,
+            winning_miner: None,
+            found_by_node: None,
+            payout_status: PayoutStatus::Active,
+            subsidy_sats: None,
+            tx_fees_sats: None,
+        };
+        db.create_round(&round(1, 500)).expect("round 1");
+        db.create_round(&round(2, 501)).expect("round 2");
+
+        let share = |round_id: u64, miner_id: &str, hash: &str, ts: i64| ShareRecord {
+            id: None,
+            round_id,
+            miner_id: miner_id.to_string(),
+            difficulty: 1000.0,
+            work: 1000.0,
+            share_hash: hash.to_string(),
+            timestamp: ts,
+            received_by: "node1".to_string(),
+            valid: true,
+        };
+
+        // Round 1 (old): a very rare all-time-best share, ~30h ago so it falls
+        // OUTSIDE the last-24h and last-hour windows.
+        db.insert_share(&share(
+            1,
+            "bc1qminerA.w1",
+            "0000000000000000000000000000000000000000000000000000000000000abc",
+            now_s - 108_000,
+        ))
+        .expect("insert old best");
+        // Round 2 (current): a weaker share within the last hour.
+        db.insert_share(&share(
+            2,
+            "bc1qminerB.w1",
+            "00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+            now_s - 600,
+        ))
+        .expect("insert recent");
+        // A gossip-ledger twin (bare hex id, no '.') that is numerically the
+        // rarest of all — it must be excluded from every window.
+        db.insert_share(&share(
+            2,
+            "deadbeefcafef00d",
+            "0000000000000000000000000000000000000000000000000000000000000001",
+            now_s - 600,
+        ))
+        .expect("insert gossip twin");
+
+        // All-time picks the rarest real share (round 1) and resolves its
+        // block height via the round join.
+        let all_time = db.get_best_share_since(0).expect("all-time").unwrap();
+        assert_eq!(all_time.miner_id, "bc1qminerA.w1");
+        assert_eq!(all_time.block_height, Some(500));
+
+        // Last hour excludes the 30h-old round-1 share, so miner B wins.
+        let last_hour = db
+            .get_best_share_since(now_s - 3_600)
+            .expect("last-hour")
+            .unwrap();
+        assert_eq!(last_hour.miner_id, "bc1qminerB.w1");
+        assert_eq!(last_hour.block_height, Some(501));
+
+        // Current round is scoped by round_id: round 2 sees only miner B, and
+        // round 1 sees only miner A — neither leaks across, and the gossip
+        // twin never appears.
+        let cur2 = db.get_best_share_in_round(2).expect("round 2").unwrap();
+        assert_eq!(cur2.miner_id, "bc1qminerB.w1");
+        let cur1 = db.get_best_share_in_round(1).expect("round 1").unwrap();
+        assert_eq!(cur1.miner_id, "bc1qminerA.w1");
+
+        // A round with no shares yields None (frontend renders "No data yet").
+        assert!(db.get_best_share_in_round(99).expect("empty").is_none());
     }
 
     #[test]

--- a/crates/ghost-verification/src/routes.rs
+++ b/crates/ghost-verification/src/routes.rs
@@ -4651,88 +4651,113 @@ fn classify_by_weight_heuristic(weight: u64) -> BudsTier {
 }
 
 /// API v1 Mining best-hash handler
+///
+/// Returns the best (rarest hash / highest achieved difficulty) SHARE
+/// submitted by a connected miner in each window — current round, last hour,
+/// last 24h and all time — NOT the network chain tip. Each window is resolved
+/// independently from this node's `shares` table, so a lucky share only counts
+/// for the windows it actually falls within. Windows with no real-miner share
+/// yet return a null entry (the frontend renders "No data yet").
 async fn api_mining_best_hash_handler(
     State(state): State<Arc<VerificationState>>,
 ) -> impl IntoResponse {
     let health = state.get_health().await;
 
-    // Query Ghost Core for best block hash and blockchain info (5s timeout)
-    if let Some(ref rpc) = state.rpc {
-        let rpc_data = tokio::time::timeout(std::time::Duration::from_secs(5), async {
-            let best_hash = rpc.get_best_block_hash().await.ok();
-            let (difficulty, chain) = match rpc.get_blockchain_info().await {
-                Ok(info) => (info.difficulty, info.chain),
-                Err(_) => (0.0, "unknown".to_string()),
-            };
-            let network_hashrate = match rpc.get_mining_info().await {
-                Ok(info) => info.networkhashps,
-                Err(_) => 0.0,
-            };
-            (best_hash, difficulty, chain, network_hashrate)
+    let null_entry = || {
+        serde_json::json!({
+            "hash": null,
+            "difficulty": 0,
+            "timestamp": 0,
+            "miner_id": null,
+            "block_height": null
         })
-        .await;
+    };
 
-        if let Ok((best_hash, difficulty, chain, network_hashrate)) = rpc_data {
-            let now = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_secs();
+    let Some(ref db) = state.database else {
+        // No local DB — cannot attribute per-miner shares. Return empty
+        // windows rather than the misleading chain tip.
+        return Json(serde_json::json!({
+            "current_round": null_entry(),
+            "last_round": null_entry(),
+            "last_hour": null_entry(),
+            "last_24h": null_entry(),
+            "all_time": null_entry(),
+            "best_hash": null,
+            "best_difficulty": 0,
+            "block_height": health.block_height,
+            "round_id": health.round_id,
+            "message": "Database not available"
+        }));
+    };
 
-            let entry = serde_json::json!({
-                "hash": best_hash,
-                "difficulty": difficulty,
-                "timestamp": now,
-                "miner_id": null,
-                "block_height": health.block_height
-            });
+    let now_s = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i64;
 
-            let null_entry = serde_json::json!({
-                "hash": null,
-                "difficulty": 0,
-                "timestamp": 0,
-                "miner_id": null,
-                "block_height": 0
-            });
+    // Convert a stored best share into the dashboard entry shape. The
+    // displayed `difficulty` is the ACHIEVED difficulty derived from the
+    // hash (how good the share actually was), matching the pool records /
+    // leaderboard endpoints — the stored `difficulty` column is only the
+    // vardiff target. The miner_id is redacted for public display but stays
+    // non-null so the frontend can tell a real share from the old chain-tip
+    // placeholder.
+    let to_entry = |best: Option<ghost_storage::models::BestShare>| match best {
+        Some(b) => serde_json::json!({
+            "hash": b.share_hash,
+            "difficulty": share_difficulty_from_hash_hex(&b.share_hash),
+            "timestamp": b.timestamp,
+            "miner_id": redact_miner_id(&b.miner_id),
+            "block_height": b.block_height,
+        }),
+        None => null_entry(),
+    };
 
-            return Json(serde_json::json!({
-                // Dashboard-compatible per-timerange format
-                "current_round": entry,
-                "last_round": null_entry,
-                "last_hour": entry,
-                "last_24h": entry,
-                "all_time": entry,
-                // Raw fields for backwards compat
-                "best_hash": best_hash,
-                "best_difficulty": difficulty,
-                "network_hashrate": network_hashrate,
-                "block_height": health.block_height,
-                "round_id": health.round_id,
-                "chain": chain
-            }));
-        }
-        // Timeout — fall through to fallback
-    }
+    // Per-window best shares. Current round is scoped by round_id so it tracks
+    // the live round exactly; the time windows use timestamp cutoffs; all-time
+    // uses a zero cutoff (every retained share).
+    let current_round = to_entry(db.get_best_share_in_round(health.round_id).unwrap_or(None));
+    let last_hour = to_entry(db.get_best_share_since(now_s - 3_600).unwrap_or(None));
+    let last_24h = to_entry(db.get_best_share_since(now_s - 86_400).unwrap_or(None));
+    let all_time_best = db.get_best_share_since(0).unwrap_or(None);
 
-    let null_entry = serde_json::json!({
-        "hash": null,
-        "difficulty": 0,
-        "timestamp": 0,
-        "miner_id": null,
-        "block_height": 0
-    });
+    // Raw back-compat fields mirror the all-time best share (achieved score).
+    let (best_hash, best_difficulty) = match &all_time_best {
+        Some(b) => (
+            Some(b.share_hash.clone()),
+            share_difficulty_from_hash_hex(&b.share_hash),
+        ),
+        None => (None, 0.0),
+    };
+    let all_time = to_entry(all_time_best);
 
-    // Fallback
+    // Best-effort network context (never blocks the per-window share data).
+    let (network_hashrate, chain) = if let Some(ref rpc) = state.rpc {
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            let network_hashrate = rpc.get_mining_info().await.map(|i| i.networkhashps).ok();
+            let chain = rpc.get_blockchain_info().await.map(|i| i.chain).ok();
+            (network_hashrate, chain)
+        })
+        .await
+        .unwrap_or((None, None))
+    } else {
+        (None, None)
+    };
+
     Json(serde_json::json!({
-        "current_round": null_entry,
-        "last_round": null_entry,
-        "last_hour": null_entry,
-        "last_24h": null_entry,
-        "all_time": null_entry,
-        "best_hash": null,
-        "best_difficulty": 0,
+        // Dashboard-compatible per-window format
+        "current_round": current_round,
+        "last_round": null_entry(),
+        "last_hour": last_hour,
+        "last_24h": last_24h,
+        "all_time": all_time,
+        // Raw fields for backwards compat (all-time best miner share)
+        "best_hash": best_hash,
+        "best_difficulty": best_difficulty,
+        "network_hashrate": network_hashrate,
         "block_height": health.block_height,
         "round_id": health.round_id,
-        "message": "Ghost Core RPC not configured"
+        "chain": chain
     }))
 }
 


### PR DESCRIPTION
`api_mining_best_hash_handler` was pulling the chain tip via RPC and duplicating it across all four windows (miner_id null, network difficulty). Now reads the shares table: added `get_best_share_in_round` + a rounds-join for block height, and the handler populates current_round/last_hour/last_24h/all_time from real per-window best miner shares (achieved difficulty from the stored hash, non-null miner_id, real leading-zeros). Empty windows return null, not the tip. Tests green (+ new per-window/round-scoping test). Needs the ghost-pool redeploy.