### PR TITLE
feat: expose self-check over HTTP + mining-page warning banner

### DIFF
--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -5900,6 +5900,20 @@ async fn main() -> Result<()> {
         serde_json::to_value(reaper_stats_for_api.snapshot()).unwrap_or(serde_json::Value::Null)
     });
 
+    // Capability self-check (Phase 3). Construct the coordinator here so its
+    // last snapshot can be surfaced over HTTP at /api/v1/system/self-check;
+    // the background probe loop is spawned later (after the HTTP listener is
+    // up). The dashboard reads this to warn when a claimed capability's
+    // prerequisite is missing (e.g. public_mining announced but no stratum
+    // serving). Read-only: the handler reads the snapshot, it does not probe.
+    let self_check = SelfCheck::new();
+    {
+        let self_check_for_api = self_check.clone();
+        verification_state = verification_state.with_self_check(move || {
+            serde_json::to_value(self_check_for_api.snapshot()).unwrap_or(serde_json::Value::Null)
+        });
+    }
+
     // Decentralised Wraith coordinator election (read-only, gated off by
     // default). Constructed ONLY when `[coordinator] wraith_election_enabled`
     // is true; otherwise `None` and the service is inert (zero effect on the
@@ -7173,9 +7187,10 @@ async fn main() -> Result<()> {
     // Phase 3: capability self-check loop. Probes prerequisites for each
     // claimed capability (stratum ports, disk space, ghost-pay daemon,
     // reaper config) every 30s. Diagnostic only — surfaced via the dashboard
-    // and `/health/self_check`. Does not auto-demote claims; the verification
-    // mesh catches false claims at the consensus layer.
-    let self_check = SelfCheck::new();
+    // (`/api/v1/system/self-check`) and `/health/self_check`. Does not
+    // auto-demote claims; the verification mesh catches false claims at the
+    // consensus layer. `self_check` was constructed earlier so the HTTP
+    // handler shares this exact snapshot; here we start its probe loop.
     self_check.clone().spawn_loop(Arc::new(config.clone()));
     info!("Capability self-check loop started (30s interval)");
 

--- a/crates/ghost-verification/src/routes.rs
+++ b/crates/ghost-verification/src/routes.rs
@@ -286,6 +286,7 @@ pub fn create_router(state: Arc<VerificationState>) -> Router {
         .route("/api/v1/watchdog/status", get(api_watchdog_status_handler))
         .route("/api/v1/system/version", get(api_system_version_handler))
         .route("/api/v1/system/mempool", get(api_system_mempool_handler))
+        .route("/api/v1/system/self-check", get(api_self_check_handler))
         .route("/api/v1/reaper/status", get(api_reaper_status_handler))
         .route("/api/v1/payments", get(api_payments_handler))
         .route("/api/v1/backup/history", get(api_backup_history_handler))
@@ -7728,6 +7729,19 @@ async fn api_reaper_status_handler(
     Json(state.reaper_stats())
 }
 
+/// Return the capability self-check snapshot (per-capability
+/// claimed/passed/reason) computed by the background loop in ghost-pool. The
+/// dashboard reads this to warn an operator when they have CLAIMED a capability
+/// (e.g. `public_mining`) whose prerequisite is missing (e.g. no stratum
+/// listening on port 3333), so they don't silently fail to earn its shares.
+/// Read-only: hands back the last snapshot; no probing happens in the request
+/// path. Returns `null` on older deploys where the provider isn't wired.
+async fn api_self_check_handler(
+    State(state): State<Arc<VerificationState>>,
+) -> impl IntoResponse {
+    Json(state.self_check())
+}
+
 /// Read-only decentralised-coordinator election view
 /// (`tasks/plan_decentralised_coordinators.md`). Returns
 /// `{enabled, epoch, seats, my_seat, elected:[hex node ids]}` when the operator
@@ -9024,5 +9038,88 @@ mod tests {
             .with_full_node_config(cfg, path),
         );
         assert_eq!(authority(override_state).await, "customAuthorityKey123");
+    }
+
+    /// The self-check endpoint must serialise a FAILING snapshot so the
+    /// dashboard can warn the operator (e.g. public_mining claimed but no
+    /// stratum listening). Wire a provider that returns a failing capability
+    /// and assert the endpoint reflects claimed/passed/reason verbatim.
+    #[tokio::test]
+    async fn test_self_check_endpoint_serialises_failure() {
+        use ghost_common::types::NodeCapabilities;
+        use ghost_policy::PolicyProfile;
+
+        let state = Arc::new(
+            crate::server::VerificationState::new(
+                "test_node".to_string(),
+                "1.0.0".to_string(),
+                PolicyProfile::default(),
+                NodeCapabilities::default(),
+            )
+            .with_self_check(|| {
+                serde_json::json!({
+                    "public_mining": {
+                        "claimed": true,
+                        "passed": false,
+                        "reason": "SV1 stratum (port 3333) not listening — start sri-translator",
+                        "last_checked_unix": 1_700_000_000_i64,
+                    },
+                    "archive": { "claimed": false, "passed": false, "reason": null, "last_checked_unix": 1_700_000_000_i64 },
+                    "ghost_pay": { "claimed": false, "passed": false, "reason": null, "last_checked_unix": 1_700_000_000_i64 },
+                    "reaper": { "claimed": false, "passed": false, "reason": null, "last_checked_unix": 1_700_000_000_i64 },
+                })
+            }),
+        );
+        let app = super::create_router(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/api/v1/system/self-check")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(json["public_mining"]["claimed"], true);
+        assert_eq!(json["public_mining"]["passed"], false);
+        assert!(json["public_mining"]["reason"]
+            .as_str()
+            .unwrap()
+            .contains("port 3333"));
+    }
+
+    /// Pre-bounce safety: when the provider isn't wired (older deploy), the
+    /// endpoint must still respond 200 with a JSON `null` body so the frontend
+    /// can treat "absent/ok" as "render nothing".
+    #[tokio::test]
+    async fn test_self_check_endpoint_null_when_unwired() {
+        let state = create_test_state_without_auth();
+        let app = super::create_router(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/api/v1/system/self-check")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert!(json.is_null());
     }
 }

--- a/crates/ghost-verification/src/server.rs
+++ b/crates/ghost-verification/src/server.rs
@@ -1263,6 +1263,13 @@ pub struct VerificationState {
     /// concrete `ReaperStats` type lives in `bins/ghost-pool` and we don't
     /// want a reverse dep from ghost-verification.
     get_reaper_stats: Option<Box<dyn Fn() -> serde_json::Value + Send + Sync>>,
+    /// Capability self-check snapshot callback. Returns a JSON-serializable
+    /// snapshot of the current `SelfCheckState` (per-capability
+    /// claimed/passed/reason) so the dashboard can surface drift between a
+    /// claimed capability and its missing prerequisite. Pre-serialized to JSON
+    /// because the concrete `SelfCheckState` type lives in `bins/ghost-pool`
+    /// and we don't want a reverse dep from ghost-verification.
+    get_self_check: Option<Box<dyn Fn() -> serde_json::Value + Send + Sync>>,
     /// Coordinator-election snapshot callback (pre-serialized JSON to avoid a
     /// reverse-dependency on the `wraith-protocol`/`ghost-pool` election types).
     /// Returns `{enabled, epoch, seats, my_seat, elected}` when the feature is
@@ -1484,6 +1491,7 @@ impl VerificationState {
             internal_auth: None,
             get_pool_peers: None,
             get_reaper_stats: None,
+            get_self_check: None,
             get_coordinator_status: None,
             get_mesh_active_miners: None,
             get_self_deduped_miners: None,
@@ -1981,6 +1989,28 @@ impl VerificationState {
         f: impl Fn() -> serde_json::Value + Send + Sync + 'static,
     ) -> Self {
         self.get_reaper_stats = Some(Box::new(f));
+        self
+    }
+
+    /// Capability self-check snapshot for `/api/v1/system/self-check`, or
+    /// `null` when not wired (older deploy). Reports, for each capability the
+    /// node CLAIMS, whether its prerequisite probe currently passes and a
+    /// human-readable reason when it does not. Read-only: reads the snapshot
+    /// the background loop already computed — no probing in the request path.
+    pub fn self_check(&self) -> serde_json::Value {
+        self.get_self_check
+            .as_ref()
+            .map(|f| f())
+            .unwrap_or(serde_json::Value::Null)
+    }
+
+    /// Set the self-check callback (pre-serialized JSON to avoid a
+    /// reverse-dependency on ghost-pool's `SelfCheckState`).
+    pub fn with_self_check(
+        mut self,
+        f: impl Fn() -> serde_json::Value + Send + Sync + 'static,
+    ) -> Self {
+        self.get_self_check = Some(Box::new(f));
         self
     }
 

--- a/dashboard/src/app/(dashboard)/mining/page.tsx
+++ b/dashboard/src/app/(dashboard)/mining/page.tsx
@@ -11,7 +11,8 @@ import { ConfirmDialog } from "@/components/ui/Dialog";
 import { SectionErrorBoundary } from "@/components/ui/SectionErrorBoundary";
 import { formatHashrate } from "@/components/ui/DataTable";
 import { SkeletonCard } from "@/components/ui/Skeleton";
-import { useMiningStatus, useBestHash, useSetPrivateMining, useSetPublicMining } from "@/hooks/queries";
+import { useMiningStatus, useBestHash, useSetPrivateMining, useSetPublicMining, useSelfCheck } from "@/hooks/queries";
+import { selfCheckFailures, type SelfCheckState } from "@/lib/api/selfCheck";
 import { useToast } from "@/components/ui/Toast";
 import { useQueryClient } from "@tanstack/react-query";
 import PoolSetupWizard from "../settings/wizards/PoolSetupWizard";
@@ -130,6 +131,15 @@ function BestHashCard({ title, entry }: { title: string; entry: BestHashEntry | 
   );
 }
 
+// Human-readable names for the self-check capabilities, used in the drift
+// warning banner. Keys mirror ghost-pool's `SelfCheckState` fields.
+const CAPABILITY_LABELS: Record<keyof SelfCheckState, string> = {
+  public_mining: "Public Mining",
+  archive: "Archive Mode",
+  ghost_pay: "Ghost Pay",
+  reaper: "Reaper",
+};
+
 type MiningMode = "private_solo" | "private_pool" | "pool";
 
 function getMiningMode(privateMining?: boolean, publicMining?: boolean): MiningMode {
@@ -147,6 +157,16 @@ const MODES: { key: MiningMode; label: string; desc: string }[] = [
 export default function MiningPage() {
   const { data: status, isLoading: statusLoading } = useMiningStatus();
   const { data: bestHashData, isLoading: bestHashLoading } = useBestHash();
+  // Capability self-check: warn when a CLAIMED capability's prerequisite is
+  // missing (e.g. public_mining enabled but no stratum listening) so the
+  // operator isn't silently failing to earn its shares. `null` (older backend,
+  // 404, or all-passing) yields no failures → banner renders nothing.
+  const { data: selfCheck } = useSelfCheck();
+  const selfCheckFailureList = selfCheckFailures(selfCheck);
+  // Dismissible per session (useState resets on reload), so the banner
+  // re-appears on the next page load while the condition persists.
+  const [selfCheckDismissed, setSelfCheckDismissed] = useState(false);
+  const showSelfCheckBanner = selfCheckFailureList.length > 0 && !selfCheckDismissed;
   const setPrivateMining = useSetPrivateMining();
   const setPublicMining = useSetPublicMining();
   const queryClient = useQueryClient();
@@ -219,6 +239,60 @@ export default function MiningPage() {
   return (
     <div className="space-y-6">
       <PageHeader eyebrow="mining" title="Hashrate, shares, miners." subtitle="Hashrate, miners, and mining configuration" />
+
+      {/* Capability drift warning — a claimed capability whose prerequisite the
+          node can't satisfy right now. Primary case: Public Mining enabled but
+          no stratum serving, so miners can't connect and the +3 shares aren't
+          being earned. Only rendered when the self-check reports a failure;
+          dismissible for the session but re-shows on reload. */}
+      {showSelfCheckBanner && (
+        <div
+          role="alert"
+          className="rounded-lg border border-amber-600/60 bg-amber-900/20 p-4"
+        >
+          <div className="flex items-start gap-3">
+            <span aria-hidden className="text-amber-400 text-lg leading-none mt-0.5">⚠</span>
+            <div className="flex-1 min-w-0 space-y-2">
+              <div className="text-sm font-semibold text-amber-300">
+                Capability prerequisite missing
+              </div>
+              <ul className="space-y-2">
+                {selfCheckFailureList.map((f) => (
+                  <li key={f.capability} className="text-sm text-amber-100/90 leading-relaxed">
+                    {f.capability === "public_mining" ? (
+                      <>
+                        You&apos;ve enabled <span className="font-medium">Public Mining</span>, but no stratum
+                        server is responding on this node (port {status?.stratum_v1_port || 3333}). Miners
+                        can&apos;t connect and you are{" "}
+                        <span className="font-semibold">NOT earning the +3 Public Mining shares</span>. Start
+                        the stratum stack (sri-translator/sri-pool) or change your mining mode.
+                      </>
+                    ) : (
+                      <>
+                        You&apos;ve enabled{" "}
+                        <span className="font-medium">{CAPABILITY_LABELS[f.capability]}</span>, but its
+                        prerequisite isn&apos;t satisfied on this node, so you are not earning its shares.
+                      </>
+                    )}
+                    {/* Exact reason straight from the node probe (true port,
+                        remediation hint) so the friendly copy above stays
+                        correct even when the configured port differs. */}
+                    <div className="text-xs text-amber-200/60 mt-1">{f.reason}</div>
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <button
+              type="button"
+              onClick={() => setSelfCheckDismissed(true)}
+              className="text-amber-300/70 hover:text-amber-200 text-sm shrink-0"
+              aria-label="Dismiss warning"
+            >
+              Dismiss
+            </button>
+          </div>
+        </div>
+      )}
 
       {/* Stats row */}
       <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4">

--- a/dashboard/src/hooks/queries/index.ts
+++ b/dashboard/src/hooks/queries/index.ts
@@ -48,3 +48,6 @@ export * from './useShroudQueries';
 
 // Reaper queries
 export * from './useReaperQueries';
+
+// Capability self-check queries
+export * from './useSelfCheckQueries';

--- a/dashboard/src/hooks/queries/useSelfCheckQueries.ts
+++ b/dashboard/src/hooks/queries/useSelfCheckQueries.ts
@@ -1,0 +1,16 @@
+import { useQuery } from "@tanstack/react-query";
+import { getSelfCheck } from "@/lib/api/selfCheck";
+
+export const selfCheckKeys = {
+  all: ["selfCheck"] as const,
+  status: () => [...selfCheckKeys.all, "status"] as const,
+};
+
+export function useSelfCheck(options?: { refetchInterval?: number }) {
+  return useQuery({
+    queryKey: selfCheckKeys.status(),
+    queryFn: getSelfCheck,
+    // The backend probes every 30s; poll at the same cadence.
+    refetchInterval: options?.refetchInterval ?? 30_000,
+  });
+}

--- a/dashboard/src/lib/api/selfCheck.ts
+++ b/dashboard/src/lib/api/selfCheck.ts
@@ -1,0 +1,71 @@
+// Capability self-check — per-capability prerequisite probes computed by
+// ghost-pool's background loop and read from `/api/v1/system/self-check`.
+//
+// For every capability the node CLAIMS in its config, the node probes whether
+// the prerequisite is actually satisfied (e.g. `public_mining` requires the
+// SV1 stratum port to be listening). When a claim's prerequisite is missing the
+// operator is silently NOT earning that capability's shares, so the dashboard
+// surfaces it as a warning banner.
+import { fetchApi } from "./client";
+
+export interface CapabilityCheck {
+  // True iff the node's config asks for this capability.
+  claimed: boolean;
+  // True iff the prerequisite probe passes right now.
+  passed: boolean;
+  // Human-readable failure reason (null when passing / not claimed).
+  reason: string | null;
+  // Unix timestamp of the most recent probe.
+  last_checked_unix: number;
+}
+
+export interface SelfCheckState {
+  public_mining: CapabilityCheck;
+  archive: CapabilityCheck;
+  ghost_pay: CapabilityCheck;
+  reaper: CapabilityCheck;
+}
+
+/**
+ * Fetch the self-check snapshot. Returns `null` (rather than throwing) when the
+ * backend hasn't wired the provider yet (older deploy — the endpoint serves
+ * JSON `null`), when the endpoint is absent (404 → older backend without the
+ * route at all), or on any transport error. Callers treat `null` as "nothing
+ * to warn about", so the frontend is safe to ship before the backend bounce.
+ */
+export async function getSelfCheck(): Promise<SelfCheckState | null> {
+  try {
+    const data = await fetchApi<unknown>("/api/v1/system/self-check");
+    return data && typeof data === "object" && "public_mining" in data
+      ? (data as SelfCheckState)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+// A single failing capability, flattened for banner rendering.
+export interface SelfCheckFailure {
+  capability: keyof SelfCheckState;
+  reason: string;
+}
+
+// Extract the capabilities that are CLAIMED but whose prerequisite is missing.
+// Empty array when the snapshot is null or everything claimed is passing.
+export function selfCheckFailures(
+  state: SelfCheckState | null | undefined,
+): SelfCheckFailure[] {
+  if (!state) return [];
+  const caps: (keyof SelfCheckState)[] = [
+    "public_mining",
+    "archive",
+    "ghost_pay",
+    "reaper",
+  ];
+  return caps
+    .filter((c) => state[c]?.claimed && !state[c]?.passed)
+    .map((c) => ({
+      capability: c,
+      reason: state[c]?.reason ?? "prerequisite not satisfied",
+    }));
+}


### PR DESCRIPTION
Backend: GET /api/v1/system/self-check exposes SelfCheckState (claimed/passed/reason per capability) — surfaces the logs-only 'public_mining announced but stratum not serving' warning. Frontend: amber banner on the mining page when any claimed capability's prerequisite is missing; safe pre-bounce (renders nothing on 404/null). Backend deploys in the bounce; frontend to canary.