### PR TITLE
policy: rename bitcoin_pure→strict, add real policy-profile endpoint, remove dead ones

### DIFF
--- a/crates/ghost-buds/src/classifier.rs
+++ b/crates/ghost-buds/src/classifier.rs
@@ -393,7 +393,7 @@ impl PolicyPreset {
     /// Bitcoin Pure: Only T0 and T1 (financial transactions only)
     pub fn bitcoin_pure() -> Self {
         Self {
-            name: "bitcoin_pure",
+            name: "strict",
             allowed_tiers: vec![BudsTier::T0, BudsTier::T1],
         }
     }

--- a/crates/ghost-common/src/config.rs
+++ b/crates/ghost-common/src/config.rs
@@ -1283,7 +1283,10 @@ impl Default for PolicyConfig {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum PolicyProfile {
-    /// Only T0 + T1 transactions (financial-only)
+    /// Only T0 + T1 transactions (financial-only). Serialized as `strict`; the
+    /// legacy `bitcoin_pure` value is still accepted so existing pool.toml files
+    /// keep parsing. The internal `BitcoinPure` identifier is unchanged.
+    #[serde(rename = "strict", alias = "bitcoin_pure")]
     BitcoinPure,
     /// T0 + T1 + T2 (most common)
     Permissive,

--- a/crates/ghost-policy/src/profile.rs
+++ b/crates/ghost-policy/src/profile.rs
@@ -65,7 +65,7 @@ impl PolicyProfile {
     /// No OP_RETURN, inscriptions, or exotic data
     pub fn bitcoin_pure() -> Self {
         Self {
-            name: "bitcoin_pure".to_string(),
+            name: "strict".to_string(),
             description: "Financial transactions only (T0+T1), no data embedding".to_string(),
             allowed_tiers: vec![BudsTier::T0, BudsTier::T1],
             max_op_return_size: 0,
@@ -181,6 +181,7 @@ impl Default for PolicyProfile {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ProfilePreset {
+    #[serde(rename = "strict", alias = "bitcoin_pure")]
     BitcoinPure,
     Permissive,
     FullOpen,
@@ -199,7 +200,7 @@ impl ProfilePreset {
 
     pub fn name(&self) -> &'static str {
         match self {
-            Self::BitcoinPure => "bitcoin_pure",
+            Self::BitcoinPure => "strict",
             Self::Permissive => "permissive",
             Self::FullOpen => "full_open",
             Self::Custom => "custom",

--- a/crates/ghost-template/src/filter.rs
+++ b/crates/ghost-template/src/filter.rs
@@ -272,7 +272,7 @@ mod tests {
     #[test]
     fn test_policy_profiles() {
         let bitcoin_pure = TemplateFilter::bitcoin_pure();
-        assert_eq!(bitcoin_pure.profile().name, "bitcoin_pure");
+        assert_eq!(bitcoin_pure.profile().name, "strict");
 
         let permissive = TemplateFilter::permissive();
         assert_eq!(permissive.profile().name, "permissive");

--- a/crates/ghost-verification/src/routes.rs
+++ b/crates/ghost-verification/src/routes.rs
@@ -478,6 +478,10 @@ pub fn create_router(state: Arc<VerificationState>) -> Router {
             post(api_config_template_profile_post_handler),
         )
         .route(
+            "/api/v1/config/policy_profile",
+            post(api_config_policy_profile_post_handler),
+        )
+        .route(
             "/api/v1/config/reaper",
             post(api_config_reaper_post_handler),
         )
@@ -5329,6 +5333,106 @@ fn ghost_common_now(state: &str, message: impl Into<String>) -> crate::server::G
 /// result lands on the reaper GET endpoint's `ghostd_apply`. A legacy
 /// `{ "enabled": bool }` body still works (the per-vector fields fall back to
 /// their serde defaults = all-on).
+/// Request body for the policy-profile POST endpoint.
+#[derive(Debug, Deserialize)]
+struct PolicyProfileRequest {
+    /// One of `strict` (legacy alias `bitcoin_pure`), `permissive`, `full_open`.
+    profile: String,
+}
+
+/// API v1 Config policy_profile POST handler.
+///
+/// This is the REAL lever for which BUDS tiers get mined: it writes
+/// `[policy].profile` into the node config (pool.toml) and persists it, then
+/// requests a graceful ghost-pool restart so the new profile is resolved at
+/// startup. Unlike the cosmetic `mempool_profile`/`template_profile` dashboard
+/// mirrors, changing this actually alters template construction.
+async fn api_config_policy_profile_post_handler(
+    State(state): State<Arc<VerificationState>>,
+    Json(payload): Json<PolicyProfileRequest>,
+) -> impl IntoResponse {
+    use ghost_common::config::PolicyProfile;
+
+    // Map the incoming string to the config enum. Accept the new `strict`
+    // spelling and the legacy `bitcoin_pure` alias; reject anything else 400.
+    let profile = match payload.profile.trim().to_ascii_lowercase().as_str() {
+        "strict" | "bitcoin_pure" => PolicyProfile::BitcoinPure,
+        "permissive" => PolicyProfile::Permissive,
+        "full_open" => PolicyProfile::FullOpen,
+        other => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({
+                    "success": false,
+                    "error": format!("Unknown policy profile: {other}"),
+                    "code": "INVALID_PROFILE",
+                })),
+            )
+                .into_response();
+        }
+    };
+
+    // The canonical serialized name we echo back to the caller.
+    let profile_name = match profile {
+        PolicyProfile::BitcoinPure => "strict",
+        PolicyProfile::Permissive => "permissive",
+        PolicyProfile::FullOpen => "full_open",
+        PolicyProfile::Custom => "custom",
+    };
+
+    // Require the full node config + a path to persist to; otherwise the change
+    // can't survive a restart, so fail-closed with SERVICE_UNAVAILABLE.
+    let Some(ref full) = state.full_node_config else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(serde_json::json!({
+                "success": false,
+                "error": "Config update API not available: full node config not loaded",
+                "code": "CONFIG_NOT_LOADED",
+            })),
+        )
+            .into_response();
+    };
+    let Some(ref path) = state.full_node_config_path else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(serde_json::json!({
+                "success": false,
+                "error": "Config update API not available: no node config path configured",
+                "code": "CONFIG_NOT_LOADED",
+            })),
+        )
+            .into_response();
+    };
+
+    {
+        let mut cfg = full.write();
+        cfg.policy.profile = profile;
+        if let Err(e) = cfg.save_atomic(path) {
+            error!(error = %e, "Failed to persist policy profile");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({
+                    "success": false,
+                    "error": format!("Failed to persist policy profile: {e}"),
+                    "code": "PERSIST_FAILED",
+                })),
+            )
+                .into_response();
+        }
+    }
+
+    // The profile is resolved at startup, so a graceful restart applies it.
+    state.request_restart();
+
+    Json(serde_json::json!({
+        "success": true,
+        "profile": profile_name,
+        "restart_pending": true,
+    }))
+    .into_response()
+}
+
 async fn api_config_reaper_post_handler(
     State(state): State<Arc<VerificationState>>,
     Json(payload): Json<ghost_common::config::ReaperSettings>,
@@ -8408,6 +8512,114 @@ mod tests {
         assert_eq!(on["enabled"].as_bool(), Some(true));
         let reloaded = FullNodeConfig::load(&path).unwrap();
         assert!(reloaded.wraith_enabled(), "enable must persist to disk");
+    }
+
+    /// The policy_profile POST is the real lever for mined BUDS tiers: without
+    /// HMAC it must 401, and with a valid signature it must persist
+    /// `[policy].profile` to pool.toml and request a graceful restart.
+    #[tokio::test]
+    async fn test_config_policy_profile_post_persists_and_restarts() {
+        use ghost_common::config::NodeConfig as FullNodeConfig;
+        use ghost_common::config::PolicyProfile as CfgProfile;
+        use ghost_common::types::NodeCapabilities;
+        use ghost_policy::PolicyProfile;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("pool.toml");
+
+        let auth = crate::auth::InternalAuth::new(&test_secret()).unwrap();
+        let state = Arc::new(
+            crate::server::VerificationState::new(
+                "test_node".to_string(),
+                "1.0.0".to_string(),
+                PolicyProfile::default(),
+                NodeCapabilities::default(),
+            )
+            .with_internal_auth(auth.clone())
+            .with_full_node_config(FullNodeConfig::default(), path.clone()),
+        );
+
+        // Without auth → 401.
+        let unauth = super::create_router(Arc::clone(&state))
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/config/policy_profile")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(r#"{"profile": "strict"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            unauth.status(),
+            StatusCode::UNAUTHORIZED,
+            "policy_profile POST without auth must 401"
+        );
+        assert!(!state.restart_requested());
+
+        // With valid HMAC → persists `strict` and requests restart.
+        let body = r#"{"profile": "strict"}"#;
+        let timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let signature = auth.sign(timestamp, body.as_bytes());
+        let response = super::create_router(Arc::clone(&state))
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/config/policy_profile")
+                    .header("Content-Type", "application/json")
+                    .header("X-Ghost-Signature", signature)
+                    .header("X-Ghost-Timestamp", timestamp.to_string())
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(json["success"].as_bool(), Some(true));
+        assert_eq!(json["profile"].as_str(), Some("strict"));
+        assert_eq!(json["restart_pending"].as_bool(), Some(true));
+
+        // Persisted to disk as BitcoinPure and restart requested.
+        let reloaded = FullNodeConfig::load(&path).unwrap();
+        assert_eq!(reloaded.policy.profile, CfgProfile::BitcoinPure);
+        assert!(
+            state.restart_requested(),
+            "policy_profile change must request a restart"
+        );
+
+        // Unknown profile → 400.
+        let bad = r#"{"profile": "nonsense"}"#;
+        let timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let signature = auth.sign(timestamp, bad.as_bytes());
+        let bad_resp = super::create_router(Arc::clone(&state))
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/config/policy_profile")
+                    .header("Content-Type", "application/json")
+                    .header("X-Ghost-Signature", signature)
+                    .header("X-Ghost-Timestamp", timestamp.to_string())
+                    .body(Body::from(bad))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            bad_resp.status(),
+            StatusCode::BAD_REQUEST,
+            "unknown policy profile must 400"
+        );
     }
 
     /// CRIT-6: Test that all config POST endpoints require auth

--- a/crates/ghost-verification/src/routes.rs
+++ b/crates/ghost-verification/src/routes.rs
@@ -321,14 +321,6 @@ pub fn create_router(state: Arc<VerificationState>) -> Router {
         // CRIT-6: POST handlers moved to internal_router to require authentication
         .route("/api/v1/config/full", get(api_config_full_handler))
         .route(
-            "/api/v1/config/profiles/mempool",
-            get(api_config_profiles_mempool_handler),
-        )
-        .route(
-            "/api/v1/config/profiles/template",
-            get(api_config_profiles_template_handler),
-        )
-        .route(
             "/api/v1/config/archive_mode",
             get(api_config_archive_mode_handler),
         )
@@ -466,16 +458,8 @@ pub fn create_router(state: Arc<VerificationState>) -> Router {
             post(api_config_ghost_mode_post_handler),
         )
         .route(
-            "/api/v1/config/mempool_profile",
-            post(api_config_mempool_profile_post_handler),
-        )
-        .route(
             "/api/v1/config/public_mining",
             post(api_config_public_mining_post_handler),
-        )
-        .route(
-            "/api/v1/config/template_profile",
-            post(api_config_template_profile_post_handler),
         )
         .route(
             "/api/v1/config/policy_profile",
@@ -4944,34 +4928,6 @@ async fn api_config_full_handler(State(state): State<Arc<VerificationState>>) ->
     }))
 }
 
-/// API v1 Config profiles mempool handler
-async fn api_config_profiles_mempool_handler(
-    State(_state): State<Arc<VerificationState>>,
-) -> impl IntoResponse {
-    Json(serde_json::json!({
-        "profiles": [
-            { "name": "permissive", "description": "Accept all standard transactions", "active": true },
-            { "name": "strict", "description": "Bitcoin Core defaults only", "active": false },
-            { "name": "custom", "description": "Custom configuration", "active": false }
-        ],
-        "current": "permissive"
-    }))
-}
-
-/// API v1 Config profiles template handler
-async fn api_config_profiles_template_handler(
-    State(_state): State<Arc<VerificationState>>,
-) -> impl IntoResponse {
-    Json(serde_json::json!({
-        "profiles": [
-            { "name": "default", "description": "Standard block template", "active": true },
-            { "name": "compact", "description": "Smaller blocks", "active": false },
-            { "name": "maximum", "description": "Maximum block size", "active": false }
-        ],
-        "current": "default"
-    }))
-}
-
 /// API v1 Config archive mode handler
 async fn api_config_archive_mode_handler(
     State(state): State<Arc<VerificationState>>,
@@ -5595,34 +5551,6 @@ async fn api_config_elder_post_handler(
         "enabled": payload.enabled,
         "slot": payload.slot,
         "message": "Elder status updated"
-    }))
-}
-
-/// API v1 Config mempool_profile POST handler
-async fn api_config_mempool_profile_post_handler(
-    State(state): State<Arc<VerificationState>>,
-    Json(payload): Json<ProfileRequest>,
-) -> impl IntoResponse {
-    let mut config = state.dashboard_config.write();
-    config.mempool_profile = payload.profile.clone();
-    Json(serde_json::json!({
-        "success": true,
-        "profile": payload.profile,
-        "message": "Mempool profile updated"
-    }))
-}
-
-/// API v1 Config template_profile POST handler
-async fn api_config_template_profile_post_handler(
-    State(state): State<Arc<VerificationState>>,
-    Json(payload): Json<ProfileRequest>,
-) -> impl IntoResponse {
-    let mut config = state.dashboard_config.write();
-    config.template_profile = payload.profile.clone();
-    Json(serde_json::json!({
-        "success": true,
-        "profile": payload.profile,
-        "message": "Template profile updated"
     }))
 }
 
