### PR TITLE
dashboard: fix Elder #undefined badge on swarm

### DIFF
--- a/dashboard/src/app/(dashboard)/swarm/page.tsx
+++ b/dashboard/src/app/(dashboard)/swarm/page.tsx
@@ -603,7 +603,7 @@ export default function SwarmPage() {
                   <Badge variant={node.public_mining ? "success" : "error"}>Public Mining +3</Badge>
                   <Badge variant={node.reaper ? "success" : "error"}>Reaper +2</Badge>
                   <Badge variant={node.elder ? "success" : "error"}>
-                    Elder {node.elder ? `#${node.elder_slot}` : ""} +1
+                    Elder{node.elder && node.elder_slot != null ? ` #${node.elder_slot}` : ""} +1
                   </Badge>
                 </div>
 


### PR DESCRIPTION
The swarm node badge rendered #${node.elder_slot} unconditionally when node.elder was true, printing 'Elder #undefined +1' because the swarm node data doesn't carry elder_slot. Now shows 'Elder #N +1' when the slot is present, 'Elder +1' otherwise. (Backend follow-up: swarm/peers API should return elder_slot per node.)