### PR TITLE
dashboard: remove Tor card, build Logs page, badge own swarm node

### DIFF
--- a/dashboard/src/app/(dashboard)/capabilities/page.tsx
+++ b/dashboard/src/app/(dashboard)/capabilities/page.tsx
@@ -137,7 +137,7 @@ export default function CapabilitiesPage() {
       <PageHeader
         eyebrow="capabilities"
         title="What this node is earning."
-        subtitle="Five capability shares. The Claimed column is what your node advertises; the Qualified column is what's earning at payout. Drift between them means challenges are failing — fix the prerequisite and watch the column flip."
+        subtitle="Five capability shares. The Claimed column is what your node advertises; the Qualified column is what's earning at payout. Drift between them means challenges are failing."
         subtitleFullWidth
         actions={
           <Badge variant={totalQualified === 15 ? "success" : totalQualified >= 6 ? "warning" : "error"}>

--- a/dashboard/src/app/(dashboard)/logs/page.tsx
+++ b/dashboard/src/app/(dashboard)/logs/page.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { useState } from "react";
+import { PageHeader } from "@/components/ui/PageHeader";
+import { Card } from "@/components/ui/Card";
+import { Button } from "@/components/ui/Button";
+import { SectionErrorBoundary } from "@/components/ui/SectionErrorBoundary";
+import { useLogs } from "@/hooks/queries";
+import type { LogEntry } from "@/types/api";
+
+const LEVELS = ["all", "error", "warn", "info", "debug", "trace"] as const;
+type Level = (typeof LEVELS)[number];
+
+const LEVEL_COLOR: Record<LogEntry["level"], string> = {
+  error: "#f85149",
+  warn: "#d29922",
+  info: "#58a6ff",
+  debug: "var(--dim)",
+  trace: "var(--fainter)",
+};
+
+// Ring-buffer timestamps are Unix seconds; guard for ms just in case.
+function formatTs(ts: number): string {
+  const ms = ts < 1e12 ? ts * 1000 : ts;
+  const d = new Date(ms);
+  if (Number.isNaN(d.getTime())) return "--:--:--";
+  return d.toLocaleTimeString(undefined, { hour12: false }) + "." + String(d.getMilliseconds()).padStart(3, "0");
+}
+
+export default function LogsPage() {
+  const [level, setLevel] = useState<Level>("all");
+  const [limit] = useState(500);
+  const { data, isLoading, isError, error, refetch, isFetching } = useLogs({
+    limit,
+    level: level === "all" ? undefined : level,
+  });
+
+  const entries = data?.entries ?? [];
+
+  const copyAll = () => {
+    const text = entries
+      .map((e) => `${formatTs(e.timestamp)} ${e.level.toUpperCase().padEnd(5)} ${e.target}  ${e.message}`)
+      .join("\n");
+    navigator.clipboard.writeText(text);
+  };
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        eyebrow="system"
+        title="Logs."
+        subtitle="Recent ghost-pool logs from the node's in-memory ring buffer. This is ghost-pool's own output, not the full journald firehose of every binary."
+        subtitleFullWidth
+      />
+
+      <SectionErrorBoundary section="Logs">
+        <Card>
+          {/* Controls */}
+          <div className="flex items-center justify-between gap-3 flex-wrap" style={{ marginBottom: "12px" }}>
+            <div className="flex items-center gap-2 flex-wrap">
+              {LEVELS.map((lv) => (
+                <button
+                  key={lv}
+                  onClick={() => setLevel(lv)}
+                  style={{
+                    padding: "4px 10px",
+                    fontSize: "12px",
+                    borderRadius: "4px",
+                    border: `1px solid ${level === lv ? "var(--accent)" : "var(--rule)"}`,
+                    background: level === lv ? "var(--accent-weak)" : "transparent",
+                    color: level === lv ? "var(--fg)" : "var(--dim)",
+                    cursor: "pointer",
+                    textTransform: "uppercase",
+                    letterSpacing: "0.04em",
+                  }}
+                >
+                  {lv}
+                </button>
+              ))}
+            </div>
+            <div className="flex items-center gap-2">
+              <span style={{ color: "var(--fainter)", fontSize: "12px" }}>
+                {entries.length} line{entries.length === 1 ? "" : "s"}
+              </span>
+              <Button variant="ghost" size="sm" onClick={copyAll} disabled={!entries.length}>
+                Copy
+              </Button>
+              <Button variant="primary" size="sm" onClick={() => refetch()} disabled={isFetching}>
+                {isFetching ? "Refreshing…" : "Refresh"}
+              </Button>
+            </div>
+          </div>
+
+          {/* Log stream */}
+          <div
+            style={{
+              maxHeight: "70vh",
+              overflowY: "auto",
+              overflowX: "auto",
+              background: "var(--bg)",
+              border: "1px solid var(--rule)",
+              borderRadius: "4px",
+              padding: "10px 12px",
+              fontFamily: "var(--font-mono)",
+              fontSize: "12px",
+              lineHeight: "1.55",
+            }}
+          >
+            {isLoading ? (
+              <div style={{ color: "var(--dim)" }}>Loading logs…</div>
+            ) : isError ? (
+              <div style={{ color: "#f85149" }}>
+                Couldn&apos;t load logs{error instanceof Error ? `: ${error.message}` : "."}
+              </div>
+            ) : entries.length === 0 ? (
+              <div style={{ color: "var(--dim)" }}>No log entries in the buffer for this level.</div>
+            ) : (
+              entries.map((e, i) => (
+                <div key={i} style={{ whiteSpace: "pre-wrap", wordBreak: "break-word", display: "flex", gap: "10px" }}>
+                  <span style={{ color: "var(--fainter)", flexShrink: 0 }}>{formatTs(e.timestamp)}</span>
+                  <span style={{ color: LEVEL_COLOR[e.level] ?? "var(--dim)", flexShrink: 0, width: "44px" }}>
+                    {e.level.toUpperCase()}
+                  </span>
+                  <span style={{ color: "var(--fainter)", flexShrink: 0 }}>{e.target}</span>
+                  <span style={{ color: "var(--fg)" }}>{e.message}</span>
+                </div>
+              ))
+            )}
+          </div>
+        </Card>
+      </SectionErrorBoundary>
+    </div>
+  );
+}

--- a/dashboard/src/app/(dashboard)/swarm/page.tsx
+++ b/dashboard/src/app/(dashboard)/swarm/page.tsx
@@ -447,6 +447,11 @@ export default function SwarmPage() {
                       className={`w-2.5 h-2.5 rounded-full ${node.online ? "bg-green-500" : "bg-red-500"}`}
                     />
                     <span className="font-semibold text-gray-100">{node.name}</span>
+                    {node.is_self && (
+                      <Badge variant="info" className="text-xs">
+                        You
+                      </Badge>
+                    )}
                   </div>
                   <div className="flex items-center gap-1">
                     <Badge variant={node.online ? "success" : "error"} className="text-xs">

--- a/dashboard/src/app/(dashboard)/system/page.tsx
+++ b/dashboard/src/app/(dashboard)/system/page.tsx
@@ -1048,47 +1048,6 @@ export default function SystemPage() {
         </Card>
       </SectionErrorBoundary>
 
-      {/* ----------------------------------------------------------------- */}
-      {/* Tor Mode Status                                                    */}
-      {/* ----------------------------------------------------------------- */}
-      <SectionErrorBoundary section="Tor Mode">
-        <Card>
-          <CardHeader
-            title="Tor Mode"
-            subtitle="Onion-only networking — route all traffic through Tor"
-          />
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-            <div className="p-4 bg-gray-800/50 rounded-lg">
-              <div className="text-sm text-gray-400 mb-1">Status</div>
-              <Badge variant={status?.tor_mode ? "success" : "default"}>
-                {status?.tor_mode ? "Active" : "Disabled"}
-              </Badge>
-            </div>
-            {status?.tor_mode && status?.onion_address && (
-              <div className="p-4 bg-gray-800/50 rounded-lg col-span-2">
-                <div className="text-sm text-gray-400 mb-1">Onion Address</div>
-                <code
-                  className="text-orange-400 text-sm cursor-pointer hover:text-orange-300 break-all"
-                  onClick={() => {
-                    navigator.clipboard.writeText(status.onion_address!);
-                    success("Onion address copied");
-                  }}
-                  title="Click to copy"
-                >
-                  {status.onion_address}
-                </code>
-              </div>
-            )}
-          </div>
-          {!status?.tor_mode && (
-            <p className="text-sm text-gray-500 mt-3">
-              Start ghostd with <code className="text-gray-400">-tormode</code> to
-              route all connections through Tor. Requires restart.
-            </p>
-          )}
-        </Card>
-      </SectionErrorBoundary>
-
       {/* ================================================================= */}
       {/* Dialogs                                                            */}
       {/* ================================================================= */}


### PR DESCRIPTION
Three small dashboard fixes from the review pass. All frontend, all off `main` (no overlap with #218).

### `dashboard(system)`: remove the misplaced Tor Mode card — Fixes #222
Tor status/control already live on the Network page and Settings > Privacy; the card was off-topic on the System page (version/updates/storage/backups) and read as random.

### `dashboard(logs)`: build the `/logs` page — Fixes #221
The Logs nav item 404'd — no page existed, though the `useLogs()` hook and ring-buffer endpoint did. Adds the page: level filter, refresh, copy, level-coloured stream. Copy is explicit that this is ghost-pool's own in-memory ring buffer, **not** the full journald firehose (that endpoint was removed as a security risk).

### `dashboard(swarm)`: badge the operator's own node with "You" — addresses #219
The swarm list included this node but never marked which entry it was; now the `is_self` node shows a `You` badge (matching the Capacity page). The separate half of #219 — the `—` uptime/peers/L1/L2 stats for the self node — is a data-source fix still tracked on that issue.

### Verification
`tsc --noEmit` clean, `eslint` clean on changed files. Not deployed — part of the batched canary pass.
