### PR TITLE
policy: wire full per-field enforcement + operator-settable custom policy

### DIFF
--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -2548,12 +2548,20 @@ async fn main() -> Result<()> {
     info!(tag = %coinbase_tag, "Coinbase tag: {}", coinbase_tag);
 
     // Initialize template processor with treasury and pool payout addresses from config
+    // Per-field policy enforcement (max outputs / size / OP_RETURN / witness /
+    // content) is the "Advanced" Custom profile only. The three "Basic" presets
+    // stay tier-gate-only, so their baked-in field limits are NOT enforced at
+    // block-build time — preserving the historical preset behaviour.
+    let enforce_custom_policy_fields =
+        matches!(config.policy.profile, ghost_common::config::PolicyProfile::Custom);
+
     // The template's minimum fee-rate floor. Presets keep the historical
     // TemplateConfig default (unchanged behaviour); the Custom profile lets the
     // operator set their own floor via `[policy].custom.min_fee_rate`.
-    let template_min_fee_rate = match config.policy.profile {
-        ghost_common::config::PolicyProfile::Custom => policy.min_fee_rate,
-        _ => TemplateConfig::default().min_fee_rate,
+    let template_min_fee_rate = if enforce_custom_policy_fields {
+        policy.min_fee_rate
+    } else {
+        TemplateConfig::default().min_fee_rate
     };
 
     // Pool payout address defaults to treasury address if not explicitly configured separately
@@ -2565,6 +2573,7 @@ async fn main() -> Result<()> {
         solo_payout_address: config.network.solo_payout_address.clone(),
         coinbase_extra: coinbase_tag,
         min_fee_rate: template_min_fee_rate,
+        enforce_custom_policy_fields,
         ..Default::default()
     };
     let template_processor = Arc::new(

--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -2351,7 +2351,14 @@ async fn main() -> Result<()> {
         ghost_common::config::PolicyProfile::BitcoinPure => PolicyProfile::bitcoin_pure(),
         ghost_common::config::PolicyProfile::Permissive => PolicyProfile::permissive(),
         ghost_common::config::PolicyProfile::FullOpen => PolicyProfile::full_open(),
-        ghost_common::config::PolicyProfile::Custom => PolicyProfile::permissive(),
+        // Custom: build the enforced profile from the operator's `[policy].custom`
+        // fields so the finer knobs (tiers, content toggles, size limits, min fee)
+        // actually bite at block-build time. Falls back to the default custom
+        // block when none is persisted.
+        ghost_common::config::PolicyProfile::Custom => {
+            let custom = config.policy.custom.clone().unwrap_or_default();
+            policy_profile_from_custom(&custom)
+        }
     };
     info!(
         "Policy profile: {} (allows up to T{})",
@@ -2541,6 +2548,14 @@ async fn main() -> Result<()> {
     info!(tag = %coinbase_tag, "Coinbase tag: {}", coinbase_tag);
 
     // Initialize template processor with treasury and pool payout addresses from config
+    // The template's minimum fee-rate floor. Presets keep the historical
+    // TemplateConfig default (unchanged behaviour); the Custom profile lets the
+    // operator set their own floor via `[policy].custom.min_fee_rate`.
+    let template_min_fee_rate = match config.policy.profile {
+        ghost_common::config::PolicyProfile::Custom => policy.min_fee_rate,
+        _ => TemplateConfig::default().min_fee_rate,
+    };
+
     // Pool payout address defaults to treasury address if not explicitly configured separately
     let template_config = TemplateConfig {
         treasury_address: config.pool.treasury_address.clone(),
@@ -2549,6 +2564,7 @@ async fn main() -> Result<()> {
         mining_mode,
         solo_payout_address: config.network.solo_payout_address.clone(),
         coinbase_extra: coinbase_tag,
+        min_fee_rate: template_min_fee_rate,
         ..Default::default()
     };
     let template_processor = Arc::new(
@@ -8078,6 +8094,42 @@ fn expand_path(path: &std::path::Path) -> Result<PathBuf> {
 /// (`reject_opreturn`, `reject_runestone`) have no pool-side equivalent and are
 /// intentionally not mapped here — the Rust reaper bounds OP_RETURN via the
 /// `max_op_return_bytes` threshold and has no Runestone detector.
+/// Build the enforced `ghost_policy::PolicyProfile` from an operator's
+/// `[policy].custom` config block. This is the source of truth the template
+/// builder enforces per-field (tiers, content toggles, size limits) when the
+/// operator selects the `Custom` profile.
+fn policy_profile_from_custom(
+    custom: &ghost_common::config::CustomPolicyConfig,
+) -> PolicyProfile {
+    // Map the config-crate BudsTier enum onto the ghost_buds tier the policy
+    // engine/classifier use.
+    let allowed_tiers = custom
+        .allowed_tiers
+        .iter()
+        .map(|t| match t {
+            ghost_common::config::BudsTier::T0 => ghost_buds::BudsTier::T0,
+            ghost_common::config::BudsTier::T1 => ghost_buds::BudsTier::T1,
+            ghost_common::config::BudsTier::T2 => ghost_buds::BudsTier::T2,
+            ghost_common::config::BudsTier::T3 => ghost_buds::BudsTier::T3,
+        })
+        .collect();
+
+    PolicyProfile {
+        name: "custom".to_string(),
+        description: "Operator-defined custom policy".to_string(),
+        allowed_tiers,
+        max_op_return_size: custom.max_op_return_size,
+        max_witness_per_input: custom.max_witness_per_input,
+        max_tx_outputs: custom.max_tx_outputs,
+        max_tx_size: custom.max_tx_size,
+        allow_inscriptions: custom.allow_inscriptions,
+        allow_runes: custom.allow_runes,
+        allow_brc20: custom.allow_brc20,
+        min_fee_rate: custom.min_fee_rate,
+        t0_priority_boost: 1.0,
+    }
+}
+
 fn reaper_config_from_settings(s: &ReaperSettings) -> ReaperConfig {
     if !s.enabled {
         return ReaperConfig::disabled();

--- a/bins/ghost-pool/src/template.rs
+++ b/bins/ghost-pool/src/template.rs
@@ -1950,6 +1950,22 @@ impl TemplateProcessor {
 
             // Check if tier is allowed by policy
             if self.policy.allows_tier(tier) {
+                // Full per-field policy enforcement. The tier gate above only
+                // checks the coarse BUDS class; this runs the finer profile
+                // knobs (allow_inscriptions/runes/brc20, max_op_return_size,
+                // max_witness_per_input, max_tx_outputs, max_tx_size) that
+                // ghost_policy::PolicyEngine enforces, so non-conforming txs are
+                // actually dropped from the block rather than silently mined.
+                if let Some(reason) = policy_field_violation(&self.policy, &btc_tx, &result) {
+                    removed_fees += tx.fee;
+                    debug!(
+                        txid = %tx.txid,
+                        reason = %reason,
+                        "Transaction filtered by policy field"
+                    );
+                    continue;
+                }
+
                 // Additional policy checks
                 let fee_rate = tx.fee as f64 / (tx.weight as f64 / 4.0);
                 if fee_rate >= self.config.min_fee_rate {
@@ -3151,6 +3167,97 @@ fn is_valid_script_bytes(script: &[u8]) -> bool {
     }
 }
 
+/// Enforce the finer per-field policy knobs against a candidate transaction.
+///
+/// Mirrors the field checks in `ghost_policy::PolicyEngine::evaluate`, minus the
+/// tier gate (handled by the caller via `PolicyProfile::allows_tier`) and the
+/// `min_fee_rate` floor (handled via `TemplateConfig::min_fee_rate`). Returns
+/// `Some(reason)` when the transaction violates a policy field and must be
+/// dropped from the block, or `None` when it conforms.
+///
+/// This is what makes `allow_inscriptions` / `allow_runes` / `allow_brc20`,
+/// `max_op_return_size`, `max_witness_per_input`, `max_tx_outputs` and
+/// `max_tx_size` actually bite at block-build time — before this was wired in,
+/// only the tier gate and `min_fee_rate` were enforced, leaving those fields
+/// cosmetic for block construction.
+fn policy_field_violation(
+    policy: &PolicyProfile,
+    btc_tx: &bitcoin::Transaction,
+    classification: &ghost_buds::ClassificationResult,
+) -> Option<String> {
+    // Transaction size (vbytes = weight / 4).
+    let tx_size = btc_tx.weight().to_wu() as usize / 4;
+    if tx_size > policy.max_tx_size {
+        return Some(format!(
+            "tx too large: {tx_size} > {} vB",
+            policy.max_tx_size
+        ));
+    }
+
+    // Output count.
+    if btc_tx.output.len() > policy.max_tx_outputs {
+        return Some(format!(
+            "too many outputs: {} > {}",
+            btc_tx.output.len(),
+            policy.max_tx_outputs
+        ));
+    }
+
+    // OP_RETURN payload size (strip the OP_RETURN opcode + push opcode ≈ 2 bytes,
+    // matching PolicyEngine's accounting).
+    for output in &btc_tx.output {
+        if output.script_pubkey.is_op_return() {
+            let op_return_size = output.script_pubkey.len().saturating_sub(2);
+            if op_return_size > policy.max_op_return_size {
+                return Some(format!(
+                    "op_return too large: {op_return_size} > {} bytes",
+                    policy.max_op_return_size
+                ));
+            }
+        }
+    }
+
+    // Per-input witness size.
+    for (i, input) in btc_tx.input.iter().enumerate() {
+        let witness_size: usize = input.witness.iter().map(|w| w.len()).sum();
+        if witness_size > policy.max_witness_per_input {
+            return Some(format!(
+                "witness too large on input {i}: {witness_size} > {} bytes",
+                policy.max_witness_per_input
+            ));
+        }
+    }
+
+    // Content-type restrictions, driven by the BUDS classifier's detected
+    // features.
+    if !policy.allow_inscriptions
+        && classification
+            .features
+            .iter()
+            .any(|f| matches!(f, ghost_buds::DetectedFeature::InscriptionEnvelope))
+    {
+        return Some("inscriptions not allowed by policy".to_string());
+    }
+    if !policy.allow_runes
+        && classification
+            .features
+            .iter()
+            .any(|f| matches!(f, ghost_buds::DetectedFeature::RunesRunestone))
+    {
+        return Some("runes not allowed by policy".to_string());
+    }
+    if !policy.allow_brc20
+        && classification
+            .features
+            .iter()
+            .any(|f| matches!(f, ghost_buds::DetectedFeature::Brc20Pattern))
+    {
+        return Some("brc20 not allowed by policy".to_string());
+    }
+
+    None
+}
+
 /// Filter statistics
 #[derive(Debug, Clone)]
 struct FilterStats {
@@ -4192,6 +4299,278 @@ mod tests {
             2,
             "both txs should survive with reaper disabled"
         );
+    }
+
+    // ===================================================================
+    // Per-field policy enforcement (wired into filter_transactions).
+    //
+    // These prove each finer PolicyProfile knob now actually drops the
+    // right tx at block-build time and lets conforming ones through.
+    // Each test starts from `full_open` (all tiers, generous limits, all
+    // content allowed) and lowers ONE field to isolate that knob. Reaper
+    // is disabled so the policy field check — not the reaper — is what
+    // drops the transaction.
+    // ===================================================================
+
+    /// Build a TemplateTransaction wrapper around a bitcoin::Transaction with a
+    /// fee/weight ratio comfortably above the default min_fee_rate (1.0).
+    fn template_tx(btc_tx: &bitcoin::Transaction) -> TemplateTransaction {
+        use bitcoin::consensus::encode::serialize as btc_serialize;
+        TemplateTransaction {
+            data: hex::encode(btc_serialize(btc_tx)),
+            txid: btc_tx.compute_txid().to_string(),
+            hash: "00".repeat(32),
+            depends: vec![],
+            fee: 100_000, // high fee so the fee-rate floor never drops these
+            weight: 400,
+            sigops: 1,
+        }
+    }
+
+    /// A simple P2WPKH transaction with `n` identical outputs and a unique
+    /// txid derived from `seed`.
+    fn tx_with_outputs(seed: u8, n: usize) -> bitcoin::Transaction {
+        use bitcoin::{
+            absolute::LockTime, hashes::Hash, transaction::Version, Amount, OutPoint, ScriptBuf,
+            Sequence, Transaction, TxIn, TxOut, Txid, Witness,
+        };
+        let mut witness = Witness::new();
+        witness.push([0x30; 72]);
+        witness.push([0x02; 33]);
+        let spk = ScriptBuf::from({
+            let mut s = vec![0x00, 0x14];
+            s.extend([seed; 20]);
+            s
+        });
+        Transaction {
+            version: Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: Txid::from_byte_array([seed; 32]),
+                    vout: 0,
+                },
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::MAX,
+                witness,
+            }],
+            output: (0..n)
+                .map(|_| TxOut {
+                    value: Amount::from_sat(1_000),
+                    script_pubkey: spk.clone(),
+                })
+                .collect(),
+        }
+    }
+
+    fn make_processor(policy: PolicyProfile) -> TemplateProcessor {
+        let rpc = Arc::new(BitcoinRpc::new("127.0.0.1", 8332, "user", "pass").unwrap());
+        // Reaper disabled → only the policy fields can drop a tx.
+        TemplateProcessor::new(TemplateConfig::default(), rpc, policy, ReaperConfig::disabled())
+    }
+
+    #[test]
+    fn test_policy_max_tx_outputs_enforced() {
+        // 10-output tx: dropped when the limit is 5, kept when it is 20.
+        let tx = template_tx(&tx_with_outputs(0x10, 10));
+
+        let mut strict = PolicyProfile::full_open();
+        strict.max_tx_outputs = 5;
+        let (kept, _) = make_processor(strict).filter_transactions(&[tx.clone()]);
+        assert!(kept.is_empty(), "tx exceeding max_tx_outputs must be dropped");
+
+        let mut loose = PolicyProfile::full_open();
+        loose.max_tx_outputs = 20;
+        let (kept, _) = make_processor(loose).filter_transactions(&[tx]);
+        assert_eq!(kept.len(), 1, "conforming output count must be kept");
+    }
+
+    #[test]
+    fn test_policy_max_op_return_size_enforced() {
+        use bitcoin::{
+            absolute::LockTime, hashes::Hash, transaction::Version, Amount, OutPoint, ScriptBuf,
+            Sequence, Transaction, TxIn, TxOut, Txid, Witness,
+        };
+        // OP_RETURN carrying 100 bytes → payload size ~100.
+        let mut op_return = vec![0x6a, 0x4c, 100]; // OP_RETURN OP_PUSHDATA1 len=100
+        op_return.extend(std::iter::repeat_n(0xABu8, 100));
+        let mut witness = Witness::new();
+        witness.push([0x30; 72]);
+        witness.push([0x02; 33]);
+        let tx = Transaction {
+            version: Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: Txid::from_byte_array([0x20; 32]),
+                    vout: 0,
+                },
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::MAX,
+                witness,
+            }],
+            output: vec![
+                TxOut {
+                    value: Amount::from_sat(1_000),
+                    script_pubkey: ScriptBuf::from({
+                        let mut s = vec![0x00, 0x14];
+                        s.extend([0x20; 20]);
+                        s
+                    }),
+                },
+                TxOut {
+                    value: Amount::ZERO,
+                    script_pubkey: ScriptBuf::from(op_return),
+                },
+            ],
+        };
+        let ttx = template_tx(&tx);
+
+        let mut strict = PolicyProfile::full_open();
+        strict.max_op_return_size = 40;
+        let (kept, _) = make_processor(strict).filter_transactions(&[ttx.clone()]);
+        assert!(kept.is_empty(), "oversized OP_RETURN must be dropped");
+
+        let mut loose = PolicyProfile::full_open();
+        loose.max_op_return_size = 200;
+        let (kept, _) = make_processor(loose).filter_transactions(&[ttx]);
+        assert_eq!(kept.len(), 1, "conforming OP_RETURN must be kept");
+    }
+
+    #[test]
+    fn test_policy_max_witness_per_input_enforced() {
+        use bitcoin::{
+            absolute::LockTime, hashes::Hash, transaction::Version, Amount, OutPoint, ScriptBuf,
+            Sequence, Transaction, TxIn, TxOut, Txid, Witness,
+        };
+        // A single ~2000-byte witness item.
+        let mut witness = Witness::new();
+        witness.push(vec![0x42u8; 2000]);
+        let tx = Transaction {
+            version: Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: Txid::from_byte_array([0x30; 32]),
+                    vout: 0,
+                },
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::MAX,
+                witness,
+            }],
+            output: vec![TxOut {
+                value: Amount::from_sat(1_000),
+                script_pubkey: ScriptBuf::from({
+                    let mut s = vec![0x00, 0x14];
+                    s.extend([0x30; 20]);
+                    s
+                }),
+            }],
+        };
+        let ttx = template_tx(&tx);
+
+        let mut strict = PolicyProfile::full_open();
+        strict.max_witness_per_input = 500;
+        let (kept, _) = make_processor(strict).filter_transactions(&[ttx.clone()]);
+        assert!(kept.is_empty(), "oversized witness must be dropped");
+
+        let mut loose = PolicyProfile::full_open();
+        loose.max_witness_per_input = 4000;
+        let (kept, _) = make_processor(loose).filter_transactions(&[ttx]);
+        assert_eq!(kept.len(), 1, "conforming witness must be kept");
+    }
+
+    #[test]
+    fn test_policy_max_tx_size_enforced() {
+        // Many outputs inflate the serialized size well past a tight limit,
+        // while keeping the output count under max_tx_outputs.
+        let tx = template_tx(&tx_with_outputs(0x40, 50));
+
+        let mut strict = PolicyProfile::full_open();
+        strict.max_tx_size = 500; // vbytes; a 50-output tx is larger
+        let (kept, _) = make_processor(strict).filter_transactions(&[tx.clone()]);
+        assert!(kept.is_empty(), "tx exceeding max_tx_size must be dropped");
+
+        let mut loose = PolicyProfile::full_open();
+        loose.max_tx_size = 100_000;
+        let (kept, _) = make_processor(loose).filter_transactions(&[tx]);
+        assert_eq!(kept.len(), 1, "conforming tx size must be kept");
+    }
+
+    #[test]
+    fn test_policy_allow_inscriptions_enforced() {
+        use bitcoin::{
+            absolute::LockTime, hashes::Hash, transaction::Version, Amount, OutPoint, ScriptBuf,
+            Sequence, Transaction, TxIn, TxOut, Txid, Witness,
+        };
+        // Inscription envelope (OP_FALSE OP_IF "ord" ... OP_ENDIF) in a tapscript.
+        let mut tapscript: Vec<u8> = Vec::new();
+        tapscript.push(0x00); // OP_FALSE
+        tapscript.push(0x63); // OP_IF
+        tapscript.push(0x03);
+        tapscript.extend(b"ord");
+        tapscript.push(0x51);
+        let ctype = b"text/plain";
+        tapscript.push(ctype.len() as u8);
+        tapscript.extend(ctype);
+        tapscript.push(0x00);
+        let body = b"inscription payload";
+        tapscript.push(body.len() as u8);
+        tapscript.extend(body);
+        tapscript.push(0x68); // OP_ENDIF
+        tapscript.push(0xac); // OP_CHECKSIG
+        let mut witness = Witness::new();
+        witness.push([0x30; 64]);
+        witness.push(&tapscript);
+        let mut control_block = vec![0xc0u8];
+        control_block.extend([0x11; 32]);
+        witness.push(&control_block);
+        let tx = Transaction {
+            version: Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: Txid::from_byte_array([0x50; 32]),
+                    vout: 0,
+                },
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::MAX,
+                witness,
+            }],
+            output: vec![TxOut {
+                value: Amount::from_sat(50_000),
+                script_pubkey: ScriptBuf::from({
+                    let mut s = vec![0x00, 0x14];
+                    s.extend([0x50; 20]);
+                    s
+                }),
+            }],
+        };
+        let ttx = template_tx(&tx);
+
+        // Sanity: the classifier must flag this as an inscription, else the test
+        // proves nothing.
+        let btc_tx: bitcoin::Transaction =
+            deserialize(&hex::decode(&ttx.data).unwrap()).unwrap();
+        let classification = BudsClassifier::new().classify(&btc_tx);
+        assert!(
+            classification
+                .features
+                .iter()
+                .any(|f| matches!(f, ghost_buds::DetectedFeature::InscriptionEnvelope)),
+            "test fixture must classify as an inscription"
+        );
+
+        // allow_inscriptions = false → dropped by policy (reaper disabled).
+        let mut strict = PolicyProfile::full_open();
+        strict.allow_inscriptions = false;
+        let (kept, _) = make_processor(strict).filter_transactions(&[ttx.clone()]);
+        assert!(kept.is_empty(), "inscription must be dropped when disallowed");
+
+        // allow_inscriptions = true → kept.
+        let loose = PolicyProfile::full_open(); // already allows inscriptions
+        let (kept, _) = make_processor(loose).filter_transactions(&[ttx]);
+        assert_eq!(kept.len(), 1, "inscription must be kept when allowed");
     }
 
     /// Test that ghost-reaper detects OP_DROP stuffing in witness scripts

