### PR TITLE
fix(web): terser rate-limit notice copy

### DIFF
--- a/ghost-web/index.html
+++ b/ghost-web/index.html
@@ -107,7 +107,7 @@
   <div class="container">
     <div class="rl-notice" id="rl-notice" role="status" aria-live="polite">
       <span class="rl-dot"></span>
-      <span class="rl-text"><strong>Live stats are catching their breath.</strong> The node rate-limits requests to protect itself — the figures above are the last good reading and will resume updating in a minute or two.</span>
+      <span class="rl-text">Statistics API is exceeding rate limits. Limits will reset soon.</span>
     </div>
   </div>
 </div>

--- a/ghost-web/miner.html
+++ b/ghost-web/miner.html
@@ -67,7 +67,7 @@
   <div class="container">
     <div class="rl-notice" id="rl-notice" role="status" aria-live="polite">
       <span class="rl-dot"></span>
-      <span class="rl-text"><strong>Live stats are catching their breath.</strong> The node rate-limits requests to protect itself — the figures shown are the last good reading and will resume updating in a minute or two.</span>
+      <span class="rl-text">Statistics API is exceeding rate limits. Limits will reset soon.</span>
     </div>
   </div>
 </div>

--- a/ghost-web/pool.html
+++ b/ghost-web/pool.html
@@ -108,7 +108,7 @@
   <div class="container">
     <div class="rl-notice" id="rl-notice" role="status" aria-live="polite">
       <span class="rl-dot"></span>
-      <span class="rl-text"><strong>Live stats are catching their breath.</strong> The node rate-limits requests to protect itself — the figures above are the last good reading and will resume updating in a minute or two.</span>
+      <span class="rl-text">Statistics API is exceeding rate limits. Limits will reset soon.</span>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Replace the verbose rate-limit notice with a one-liner matching the site's terse style: 'Statistics API is exceeding rate limits. Limits will reset soon.'