### PR TITLE
dashboard: fix no way to expand a collapsed sidebar

### DIFF
--- a/dashboard/src/components/layout/Sidebar.tsx
+++ b/dashboard/src/components/layout/Sidebar.tsx
@@ -207,9 +207,20 @@ export function Sidebar() {
               )}
             </div>
           ) : (
-            <div className="w-full flex justify-center">
+            <button
+              onClick={() => toggle()}
+              title="Expand sidebar"
+              aria-label="Expand sidebar"
+              className="w-full flex justify-center"
+              style={{
+                padding: "4px",
+                background: "transparent",
+                border: "none",
+                cursor: "pointer",
+              }}
+            >
               <GhostBrand size="sm" label="" />
-            </div>
+            </button>
           )}
           {!collapsed && (
             <button


### PR DESCRIPTION
The collapse toggle only rendered when expanded, so a collapsed sidebar had no expand control. Made the collapsed logo a clickable button (title/aria 'Expand sidebar') that toggles it back open.