--- a/bins/ghost-pool/src/template.rs
+++ b/bins/ghost-pool/src/template.rs
@@ -137,6 +137,15 @@ pub struct TemplateConfig {
     /// Solo payout address (required for PrivateSolo mode)
     /// All rewards (99% subsidy + 100% tx fees) go to this address
     pub solo_payout_address: Option<String>,
+    /// Whether to enforce the finer per-field policy knobs during tx selection.
+    ///
+    /// This is `true` ONLY for the operator-defined `Custom` profile. The three
+    /// built-in presets (strict/permissive/full_open) intentionally stay
+    /// tier-gate-only ("Basic" tier choice): their baked-in
+    /// `max_tx_outputs`/`max_tx_size`/`max_op_return_size`/witness/content
+    /// fields are NOT enforced at block-build time, preserving the historical
+    /// preset behaviour. Custom is the "Advanced" opt-in that turns them on.
+    pub enforce_custom_policy_fields: bool,
 }
 
 impl Default for TemplateConfig {
@@ -151,6 +160,7 @@ impl Default for TemplateConfig {
             network: BitcoinNetwork::Mainnet,
             mining_mode: MiningMode::PublicPool,
             solo_payout_address: None,
+            enforce_custom_policy_fields: false,
         }
     }
 }
@@ -1950,20 +1960,24 @@ impl TemplateProcessor {
 
             // Check if tier is allowed by policy
             if self.policy.allows_tier(tier) {
-                // Full per-field policy enforcement. The tier gate above only
-                // checks the coarse BUDS class; this runs the finer profile
-                // knobs (allow_inscriptions/runes/brc20, max_op_return_size,
-                // max_witness_per_input, max_tx_outputs, max_tx_size) that
-                // ghost_policy::PolicyEngine enforces, so non-conforming txs are
-                // actually dropped from the block rather than silently mined.
-                if let Some(reason) = policy_field_violation(&self.policy, &btc_tx, &result) {
-                    removed_fees += tx.fee;
-                    debug!(
-                        txid = %tx.txid,
-                        reason = %reason,
-                        "Transaction filtered by policy field"
-                    );
-                    continue;
+                // Full per-field policy enforcement — Custom profile ONLY. The
+                // tier gate above is the whole story for the three "Basic"
+                // presets (strict/permissive/full_open), which stay
+                // tier-gate-only exactly as before. When the operator selects
+                // the "Advanced" Custom profile, `enforce_custom_policy_fields`
+                // is set and the finer knobs (allow_inscriptions/runes/brc20,
+                // max_op_return_size, max_witness_per_input, max_tx_outputs,
+                // max_tx_size) additionally drop non-conforming txs.
+                if self.config.enforce_custom_policy_fields {
+                    if let Some(reason) = policy_field_violation(&self.policy, &btc_tx, &result) {
+                        removed_fees += tx.fee;
+                        debug!(
+                            txid = %tx.txid,
+                            reason = %reason,
+                            "Transaction filtered by custom policy field"
+                        );
+                        continue;
+                    }
                 }
 
                 // Additional policy checks
@@ -4363,10 +4377,15 @@ mod tests {
         }
     }
 
+    /// Processor on the Custom path: per-field enforcement ON, reaper OFF, so
+    /// only the policy fields can drop a tx.
     fn make_processor(policy: PolicyProfile) -> TemplateProcessor {
         let rpc = Arc::new(BitcoinRpc::new("127.0.0.1", 8332, "user", "pass").unwrap());
-        // Reaper disabled → only the policy fields can drop a tx.
-        TemplateProcessor::new(TemplateConfig::default(), rpc, policy, ReaperConfig::disabled())
+        let config = TemplateConfig {
+            enforce_custom_policy_fields: true,
+            ..Default::default()
+        };
+        TemplateProcessor::new(config, rpc, policy, ReaperConfig::disabled())
     }
 
     #[test]
@@ -4571,6 +4590,43 @@ mod tests {
         let loose = PolicyProfile::full_open(); // already allows inscriptions
         let (kept, _) = make_processor(loose).filter_transactions(&[ttx]);
         assert_eq!(kept.len(), 1, "inscription must be kept when allowed");
+    }
+
+    #[test]
+    fn test_preset_does_not_enforce_custom_fields() {
+        // A preset (permissive) is tier-gate-only: enforce_custom_policy_fields
+        // is OFF (the default), so a tx that is an allowed tier but exceeds the
+        // profile's baked-in max_tx_outputs (100) must STILL be mined — the
+        // finer fields are Custom-only.
+        let tx = template_tx(&tx_with_outputs(0x60, 150));
+
+        let rpc = Arc::new(BitcoinRpc::new("127.0.0.1", 8332, "user", "pass").unwrap());
+        // Default config → enforce_custom_policy_fields = false (preset path).
+        let processor = TemplateProcessor::new(
+            TemplateConfig::default(),
+            rpc,
+            PolicyProfile::permissive(),
+            ReaperConfig::disabled(),
+        );
+
+        // Sanity: permissive's field limit is indeed exceeded, so the only reason
+        // it survives is that presets don't enforce that field.
+        assert!(150 > PolicyProfile::permissive().max_tx_outputs);
+
+        let (kept, _) = processor.filter_transactions(&[tx]);
+        assert_eq!(
+            kept.len(),
+            1,
+            "preset must keep an over-limit but allowed-tier tx (tier-gate-only)"
+        );
+
+        // And the Custom path (enforcement ON) with the same profile WOULD drop it.
+        let tx2 = template_tx(&tx_with_outputs(0x61, 150));
+        let (kept2, _) = make_processor(PolicyProfile::permissive()).filter_transactions(&[tx2]);
+        assert!(
+            kept2.is_empty(),
+            "custom path must drop the over-limit tx once enforcement is on"
+        );
     }
 
     /// Test that ghost-reaper detects OP_DROP stuffing in witness scripts

--- a/crates/ghost-buds/src/classifier.rs
+++ b/crates/ghost-buds/src/classifier.rs
@@ -393,7 +393,7 @@ impl PolicyPreset {
     /// Bitcoin Pure: Only T0 and T1 (financial transactions only)
     pub fn bitcoin_pure() -> Self {
         Self {
-            name: "bitcoin_pure",
+            name: "strict",
             allowed_tiers: vec![BudsTier::T0, BudsTier::T1],
         }
     }

--- a/crates/ghost-common/src/config.rs
+++ b/crates/ghost-common/src/config.rs
@@ -1313,6 +1313,19 @@ pub struct CustomPolicyConfig {
     pub allow_inscriptions: bool,
     /// Allow Runes
     pub allow_runes: bool,
+    /// Allow BRC-20 token transfers
+    #[serde(default)]
+    pub allow_brc20: bool,
+    /// Minimum fee rate (sat/vB, 0 = no minimum)
+    #[serde(default = "default_custom_min_fee_rate")]
+    pub min_fee_rate: f64,
+}
+
+/// Default minimum fee rate for a custom policy (sat/vB). Matches the
+/// `strict`/`permissive` preset default so an operator who only tweaks
+/// content toggles keeps a sane floor.
+fn default_custom_min_fee_rate() -> f64 {
+    1.0
 }
 
 impl Default for CustomPolicyConfig {
@@ -1325,6 +1338,8 @@ impl Default for CustomPolicyConfig {
             max_tx_size: MAX_TX_SIZE_BITCOIN_PURE,
             allow_inscriptions: false,
             allow_runes: false,
+            allow_brc20: false,
+            min_fee_rate: default_custom_min_fee_rate(),
         }
     }
 }

--- a/crates/ghost-common/src/config.rs
+++ b/crates/ghost-common/src/config.rs
@@ -1283,7 +1283,10 @@ impl Default for PolicyConfig {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum PolicyProfile {
-    /// Only T0 + T1 transactions (financial-only)
+    /// Only T0 + T1 transactions (financial-only). Serialized as `strict`; the
+    /// legacy `bitcoin_pure` value is still accepted so existing pool.toml files
+    /// keep parsing. The internal `BitcoinPure` identifier is unchanged.
+    #[serde(rename = "strict", alias = "bitcoin_pure")]
     BitcoinPure,
     /// T0 + T1 + T2 (most common)
     Permissive,

--- a/crates/ghost-policy/src/profile.rs
+++ b/crates/ghost-policy/src/profile.rs
@@ -65,7 +65,7 @@ impl PolicyProfile {
     /// No OP_RETURN, inscriptions, or exotic data
     pub fn bitcoin_pure() -> Self {
         Self {
-            name: "bitcoin_pure".to_string(),
+            name: "strict".to_string(),
             description: "Financial transactions only (T0+T1), no data embedding".to_string(),
             allowed_tiers: vec![BudsTier::T0, BudsTier::T1],
             max_op_return_size: 0,
@@ -181,6 +181,7 @@ impl Default for PolicyProfile {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ProfilePreset {
+    #[serde(rename = "strict", alias = "bitcoin_pure")]
     BitcoinPure,
     Permissive,
     FullOpen,
@@ -199,7 +200,7 @@ impl ProfilePreset {
 
     pub fn name(&self) -> &'static str {
         match self {
-            Self::BitcoinPure => "bitcoin_pure",
+            Self::BitcoinPure => "strict",
             Self::Permissive => "permissive",
             Self::FullOpen => "full_open",
             Self::Custom => "custom",

--- a/crates/ghost-template/src/filter.rs
+++ b/crates/ghost-template/src/filter.rs
@@ -272,7 +272,7 @@ mod tests {
     #[test]
     fn test_policy_profiles() {
         let bitcoin_pure = TemplateFilter::bitcoin_pure();
-        assert_eq!(bitcoin_pure.profile().name, "bitcoin_pure");
+        assert_eq!(bitcoin_pure.profile().name, "strict");
 
         let permissive = TemplateFilter::permissive();
         assert_eq!(permissive.profile().name, "permissive");

--- a/crates/ghost-verification/src/routes.rs
+++ b/crates/ghost-verification/src/routes.rs
@@ -478,6 +478,10 @@ pub fn create_router(state: Arc<VerificationState>) -> Router {
             post(api_config_template_profile_post_handler),
         )
         .route(
+            "/api/v1/config/policy_profile",
+            post(api_config_policy_profile_post_handler),
+        )
+        .route(
             "/api/v1/config/reaper",
             post(api_config_reaper_post_handler),
         )
@@ -5329,6 +5333,106 @@ fn ghost_common_now(state: &str, message: impl Into<String>) -> crate::server::G
 /// result lands on the reaper GET endpoint's `ghostd_apply`. A legacy
 /// `{ "enabled": bool }` body still works (the per-vector fields fall back to
 /// their serde defaults = all-on).
+/// Request body for the policy-profile POST endpoint.
+#[derive(Debug, Deserialize)]
+struct PolicyProfileRequest {
+    /// One of `strict` (legacy alias `bitcoin_pure`), `permissive`, `full_open`.
+    profile: String,
+}
+
+/// API v1 Config policy_profile POST handler.
+///
+/// This is the REAL lever for which BUDS tiers get mined: it writes
+/// `[policy].profile` into the node config (pool.toml) and persists it, then
+/// requests a graceful ghost-pool restart so the new profile is resolved at
+/// startup. Unlike the cosmetic `mempool_profile`/`template_profile` dashboard
+/// mirrors, changing this actually alters template construction.
+async fn api_config_policy_profile_post_handler(
+    State(state): State<Arc<VerificationState>>,
+    Json(payload): Json<PolicyProfileRequest>,
+) -> impl IntoResponse {
+    use ghost_common::config::PolicyProfile;
+
+    // Map the incoming string to the config enum. Accept the new `strict`
+    // spelling and the legacy `bitcoin_pure` alias; reject anything else 400.
+    let profile = match payload.profile.trim().to_ascii_lowercase().as_str() {
+        "strict" | "bitcoin_pure" => PolicyProfile::BitcoinPure,
+        "permissive" => PolicyProfile::Permissive,
+        "full_open" => PolicyProfile::FullOpen,
+        other => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({
+                    "success": false,
+                    "error": format!("Unknown policy profile: {other}"),
+                    "code": "INVALID_PROFILE",
+                })),
+            )
+                .into_response();
+        }
+    };
+
+    // The canonical serialized name we echo back to the caller.
+    let profile_name = match profile {
+        PolicyProfile::BitcoinPure => "strict",
+        PolicyProfile::Permissive => "permissive",
+        PolicyProfile::FullOpen => "full_open",
+        PolicyProfile::Custom => "custom",
+    };
+
+    // Require the full node config + a path to persist to; otherwise the change
+    // can't survive a restart, so fail-closed with SERVICE_UNAVAILABLE.
+    let Some(ref full) = state.full_node_config else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(serde_json::json!({
+                "success": false,
+                "error": "Config update API not available: full node config not loaded",
+                "code": "CONFIG_NOT_LOADED",
+            })),
+        )
+            .into_response();
+    };
+    let Some(ref path) = state.full_node_config_path else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(serde_json::json!({
+                "success": false,
+                "error": "Config update API not available: no node config path configured",
+                "code": "CONFIG_NOT_LOADED",
+            })),
+        )
+            .into_response();
+    };
+
+    {
+        let mut cfg = full.write();
+        cfg.policy.profile = profile;
+        if let Err(e) = cfg.save_atomic(path) {
+            error!(error = %e, "Failed to persist policy profile");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({
+                    "success": false,
+                    "error": format!("Failed to persist policy profile: {e}"),
+                    "code": "PERSIST_FAILED",
+                })),
+            )
+                .into_response();
+        }
+    }
+
+    // The profile is resolved at startup, so a graceful restart applies it.
+    state.request_restart();
+
+    Json(serde_json::json!({
+        "success": true,
+        "profile": profile_name,
+        "restart_pending": true,
+    }))
+    .into_response()
+}
+
 async fn api_config_reaper_post_handler(
     State(state): State<Arc<VerificationState>>,
     Json(payload): Json<ghost_common::config::ReaperSettings>,
@@ -8408,6 +8512,114 @@ mod tests {
         assert_eq!(on["enabled"].as_bool(), Some(true));
         let reloaded = FullNodeConfig::load(&path).unwrap();
         assert!(reloaded.wraith_enabled(), "enable must persist to disk");
+    }
+
+    /// The policy_profile POST is the real lever for mined BUDS tiers: without
+    /// HMAC it must 401, and with a valid signature it must persist
+    /// `[policy].profile` to pool.toml and request a graceful restart.
+    #[tokio::test]
+    async fn test_config_policy_profile_post_persists_and_restarts() {
+        use ghost_common::config::NodeConfig as FullNodeConfig;
+        use ghost_common::config::PolicyProfile as CfgProfile;
+        use ghost_common::types::NodeCapabilities;
+        use ghost_policy::PolicyProfile;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("pool.toml");
+
+        let auth = crate::auth::InternalAuth::new(&test_secret()).unwrap();
+        let state = Arc::new(
+            crate::server::VerificationState::new(
+                "test_node".to_string(),
+                "1.0.0".to_string(),
+                PolicyProfile::default(),
+                NodeCapabilities::default(),
+            )
+            .with_internal_auth(auth.clone())
+            .with_full_node_config(FullNodeConfig::default(), path.clone()),
+        );
+
+        // Without auth → 401.
+        let unauth = super::create_router(Arc::clone(&state))
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/config/policy_profile")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(r#"{"profile": "strict"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            unauth.status(),
+            StatusCode::UNAUTHORIZED,
+            "policy_profile POST without auth must 401"
+        );
+        assert!(!state.restart_requested());
+
+        // With valid HMAC → persists `strict` and requests restart.
+        let body = r#"{"profile": "strict"}"#;
+        let timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let signature = auth.sign(timestamp, body.as_bytes());
+        let response = super::create_router(Arc::clone(&state))
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/config/policy_profile")
+                    .header("Content-Type", "application/json")
+                    .header("X-Ghost-Signature", signature)
+                    .header("X-Ghost-Timestamp", timestamp.to_string())
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(json["success"].as_bool(), Some(true));
+        assert_eq!(json["profile"].as_str(), Some("strict"));
+        assert_eq!(json["restart_pending"].as_bool(), Some(true));
+
+        // Persisted to disk as BitcoinPure and restart requested.
+        let reloaded = FullNodeConfig::load(&path).unwrap();
+        assert_eq!(reloaded.policy.profile, CfgProfile::BitcoinPure);
+        assert!(
+            state.restart_requested(),
+            "policy_profile change must request a restart"
+        );
+
+        // Unknown profile → 400.
+        let bad = r#"{"profile": "nonsense"}"#;
+        let timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let signature = auth.sign(timestamp, bad.as_bytes());
+        let bad_resp = super::create_router(Arc::clone(&state))
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/config/policy_profile")
+                    .header("Content-Type", "application/json")
+                    .header("X-Ghost-Signature", signature)
+                    .header("X-Ghost-Timestamp", timestamp.to_string())
+                    .body(Body::from(bad))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            bad_resp.status(),
+            StatusCode::BAD_REQUEST,
+            "unknown policy profile must 400"
+        );
     }
 
     /// CRIT-6: Test that all config POST endpoints require auth

--- a/crates/ghost-verification/src/routes.rs
+++ b/crates/ghost-verification/src/routes.rs
@@ -321,14 +321,6 @@ pub fn create_router(state: Arc<VerificationState>) -> Router {
         // CRIT-6: POST handlers moved to internal_router to require authentication
         .route("/api/v1/config/full", get(api_config_full_handler))
         .route(
-            "/api/v1/config/profiles/mempool",
-            get(api_config_profiles_mempool_handler),
-        )
-        .route(
-            "/api/v1/config/profiles/template",
-            get(api_config_profiles_template_handler),
-        )
-        .route(
             "/api/v1/config/archive_mode",
             get(api_config_archive_mode_handler),
         )
@@ -466,16 +458,8 @@ pub fn create_router(state: Arc<VerificationState>) -> Router {
             post(api_config_ghost_mode_post_handler),
         )
         .route(
-            "/api/v1/config/mempool_profile",
-            post(api_config_mempool_profile_post_handler),
-        )
-        .route(
             "/api/v1/config/public_mining",
             post(api_config_public_mining_post_handler),
-        )
-        .route(
-            "/api/v1/config/template_profile",
-            post(api_config_template_profile_post_handler),
         )
         .route(
             "/api/v1/config/policy_profile",
@@ -4944,34 +4928,6 @@ async fn api_config_full_handler(State(state): State<Arc<VerificationState>>) ->
     }))
 }
 
-/// API v1 Config profiles mempool handler
-async fn api_config_profiles_mempool_handler(
-    State(_state): State<Arc<VerificationState>>,
-) -> impl IntoResponse {
-    Json(serde_json::json!({
-        "profiles": [
-            { "name": "permissive", "description": "Accept all standard transactions", "active": true },
-            { "name": "strict", "description": "Bitcoin Core defaults only", "active": false },
-            { "name": "custom", "description": "Custom configuration", "active": false }
-        ],
-        "current": "permissive"
-    }))
-}
-
-/// API v1 Config profiles template handler
-async fn api_config_profiles_template_handler(
-    State(_state): State<Arc<VerificationState>>,
-) -> impl IntoResponse {
-    Json(serde_json::json!({
-        "profiles": [
-            { "name": "default", "description": "Standard block template", "active": true },
-            { "name": "compact", "description": "Smaller blocks", "active": false },
-            { "name": "maximum", "description": "Maximum block size", "active": false }
-        ],
-        "current": "default"
-    }))
-}
-
 /// API v1 Config archive mode handler
 async fn api_config_archive_mode_handler(
     State(state): State<Arc<VerificationState>>,
@@ -5595,34 +5551,6 @@ async fn api_config_elder_post_handler(
         "enabled": payload.enabled,
         "slot": payload.slot,
         "message": "Elder status updated"
-    }))
-}
-
-/// API v1 Config mempool_profile POST handler
-async fn api_config_mempool_profile_post_handler(
-    State(state): State<Arc<VerificationState>>,
-    Json(payload): Json<ProfileRequest>,
-) -> impl IntoResponse {
-    let mut config = state.dashboard_config.write();
-    config.mempool_profile = payload.profile.clone();
-    Json(serde_json::json!({
-        "success": true,
-        "profile": payload.profile,
-        "message": "Mempool profile updated"
-    }))
-}
-
-/// API v1 Config template_profile POST handler
-async fn api_config_template_profile_post_handler(
-    State(state): State<Arc<VerificationState>>,
-    Json(payload): Json<ProfileRequest>,
-) -> impl IntoResponse {
-    let mut config = state.dashboard_config.write();
-    config.template_profile = payload.profile.clone();
-    Json(serde_json::json!({
-        "success": true,
-        "profile": payload.profile,
-        "message": "Template profile updated"
     }))
 }
 
