### PR TITLE
dashboard: Ghost Pool nav group (Mining + Capacity)

### DIFF
--- a/dashboard/src/components/layout/Sidebar.tsx
+++ b/dashboard/src/components/layout/Sidebar.tsx
@@ -60,15 +60,20 @@ const GROUPS: NavGroup[] = [
     label: "overview",
     items: [
       { href: "/", label: "Overview", icon: <LayoutDashboard {...ICON} /> },
-      { href: "/mining", label: "Mining", icon: <Pickaxe {...ICON} /> },
       { href: "/mempool", label: "Mempool", icon: <Activity {...ICON} /> },
       { href: "/capabilities", label: "Capabilities", icon: <ShieldCheck {...ICON} /> },
     ],
   },
   {
+    label: "ghost pool",
+    items: [
+      { href: "/mining", label: "Mining", icon: <Pickaxe {...ICON} /> },
+      { href: "/capacity", label: "Capacity", icon: <Gauge {...ICON} /> },
+    ],
+  },
+  {
     label: "operate",
     items: [
-      { href: "/capacity", label: "Capacity", icon: <Gauge {...ICON} /> },
       { href: "/swarm", label: "Swarm", icon: <NetworkIcon {...ICON} /> },
       { href: "/rewards", label: "Rewards", icon: <Coins {...ICON} /> },
     ],


### PR DESCRIPTION
Moves Mining (was under overview) and Capacity (was under operate) into a dedicated Ghost Pool left-nav group, parallel to Ghost Pay. Reversible nav-only change.