### PR TITLE
feat(pool): deduped per-node miner counts in mesh capacity data

### DIFF
--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -5774,9 +5774,15 @@ async fn main() -> Result<()> {
     );
 
     // Wire pool-peers callback for the translator load-balancer endpoint.
+    // `deduped_miner_count` is the per-node share of the mesh-wide active-miner
+    // total (attributed over the same 300s window as `mesh_active_miners`), so
+    // the Capacity page's per-node rows sum to the deduped grand total instead
+    // of over-counting miners that fail over between nodes. The raw
+    // `miner_count` is left untouched for the LB's utilisation routing.
     let mesh_for_pool_peers = Arc::clone(&mesh);
     verification_state = verification_state.with_pool_peers(move || {
         use ghost_verification::PoolPeerInfo;
+        let deduped = mesh_for_pool_peers.deduped_miner_counts(300);
         mesh_for_pool_peers
             .peers()
             .get_connected_peers(30)
@@ -5788,6 +5794,7 @@ async fn main() -> Result<()> {
                 public_mining: true,
                 last_seen: p.last_seen,
                 max_capacity: p.max_capacity,
+                deduped_miner_count: deduped.get(&p.node_id).copied().unwrap_or(0),
             })
             .collect()
     });
@@ -5801,6 +5808,9 @@ async fn main() -> Result<()> {
     let mesh_for_node_list = Arc::clone(&mesh);
     verification_state = verification_state.with_mesh_nodes(move || {
         use ghost_verification::MeshNodeInfo;
+        // Deduped per-node counts over the 300s active-miner window (matching
+        // the mesh grand total) so the mesh-nodes list sums consistently.
+        let deduped = mesh_for_node_list.deduped_miner_counts(300);
         mesh_for_node_list
             .peers()
             .get_connected_peers(120)
@@ -5816,6 +5826,7 @@ async fn main() -> Result<()> {
                 cap_elder: p.capabilities.elder_status,
                 hashrate_th: p.local_hashrate_th,
                 miner_count: p.miner_count,
+                deduped_miner_count: deduped.get(&p.node_id).copied().unwrap_or(0),
                 // get_connected_peers already filtered to Connected + fresh.
                 healthy: true,
             })
@@ -5837,6 +5848,18 @@ async fn main() -> Result<()> {
     let mesh_for_active = Arc::clone(&mesh);
     verification_state = verification_state
         .with_mesh_active_miners(move || mesh_for_active.mesh_active_miner_count(300) as u32);
+
+    // This node's (self) deduped share of that mesh-wide total, from the same
+    // attribution that fills each peer's `deduped_miner_count`. Surfaced on the
+    // self/`this_node` entries so `self + peers` sum to `mesh_active_miners`.
+    let mesh_for_self_deduped = Arc::clone(&mesh);
+    verification_state = verification_state.with_self_deduped_miner_count(move || {
+        let counts = mesh_for_self_deduped.deduped_miner_counts(300);
+        counts
+            .get(&mesh_for_self_deduped.peers().our_node_id())
+            .copied()
+            .unwrap_or(0)
+    });
 
     // Mesh-wide pool hashrate (TH/s) — sum of every node's own realized
     // hashrate (60s peer freshness). One term per node, scoped by received_by

--- a/crates/ghost-consensus/src/mesh.rs
+++ b/crates/ghost-consensus/src/mesh.rs
@@ -1128,6 +1128,34 @@ impl MeshNetwork {
         set.len()
     }
 
+    /// Deduplicated per-node active-miner counts across the mesh: every
+    /// connected peer within `freshness_secs` plus this node (self). Each unique
+    /// miner-id hash is attributed to exactly one node by
+    /// [`attribute_miner_counts`](crate::peer::attribute_miner_counts), so the returned counts sum to
+    /// [`Self::mesh_active_miner_count`] for the same window — the grand total
+    /// the frontend shows. This dedupes the per-node breakdown served by the
+    /// capacity / pool-nodes / mesh-nodes endpoints, whose raw per-peer
+    /// `miner_count`s double-count miners that fail over between nodes.
+    ///
+    /// Keyed by `NodeId`; self is keyed by our own node id. Self is given a
+    /// `last_seen` of "now" so a miner active locally right now is attributed
+    /// here rather than to a peer whose activity window is going stale. A node
+    /// absent from the map owns zero deduped miners.
+    pub fn deduped_miner_counts(&self, freshness_secs: u64) -> HashMap<NodeId, u32> {
+        let mut inputs: Vec<(NodeId, u64, Vec<[u8; 16]>)> = Vec::new();
+        let now = chrono::Utc::now().timestamp() as u64;
+        let local_hashes = self
+            .active_miner_hashes_fn
+            .as_ref()
+            .map(|f| f())
+            .unwrap_or_default();
+        inputs.push((self.peers.our_node_id(), now, local_hashes));
+        for peer in self.peers.get_connected_peers(freshness_secs) {
+            inputs.push((peer.node_id, peer.last_seen, peer.active_miner_id_hashes));
+        }
+        crate::peer::attribute_miner_counts(&inputs)
+    }
+
     /// Set a callback providing this node's own realized hashrate (TH/s) over a
     /// trailing window, gossiped in health pings for mesh-wide summation.
     pub fn set_local_hashrate_provider(&mut self, f: Arc<dyn Fn() -> f64 + Send + Sync>) {

--- a/crates/ghost-consensus/src/peer.rs
+++ b/crates/ghost-consensus/src/peer.rs
@@ -96,6 +96,51 @@ fn extract_ipv4_subnet(address: &str) -> Option<String> {
 /// Limits eclipse attack surface while allowing legitimate multi-node operators.
 const MAX_PEERS_PER_SUBNET: usize = 3;
 
+/// Attribute each unique active miner-id hash to exactly one node so the
+/// per-node counts sum to the mesh-wide unique total (the same union
+/// [`MeshNetwork::mesh_active_miner_count`](crate::mesh::MeshNetwork) reports as
+/// the grand total).
+///
+/// A miner that fails over between nodes is gossiped in more than one node's
+/// `active_miner_id_hashes`, so a naive per-node sum of the raw `miner_count`s
+/// over-counts it (e.g. `0+2+1+4` reads as 7 while the deduplicated union is 6).
+/// To dedupe the per-node breakdown, each unique hash is attributed to a single
+/// owner:
+///
+///   - the node reporting it with the most recent `last_seen` (freshest gossip
+///     wins — the miner is most likely currently mining on that node);
+///   - ties broken by the lexicographically smallest `node_id`.
+///
+/// Both keys are deterministic, so every node computing this over the same peer
+/// set derives the identical attribution. Input is one `(node_id, last_seen,
+/// hashes)` triple per node (peers plus self); output maps `node_id -> deduped
+/// count`. A node that owns no hash is omitted (callers treat it as 0). The sum
+/// of all returned counts equals the number of distinct hashes across the
+/// input — i.e. the deduplicated mesh-wide active-miner total.
+pub fn attribute_miner_counts(nodes: &[(NodeId, u64, Vec<[u8; 16]>)]) -> HashMap<NodeId, u32> {
+    // Pass 1: resolve each hash's owner (max last_seen, tie -> min node_id).
+    let mut owner: HashMap<[u8; 16], (u64, NodeId)> = HashMap::new();
+    for (node_id, last_seen, hashes) in nodes {
+        for h in hashes {
+            let take = match owner.get(h) {
+                Some((seen, owner_id)) => {
+                    last_seen > seen || (last_seen == seen && node_id < owner_id)
+                }
+                None => true,
+            };
+            if take {
+                owner.insert(*h, (*last_seen, *node_id));
+            }
+        }
+    }
+    // Pass 2: tally one count per owning node.
+    let mut counts: HashMap<NodeId, u32> = HashMap::new();
+    for (_, owner_id) in owner.into_values() {
+        *counts.entry(owner_id).or_insert(0) += 1;
+    }
+    counts
+}
+
 /// Peer manager for tracking connected peers
 #[derive(Debug)]
 pub struct PeerManager {
@@ -608,6 +653,74 @@ pub fn select_best_peers(peers: &[Peer], count: usize) -> Vec<&Peer> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // Helper: build a 16-byte miner-id hash from a single tag byte.
+    fn h(tag: u8) -> [u8; 16] {
+        [tag; 16]
+    }
+
+    #[test]
+    fn test_attribute_miner_counts_dedupes_overlap_to_union_size() {
+        // Three nodes whose active-miner sets OVERLAP because miners fail over
+        // between them. Raw per-node counts (3, 3, 2) sum to 8, but the union
+        // of distinct hashes is {1,2,3,4,5} = 5. The deduped per-node counts
+        // must sum to exactly 5 — the same figure `mesh_active_miner_count`
+        // reports as the grand total.
+        let node_a = [0xAAu8; 32];
+        let node_b = [0xBBu8; 32];
+        let node_c = [0xCCu8; 32];
+
+        let nodes = vec![
+            // node_a seen most recently (t=300) — wins every hash it shares.
+            (node_a, 300u64, vec![h(1), h(2), h(3)]),
+            // node_b shares 2 and 3 with A, plus its own 4.
+            (node_b, 200u64, vec![h(2), h(3), h(4)]),
+            // node_c shares 3 with A/B, plus its own 5.
+            (node_c, 100u64, vec![h(3), h(5)]),
+        ];
+
+        let counts = attribute_miner_counts(&nodes);
+
+        // Sum equals the union size (deduped total).
+        let total: u32 = counts.values().sum();
+        assert_eq!(total, 5, "deduped per-node counts must sum to the union size");
+
+        // Freshest node (A, t=300) owns all three of its hashes (1,2,3).
+        assert_eq!(counts.get(&node_a).copied().unwrap_or(0), 3);
+        // B owns only its unique 4 (2 and 3 went to fresher A).
+        assert_eq!(counts.get(&node_b).copied().unwrap_or(0), 1);
+        // C owns only its unique 5 (3 went to fresher A).
+        assert_eq!(counts.get(&node_c).copied().unwrap_or(0), 1);
+    }
+
+    #[test]
+    fn test_attribute_miner_counts_tie_breaks_on_smallest_node_id() {
+        // Equal `last_seen`: the shared hash must go to the lexicographically
+        // smallest node_id, deterministically, so every node computing this
+        // agrees. node_lo < node_hi, both report hash 7 at t=50.
+        let node_lo = [0x01u8; 32];
+        let node_hi = [0x02u8; 32];
+        let nodes = vec![
+            (node_hi, 50u64, vec![h(7), h(8)]),
+            (node_lo, 50u64, vec![h(7), h(9)]),
+        ];
+
+        let counts = attribute_miner_counts(&nodes);
+        // Union {7,8,9} = 3.
+        assert_eq!(counts.values().sum::<u32>(), 3);
+        // Shared 7 attributed to the smaller id (lo), so lo=2 (7,9), hi=1 (8).
+        assert_eq!(counts.get(&node_lo).copied().unwrap_or(0), 2);
+        assert_eq!(counts.get(&node_hi).copied().unwrap_or(0), 1);
+    }
+
+    #[test]
+    fn test_attribute_miner_counts_empty_and_single() {
+        assert!(attribute_miner_counts(&[]).is_empty());
+        let only = [0x09u8; 32];
+        let counts = attribute_miner_counts(&[(only, 10, vec![h(1), h(2)])]);
+        assert_eq!(counts.get(&only).copied().unwrap_or(0), 2);
+        assert_eq!(counts.values().sum::<u32>(), 2);
+    }
 
     #[test]
     fn test_peer_manager() {

--- a/crates/ghost-verification/src/routes.rs
+++ b/crates/ghost-verification/src/routes.rs
@@ -2393,6 +2393,7 @@ fn mesh_node_to_json(node: &MeshNodeInfo) -> serde_json::Value {
         },
         "hashrate_th": node.hashrate_th,
         "miner_count": node.miner_count,
+        "deduped_miner_count": node.deduped_miner_count,
         "healthy": node.healthy,
         "is_self": false,
     })
@@ -2447,6 +2448,9 @@ async fn api_pool_mesh_nodes_handler(
         // 0.0 on deploys without the local-hashrate provider wired.
         "hashrate_th": state.local_hashrate().unwrap_or(0.0),
         "miner_count": health.miner_count,
+        // Deduped share attributed to this node (see `deduped_miner_counts`);
+        // self + peers sum to the deduped mesh-wide active-miner total.
+        "deduped_miner_count": state.self_deduped_miner_count(),
         // Self is serving this request, so it is healthy by definition.
         "healthy": true,
         "is_self": true,
@@ -7500,6 +7504,9 @@ async fn pool_nodes_handler(State(state): State<Arc<VerificationState>>) -> impl
         "this_node": {
             "miner_count": state.miner_count(),
             "max_capacity": state.max_capacity(),
+            // Deduped share attributed to this node; `this_node` + every peer's
+            // `deduped_miner_count` sum to the deduped `mesh_active_miners`.
+            "deduped_miner_count": state.self_deduped_miner_count(),
         },
         "peers": state.pool_peers(),
     }))
@@ -8211,6 +8218,7 @@ mod tests {
             cap_elder: true,
             hashrate_th: 12.5,
             miner_count: 3,
+            deduped_miner_count: 2,
             healthy: true,
         };
 
@@ -8220,6 +8228,7 @@ mod tests {
         assert_eq!(v["elder"], true);
         assert_eq!(v["hashrate_th"], 12.5);
         assert_eq!(v["miner_count"], 3);
+        assert_eq!(v["deduped_miner_count"], 2);
         assert_eq!(v["healthy"], true);
         // Peers are never self.
         assert_eq!(v["is_self"], false);
@@ -8247,6 +8256,7 @@ mod tests {
             cap_elder: false,
             hashrate_th: 0.0,
             miner_count: 0,
+            deduped_miner_count: 0,
             healthy: false,
         };
 
@@ -8254,6 +8264,7 @@ mod tests {
         assert_eq!(v["address"], "");
         assert_eq!(v["hashrate_th"], 0.0);
         assert_eq!(v["miner_count"], 0);
+        assert_eq!(v["deduped_miner_count"], 0);
         assert_eq!(v["healthy"], false);
         assert!(v["capabilities"].is_object());
     }

--- a/crates/ghost-verification/src/server.rs
+++ b/crates/ghost-verification/src/server.rs
@@ -864,6 +864,16 @@ pub struct PoolPeerInfo {
     /// reported it yet (treated as "unknown" / excluded from routing).
     #[serde(default)]
     pub max_capacity: u32,
+    /// Deduplicated share of the mesh-wide active-miner total attributed to
+    /// this peer: each unique miner-id hash is owned by exactly one node
+    /// (freshest gossip wins, ties by node id), so summing this across all
+    /// nodes (self + peers) equals the deduped `mesh_active_miners` grand total.
+    /// The raw `miner_count` above is kept unchanged for the translator load
+    /// balancer (utilisation = miner_count / max_capacity); this field is for
+    /// the Capacity page's per-node breakdown, which must not double-count a
+    /// miner that fails over between nodes.
+    #[serde(default)]
+    pub deduped_miner_count: u32,
 }
 
 /// One mesh node as surfaced by the public `/api/v1/pool/mesh-nodes`
@@ -901,6 +911,12 @@ pub struct MeshNodeInfo {
     pub hashrate_th: f64,
     /// Miners currently connected to this node.
     pub miner_count: u32,
+    /// Deduplicated share of the mesh-wide active-miner total attributed to
+    /// this node: each unique miner-id hash is owned by exactly one node, so
+    /// summing this across the mesh-nodes list (self + peers) equals the
+    /// deduped grand total. The raw `miner_count` is retained for display; this
+    /// is the sum-consistent figure that avoids double-counting fail-over.
+    pub deduped_miner_count: u32,
     /// Whether the node is considered healthy/reachable on the mesh.
     pub healthy: bool,
 }
@@ -993,6 +1009,13 @@ pub struct VerificationState {
     /// count that's stable across the round rotations and load-balancer
     /// hopping that make per-VM counts misleading when summed.
     get_mesh_active_miners: Option<Box<dyn Fn() -> u32 + Send + Sync>>,
+    /// This node's (self) deduplicated share of the mesh-wide active-miner
+    /// total — the count attributed to our own node id by the same
+    /// per-node attribution that fills each peer's `deduped_miner_count`.
+    /// Surfaced on the `this_node`/self entries of the pool-nodes and
+    /// mesh-nodes responses so `self + peers` sum to `get_mesh_active_miners`.
+    /// None on older deploys without the provider wired.
+    get_self_deduped_miners: Option<Box<dyn Fn() -> u32 + Send + Sync>>,
     /// Mesh-wide pool hashrate (TH/s): sum of every node's own realized
     /// hashrate (one term per node, scoped by `received_by` at source so it
     /// can't double-count), so load-balancer migrations don't crater or inflate
@@ -1193,6 +1216,7 @@ impl VerificationState {
             get_reaper_stats: None,
             get_coordinator_status: None,
             get_mesh_active_miners: None,
+            get_self_deduped_miners: None,
             get_mesh_total_hashrate: None,
             get_local_hashrate: None,
             get_mesh_best_records: None,
@@ -1708,6 +1732,25 @@ impl VerificationState {
     /// callback has been wired up (older deploys without the mesh provider).
     pub fn mesh_active_miners(&self) -> Option<u32> {
         self.get_mesh_active_miners.as_ref().map(|f| f())
+    }
+
+    /// Set the self (this-node) deduplicated active-miner-count callback.
+    pub fn with_self_deduped_miner_count(
+        mut self,
+        f: impl Fn() -> u32 + Send + Sync + 'static,
+    ) -> Self {
+        self.get_self_deduped_miners = Some(Box::new(f));
+        self
+    }
+
+    /// This node's deduplicated share of the mesh-wide active-miner total, or 0
+    /// when the provider isn't wired (older deploys) — in which case the
+    /// per-node breakdown simply omits self's deduped figure.
+    pub fn self_deduped_miner_count(&self) -> u32 {
+        self.get_self_deduped_miners
+            .as_ref()
+            .map(|f| f())
+            .unwrap_or(0)
     }
 
     /// Set the mesh-wide pool hashrate (TH/s) callback.


### PR DESCRIPTION
Per-node `miner_count` was surfaced verbatim from health-ping gossip, so miners that fail over between nodes were counted on each — the per-node rows summed higher than the deduped `mesh_active_miners` total. Added `attribute_miner_counts` (each unique miner-id hash → the node with the freshest `last_seen`, tie-break smallest node_id, over the same 300s window as the grand total) and a new `deduped_miner_count` field on `/api/internal/pool-nodes` + `/api/v1/pool/mesh-nodes` (raw `miner_count` retained — the translator LB routes on true local load). Per-node deduped counts now sum to the mesh total. 262+131 tests pass. Needs the ghost-pool redeploy.