@@ -7538,9 +7466,15 @@ async fn api_config_profiles_mempool_activate_handler(
     State(state): State<Arc<VerificationState>>,
     Path(name): Path<String>,
 ) -> impl IntoResponse {
-    // Delegate to the existing mempool_profile POST handler
-    api_config_mempool_profile_post_handler(State(state), Json(ProfileRequest { profile: name }))
-        .await
+    // Record the selection in the dashboard mirror. This is a cosmetic display
+    // field; the real mining lever is `/api/v1/config/policy_profile`.
+    let mut config = state.dashboard_config.write();
+    config.mempool_profile = name.clone();
+    Json(serde_json::json!({
+        "success": true,
+        "profile": name,
+        "message": "Mempool profile updated"
+    }))
 }
 
 /// API v1 Config: Save custom template profile
@@ -7586,8 +7520,15 @@ async fn api_config_profiles_template_activate_handler(
     State(state): State<Arc<VerificationState>>,
     Path(name): Path<String>,
 ) -> impl IntoResponse {
-    api_config_template_profile_post_handler(State(state), Json(ProfileRequest { profile: name }))
-        .await
+    // Cosmetic dashboard mirror; the real mining lever is
+    // `/api/v1/config/policy_profile`.
+    let mut config = state.dashboard_config.write();
+    config.template_profile = name.clone();
+    Json(serde_json::json!({
+        "success": true,
+        "profile": name,
+        "message": "Template profile updated"
+    }))
 }
 
 /// GhostPay payout address body