@@ -7538,9 +7466,15 @@ async fn api_config_profiles_mempool_activate_handler(
     State(state): State<Arc<VerificationState>>,
     Path(name): Path<String>,
 ) -> impl IntoResponse {
-    // Delegate to the existing mempool_profile POST handler
-    api_config_mempool_profile_post_handler(State(state), Json(ProfileRequest { profile: name }))
-        .await
+    // Record the selection in the dashboard mirror. This is a cosmetic display
+    // field; the real mining lever is `/api/v1/config/policy_profile`.
+    let mut config = state.dashboard_config.write();
+    config.mempool_profile = name.clone();
+    Json(serde_json::json!({
+        "success": true,
+        "profile": name,
+        "message": "Mempool profile updated"
+    }))
 }
 
 /// API v1 Config: Save custom template profile
@@ -7586,8 +7520,15 @@ async fn api_config_profiles_template_activate_handler(
     State(state): State<Arc<VerificationState>>,
     Path(name): Path<String>,
 ) -> impl IntoResponse {
-    api_config_template_profile_post_handler(State(state), Json(ProfileRequest { profile: name }))
-        .await
+    // Cosmetic dashboard mirror; the real mining lever is
+    // `/api/v1/config/policy_profile`.
+    let mut config = state.dashboard_config.write();
+    config.template_profile = name.clone();
+    Json(serde_json::json!({
+        "success": true,
+        "profile": name,
+        "message": "Template profile updated"
+    }))
 }
 
 /// GhostPay payout address body
