### PR TITLE
feat(web): friendly rate-limit notice on live-stats pages

### DIFF
--- a/ghost-web/index.html
+++ b/ghost-web/index.html
@@ -103,6 +103,15 @@
   </div>
 </section>
 
+<div class="rl-notice-wrap">
+  <div class="container">
+    <div class="rl-notice" id="rl-notice" role="status" aria-live="polite">
+      <span class="rl-dot"></span>
+      <span class="rl-text"><strong>Live stats are catching their breath.</strong> The node rate-limits requests to protect itself — the figures above are the last good reading and will resume updating in a minute or two.</span>
+    </div>
+  </div>
+</div>
+
 <section class="block">
   <div class="container">
     <div class="section-label">What Ghost is</div>
@@ -581,6 +590,13 @@
       if (ths < 1e6)   return (ths / 1000).toFixed(2) + '<span class="unit">PH/s</span>';
       return (ths / 1e6).toFixed(2) + '<span class="unit">EH/s</span>';
     }
+    // Rate-limit notice: shown when the pool API throttles us (HTTP 429) and a
+    // poll returns no fresh data; cleared the moment any seed answers cleanly.
+    var rlNotice = document.getElementById('rl-notice');
+    function setRateLimited(on) {
+      if (rlNotice) rlNotice.classList.toggle('show', !!on);
+    }
+
     async function refresh() {
       try {
         // Kick off the whole-mesh node fetch in parallel with the per-seed
@@ -590,11 +606,19 @@
           var ctl = new AbortController();
           var t = setTimeout(function () { ctl.abort(); }, 5000);
           return fetch('/api/pool/' + vm + '/api/v1/mining/status', { signal: ctl.signal })
-            .then(function (r) { clearTimeout(t); return r.ok ? r.json() : null; })
+            .then(function (r) { clearTimeout(t); if (r.status === 429) return { __rl: true }; return r.ok ? r.json() : null; })
             .catch(function () { clearTimeout(t); return null; });
         }));
+        // A 429 poll returns { __rl: true }; keep only real data in `good`.
+        var rateLimited = results.some(function (r) { return r && r.__rl; });
+        var good = results.filter(function (r) { return r && !r.__rl; });
+        // Clear the notice as soon as any seed answers cleanly; raise it when
+        // this tick was throttled with nothing fresh to show. The tiles below
+        // keep their last-known values either way.
+        if (good.length > 0) setRateLimited(false);
+        else if (rateLimited) setRateLimited(true);
         var online = 0, hash = 0, meshHash = null, sumLocal = 0, height = 0, mesh = null, maxActive = 0;