@@ -8631,9 +8572,8 @@ mod tests {
         let config_endpoints = [
             "/api/v1/config/archive_mode",
             "/api/v1/config/ghost_mode",
-            "/api/v1/config/mempool_profile",
+            "/api/v1/config/policy_profile",
             "/api/v1/config/public_mining",
-            "/api/v1/config/template_profile",
             "/api/v1/config/reaper",
             "/api/v1/config/ghost_pay",
             "/api/v1/config/wraith",
@@ -8645,9 +8585,8 @@ mod tests {
             let app = super::create_router(Arc::clone(&state));
 
             let body = match endpoint {
-                "/api/v1/config/mempool_profile"
-                | "/api/v1/config/template_profile"
-                | "/api/v1/config/prune_profile" => r#"{"profile": "standard"}"#,
+                "/api/v1/config/policy_profile" => r#"{"profile": "strict"}"#,
+                "/api/v1/config/prune_profile" => r#"{"profile": "standard"}"#,
                 "/api/v1/config/elder" => r#"{"enabled": true, "slot": 1}"#,
                 _ => r#"{"enabled": true}"#,
             };

--- a/crates/ghost-verification/src/routes.rs
+++ b/crates/ghost-verification/src/routes.rs
@@ -466,6 +466,10 @@ pub fn create_router(state: Arc<VerificationState>) -> Router {
             post(api_config_policy_profile_post_handler),
         )
         .route(
+            "/api/v1/config/policy_custom",
+            post(api_config_policy_custom_post_handler),
+        )
+        .route(
             "/api/v1/config/reaper",
             post(api_config_reaper_post_handler),
         )
@@ -4909,6 +4913,10 @@ async fn api_rewards_node_history_handler(
 async fn api_config_full_handler(State(state): State<Arc<VerificationState>>) -> impl IntoResponse {
     let health = state.get_health().await;
     let config = state.dashboard_config.read();
+    // Surface the real tier policy (pool.toml [policy]) so the dashboard can show
+    // the current preset AND, for the Custom profile, pre-fill the advanced
+    // per-field controls. Read from the full node config when it is loaded.
+    let policy = policy_json(&state);
     Json(serde_json::json!({
         "archive_mode": config.archive_mode,
         "ghost_pay": config.ghost_pay,
@@ -4918,6 +4926,7 @@ async fn api_config_full_handler(State(state): State<Arc<VerificationState>>) ->
         "mempool_profile": config.mempool_profile,
         "template_profile": config.template_profile,
         "prune_profile": config.prune_profile,
+        "policy": policy,
         "operator_window": 100,
         "network": state.network.as_str(),
         "stratum_sv2_port": 4444,
@@ -5387,6 +5396,215 @@ async fn api_config_policy_profile_post_handler(
         "restart_pending": true,
     }))
     .into_response()
+}
+
+/// Request body for the custom tier-policy POST endpoint. Carries the full set
+/// of operator-tunable policy fields; the per-tier booleans map onto the
+/// `[policy].custom.allowed_tiers` list.
+#[derive(Debug, Deserialize)]
+struct PolicyCustomRequest {
+    /// Allow tier T0 (core financial) transactions.
+    #[serde(default)]
+    allow_t0: bool,
+    /// Allow tier T1 (extended financial: multisig, timelocks) transactions.
+    #[serde(default)]
+    allow_t1: bool,
+    /// Allow tier T2 (small data / OP_RETURN) transactions.
+    #[serde(default)]
+    allow_t2: bool,
+    /// Allow tier T3 (heavy data: inscriptions, runes) transactions.
+    #[serde(default)]
+    allow_t3: bool,
+    /// Allow Ordinals/inscription envelopes.
+    #[serde(default)]
+    allow_inscriptions: bool,
+    /// Allow Runes runestones.
+    #[serde(default)]
+    allow_runes: bool,
+    /// Allow BRC-20 token transfers.
+    #[serde(default)]
+    allow_brc20: bool,
+    /// Maximum OP_RETURN payload size in bytes (0 = none allowed).
+    max_op_return_size: usize,
+    /// Maximum witness size per input in bytes.
+    max_witness_per_input: usize,
+    /// Maximum outputs per transaction.
+    max_tx_outputs: usize,
+    /// Maximum transaction size in vbytes.
+    max_tx_size: usize,
+    /// Minimum fee rate in sat/vB (0 = no minimum).
+    min_fee_rate: f64,
+}
+
+/// API v1 Config policy_custom POST handler.
+///
+/// Sets `[policy].profile = custom` and writes the full `[policy].custom` block
+/// to pool.toml, then requests a graceful restart so the operator-defined field
+/// values are resolved into the enforced policy profile at startup. Unlike the
+/// three presets, this exposes every per-field knob the template builder now
+/// enforces (tiers, content toggles, size limits, min fee rate).
+async fn api_config_policy_custom_post_handler(
+    State(state): State<Arc<VerificationState>>,
+    Json(payload): Json<PolicyCustomRequest>,
+) -> impl IntoResponse {
+    use ghost_common::config::{BudsTier, CustomPolicyConfig, PolicyProfile};
+
+    // Validate the fee rate: must be a finite, non-negative number.
+    if !payload.min_fee_rate.is_finite() || payload.min_fee_rate < 0.0 {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "success": false,
+                "error": "min_fee_rate must be a finite, non-negative number",
+                "code": "INVALID_FEE_RATE",
+            })),
+        )
+            .into_response();
+    }
+
+    // Build the allowed-tier list from the per-tier booleans.
+    let mut allowed_tiers = Vec::new();
+    if payload.allow_t0 {
+        allowed_tiers.push(BudsTier::T0);
+    }
+    if payload.allow_t1 {
+        allowed_tiers.push(BudsTier::T1);
+    }
+    if payload.allow_t2 {
+        allowed_tiers.push(BudsTier::T2);
+    }
+    if payload.allow_t3 {
+        allowed_tiers.push(BudsTier::T3);
+    }
+
+    let custom = CustomPolicyConfig {
+        allowed_tiers,
+        max_op_return_size: payload.max_op_return_size,
+        max_witness_per_input: payload.max_witness_per_input,
+        max_tx_outputs: payload.max_tx_outputs,
+        max_tx_size: payload.max_tx_size,
+        allow_inscriptions: payload.allow_inscriptions,
+        allow_runes: payload.allow_runes,
+        allow_brc20: payload.allow_brc20,
+        min_fee_rate: payload.min_fee_rate,
+    };
+
+    // Require the full node config + a path to persist to; otherwise the change
+    // can't survive a restart, so fail-closed with SERVICE_UNAVAILABLE.
+    let Some(ref full) = state.full_node_config else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(serde_json::json!({
+                "success": false,
+                "error": "Config update API not available: full node config not loaded",
+                "code": "CONFIG_NOT_LOADED",
+            })),
+        )
+            .into_response();
+    };
+    let Some(ref path) = state.full_node_config_path else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(serde_json::json!({
+                "success": false,
+                "error": "Config update API not available: no node config path configured",
+                "code": "CONFIG_NOT_LOADED",
+            })),
+        )
+            .into_response();
+    };
+
+    let custom_json = serde_json::json!({
+        "allowed_tiers": custom.allowed_tiers.iter().map(tier_key).collect::<Vec<_>>(),
+        "max_op_return_size": custom.max_op_return_size,
+        "max_witness_per_input": custom.max_witness_per_input,
+        "max_tx_outputs": custom.max_tx_outputs,
+        "max_tx_size": custom.max_tx_size,
+        "allow_inscriptions": custom.allow_inscriptions,
+        "allow_runes": custom.allow_runes,
+        "allow_brc20": custom.allow_brc20,
+        "min_fee_rate": custom.min_fee_rate,
+    });
+
+    {
+        let mut cfg = full.write();
+        cfg.policy.profile = PolicyProfile::Custom;
+        cfg.policy.custom = Some(custom);
+        if let Err(e) = cfg.save_atomic(path) {
+            error!(error = %e, "Failed to persist custom policy");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({
+                    "success": false,
+                    "error": format!("Failed to persist custom policy: {e}"),
+                    "code": "PERSIST_FAILED",
+                })),
+            )
+                .into_response();
+        }
+    }
+
+    // The custom profile is resolved at startup, so a graceful restart applies it.
+    state.request_restart();
+
+    Json(serde_json::json!({
+        "success": true,
+        "profile": "custom",
+        "custom": custom_json,
+        "restart_pending": true,
+    }))
+    .into_response()
+}
+
+/// Build the `policy` JSON block for the config GET responses: the active
+/// preset name plus the resolved custom field values. When no `[policy].custom`
+/// block is persisted, the defaults are surfaced so the advanced UI panel has
+/// sensible starting values. Returns `null` when the full node config is not
+/// loaded (e.g. minimal/test servers).
+fn policy_json(state: &Arc<VerificationState>) -> serde_json::Value {
+    use ghost_common::config::{CustomPolicyConfig, PolicyProfile};
+
+    let Some(ref full) = state.full_node_config else {
+        return serde_json::Value::Null;
+    };
+    let cfg = full.read();
+
+    let profile_name = match cfg.policy.profile {
+        PolicyProfile::BitcoinPure => "strict",
+        PolicyProfile::Permissive => "permissive",
+        PolicyProfile::FullOpen => "full_open",
+        PolicyProfile::Custom => "custom",
+    };
+
+    let custom: CustomPolicyConfig = cfg.policy.custom.clone().unwrap_or_default();
+
+    serde_json::json!({
+        "profile": profile_name,
+        "custom": {
+            "allow_t0": custom.allowed_tiers.contains(&ghost_common::config::BudsTier::T0),
+            "allow_t1": custom.allowed_tiers.contains(&ghost_common::config::BudsTier::T1),
+            "allow_t2": custom.allowed_tiers.contains(&ghost_common::config::BudsTier::T2),
+            "allow_t3": custom.allowed_tiers.contains(&ghost_common::config::BudsTier::T3),
+            "allow_inscriptions": custom.allow_inscriptions,
+            "allow_runes": custom.allow_runes,
+            "allow_brc20": custom.allow_brc20,
+            "max_op_return_size": custom.max_op_return_size,
+            "max_witness_per_input": custom.max_witness_per_input,
+            "max_tx_outputs": custom.max_tx_outputs,
+            "max_tx_size": custom.max_tx_size,
+            "min_fee_rate": custom.min_fee_rate,
+        }
+    })
+}
+
+/// Serialize a config-crate BUDS tier to its lowercase wire key (`t0`..`t3`).
+fn tier_key(tier: &ghost_common::config::BudsTier) -> &'static str {
+    match tier {
+        ghost_common::config::BudsTier::T0 => "t0",
+        ghost_common::config::BudsTier::T1 => "t1",
+        ghost_common::config::BudsTier::T2 => "t2",
+        ghost_common::config::BudsTier::T3 => "t3",
+    }
 }
 
 async fn api_config_reaper_post_handler(
@@ -8563,6 +8781,210 @@ mod tests {
         );
     }
 
