### PR TITLE
fix(dashboard): consume deduped miner counts, API authority key, operator miners table

### DIFF
--- a/dashboard/src/app/(dashboard)/capacity/page.tsx
+++ b/dashboard/src/app/(dashboard)/capacity/page.tsx
@@ -24,6 +24,11 @@ interface PoolNode {
   public_address?: string;
   public_mining?: boolean;
   last_seen?: number;
+  // Deduplicated share of the mesh-wide active-miner total attributed to this
+  // node. Unlike the raw `miner_count` (kept for the load-balancer utilisation
+  // view), these DO sum to the deduped `mesh_active_miners` total because each
+  // unique miner is owned by exactly one node. Absent on pre-redeploy nodes.
+  deduped_miner_count?: number;
 }
 
 interface PoolNodesResponse {
@@ -137,6 +142,12 @@ export default function CapacityPage() {
   const me = data.this_node;
   const myPct = utilPct(me);
 
+  // Post-redeploy nodes report a `deduped_miner_count` per node that sums to the
+  // deduped mesh total. When present, the peer table shows those (labelled just
+  // "Miners") and drops the "don't sum" caveat. Pre-redeploy nodes omit it, so
+  // we fall back to the raw routed `miner_count` and keep the caveat.
+  const dedupAvailable = me.deduped_miner_count !== undefined;
+
   return (
     <div className="space-y-6">
       <PageHeader
@@ -202,9 +213,16 @@ export default function CapacityPage() {
             {meshTotal !== undefined && (
               <p style={{ color: "var(--fainter)", fontSize: "12px", marginTop: "8px" }}>
                 <strong style={{ color: "var(--fg)" }}>{meshTotal}</strong> distinct active{" "}
-                {meshTotal === 1 ? "miner" : "miners"} across the mesh (deduplicated). The per-peer
-                counts below are a routing view and may overlap — a miner failing over between nodes
-                appears on more than one peer, so <em>don&apos;t sum the rows</em>.
+                {meshTotal === 1 ? "miner" : "miners"} across the mesh (deduplicated).{" "}
+                {dedupAvailable ? (
+                  <>The per-node counts below are deduplicated and sum to this total.</>
+                ) : (
+                  <>
+                    The per-peer counts below are a routing view and may overlap — a miner failing
+                    over between nodes appears on more than one peer, so{" "}
+                    <em>don&apos;t sum the rows</em>.
+                  </>
+                )}
               </p>
             )}
           </div>
@@ -215,7 +233,7 @@ export default function CapacityPage() {
                 <thead>
                   <tr style={{ borderBottom: "1px solid var(--rule)" }}>
                     <th style={thStyle}>Peer</th>
-                    <th style={thStyle}>Miners (routed)</th>
+                    <th style={thStyle}>{dedupAvailable ? "Miners" : "Miners (routed)"}</th>
                     <th style={thStyle}>Capacity</th>
                     <th style={thStyle}>Utilisation</th>
                     <th style={{ ...thStyle, width: "30%" }}>&nbsp;</th>
@@ -239,7 +257,7 @@ export default function CapacityPage() {
                             )}
                           </td>
                           <td style={{ ...tdStyle, fontFamily: "var(--font-mono)" }}>
-                            {p.miner_count}
+                            {dedupAvailable ? p.deduped_miner_count ?? 0 : p.miner_count}
                           </td>
                           <td style={{ ...tdStyle, fontFamily: "var(--font-mono)", color: "var(--dim)" }}>
                             {p.max_capacity || "—"}

--- a/dashboard/src/app/(dashboard)/mining/page.tsx
+++ b/dashboard/src/app/(dashboard)/mining/page.tsx
@@ -68,6 +68,22 @@ const minerColumns: ColumnDef<MinerInfo>[] = [
     },
   },
   {
+    accessorKey: "difficulty",
+    header: "Difficulty",
+    cell: ({ row }) => {
+      const diff = row.original.difficulty ?? 0;
+      return <span className="font-mono">{diff > 0 ? formatDifficulty(diff) : "—"}</span>;
+    },
+  },
+  {
+    accessorKey: "last_share",
+    header: "Last Share",
+    cell: ({ row }) => {
+      const last = row.original.last_share ?? row.original.last_share_at ?? 0;
+      return <span className="text-gray-400">{formatTimeAgo(last)}</span>;
+    },
+  },
+  {
     accessorKey: "connected_at",
     header: "Uptime",
     cell: ({ row }) => {
@@ -112,11 +128,11 @@ function formatDifficulty(d: number): string {
 const PUBLIC_POOL_HOST = "pool.bitcoinghost.org";
 
 // SV2/Noise clients must pin the pool's authority public key to connect.
-// NOTE: the node API does NOT currently expose this — it lives in pool_sv2's
-// pool.toml as `authority_public_key`, identical across every node — so it is
-// mirrored here as a constant. Backend enhancement: surface it on
-// /api/v1/mining/status so this can be sourced dynamically.
-const SV2_AUTHORITY_PUBLIC_KEY = "9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72";
+// The node now surfaces this on /api/v1/mining/status as `authority_public_key`
+// (sourced from pool_sv2's pool.toml, identical across every node). This
+// constant is the FALLBACK used only when that field is absent — i.e. a
+// pre-redeploy node — so the copyable row never renders blank.
+const SV2_AUTHORITY_PUBLIC_KEY_FALLBACK = "9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72";
 
 // The backend currently derives every window (current round / last hour /
 // last 24h / all time) from the same source and returns an IDENTICAL entry for
@@ -185,17 +201,24 @@ export default function MiningPage() {
   const [poolSetupOpen, setPoolSetupOpen] = useState(false);
 
   const miners = minersData?.miners ?? [];
-  // The miners/full `total` only counts miners seen in the last 600s, so it
+  // True when the backend withheld the per-miner list — either an unsigned/
+  // public request or a pre-redeploy node without the operator-authed detail
+  // mode. In that state we show the aggregate count instead of a table.
+  const minersRedacted = minersData?.miners_redacted === true;
+  // The detailed list only counts miners seen in the last 600s, so its `total`
   // reads 0 for TCP-connected-but-idle miners. Use the authoritative
   // connected-miner counts from mining status as a floor so the header never
   // understates reality (backend `active_miners` = local miners with recent
   // shares; `local_connected_miners` = TCP-connected on this node).
   const connectedMinerCount = Math.max(
     miners.length,
-    minersData?.total ?? 0,
+    minersData?.total_miners ?? minersData?.total ?? 0,
     status?.active_miners ?? 0,
     status?.local_connected_miners ?? 0,
   );
+  // Authority key: prefer the value the node now reports, fall back to the
+  // bundled constant for pre-redeploy nodes that don't expose it yet.
+  const authorityPublicKey = status?.authority_public_key ?? SV2_AUTHORITY_PUBLIC_KEY_FALLBACK;
   const nodeHost = typeof window !== "undefined" ? window.location.hostname : "localhost";
   const isPending = setPrivateMining.isPending || setPublicMining.isPending;
 
@@ -370,9 +393,9 @@ export default function MiningPage() {
                   <div className="flex items-center justify-between p-2 bg-gray-900/50 rounded">
                     <div className="min-w-0">
                       <div className="text-xs text-gray-500">SV2 authority public key</div>
-                      <code className="text-orange-400 text-sm block truncate">{SV2_AUTHORITY_PUBLIC_KEY}</code>
+                      <code className="text-orange-400 text-sm block truncate">{authorityPublicKey}</code>
                     </div>
-                    <CopyButton text={SV2_AUTHORITY_PUBLIC_KEY} />
+                    <CopyButton text={authorityPublicKey} />
                   </div>
                 </div>
                 <div className="text-xs text-gray-500 mt-2">SV2/Noise miners must pin the authority public key to connect.</div>
@@ -452,22 +475,22 @@ export default function MiningPage() {
             />
           ) : minersLoading ? (
             <div className="py-8 text-center text-sm text-gray-500">Loading…</div>
-          ) : connectedMinerCount > 0 ? (
-            // The node reports an aggregate connected-miner count, but the
-            // per-miner detail endpoint (/api/v1/mining/miners/full) requires the
-            // mesh HMAC signature, which the dashboard's operator INTERNAL_AUTH_KEY
-            // cannot produce — so the individual rows come back redacted. Show the
-            // aggregate clearly instead of a blank/broken table.
-            // Backend follow-up: expose an operator-authed miner-details endpoint.
+          ) : minersRedacted && connectedMinerCount > 0 ? (
+            // Pre-redeploy fallback: the node reports an aggregate connected-miner
+            // count but withheld the per-miner list (`miners_redacted: true`),
+            // because it lacks the operator-authed detail mode on
+            // /api/v1/mining/miners. Show the aggregate clearly instead of a
+            // blank/broken table. Once the node is redeployed, the signed GET
+            // returns the full list and the table above renders instead.
             <div className="py-8 px-4 text-center">
               <div className="text-3xl font-semibold text-orange-400">{connectedMinerCount}</div>
               <div className="text-sm text-gray-400 mt-1">
                 {connectedMinerCount === 1 ? "miner" : "miners"} connected to this node
               </div>
               <div className="text-xs text-gray-500 mt-3 max-w-md mx-auto leading-relaxed">
-                Per-miner details (worker, hashrate, shares) require mesh authentication and are not
-                available through the operator dashboard yet. The aggregate count above is
-                authoritative.
+                Per-miner details (worker, hashrate, shares) are not yet exposed by this node — they
+                appear here automatically once it is updated to the latest build. The aggregate count
+                above is authoritative.
               </div>
             </div>
           ) : (

--- a/dashboard/src/lib/api/mining.ts
+++ b/dashboard/src/lib/api/mining.ts
@@ -7,8 +7,12 @@ export async function getMiningStatus(): Promise<MiningStatus> {
 }
 
 export async function getMiners(): Promise<MinersResponse> {
-  // Use the internal unredacted endpoint (HMAC-protected, proxied via Next.js)
-  return fetchApi<MinersResponse>('/api/v1/mining/miners/full');
+  // Dual-mode endpoint: the Next.js proxy signs this GET with the operator
+  // INTERNAL_AUTH_KEY (HMAC over an empty body), so the node returns the FULL
+  // unredacted connected-miner list (`miners_redacted: false`). Pre-redeploy
+  // nodes — or an unsigned request — get the redacted aggregate instead, which
+  // the mining page renders as an aggregate count rather than a table.
+  return fetchApi<MinersResponse>('/api/v1/mining/miners');
 }
 
 export async function getBestHash(): Promise<BestHashResponse> {

--- a/dashboard/src/types/api.ts
+++ b/dashboard/src/types/api.ts
@@ -225,6 +225,11 @@ export interface MiningStatus {
   round_id?: number;
   blocks_found?: number;
   is_synced?: boolean;
+  // SV2/Noise authority public key that miners must pin. Sourced from the
+  // node's `[network] sv2_authority_public_key`, falling back to the
+  // network-wide default. Optional: absent on pre-redeploy nodes, in which
+  // case the frontend falls back to its bundled constant.
+  authority_public_key?: string;
 }
 
 export interface MinerInfo {
@@ -247,8 +252,16 @@ export interface MinerInfo {
 }
 
 export interface MinersResponse {
-  total: number;
+  // `/api/v1/mining/miners/full` returns `total`; the operator-authed
+  // `/api/v1/mining/miners` returns `total_miners`. Both are optional so the
+  // count can be sourced from whichever endpoint answered.
+  total?: number;
+  total_miners?: number;
   miners?: MinerInfo[];
+  // True when the backend withheld the per-miner list (public/unauthed path or
+  // a pre-redeploy node that lacks the operator-authed detail mode). When true,
+  // `miners` is absent and the UI shows the aggregate count instead of a table.
+  miners_redacted?: boolean;
   // Aggregate stats returned when miners array is not available (no HMAC auth)
   total_hashrate_th?: number;
   total_shares_accepted?: number;


### PR DESCRIPTION
Wires the dashboard to the newly-deployed backend fields with graceful fallback: Capacity uses deduped_miner_count (rows sum to total); Mining sources authority_public_key from the API (constant fallback); Connected Miners fetches the operator-authed /api/v1/mining/miners and renders real per-miner rows. tsc/lint/build clean.