### PR TITLE
verification: persist node nickname, deduped Watchdog miner count

### DIFF
--- a/crates/ghost-verification/src/config.rs
+++ b/crates/ghost-verification/src/config.rs
@@ -39,6 +39,11 @@ pub struct NodeConfig {
     /// Requires ghost-core restart with -shroud=1 flag to take effect.
     #[serde(default)]
     pub shroud_enabled: bool,
+    /// Operator's display nickname for this node. Persisted so it survives
+    /// restarts (it used to live only in the in-memory dashboard config and was
+    /// lost on every restart). None = no nickname set (falls back to short id).
+    #[serde(default)]
+    pub nickname: Option<String>,
 }
 
 impl NodeConfig {
@@ -124,12 +129,14 @@ mod tests {
         let config = NodeConfig {
             ghost_mode: true,
             shroud_enabled: false,
+            nickname: Some("my-node".to_string()),
         };
         config.save(path).unwrap();
 
         let loaded = NodeConfig::load(path).unwrap();
         assert!(loaded.ghost_mode);
         assert!(!loaded.shroud_enabled);
+        assert_eq!(loaded.nickname.as_deref(), Some("my-node"));
     }
 
     #[test]

--- a/crates/ghost-verification/src/routes.rs
+++ b/crates/ghost-verification/src/routes.rs
@@ -3113,7 +3113,12 @@ async fn api_resources_handler(State(state): State<Arc<VerificationState>>) -> i
         "disk_total_gb": disk_total_gb,
         "uptime_seconds": health.uptime_secs,
         "uptime_secs": health.uptime_secs,
-        "connected_miners": health.miner_count,
+        // Deduplicated mesh-wide active-miner count (same source as
+        // /api/v1/network/pool), NOT the raw `miner_count` — the raw value is a
+        // load-balancer routing view that double-counts miners failing over
+        // between nodes, so the Watchdog was showing an inflated figure that
+        // could exceed the real distinct total. Falls back to raw if unavailable.
+        "connected_miners": state.mesh_active_miners().unwrap_or(health.miner_count),
         "estimated_capacity": 1000,
         "status": status,
         "last_redirect_count": 0,
@@ -7176,10 +7181,35 @@ async fn api_nickname_post_handler(
             .into_response();
     }
 
-    // Store in dashboard config
+    let value = if nickname.is_empty() {
+        None
+    } else {
+        Some(nickname.to_string())
+    };
+
+    // Store in the in-memory dashboard config (what the GET handler and the rest
+    // of the process read live).
     {
         let mut config = state.dashboard_config.write();
-        config.nickname = Some(nickname.to_string());
+        config.nickname = value.clone();
+    }
+
+    // Persist to the node config file so the nickname survives a restart. It
+    // previously lived only in the in-memory dashboard config and was lost on
+    // every restart.
+    {
+        let mut node_config = state.node_config.write();
+        node_config.nickname = value;
+        if let Some(ref path) = state.node_config_path {
+            if let Err(e) = node_config.save(path) {
+                error!(error = %e, "Failed to persist node nickname");
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({"error": format!("Failed to persist nickname: {}", e)})),
+                )
+                    .into_response();
+            }
+        }
     }
 
     Json(serde_json::json!({

--- a/crates/ghost-verification/src/routes.rs
+++ b/crates/ghost-verification/src/routes.rs
@@ -3347,6 +3347,13 @@ async fn api_swarm_handler(State(state): State<Arc<VerificationState>>) -> impl 
         self_caps.elder_status,
     );
 
+    // The per-peer uptime %, peer count and L1/L2 heights are not gossiped, so
+    // they render as "—" for mesh peers — but THIS node knows its own locally,
+    // so populate them here. (uptime_percent is the trailing-7-day qualification
+    // metric and isn't available on the health snapshot; left unset for now.)
+    let self_l2_height =
+        check_ghostpay_local(&state).and_then(|gp| (gp.sync_state != "disabled").then_some(gp.virtual_block));
+
     let self_node = serde_json::json!({
         "node_id": health.node_id.clone(),
         "name": self_name.clone(),
@@ -3365,6 +3372,10 @@ async fn api_swarm_handler(State(state): State<Arc<VerificationState>>) -> impl 
         "public_mining": self_caps.public_mining,
         "reaper": self_caps.reaper,
         "elder": self_caps.elder_status,
+        // Locally-known stats the mesh doesn't gossip (fixes the self row's "—").
+        "peer_count": health.peer_count,
+        "l1_height": health.block_height,
+        "l2_height": self_l2_height,
     });
 
     let mut nodes = vec![self_node];

--- a/crates/ghost-verification/src/server.rs
+++ b/crates/ghost-verification/src/server.rs
@@ -1754,10 +1754,15 @@ impl VerificationState {
     /// Set the node config path and load config from disk
     pub fn with_node_config_path(mut self, path: PathBuf) -> Self {
         let config = NodeConfig::load_or_default(&path);
-        // Sync dashboard_config ghost_mode with loaded node_config
+        // Sync dashboard_config with the persisted node_config so restored
+        // values (ghost_mode, nickname) are reflected on the live config the
+        // dashboard reads.
         {
             let mut dashboard = self.dashboard_config.write();
             dashboard.ghost_mode = config.ghost_mode;
+            if config.nickname.is_some() {
+                dashboard.nickname = config.nickname.clone();
+            }
         }
         self.node_config = parking_lot::RwLock::new(config);
         self.node_config_path = Some(path);


### PR DESCRIPTION
Two backend fixes from the review pass. `cargo check -p ghost-verification` clean; `config::tests::test_save_and_load` passes.

### `#224` — persist the node nickname
The nickname lived only in the in-memory `dashboard_config`, so it was lost on every restart (fell back to the short node id). Now:
- `NodeConfig` gains a persisted `nickname: Option<String>` field.
- The nickname POST handler writes it to the node config file (and clears on an empty value), erroring if persistence fails rather than silently keeping it in memory.
- The startup sync loads the persisted nickname back into `dashboard_config` so the GET reflects it after a restart.

(The separate 401-on-save half of #224 was an internal-auth key mismatch — reconciled on the running nodes, and prevented going forward by #226.)

### `#223` — deduped Watchdog "Connected Miners"
`/api/v1/resources/status` reported the raw `miner_count`, a load-balancer routing view that double-counts miners failing over between nodes — so the Watchdog showed an inflated figure (8 when the real distinct total was lower). It now uses the deduped `state.mesh_active_miners()` (same source as `/api/v1/network/pool` and the Capacity page), falling back to raw only if unavailable.

Fixes #223
Fixes #224
