### PR TITLE
dashboard: dark default, Overview landing, swarm/capacity fixes

### DIFF
--- a/dashboard/src/app/(dashboard)/capacity/page.tsx
+++ b/dashboard/src/app/(dashboard)/capacity/page.tsx
@@ -140,7 +140,11 @@ export default function CapacityPage() {
   }
 
   const me = data.this_node;
-  const myPct = utilPct(me);
+  // Use this node's DEDUPED count for its own figures — the raw miner_count is a
+  // double-counted load-balancer metric that can exceed the mesh total (nonsense
+  // for a single node). Keeps the tile consistent with the peer table below.
+  const myMiners = me.deduped_miner_count ?? me.miner_count;
+  const myPct = me.max_capacity ? Math.round((myMiners * 100) / me.max_capacity) : 0;
 
   // Post-redeploy nodes report a `deduped_miner_count` per node that sums to the
   // deduped mesh total. When present, the peer table shows those (labelled just
@@ -176,7 +180,7 @@ export default function CapacityPage() {
           </div>
 
           <div className="grid grid-cols-2 md:grid-cols-4 gap-6 mb-6">
-            <Stat label="connected miners" value={me.miner_count.toLocaleString()} />
+            <Stat label="connected miners" value={myMiners.toLocaleString()} />
             <Stat label="capacity ceiling" value={me.max_capacity.toLocaleString()} />
             <Stat label="utilisation" value={`${myPct}%`} accent={utilColor(myPct)} />
             <Stat
@@ -194,7 +198,7 @@ export default function CapacityPage() {
             />
           </div>
 
-          <UtilisationBar pct={myPct} label={`${me.miner_count} of ${me.max_capacity} (${myPct}%)`} />
+          <UtilisationBar pct={myPct} label={`${myMiners} of ${me.max_capacity} (${myPct}%)`} />
         </Card>
       </SectionErrorBoundary>
 

--- a/dashboard/src/app/(dashboard)/swarm/page.tsx
+++ b/dashboard/src/app/(dashboard)/swarm/page.tsx
@@ -369,7 +369,6 @@ export default function SwarmPage() {
           <StatCard
             label="Nodes"
             value={stats?.total_nodes ?? 0}
-            sublabel={`${stats?.online_nodes ?? 0} online`}
             loading={swarmLoading}
           />
           <StatCard

--- a/dashboard/src/app/layout.tsx
+++ b/dashboard/src/app/layout.tsx
@@ -25,14 +25,13 @@ export const metadata: Metadata = {
 };
 
 // Inline script that runs before paint so there's no flash of wrong theme on
-// load. Order: explicit user choice in localStorage > OS preference > dark.
-// Mirrors the website's theme-toggle pattern.
+// load. Order: explicit user choice in localStorage > dark (default).
+// Dark is the default regardless of OS preference; light mode is opt-in only.
 const themeBootstrap = `
 (function() {
   try {
     var stored = localStorage.getItem('ghost-theme');
-    var theme = stored
-      || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+    var theme = stored || 'dark';
     document.documentElement.setAttribute('data-theme', theme);
   } catch (e) {
     document.documentElement.setAttribute('data-theme', 'dark');

--- a/dashboard/src/app/login/page.tsx
+++ b/dashboard/src/app/login/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Suspense, useState } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useRouter } from "next/navigation";
 import { Ghost } from "lucide-react";
 
 function LoginForm() {
@@ -9,7 +9,6 @@ function LoginForm() {
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
   const router = useRouter();
-  const searchParams = useSearchParams();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -24,8 +23,9 @@ function LoginForm() {
       });
 
       if (res.ok) {
-        const redirect = searchParams.get("redirect") || "/";
-        router.push(redirect);
+        // Always land on Overview after sign-in, regardless of the page the
+        // middleware bounced from — the dashboard opens on the home view.
+        router.push("/");
       } else {
         setError("Invalid password");
       }


### PR DESCRIPTION
Theme defaults to dark regardless of OS (light opt-in only). Login always lands on Overview (/) not the bounced-from page. Swarm: drop redundant 'N online' sublabel on the Nodes tile (Online has its own tile). Capacity: This-node tile/utilisation/bar now use the deduped count (was the raw double-counted miner_count that could exceed the mesh total).