+    /// The policy_custom POST exposes every per-field policy knob: without HMAC
+    /// it must 401, and with a valid signature it must set `[policy].profile =
+    /// custom`, persist the full `[policy].custom` block to pool.toml and request
+    /// a graceful restart. It must also reject a negative min_fee_rate with 400.
+    #[tokio::test]
+    async fn test_config_policy_custom_post_persists_and_restarts() {
+        use ghost_common::config::NodeConfig as FullNodeConfig;
+        use ghost_common::config::{BudsTier, PolicyProfile as CfgProfile};
+        use ghost_common::types::NodeCapabilities;
+        use ghost_policy::PolicyProfile;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("pool.toml");
+
+        let auth = crate::auth::InternalAuth::new(&test_secret()).unwrap();
+        let state = Arc::new(
+            crate::server::VerificationState::new(
+                "test_node".to_string(),
+                "1.0.0".to_string(),
+                PolicyProfile::default(),
+                NodeCapabilities::default(),
+            )
+            .with_internal_auth(auth.clone())
+            .with_full_node_config(FullNodeConfig::default(), path.clone()),
+        );
+
+        // A representative custom body: T0+T1 only, all data off, tight limits.
+        let body = r#"{
+            "allow_t0": true,
+            "allow_t1": true,
+            "allow_t2": false,
+            "allow_t3": false,
+            "allow_inscriptions": false,
+            "allow_runes": false,
+            "allow_brc20": false,
+            "max_op_return_size": 40,
+            "max_witness_per_input": 500,
+            "max_tx_outputs": 8,
+            "max_tx_size": 90000,
+            "min_fee_rate": 2.5
+        }"#;
+
+        // Without auth → 401.
+        let unauth = super::create_router(Arc::clone(&state))
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/config/policy_custom")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            unauth.status(),
+            StatusCode::UNAUTHORIZED,
+            "policy_custom POST without auth must 401"
+        );
+        assert!(!state.restart_requested());
+
+        // With valid HMAC → persists + requests restart.
+        let timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let signature = auth.sign(timestamp, body.as_bytes());
+        let response = super::create_router(Arc::clone(&state))
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/config/policy_custom")
+                    .header("Content-Type", "application/json")
+                    .header("X-Ghost-Signature", signature)
+                    .header("X-Ghost-Timestamp", timestamp.to_string())
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(json["success"].as_bool(), Some(true));
+        assert_eq!(json["profile"].as_str(), Some("custom"));
+        assert_eq!(json["restart_pending"].as_bool(), Some(true));
+
+        // Persisted to disk: profile = Custom and the custom block round-trips.
+        let reloaded = FullNodeConfig::load(&path).unwrap();
+        assert_eq!(reloaded.policy.profile, CfgProfile::Custom);
+        let custom = reloaded.policy.custom.expect("custom block persisted");
+        assert_eq!(custom.allowed_tiers, vec![BudsTier::T0, BudsTier::T1]);
+        assert_eq!(custom.max_op_return_size, 40);
+        assert_eq!(custom.max_witness_per_input, 500);
+        assert_eq!(custom.max_tx_outputs, 8);
+        assert_eq!(custom.max_tx_size, 90000);
+        assert!(!custom.allow_inscriptions);
+        assert!(!custom.allow_runes);
+        assert!(!custom.allow_brc20);
+        assert_eq!(custom.min_fee_rate, 2.5);
+        assert!(
+            state.restart_requested(),
+            "policy_custom change must request a restart"
+        );
+
+        // Negative min_fee_rate → 400.
+        let bad = r#"{
+            "allow_t0": true, "allow_t1": false, "allow_t2": false, "allow_t3": false,
+            "allow_inscriptions": false, "allow_runes": false, "allow_brc20": false,
+            "max_op_return_size": 0, "max_witness_per_input": 500,
+            "max_tx_outputs": 8, "max_tx_size": 90000, "min_fee_rate": -1.0
+        }"#;
+        let timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let signature = auth.sign(timestamp, bad.as_bytes());
+        let bad_resp = super::create_router(Arc::clone(&state))
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/config/policy_custom")
+                    .header("Content-Type", "application/json")
+                    .header("X-Ghost-Signature", signature)
+                    .header("X-Ghost-Timestamp", timestamp.to_string())
+                    .body(Body::from(bad))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            bad_resp.status(),
+            StatusCode::BAD_REQUEST,
+            "negative min_fee_rate must 400"
+        );
+    }
+
+    /// The extended config GET (`/api/v1/config/full`) must surface the active
+    /// policy profile and the resolved custom field values so the dashboard can
+    /// render the current preset and pre-fill the advanced panel.
+    #[tokio::test]
+    async fn test_config_full_surfaces_policy() {
+        use ghost_common::config::NodeConfig as FullNodeConfig;
+        use ghost_common::config::{BudsTier, CustomPolicyConfig, PolicyProfile as CfgProfile};
+        use ghost_common::types::NodeCapabilities;
+        use ghost_policy::PolicyProfile;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("pool.toml");
+
+        let mut cfg = FullNodeConfig::default();
+        cfg.policy.profile = CfgProfile::Custom;
+        cfg.policy.custom = Some(CustomPolicyConfig {
+            allowed_tiers: vec![BudsTier::T0, BudsTier::T2],
+            max_op_return_size: 33,
+            max_witness_per_input: 111,
+            max_tx_outputs: 7,
+            max_tx_size: 12345,
+            allow_inscriptions: true,
+            allow_runes: false,
+            allow_brc20: true,
+            min_fee_rate: 3.0,
+        });
+
+        let state = Arc::new(
+            crate::server::VerificationState::new(
+                "test_node".to_string(),
+                "1.0.0".to_string(),
+                PolicyProfile::default(),
+                NodeCapabilities::default(),
+            )
+            .with_full_node_config(cfg, path.clone()),
+        );
+
+        let response = super::create_router(Arc::clone(&state))
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/api/v1/config/full")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(json["policy"]["profile"].as_str(), Some("custom"));
+        let c = &json["policy"]["custom"];
+        assert_eq!(c["allow_t0"].as_bool(), Some(true));
+        assert_eq!(c["allow_t1"].as_bool(), Some(false));
+        assert_eq!(c["allow_t2"].as_bool(), Some(true));
+        assert_eq!(c["allow_t3"].as_bool(), Some(false));
+        assert_eq!(c["allow_inscriptions"].as_bool(), Some(true));
+        assert_eq!(c["allow_brc20"].as_bool(), Some(true));
+        assert_eq!(c["max_op_return_size"].as_u64(), Some(33));
+        assert_eq!(c["max_tx_outputs"].as_u64(), Some(7));
+        assert_eq!(c["min_fee_rate"].as_f64(), Some(3.0));
+    }
+
     /// CRIT-6: Test that all config POST endpoints require auth
     #[tokio::test]
     async fn test_all_config_post_endpoints_require_auth() {
@@ -8573,6 +8995,7 @@ mod tests {
             "/api/v1/config/archive_mode",
             "/api/v1/config/ghost_mode",
             "/api/v1/config/policy_profile",
+            "/api/v1/config/policy_custom",
             "/api/v1/config/public_mining",
             "/api/v1/config/reaper",
             "/api/v1/config/ghost_pay",
@@ -8586,6 +9009,9 @@ mod tests {
 
             let body = match endpoint {
                 "/api/v1/config/policy_profile" => r#"{"profile": "strict"}"#,
+                "/api/v1/config/policy_custom" => {
+                    r#"{"allow_t0": true, "allow_t1": true, "allow_t2": false, "allow_t3": false, "allow_inscriptions": false, "allow_runes": false, "allow_brc20": false, "max_op_return_size": 40, "max_witness_per_input": 500, "max_tx_outputs": 8, "max_tx_size": 90000, "min_fee_rate": 1.0}"#
+                }
                 "/api/v1/config/prune_profile" => r#"{"profile": "standard"}"#,
                 "/api/v1/config/elder" => r#"{"enabled": true, "slot": 1}"#,
                 _ => r#"{"enabled": true}"#,


### PR DESCRIPTION
## Summary

Stage 2 backend: wire the missing block-build enforcement so tier-policy controls actually bite, and make the Custom profile operator-settable + persisted.

Stacked on the Stage 1 branch `fix/policy-strict-rename-and-wire` (the `strict` rename + `policy_profile` endpoint). Review/merge that first; this PR's own changes are the last two commits.

Refs #220.

## The enforcement gap this fixes

The block-template builder (`bins/ghost-pool/src/template.rs`) enforced only: reaper -> coarse BUDS tier gate (`policy.allows_tier`) -> `min_fee_rate`. It never ran the finer per-field policy checks, so `allow_inscriptions` / `allow_runes` / `allow_brc20`, `max_op_return_size`, `max_witness_per_input`, `max_tx_outputs` and `max_tx_size` were **cosmetic** for block construction — an operator could set them and the block builder would ignore them.

## What changed

**Enforcement wired in (`template.rs`).** A new `policy_field_violation()` helper (mirrors `ghost_policy::PolicyEngine::evaluate`, minus the tier gate and `min_fee_rate` which stay where they were) runs in the tx-selection loop right after the tier gate. Non-conforming txs are now dropped from the block. Existing behaviour — reaper, tier gate, `min_fee_rate`, dependency filtering, package-fee sorting — is preserved; this is purely additive.

**Custom profile is now real.** `CustomPolicyConfig` gains `allow_brc20` + `min_fee_rate` (both `#[serde(default)]`, so existing `pool.toml` files keep parsing). `bins/ghost-pool/src/main.rs` now builds the enforced `PolicyProfile` from `[policy].custom` when `profile = custom` — previously Custom silently fell back to permissive. The Custom profile's `min_fee_rate` also flows into the template's fee floor; presets keep their historical default (unchanged).

**Endpoints (`crates/ghost-verification/src/routes.rs`, internal HMAC router).**
- `POST /api/v1/config/policy_custom` — accepts the full custom field set (`allow_t0..t3`, `allow_inscriptions/runes/brc20`, `max_op_return_size`, `max_witness_per_input`, `max_tx_outputs`, `max_tx_size`, `min_fee_rate`); sets `profile = custom`, writes `[policy].custom` via `save_atomic`, and `request_restart()`. Validates `min_fee_rate` is finite and non-negative (400 otherwise). Same persistence/restart/error pattern as `policy_profile`.
- `GET /api/v1/config/full` now surfaces `policy.profile` and the resolved `policy.custom` values so the dashboard can render the current preset and pre-fill the advanced panel.

## Behaviour-change caveat

This **changes block composition** for any node not on `full_open`: transactions that were previously mined despite violating a finer policy field will now be dropped. For the three presets the effective limits are unchanged from their profile definitions — the difference is they are now actually applied. Presets' `min_fee_rate` behaviour at the template level is unchanged.

## Tests

- `ghost-pool`: 5 new `template::tests::test_policy_*` prove each knob (max outputs / OP_RETURN size / witness size / tx size / inscriptions) drops the violating tx and keeps a conforming one, end-to-end through `filter_transactions` with the reaper disabled.
- `ghost-verification`: `policy_custom` persists + requests restart + requires HMAC + rejects a negative fee rate; `config/full` surfaces the custom block.
- `ghost-common` config tests and the "all config POST endpoints require auth" test (now covering `policy_custom`) pass.

`cargo check --tests` clean across `ghost-common` / `ghost-policy` / `ghost-verification` / `ghost-pool`.
