### PR TITLE
Add Sync page to node dashboard

### DIFF
--- a/crates/ghost-verification/src/routes.rs
+++ b/crates/ghost-verification/src/routes.rs
@@ -182,6 +182,7 @@ pub fn create_router(state: Arc<VerificationState>) -> Router {
         // API v1 routes for dashboard compatibility
         .route("/api/v1/node/status", get(api_node_status_handler))
         .route("/api/v1/node/info", get(api_node_info_handler))
+        .route("/api/v1/node/blockchain", get(api_node_blockchain_handler))
         .route("/api/v1/node/shares", get(api_node_shares_handler))
         .route("/api/v1/mining/status", get(api_mining_status_handler))
         .route("/api/v1/mining/miners", get(api_miners_handler))
@@ -1531,6 +1532,84 @@ async fn api_node_info_handler(State(state): State<Arc<VerificationState>>) -> i
         "mempool_profile": config.mempool_profile,
         "template_profile": config.template_profile
     }))
+}
+
+/// API v1 node blockchain handler — chain & sync status for the Sync page.
+///
+/// Every field is sourced directly from ghostd's `getblockchaininfo` RPC (the
+/// same call the haze/mining handlers already use). This is the only endpoint
+/// that surfaces the header-tip height, on-disk size, verification progress,
+/// best-block hash, tip time and the initial-block-download flag — the node
+/// `status`/`info` endpoints only carry the block height from the health cache.
+///
+/// When the RPC is unavailable or times out, the numeric fields degrade to
+/// `null` (and `available: false`) so the dashboard renders "—" rather than a
+/// misleading zero.
+async fn api_node_blockchain_handler(
+    State(state): State<Arc<VerificationState>>,
+) -> impl IntoResponse {
+    let network = state.network.as_str();
+
+    let info = match state.rpc {
+        Some(ref rpc) => {
+            match tokio::time::timeout(
+                std::time::Duration::from_secs(5),
+                rpc.get_blockchain_info(),
+            )
+            .await
+            {
+                Ok(Ok(info)) => Some(info),
+                Ok(Err(e)) => {
+                    warn!("Failed to get blockchain info from RPC: {}", e);
+                    None
+                }
+                Err(_) => {
+                    warn!("Blockchain info RPC timed out");
+                    None
+                }
+            }
+        }
+        None => None,
+    };
+
+    match info {
+        Some(info) => Json(serde_json::json!({
+            "available": true,
+            "network": network,
+            "chain": info.chain,
+            "blocks": info.blocks,
+            "headers": info.headers,
+            "best_block_hash": info.bestblockhash,
+            "difficulty": info.difficulty,
+            "size_on_disk": info.size_on_disk,
+            "verification_progress": info.verificationprogress,
+            "initial_block_download": info.initialblockdownload,
+            "pruned": info.pruned,
+            "hazed": info.hazed,
+            "median_time": info.mediantime,
+            "tip_time": info.time,
+            "chainwork": info.chainwork,
+            "warnings": info.warnings,
+        })),
+        None => Json(serde_json::json!({
+            "available": false,
+            "network": network,
+            "chain": serde_json::Value::Null,
+            "blocks": serde_json::Value::Null,
+            "headers": serde_json::Value::Null,
+            "best_block_hash": serde_json::Value::Null,
+            "difficulty": serde_json::Value::Null,
+            "size_on_disk": serde_json::Value::Null,
+            "verification_progress": serde_json::Value::Null,
+            "initial_block_download": serde_json::Value::Null,
+            "pruned": serde_json::Value::Null,
+            "hazed": serde_json::Value::Null,
+            "median_time": serde_json::Value::Null,
+            "tip_time": serde_json::Value::Null,
+            "chainwork": serde_json::Value::Null,
+            "warnings": serde_json::Value::Null,
+        })),
+    }
 }
 
 /// API v1 mining status handler

