### PR TITLE
feat(pool): expose per-block reaper reaped count on /api/v1/reaper/status

### DIFF
--- a/bins/ghost-pool/src/reaper_stats.rs
+++ b/bins/ghost-pool/src/reaper_stats.rs
@@ -31,6 +31,17 @@ pub struct ReaperStats {
     by_type: [AtomicU64; 10],
     /// Last reap timestamp (Unix seconds). 0 = never.
     last_reaped_unix: AtomicU64,
+    /// Transactions reaped while building the most-recently-built block
+    /// template. SNAPSHOT of the latest template — overwritten each build,
+    /// NOT cumulative. Powers the dashboard's "Reaped this block" tile.
+    last_block_reaped: AtomicU64,
+    /// Dead bytes reaped while building the most-recently-built block
+    /// template. Snapshot, overwritten each build.
+    last_block_dead_bytes: AtomicU64,
+    /// Unix seconds when the most recent block template was built. 0 = no
+    /// template built yet this run — lets the dashboard distinguish "0 reaped
+    /// this block" from "no block data yet".
+    last_block_unix: AtomicU64,
 }
 
 impl ReaperStats {
@@ -55,6 +66,19 @@ impl ReaperStats {
         }
     }
 
+    /// Records a snapshot of the most-recently-built block template's Reaper
+    /// impact: how many transactions it reaped and how many dead bytes those
+    /// carried. Called ONCE per template build. Overwrites the previous
+    /// snapshot — these are per-template values, NOT cumulative (the running
+    /// totals live in `record`). The build timestamp is stamped so the
+    /// dashboard can distinguish "0 reaped this block" from "no block yet".
+    pub fn record_block(&self, reaped: u64, dead_bytes: u64) {
+        self.last_block_reaped.store(reaped, Ordering::Relaxed);
+        self.last_block_dead_bytes
+            .store(dead_bytes, Ordering::Relaxed);
+        self.last_block_unix.store(now_unix(), Ordering::Relaxed);
+    }
+
     pub fn snapshot(&self) -> ReaperStatsSnapshot {
         ReaperStatsSnapshot {
             txs_evaluated: self.txs_evaluated.load(Ordering::Relaxed),
@@ -63,6 +87,16 @@ impl ReaperStats {
             dead_bytes_total: self.dead_bytes_total.load(Ordering::Relaxed),
             last_reaped_unix: {
                 let v = self.last_reaped_unix.load(Ordering::Relaxed);
+                if v == 0 {
+                    None
+                } else {
+                    Some(v as i64)
+                }
+            },
+            last_block_reaped: self.last_block_reaped.load(Ordering::Relaxed),
+            last_block_dead_bytes: self.last_block_dead_bytes.load(Ordering::Relaxed),
+            last_block_unix: {
+                let v = self.last_block_unix.load(Ordering::Relaxed);
                 if v == 0 {
                     None
                 } else {
@@ -93,6 +127,17 @@ pub struct ReaperStatsSnapshot {
     pub dead_bytes_total: u64,
     /// Unix seconds of the most recent reap. None if never.
     pub last_reaped_unix: Option<i64>,
+    /// Transactions reaped while building the most recent block template.
+    /// Snapshot of the latest template only (not cumulative). Interpret
+    /// alongside `last_block_unix`: 0 with a present timestamp means "a block
+    /// was built and it reaped nothing".
+    pub last_block_reaped: u64,
+    /// Dead bytes reaped in the most recent block template. Snapshot only.
+    pub last_block_dead_bytes: u64,
+    /// Unix seconds when the most recent block template was built. None = no
+    /// template built yet this run (so `last_block_reaped` is "no data", not
+    /// a real zero).
+    pub last_block_unix: Option<i64>,
     pub by_type: ByDeadCodeType,
 }
 
@@ -188,6 +233,53 @@ mod tests {
         assert_eq!(snap.by_type.drop_stuffing, 1);
         assert_eq!(snap.by_type.unreachable_code, 0);
         assert!(snap.last_reaped_unix.is_some());
+    }
+
+    #[test]
+    fn no_block_snapshot_before_any_build() {
+        let s = ReaperStats::new();
+        let snap = s.snapshot();
+        // Distinguishable "no data" state: timestamp absent, count reads 0.
+        assert_eq!(snap.last_block_unix, None);
+        assert_eq!(snap.last_block_reaped, 0);
+        assert_eq!(snap.last_block_dead_bytes, 0);
+    }
+
+    #[test]
+    fn record_block_updates_snapshot_and_is_not_cumulative() {
+        let s = ReaperStats::new();
+        s.record_block(3, 256);
+        let snap = s.snapshot();
+        assert_eq!(snap.last_block_reaped, 3);
+        assert_eq!(snap.last_block_dead_bytes, 256);
+        assert!(
+            snap.last_block_unix.is_some(),
+            "building a block stamps the timestamp"
+        );
+        // A quieter subsequent block OVERWRITES (snapshot, not a running sum).
+        s.record_block(0, 0);
+        let snap = s.snapshot();
+        assert_eq!(snap.last_block_reaped, 0);
+        assert_eq!(snap.last_block_dead_bytes, 0);
+        // A zero-reap block still counts as a built block (timestamp present),
+        // so the dashboard shows "0 reaped this block", not "no data".
+        assert!(snap.last_block_unix.is_some());
+    }
+
+    #[test]
+    fn record_block_is_independent_of_cumulative_counters() {
+        let s = ReaperStats::new();
+        s.record(&corpse_verdict(vec![DeadCodeType::InscriptionEnvelope], 40));
+        s.record(&corpse_verdict(vec![DeadCodeType::DropStuffing], 40));
+        // Only the latest template reaped a single tx.
+        s.record_block(1, 40);
+        let snap = s.snapshot();
+        // Cumulative untouched by record_block…
+        assert_eq!(snap.txs_reaped, 2);
+        assert_eq!(snap.dead_bytes_total, 80);
+        // …and per-block reflects just the latest template.
+        assert_eq!(snap.last_block_reaped, 1);
+        assert_eq!(snap.last_block_dead_bytes, 40);
     }
 
     #[test]

--- a/bins/ghost-pool/src/template.rs
+++ b/bins/ghost-pool/src/template.rs
@@ -1886,6 +1886,7 @@ impl TemplateProcessor {
         let mut kept = Vec::with_capacity(original_count);
         let mut removed_fees = 0u64;
         let mut reaped_count = 0usize;
+        let mut reaped_dead_bytes = 0u64;
 
         // Track seen TXIDs to detect duplicates
         let mut seen_txids: HashSet<String> = HashSet::with_capacity(transactions.len());
@@ -1932,6 +1933,7 @@ impl TemplateProcessor {
                 if reaper_verdict.is_corpse() {
                     removed_fees += tx.fee;
                     reaped_count += 1;
+                    reaped_dead_bytes += reaper_verdict.total_dead_bytes as u64;
                     debug!(
                         txid = %tx.txid,
                         dead_bytes = reaper_verdict.total_dead_bytes,
@@ -1992,7 +1994,15 @@ impl TemplateProcessor {
             removed: original_count - kept.len(),
             removed_fees,
             reaped: reaped_count,
+            reaped_dead_bytes,
         };
+
+        // Snapshot this template's Reaper impact for the "Reaped this block"
+        // dashboard tile. Runs on EVERY build (even zero-reap ones) so the
+        // stamped timestamp lets the API distinguish "0 reaped" from "no
+        // block yet". Separate from the cumulative `record` calls above.
+        self.reaper_stats
+            .record_block(stats.reaped as u64, stats.reaped_dead_bytes);
 
         (kept, stats)
     }
@@ -3149,6 +3159,8 @@ struct FilterStats {
     removed: usize,
     removed_fees: u64,
     reaped: usize,
+    /// Dead bytes carried by the reaped transactions in this template.
+    reaped_dead_bytes: u64,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Adds last_block_reaped + last_block_dead_bytes + last_block_unix snapshot fields to ReaperStats/ReaperStatsSnapshot, recorded via record_block() on every template build (template.rs, real per-template dead bytes from reaper_verdict.total_dead_bytes). last_block_unix null = no template yet (distinguishes '0 reaped' from 'no data'). Existing fields unchanged. 3 new tests. Powers the dashboard 'Reaped this block' tile. BATCHED — v1 pool bounce, not now.