@@ -8631,9 +8572,8 @@ mod tests {
         let config_endpoints = [
             "/api/v1/config/archive_mode",
             "/api/v1/config/ghost_mode",
-            "/api/v1/config/mempool_profile",
+            "/api/v1/config/policy_profile",
             "/api/v1/config/public_mining",
-            "/api/v1/config/template_profile",
             "/api/v1/config/reaper",
             "/api/v1/config/ghost_pay",
             "/api/v1/config/wraith",
@@ -8645,9 +8585,8 @@ mod tests {
             let app = super::create_router(Arc::clone(&state));
 
             let body = match endpoint {
-                "/api/v1/config/mempool_profile"
-                | "/api/v1/config/template_profile"
-                | "/api/v1/config/prune_profile" => r#"{"profile": "standard"}"#,
+                "/api/v1/config/policy_profile" => r#"{"profile": "strict"}"#,
+                "/api/v1/config/prune_profile" => r#"{"profile": "standard"}"#,
                 "/api/v1/config/elder" => r#"{"enabled": true, "slot": 1}"#,
                 _ => r#"{"enabled": true}"#,
             };


### PR DESCRIPTION
Backend half of #220 — make the BUDS tier policy actually settable, and rename the strict profile. `cargo check` clean; 21/21 config tests pass (incl. the new endpoint test).

### 1. Rename `bitcoin_pure` → `strict` (safe scope)
The `pool.toml [policy].profile` value now serializes as `strict` (was `bitcoin_pure`), with `#[serde(alias = "bitcoin_pure")]` so existing configs keep parsing. Profile display-name strings in ghost-policy/ghost-buds updated too. The internal `BitcoinPure` enum identifier and the ghost-consensus policy capability are **untouched** — user-facing name change only, no consensus impact.

### 2. Real policy-change endpoint (the missing lever)
`POST /api/v1/config/policy_profile` on the internal HMAC router:
- body `{ "profile": "strict" | "permissive" | "full_open" }` (legacy `bitcoin_pure` accepted)
- writes `[policy].profile` to pool.toml (`save_atomic`) and calls `request_restart()` — the profile is resolved at startup, so it takes effect on the graceful restart
- 200 `{ success, profile, restart_pending: true }`; 400 unknown profile; 503 no config; 401 unauth
- test: requires HMAC + persists + requests restart

### 3. Remove dead cosmetic endpoints
`mempool_profile`/`template_profile` POST handlers and the two placeholder profile-list endpoints (which advertised names the backend never honoured) are removed. This is what made a selector on them a silent no-op.

Frontend selector (3 presets → this endpoint, with a restart confirm) follows in a separate dashboard PR. Stage 2 (finer per-knob tuning) is tracked separately.

Refs #220
