### PR TITLE
dashboard: remove redundant mempool embed card title

### DIFF
--- a/dashboard/src/app/(dashboard)/mempool/page.tsx
+++ b/dashboard/src/app/(dashboard)/mempool/page.tsx
@@ -354,9 +354,6 @@ function NodeMempoolExplorer() {
 
   return (
     <Card>
-      <CardHeader
-        title="Your node's mempool"
-      />
       <div className="flex items-center gap-3" style={{ marginBottom: "12px" }}>
         <Badge variant="info">mempool.space · this node</Badge>
         {openLink}


### PR DESCRIPTION
The mempool.space embed card carried its own 'Your node's mempool' title, duplicating the page header of the same name. Removed the CardHeader; the mempool.space·this node badge + open-in-new-tab link + embed remain.