### PR TITLE
fix(dashboard): mining tooltip no-clip + network hashrate unit

### DIFF
--- a/dashboard/src/app/(dashboard)/mining/page.tsx
+++ b/dashboard/src/app/(dashboard)/mining/page.tsx
@@ -224,7 +224,7 @@ export default function MiningPage() {
       <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4">
         <StatCard
           label="Network Hashrate"
-          value={bestHashData?.network_hashrate ? formatHashrate(bestHashData.network_hashrate) : "--"}
+          value={bestHashData?.network_hashrate ? formatHashrate(bestHashData.network_hashrate, 0) : "--"}
           sublabel="global estimate"
           tooltip={TOOLTIPS.network_hashrate}
           loading={bestHashLoading}

--- a/dashboard/src/components/ui/DataTable.tsx
+++ b/dashboard/src/components/ui/DataTable.tsx
@@ -198,13 +198,19 @@ export function formatBtc(sats: number): string {
   return (sats / 100_000_000).toFixed(8);
 }
 
-export function formatHashrate(hashrate: number): string {
-  if (hashrate >= 1e15) return `${(hashrate / 1e15).toFixed(2)} PH/s`;
-  if (hashrate >= 1e12) return `${(hashrate / 1e12).toFixed(2)} TH/s`;
-  if (hashrate >= 1e9) return `${(hashrate / 1e9).toFixed(2)} GH/s`;
-  if (hashrate >= 1e6) return `${(hashrate / 1e6).toFixed(2)} MH/s`;
-  if (hashrate >= 1e3) return `${(hashrate / 1e3).toFixed(2)} KH/s`;
-  return `${hashrate.toFixed(2)} H/s`;
+// Auto-scaling hashrate formatter. `digits` controls decimal places (default 2);
+// pass 0 for the global network-hashrate tile, which reaches EH/s magnitudes and
+// needs to stay compact so the unit isn't truncated. Scales up to ZH/s so
+// exahash-scale network estimates keep their unit rather than overflowing PH/s.
+export function formatHashrate(hashrate: number, digits = 2): string {
+  if (hashrate >= 1e21) return `${(hashrate / 1e21).toFixed(digits)} ZH/s`;
+  if (hashrate >= 1e18) return `${(hashrate / 1e18).toFixed(digits)} EH/s`;
+  if (hashrate >= 1e15) return `${(hashrate / 1e15).toFixed(digits)} PH/s`;
+  if (hashrate >= 1e12) return `${(hashrate / 1e12).toFixed(digits)} TH/s`;
+  if (hashrate >= 1e9) return `${(hashrate / 1e9).toFixed(digits)} GH/s`;
+  if (hashrate >= 1e6) return `${(hashrate / 1e6).toFixed(digits)} MH/s`;
+  if (hashrate >= 1e3) return `${(hashrate / 1e3).toFixed(digits)} KH/s`;
+  return `${hashrate.toFixed(digits)} H/s`;
 }
 
 export function formatDuration(seconds: number): string {

--- a/dashboard/src/components/ui/Tooltip.tsx
+++ b/dashboard/src/components/ui/Tooltip.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { CSSProperties, ReactNode, useCallback, useRef, useState } from 'react';
+import { ReactNode, useCallback, useLayoutEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { useUIStore } from '@/stores';
 
 interface TooltipProps {
@@ -9,117 +10,141 @@ interface TooltipProps {
   position?: 'top' | 'bottom' | 'left' | 'right';
 }
 
-const positionClasses = {
-  top: 'bottom-full left-1/2 mb-2',
-  bottom: 'top-full left-1/2 mt-2',
-  left: 'right-full top-1/2 mr-2',
-  right: 'left-full top-1/2 ml-2',
-};
-
-const arrowClasses = {
-  top: 'top-full left-1/2 border-t-gray-700 border-x-transparent border-b-transparent',
-  bottom: 'bottom-full left-1/2 border-b-gray-700 border-x-transparent border-t-transparent',
-  left: 'left-full top-1/2 border-l-gray-700 border-y-transparent border-r-transparent',
-  right: 'right-full top-1/2 border-r-gray-700 border-y-transparent border-l-transparent',
-};
+type Side = 'top' | 'bottom' | 'left' | 'right';
 
 // Gap kept between the tooltip box and the viewport edge.
 const MARGIN = 8;
+// Gap between the trigger and the tooltip box (leaves room for the arrow).
+const GAP = 8;
+// Half-width of the 4px CSS-border arrow, used to keep it clear of the corners.
+const ARROW = 4;
 
+const arrowClasses: Record<Side, string> = {
+  top: 'border-t-gray-700 border-x-transparent border-b-transparent',
+  bottom: 'border-b-gray-700 border-x-transparent border-t-transparent',
+  left: 'border-l-gray-700 border-y-transparent border-r-transparent',
+  right: 'border-r-gray-700 border-y-transparent border-l-transparent',
+};
+
+function clamp(v: number, lo: number, hi: number): number {
+  return Math.max(lo, Math.min(v, hi));
+}
+
+// The tooltip box is rendered through a portal to document.body with fixed
+// positioning. This is deliberate: the dashboard's <main> wrapper is
+// `overflow-auto`, so an absolutely-positioned tooltip inside a card gets
+// clipped at main's left edge (which abuts the sidebar) whenever the card sits
+// near that edge. Portalling out of the scroll container and positioning against
+// the viewport means the tooltip is never clipped and always paints above the
+// sidebar. Placement is applied imperatively (DOM refs) in a layout effect so it
+// is measured-then-positioned before paint, with no intermediate flash.
 export function Tooltip({ content, children, position = 'top' }: TooltipProps) {
   const tooltipsEnabled = useUIStore((s) => s.tooltipsEnabled);
   const wrapperRef = useRef<HTMLDivElement>(null);
   const tipRef = useRef<HTMLDivElement>(null);
-  const [effective, setEffective] = useState(position);
-  const [shift, setShift] = useState(0);
+  const arrowRef = useRef<HTMLDivElement>(null);
+  const [open, setOpen] = useState(false);
 
-  // Measure on show and nudge the tooltip so it never leaves the viewport:
-  // top/bottom clamp horizontally (and flip vertically if there is no room),
-  // left/right clamp vertically (and flip horizontally). The arrow is
-  // counter-shifted so it keeps pointing at the trigger.
+  // Measure the trigger and the tooltip, pick the side (flipping if the
+  // preferred side has no room), clamp the box to the viewport, and offset the
+  // arrow so it keeps pointing at the trigger centre.
   const reposition = useCallback(() => {
     const wrapper = wrapperRef.current;
     const tip = tipRef.current;
-    if (!wrapper || !tip) return;
+    const arrow = arrowRef.current;
+    if (!wrapper || !tip || !arrow) return;
 
     const w = wrapper.getBoundingClientRect();
     const tw = tip.offsetWidth;
     const th = tip.offsetHeight;
     const vw = window.innerWidth;
     const vh = window.innerHeight;
+    const off = GAP + ARROW;
 
-    let pos = position;
-
+    let side: Side = position;
     if (position === 'top' || position === 'bottom') {
-      // Flip vertically if the preferred side has no room.
-      if (position === 'top' && w.top - th - MARGIN < 0 && w.bottom + th + MARGIN <= vh) {
-        pos = 'bottom';
-      } else if (position === 'bottom' && w.bottom + th + MARGIN > vh && w.top - th - MARGIN >= 0) {
-        pos = 'top';
-      }
-      // Horizontal clamp: tooltip is centred on the trigger.
-      const centerX = w.left + w.width / 2;
-      const left = centerX - tw / 2;
-      const right = centerX + tw / 2;
-      let s = 0;
-      if (left < MARGIN) s = MARGIN - left;
-      else if (right > vw - MARGIN) s = vw - MARGIN - right;
-      setShift(s);
+      if (position === 'top' && w.top - th - off < MARGIN && w.bottom + th + off + MARGIN <= vh) side = 'bottom';
+      else if (position === 'bottom' && w.bottom + th + off + MARGIN > vh && w.top - th - off >= MARGIN) side = 'top';
     } else {
-      // Flip horizontally if the preferred side has no room.
-      if (position === 'left' && w.left - tw - MARGIN < 0 && w.right + tw + MARGIN <= vw) {
-        pos = 'right';
-      } else if (position === 'right' && w.right + tw + MARGIN > vw && w.left - tw - MARGIN >= 0) {
-        pos = 'left';
-      }
-      // Vertical clamp: tooltip is centred on the trigger.
-      const centerY = w.top + w.height / 2;
-      const top = centerY - th / 2;
-      const bottom = centerY + th / 2;
-      let s = 0;
-      if (top < MARGIN) s = MARGIN - top;
-      else if (bottom > vh - MARGIN) s = vh - MARGIN - bottom;
-      setShift(s);
+      if (position === 'left' && w.left - tw - off < MARGIN && w.right + tw + off + MARGIN <= vw) side = 'right';
+      else if (position === 'right' && w.right + tw + off + MARGIN > vw && w.left - tw - off >= MARGIN) side = 'left';
     }
 
-    setEffective(pos);
+    const centerX = w.left + w.width / 2;
+    const centerY = w.top + w.height / 2;
+    let left: number;
+    let top: number;
+    let arrowOffset: number;
+
+    if (side === 'top' || side === 'bottom') {
+      left = clamp(centerX - tw / 2, MARGIN, vw - tw - MARGIN);
+      top = side === 'top' ? w.top - th - off : w.bottom + off;
+      arrowOffset = clamp(centerX - left, ARROW + 4, tw - ARROW - 4);
+    } else {
+      top = clamp(centerY - th / 2, MARGIN, vh - th - MARGIN);
+      left = side === 'left' ? w.left - tw - off : w.right + off;
+      arrowOffset = clamp(centerY - top, ARROW + 4, th - ARROW - 4);
+    }
+
+    tip.style.left = `${left}px`;
+    tip.style.top = `${top}px`;
+    tip.style.opacity = '1';
+
+    arrow.className = `absolute w-0 h-0 border-4 ${arrowClasses[side]}`;
+    arrow.style.left = '';
+    arrow.style.right = '';
+    arrow.style.top = '';
+    arrow.style.bottom = '';
+    if (side === 'top' || side === 'bottom') {
+      arrow.style.left = `${arrowOffset}px`;
+      arrow.style.transform = 'translateX(-50%)';
+      arrow.style[side === 'top' ? 'top' : 'bottom'] = '100%';
+    } else {
+      arrow.style.top = `${arrowOffset}px`;
+      arrow.style.transform = 'translateY(-50%)';
+      arrow.style[side === 'left' ? 'left' : 'right'] = '100%';
+    }
   }, [position]);
+
+  // Position on open, and keep it anchored while the page scrolls or resizes.
+  useLayoutEffect(() => {
+    if (!open) return;
+    reposition();
+    window.addEventListener('scroll', reposition, true);
+    window.addEventListener('resize', reposition);
+    return () => {
+      window.removeEventListener('scroll', reposition, true);
+      window.removeEventListener('resize', reposition);
+    };
+  }, [open, reposition]);
 
   if (!tooltipsEnabled) {
     return <>{children}</>;
   }
 
-  const horizontal = effective === 'top' || effective === 'bottom';
-  const boxStyle: CSSProperties = horizontal
-    ? { transform: `translateX(calc(-50% + ${shift}px))` }
-    : { transform: `translateY(calc(-50% + ${shift}px))` };
-  const arrowStyle: CSSProperties = horizontal
-    ? { transform: `translateX(calc(-50% - ${shift}px))` }
-    : { transform: `translateY(calc(-50% - ${shift}px))` };
-
   return (
     <div
       ref={wrapperRef}
-      className="relative group/tooltip"
-      onMouseEnter={reposition}
-      onFocusCapture={reposition}
+      onMouseEnter={() => setOpen(true)}
+      onMouseLeave={() => setOpen(false)}
+      onFocusCapture={() => setOpen(true)}
+      onBlurCapture={() => setOpen(false)}
     >
       {children}
-      <div
-        ref={tipRef}
-        style={boxStyle}
-        className={`
-          absolute z-50 pointer-events-none
-          opacity-0 group-hover/tooltip:opacity-100
-          transition-opacity duration-150
-          ${positionClasses[effective]}
-        `}
-      >
-        <div className="bg-gray-800 border border-gray-700 text-gray-200 text-xs rounded-lg px-3 py-2 w-72 max-w-[calc(100vw-1rem)] shadow-lg whitespace-normal">
-          {content}
-        </div>
-        <div className={`absolute w-0 h-0 border-4 ${arrowClasses[effective]}`} style={arrowStyle} />
-      </div>
+      {open && typeof document !== 'undefined' &&
+        createPortal(
+          <div
+            ref={tipRef}
+            style={{ left: 0, top: 0, opacity: 0 }}
+            className="fixed z-[9999] pointer-events-none transition-opacity duration-150"
+          >
+            <div className="relative bg-gray-800 border border-gray-700 text-gray-200 text-xs rounded-lg px-3 py-2 w-72 max-w-[calc(100vw-1rem)] shadow-lg whitespace-normal">
+              {content}
+              <div ref={arrowRef} className={`absolute w-0 h-0 border-4 ${arrowClasses[position]}`} />
+            </div>
+          </div>,
+          document.body,
+        )}
     </div>
   );
 }


### PR DESCRIPTION
Tooltip: portal to document.body, position:fixed, z-9999 + viewport clamp/flip — no longer clipped behind the sidebar's overflow-auto container. Network Hashrate: formatHashrate gains EH/s + ZH/s tiers + a digits arg; global tile uses 0 decimals so it renders '961 EH/s' (was '961229.45 ...' with the unit cut off). Ghost/This-Node tiles unchanged.