-        results.forEach(function (r) {
+        good.forEach(function (r) {
           if (!r) return;
           online++;
           // Pool hashrate: prefer the mesh-wide `total_hashrate` (the SAME pool

--- a/ghost-web/miner.html
+++ b/ghost-web/miner.html
@@ -63,6 +63,15 @@
   </div>
 </header>
 
+<div class="rl-notice-wrap">
+  <div class="container">
+    <div class="rl-notice" id="rl-notice" role="status" aria-live="polite">
+      <span class="rl-dot"></span>
+      <span class="rl-text"><strong>Live stats are catching their breath.</strong> The node rate-limits requests to protect itself — the figures shown are the last good reading and will resume updating in a minute or two.</span>
+    </div>
+  </div>
+</div>
+
 <!-- ───── Address mode ───── -->
 <section class="block mp-hero" id="addr-mode" style="display:none">
   <div class="container">
@@ -338,6 +347,29 @@
 
   function showMode(id) { document.getElementById(id).style.display = 'block'; }
 
+  // ───────── Rate-limit notice ─────────
+  // A 429 from the pool API means we're being throttled, not that the miner is
+  // gone — so surface a calm notice and keep the last-known figures on screen
+  // rather than flashing "not found" or zeros. Fetch handlers return a
+  // { __rl: true } marker on HTTP 429; siftBatch strips those markers out of a
+  // per-node batch and drives the notice: any clean response hides it, a
+  // throttled batch with no clean response shows it. Nulls (ordinary transient
+  // failures) pass through untouched so existing preserve-on-failure logic
+  // behaves exactly as before.
+  var rlNotice = document.getElementById('rl-notice');
+  function siftBatch(perNode) {
+    var good = [], rl = false;
+    perNode.forEach(function (d) {
+      if (d && d.__rl) rl = true;
+      else good.push(d);
+    });
+    if (rlNotice) {
+      if (good.some(function (d) { return d !== null; })) rlNotice.classList.remove('show');
+      else if (rl) rlNotice.classList.add('show');
+    }
+    return good;
+  }
+
   if (!rawId) {
     showMode('empty-mode');
   } else if (rawId.indexOf('.') >= 0 && rawId.split('.').slice(1).join('.').length > 0) {
@@ -354,11 +386,11 @@
     document.title = address.slice(0, 10) + '… · Bitcoin Ghost';
 
     async function load() {
-      var perNode = await Promise.all(POOL_NODES.map(function (n) {
+      var perNode = siftBatch(await Promise.all(POOL_NODES.map(function (n) {
         return fetch('/api/pool/' + n.id + '/api/v1/miners/workers?address=' + encodeURIComponent(address))
-          .then(function (r) { return r.ok ? r.json() : null; })
+          .then(function (r) { if (r.status === 429) return { __rl: true }; return r.ok ? r.json() : null; })
           .catch(function () { return null; });
-      }));
+      })));
       // Merge per-worker across nodes, keeping pool-wide totals
       var byWorker = new Map();
       perNode.forEach(function (d) {
@@ -585,11 +617,11 @@
 
     var lookupEverSeen = false;
     async function loadLookup() {
-      var perNode = await Promise.all(POOL_NODES.map(function (n) {
+      var perNode = siftBatch(await Promise.all(POOL_NODES.map(function (n) {
         return fetch('/api/pool/' + n.id + '/api/v1/miners/lookup?miner_id=' + encodeURIComponent(minerId))
-          .then(function (r) { return r.ok ? r.json() : null; })
+          .then(function (r) { if (r.status === 429) return { __rl: true }; return r.ok ? r.json() : null; })
           .catch(function () { return null; });
-      }));
+      })));
       var okCount = perNode.filter(function (d) { return d !== null; }).length;
       var hits = perNode.filter(function (d) { return d && d.found === true; });
 

--- a/ghost-web/pool.html
+++ b/ghost-web/pool.html
@@ -104,6 +104,15 @@
   </div>
 </section>
 
+<div class="rl-notice-wrap">
+  <div class="container">
+    <div class="rl-notice" id="rl-notice" role="status" aria-live="polite">
+      <span class="rl-dot"></span>
+      <span class="rl-text"><strong>Live stats are catching their breath.</strong> The node rate-limits requests to protect itself — the figures above are the last good reading and will resume updating in a minute or two.</span>
+    </div>
+  </div>
+</div>
+
 <section class="viz-section">
   <div class="container">
     <div class="viz-tabs">
@@ -588,11 +597,20 @@
     document.getElementById('miners-window').textContent = formatWindow(chartHistory.miners);
   }
 
+  // Rate-limit notice: shown when the pool API throttles us (HTTP 429) and a
+  // poll yields no fresh data; cleared the moment any node answers cleanly. A
+  // 429 poll returns the { __rl: true } marker so refreshPool can tell "the
+  // node is protecting itself" apart from an ordinary dropped fetch (null).
+  var rlNotice = document.getElementById('rl-notice');
+  function setRateLimited(on) {
+    if (rlNotice) rlNotice.classList.toggle('show', !!on);
+  }
+
   function fetchNode(node) {
     var ctl = new AbortController();
     var t = setTimeout(function () { ctl.abort(); }, 5000);
     return fetch('/api/pool/' + node.id + '/api/v1/mining/status', { signal: ctl.signal })
-      .then(function (r) { clearTimeout(t); return r.ok ? r.json() : null; })
+      .then(function (r) { clearTimeout(t); if (r.status === 429) return { __rl: true }; return r.ok ? r.json() : null; })
       .catch(function () { clearTimeout(t); return null; });
   }
 
@@ -623,15 +641,25 @@
     try {
       dbg('polling 4 nodes…');
       var results = await Promise.all(POOL_NODES.map(fetchNode));
-      var okCount = results.filter(function (r) { return !!r; }).length;
-      // All four fetches failed (rate limit / transient) — don't blank the
-      // tiles. Keep the last good numbers, user can ignore one missed tick.
+      // Split the throttle markers out from real data. `good` is every node
+      // that returned usable JSON; a rate-limited (HTTP 429) poll left a
+      // { __rl: true } marker instead.
+      var rateLimited = results.some(function (r) { return r && r.__rl; });
+      var good = results.filter(function (r) { return r && !r.__rl; });
+      var okCount = good.length;
+      // Clear the notice the instant any node answers cleanly; raise it when
+      // we were throttled this tick and have no fresh data to show.
+      if (okCount > 0) setRateLimited(false);
+      else if (rateLimited) setRateLimited(true);
+      // No usable responses (throttled or transient) — don't blank the tiles.
+      // Keep the last good numbers; the notice explains the pause.
       if (okCount === 0 && lastStats.height) {
-        dbg('poll skip · 0/4 nodes — preserving last view');
+        dbg(rateLimited ? 'poll skip · rate-limited — preserving last view'
+                        : 'poll skip · 0/4 nodes — preserving last view');
         return;
       }
       var hashrate = 0, meshHashrate = null, sumLocal = 0, blocks = 0, height = 0, mesh = null, maxActive = 0;
-      results.forEach(function (r) {
+      good.forEach(function (r) {
         if (!r) return;
         // Pool hashrate: prefer the mesh-wide `total_hashrate` (every post-PR#27
         // node reports the SAME pool-wide figure, built from gossiped per-node
@@ -674,7 +702,7 @@
       // Used by the quasar HUD clock so "time since last block" is
       // real on first page load, not just "time since page open".
       var tipTime = null;
-      results.forEach(function (r) {
+      good.forEach(function (r) {
         if (r && typeof r.last_block_time === 'number') {
           if (tipTime === null || r.last_block_time > tipTime) tipTime = r.last_block_time;
         }
@@ -687,7 +715,7 @@
       lastStats.miners = mesh !== null ? mesh : maxActive;
       lastStats.blocks = blocks;
       lastStats.height = height;
-      lastStats.nodes = results;
+      lastStats.nodes = good;
       renderMetrics();
       pushHistory(hashrate, lastStats.miners);
       renderCharts();

--- a/ghost-web/style.css
+++ b/ghost-web/style.css
@@ -595,6 +595,27 @@ h2.section-title {
   margin-top: 8px; text-shadow: none;
 }
 
+/* Rate-limit notice — stats are throttled, not broken. Calm accent pill,
+   never a red error. Hidden until a poll returns HTTP 429; cleared the
+   moment a poll succeeds again. Shared by pool.html, index.html, miner.html. */
+.rl-notice-wrap .container { padding-top: 0; padding-bottom: 0; }
+.rl-notice {
+  display: none; align-items: center; gap: 10px;
+  margin: 14px 0 0; padding: 10px 14px;
+  border: 1px solid var(--rule-strong);
+  border-left: 3px solid var(--accent);
+  border-radius: 6px; background: var(--accent-weak);
+  font-family: var(--font-mono); font-size: 12.5px; line-height: 1.5;
+  color: var(--dim);
+}
+.rl-notice.show { display: flex; }
+.rl-notice .rl-dot {
+  flex: 0 0 auto; width: 7px; height: 7px; border-radius: 50%;
+  background: var(--accent); animation: rl-pulse 1.6s ease-in-out infinite;
+}
+.rl-notice .rl-text strong { color: var(--fg); font-weight: 500; }
+@keyframes rl-pulse { 0%, 100% { opacity: 0.35; } 50% { opacity: 1; } }
+
 /* Pool tabs */
 .pool-tabs { padding: 56px 0 72px; }
 .tabs-nav {


### PR DESCRIPTION
When the pool API returns 429, show a calm 'stats are catching their breath, the node rate-limits to protect itself, back in a minute or two' pill (not a red error) on pool.html/index.html/miner.html + shared .rl-notice style. Keeps the last-known values visible instead of blanking; clears automatically on the next clean poll. Detects 429 distinctly from ordinary dropped fetches.