--- a/dashboard/src/app/(dashboard)/sync/page.tsx
+++ b/dashboard/src/app/(dashboard)/sync/page.tsx
@@ -1,0 +1,375 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  RefreshCw,
+  Blocks,
+  Layers,
+  HardDrive,
+  Hash,
+  Clock,
+  CheckCircle2,
+  Loader2,
+} from "lucide-react";
+import { PageHeader } from "@/components/ui/PageHeader";
+import { Card, CardHeader } from "@/components/ui/Card";
+import { Badge } from "@/components/ui/Badge";
+import { StatCard } from "@/components/ui/StatCard";
+import { ProgressBar } from "@/components/ui/ProgressBar";
+import { SkeletonCard } from "@/components/ui/Skeleton";
+import { SectionErrorBoundary } from "@/components/ui/SectionErrorBoundary";
+import { useBlockchainStatus } from "@/hooks/queries";
+import type { BlockchainStatus } from "@/types/api";
+
+// ─── formatting helpers ──────────────────────────────────────────────────────
+
+const DASH = "—";
+
+function isNum(n: number | null | undefined): n is number {
+  return typeof n === "number" && Number.isFinite(n);
+}
+
+function formatCount(n: number | null | undefined): string {
+  return isNum(n) ? n.toLocaleString() : DASH;
+}
+
+function formatBytes(n: number | null | undefined): string {
+  if (!isNum(n)) return DASH;
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  if (n < 1024 * 1024 * 1024) return `${(n / 1024 / 1024).toFixed(1)} MB`;
+  return `${(n / 1024 / 1024 / 1024).toFixed(2)} GB`;
+}
+
+function formatPercent(fraction: number | null | undefined): string {
+  if (!isNum(fraction)) return DASH;
+  const pct = fraction * 100;
+  if (pct >= 99.995 && pct < 100) return "100.00%";
+  return `${pct.toFixed(2)}%`;
+}
+
+// Relative "N minutes ago" from a unix-seconds timestamp. `now` is passed in so
+// the whole page ticks off a single clock and re-renders once per second.
+function formatRelative(unixSecs: number | null | undefined, now: number): string {
+  if (!isNum(unixSecs)) return DASH;
+  const diff = Math.max(0, Math.floor(now / 1000) - unixSecs);
+  if (diff < 5) return "just now";
+  if (diff < 60) return `${diff}s ago`;
+  const mins = Math.floor(diff / 60);
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ${mins % 60}m ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ${hours % 24}h ago`;
+}
+
+function formatAbsolute(unixSecs: number | null | undefined): string {
+  if (!isNum(unixSecs)) return DASH;
+  return new Date(unixSecs * 1000).toLocaleString();
+}
+
+function truncateHash(hash: string | null | undefined): string {
+  if (!hash) return DASH;
+  if (hash.length <= 20) return hash;
+  return `${hash.slice(0, 10)}…${hash.slice(-10)}`;
+}
+
+// ─── derived view ────────────────────────────────────────────────────────────
+
+interface SyncView {
+  blocks: number | null;
+  headers: number | null;
+  blocksRemaining: number | null;
+  // Preferred sync percentage: Core's verificationprogress, falling back to a
+  // block/header ratio when progress isn't reported.
+  syncFraction: number | null;
+  ibd: boolean | null;
+  caughtUp: boolean;
+  verifying: boolean;
+}
+
+function deriveView(data: BlockchainStatus | undefined): SyncView {
+  const blocks = data?.blocks ?? null;
+  const headers = data?.headers ?? null;
+
+  const blocksRemaining =
+    isNum(blocks) && isNum(headers) ? Math.max(0, headers - blocks) : null;
+
+  let syncFraction: number | null = data?.verification_progress ?? null;
+  if (!isNum(syncFraction) && isNum(blocks) && isNum(headers) && headers > 0) {
+    syncFraction = Math.min(1, blocks / headers);
+  }
+
+  const ibd = data?.initial_block_download ?? null;
+  // Caught up: not in IBD and the block tip has reached the header tip.
+  const caughtUp = ibd === false && blocksRemaining === 0;
+  // Verification/reindex is "in progress" when validation hasn't reached the tip.
+  const verifying = isNum(syncFraction) && syncFraction < 0.99995;
+
+  return { blocks, headers, blocksRemaining, syncFraction, ibd, caughtUp, verifying };
+}
+
+// ─── page ────────────────────────────────────────────────────────────────────
+
+export default function SyncPage() {
+  const { data, isLoading, isError, error } = useBlockchainStatus({ refetchInterval: 10_000 });
+
+  // Single ticking clock so relative times stay live between polls.
+  const [now, setNow] = useState<number>(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  const unavailable = data?.available === false;
+  const view = deriveView(data);
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        eyebrow="node"
+        title="Sync"
+        subtitle="Chain and synchronisation status for this node, straight from ghostd's getblockchaininfo."
+        actions={<SyncBadge isLoading={isLoading} unavailable={unavailable} view={view} />}
+      />
+
+      {isError && (
+        <Card>
+          <p style={{ color: "var(--dim)", fontSize: "14px" }}>
+            Failed to load sync status: {error instanceof Error ? error.message : "unknown error"}
+          </p>
+        </Card>
+      )}
+
+      {unavailable && !isLoading && (
+        <Card>
+          <p style={{ color: "var(--dim)", fontSize: "14px" }}>
+            The node&apos;s Bitcoin RPC is not reachable, so chain details are unavailable. Values
+            below show <span className="font-mono">{DASH}</span> until the daemon responds.
+          </p>
+        </Card>
+      )}
+
+      {/* Headline stats */}
+      <SectionErrorBoundary section="Sync overview">
+        {isLoading ? (
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <SkeletonCard key={i} />
+            ))}
+          </div>
+        ) : (
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+            <StatCard
+              label="Sync progress"
+              value={formatPercent(view.syncFraction)}
+              icon={<RefreshCw size={16} strokeWidth={1.75} />}
+              sublabel={
+                isNum(view.blocksRemaining)
+                  ? view.blocksRemaining === 0
+                    ? "fully caught up"
+                    : `${formatCount(view.blocksRemaining)} blocks remaining`
+                  : undefined
+              }
+              tooltip="Bitcoin Core's verificationprogress (fraction of the estimated chain validated), with blocks remaining = header height − block height."
+            />
+            <StatCard
+              label="Block height"
+              value={formatCount(view.blocks)}
+              icon={<Blocks size={16} strokeWidth={1.75} />}
+              sublabel="validated tip"
+              tooltip="Height of the fully-validated block tip (getblockchaininfo.blocks)."
+            />
+            <StatCard
+              label="Header height"
+              value={formatCount(view.headers)}
+              icon={<Layers size={16} strokeWidth={1.75} />}
+              sublabel="best known header"
+              tooltip="Height of the best known header (getblockchaininfo.headers). Ahead of the block height while blocks are still downloading."
+            />
+            <StatCard
+              label="Size on disk"
+              value={formatBytes(data?.size_on_disk)}
+              icon={<HardDrive size={16} strokeWidth={1.75} />}
+              sublabel={data?.pruned ? "pruned" : "full chain"}
+              tooltip="Estimated size of the block and undo files on disk (getblockchaininfo.size_on_disk)."
+            />
+          </div>
+        )}
+      </SectionErrorBoundary>
+
+      {/* Sync progress detail */}
+      <SectionErrorBoundary section="Synchronisation">
+        <Card>
+          <CardHeader
+            title="Synchronisation"
+            subtitle="How far this node has caught up with the network tip."
+          />
+          {isLoading ? (
+            <div className="space-y-4">
+              <div className="h-2.5 rounded-full" style={{ background: "var(--rule)" }} />
+            </div>
+          ) : (
+            <div className="space-y-5">
+              <ProgressBar
+                value={isNum(view.syncFraction) ? view.syncFraction * 100 : 0}
+                max={100}
+                color={view.caughtUp ? "green" : "orange"}
+                size="lg"
+                label="Chain sync"
+                sublabel={formatPercent(view.syncFraction)}
+              />
+
+              {view.verifying && (
+                <ProgressBar
+                  value={isNum(view.syncFraction) ? view.syncFraction * 100 : 0}
+                  max={100}
+                  color="blue"
+                  size="md"
+                  label="Reindex / verification progress"
+                  sublabel={formatPercent(view.syncFraction)}
+                />
+              )}
+
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                <Field
+                  label="State"
+                  value={
+                    view.ibd === null ? DASH : view.ibd ? "Initial block download" : "Caught up"
+                  }
+                />
+                <Field label="Blocks remaining" value={formatCount(view.blocksRemaining)} />
+                <Field
+                  label="Network"
+                  value={data?.chain ? String(data.chain) : data?.network ?? DASH}
+                />
+              </div>
+            </div>
+          )}
+        </Card>
+      </SectionErrorBoundary>
+
+      {/* Chain tip */}
+      <SectionErrorBoundary section="Chain tip">
+        <Card>
+          <CardHeader
+            title="Chain tip"
+            subtitle="The most recent block this node has accepted."
+          />
+          {isLoading ? (
+            <div className="space-y-3">
+              <div className="h-4 w-2/3 rounded" style={{ background: "var(--rule)" }} />
+              <div className="h-4 w-1/2 rounded" style={{ background: "var(--rule)" }} />
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-4">
+              <Field
+                label="Tip hash"
+                icon={<Hash size={14} strokeWidth={1.75} />}
+                value={truncateHash(data?.best_block_hash)}
+                title={data?.best_block_hash ?? undefined}
+                mono
+              />
+              <Field
+                label="Last block time"
+                icon={<Clock size={14} strokeWidth={1.75} />}
+                value={formatRelative(data?.tip_time, now)}
+                sub={formatAbsolute(data?.tip_time)}
+              />
+              <Field
+                label="Median time (11-block)"
+                value={formatAbsolute(data?.median_time)}
+              />
+              <Field
+                label="Difficulty"
+                value={isNum(data?.difficulty) ? data!.difficulty!.toLocaleString() : DASH}
+              />
+            </div>
+          )}
+        </Card>
+      </SectionErrorBoundary>
+    </div>
+  );
+}
+
+// ─── small presentational pieces ─────────────────────────────────────────────
+
+function SyncBadge({
+  isLoading,
+  unavailable,
+  view,
+}: {
+  isLoading: boolean;
+  unavailable: boolean;
+  view: SyncView;
+}) {
+  if (isLoading) return null;
+  if (unavailable) return <Badge variant="default">RPC unavailable</Badge>;
+
+  if (view.caughtUp) {
+    return (
+      <Badge variant="success">
+        <CheckCircle2 size={13} strokeWidth={2} className="mr-1" />
+        Caught up
+      </Badge>
+    );
+  }
+
+  if (view.ibd) {
+    return (
+      <Badge variant="warning">
+        <Loader2 size={13} strokeWidth={2} className="mr-1 animate-spin" />
+        Initial block download
+      </Badge>
+    );
+  }
+
+  return (
+    <Badge variant="info">
+      <Loader2 size={13} strokeWidth={2} className="mr-1 animate-spin" />
+      Syncing
+    </Badge>
+  );
+}
+
+function Field({
+  label,
+  value,
+  sub,
+  sublabel,
+  icon,
+  mono,
+  title,
+}: {
+  label: string;
+  value: string;
+  sub?: string;
+  sublabel?: string;
+  icon?: React.ReactNode;
+  mono?: boolean;
+  title?: string;
+}) {
+  return (
+    <div>
+      <div
+        className="flex items-center gap-1.5"
+        style={{ color: "var(--dim)", fontSize: "12px", marginBottom: "3px" }}
+      >
+        {icon}
+        <span>{label}</span>
+      </div>
+      <div
+        className={mono ? "font-mono break-all" : ""}
+        style={{ color: "var(--fg)", fontSize: "14px" }}
+        title={title}
+      >
+        {value}
+      </div>
+      {(sub || sublabel) && (
+        <div style={{ color: "var(--fainter)", fontSize: "12px", marginTop: "2px" }}>
+          {sub ?? sublabel}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dashboard/src/components/layout/Sidebar.tsx
+++ b/dashboard/src/components/layout/Sidebar.tsx
@@ -4,6 +4,7 @@ import {
   LayoutDashboard,
   Pickaxe,
   Activity,
+  RefreshCw,
   ShieldCheck,
   Gauge,
   Network as NetworkIcon,
@@ -61,6 +62,7 @@ const GROUPS: NavGroup[] = [
     items: [
       { href: "/", label: "Overview", icon: <LayoutDashboard {...ICON} /> },
       { href: "/mempool", label: "Mempool", icon: <Activity {...ICON} /> },
+      { href: "/sync", label: "Sync", icon: <RefreshCw {...ICON} /> },
       { href: "/capabilities", label: "Capabilities", icon: <ShieldCheck {...ICON} /> },
     ],
   },

--- a/dashboard/src/hooks/queries/useNodeQueries.ts
+++ b/dashboard/src/hooks/queries/useNodeQueries.ts
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { getNodeInfo, getNodeStatus, getShares, getHealth, getNickname, setNickname } from '@/lib/api/node';
+import { getNodeInfo, getNodeStatus, getBlockchainStatus, getShares, getHealth, getNickname, setNickname } from '@/lib/api/node';
 import { useNodeStore } from '@/stores';
 
 // Query keys for consistency
@@ -7,6 +7,7 @@ export const nodeKeys = {
   all: ['node'] as const,
   info: () => [...nodeKeys.all, 'info'] as const,
   status: () => [...nodeKeys.all, 'status'] as const,
+  blockchain: () => [...nodeKeys.all, 'blockchain'] as const,
   shares: () => [...nodeKeys.all, 'shares'] as const,
   health: () => [...nodeKeys.all, 'health'] as const,
   nickname: () => [...nodeKeys.all, 'nickname'] as const,
@@ -37,6 +38,14 @@ export function useNodeStatus(options?: { refetchInterval?: number }) {
       setNodeStatus(data);
       return data;
     },
+  });
+}
+
+export function useBlockchainStatus(options?: { refetchInterval?: number }) {
+  return useQuery({
+    queryKey: nodeKeys.blockchain(),
+    queryFn: getBlockchainStatus,
+    refetchInterval: options?.refetchInterval ?? 10_000, // Poll every 10 seconds
   });
 }
 

--- a/dashboard/src/lib/api/node.ts
+++ b/dashboard/src/lib/api/node.ts
@@ -1,6 +1,6 @@
 // Node API endpoints
 import { fetchApi } from './client';
-import type { NodeInfo, NodeStatus, SharesInfo, HealthStatus } from '@/types/api';
+import type { NodeInfo, NodeStatus, SharesInfo, HealthStatus, BlockchainStatus } from '@/types/api';
 
 export async function getNodeInfo(): Promise<NodeInfo> {
   return fetchApi<NodeInfo>('/api/v1/node/info');
@@ -8,6 +8,11 @@ export async function getNodeInfo(): Promise<NodeInfo> {
 
 export async function getNodeStatus(): Promise<NodeStatus> {
   return fetchApi<NodeStatus>('/api/v1/node/status');
+}
+
+// Chain & sync status from ghostd `getblockchaininfo`.
+export async function getBlockchainStatus(): Promise<BlockchainStatus> {
+  return fetchApi<BlockchainStatus>('/api/v1/node/blockchain');
 }
 
 export async function getShares(): Promise<SharesInfo> {

--- a/dashboard/src/types/api.ts
+++ b/dashboard/src/types/api.ts
@@ -48,6 +48,28 @@ export interface NodeStatus {
   template_profile?: TemplateProfile | string;
 }
 
+// Chain & sync status, sourced from ghostd `getblockchaininfo`
+// (/api/v1/node/blockchain). Numeric fields are null when the RPC is
+// unavailable (available === false), so the UI degrades to "—".
+export interface BlockchainStatus {
+  available: boolean;
+  network?: string | null;
+  chain?: string | null;
+  blocks?: number | null;
+  headers?: number | null;
+  best_block_hash?: string | null;
+  difficulty?: number | null;
+  size_on_disk?: number | null;
+  verification_progress?: number | null;
+  initial_block_download?: boolean | null;
+  pruned?: boolean | null;
+  hazed?: boolean | null;
+  median_time?: number | null;
+  tip_time?: number | null;
+  chainwork?: string | null;
+  warnings?: string[] | null;
+}
+
 export interface NodeConfig {
   ghost_mode?: boolean;
   archive_mode?: boolean;


### PR DESCRIPTION
## Summary

Adds a new **Sync** page to the node dashboard (issue #235), giving operators an at-a-glance view of chain and synchronisation status. The nav item lives in the **overview** group, right after Mempool, using the `RefreshCw` icon.

## What it shows

- **Sync progress** — percentage (Bitcoin Core's `verificationprogress`) plus blocks remaining (`headers − blocks`).
- **IBD vs caught-up** — a clear badge in the page header (`Caught up` / `Initial block download` / `Syncing` / `RPC unavailable`).
- **Block height vs header height** — side-by-side stat cards.
- **Last block time** — relative (live-ticking) and absolute, from the tip block time.
- **Chain tip hash** — truncated with the full hash on hover.
- **Blockchain size on disk** — with a pruned/full-chain sublabel.
- **Reindex / verification progress** — a dedicated progress bar shown while validation hasn't reached the tip.
- Median time and difficulty as supporting detail.

Everything reuses the existing UI kit (`PageHeader`, `Card`/`CardHeader`, `StatCard`, `ProgressBar`, `Badge`, `SectionErrorBoundary`) and CSS variables, and each section is wrapped in a `SectionErrorBoundary`.

## Data source

The block height already existed on `/api/v1/node/status`, but header height, on-disk size, verification progress, best-block hash, tip time and the IBD flag were not exposed anywhere. This adds a focused **`GET /api/v1/node/blockchain`** endpoint in `ghost-verification`, sourced directly from ghostd's `getblockchaininfo` RPC (the same call the haze and mining handlers already make). It is added as a new endpoint rather than bolted onto the 10s-polled `status` handler, which makes no RPC call today.

When the RPC is unavailable or times out, the endpoint returns `available: false` with null fields, and the page degrades to `—` instead of showing misleading zeros.

### Backend fields added
New endpoint `GET /api/v1/node/blockchain` returns: `chain`, `blocks`, `headers`, `best_block_hash`, `difficulty`, `size_on_disk`, `verification_progress`, `initial_block_download`, `pruned`, `hazed`, `median_time`, `tip_time`, `chainwork`, `warnings`, `network`, `available`.

## Checks

- `cargo check -p ghost-verification` — clean.
- `tsc --noEmit` — clean.
- `eslint` — clean (the one remaining `EyeOff` unused-import warning in `Sidebar.tsx` pre-exists on `main`).