### PR TITLE
dashboard: add Geo page mapping mesh peers to a world map (#234)

### DIFF
--- a/dashboard/src/app/(dashboard)/geo/page.tsx
+++ b/dashboard/src/app/(dashboard)/geo/page.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Info } from "lucide-react";
+
+import { PageHeader } from "@/components/ui/PageHeader";
+import { StatCard } from "@/components/ui/StatCard";
+import { Card, CardHeader } from "@/components/ui/Card";
+import { StatusDot } from "@/components/ui/StatusDot";
+import { SectionErrorBoundary } from "@/components/ui/SectionErrorBoundary";
+import { WorldMap, type MapPoint } from "@/components/geo/WorldMap";
+import { usePeers } from "@/hooks/queries";
+import { resolveLocation, jitterFor } from "@/lib/geo/ipLocation";
+import type { PeerInfo } from "@/types/api";
+
+const TOOLTIPS = {
+  peers: "Mesh peers this node currently knows, from the network peers endpoint.",
+  plotted: "Peers whose address resolved to a routable region and are drawn on the map.",
+  regions: "Distinct Regional Internet Registry regions your peers resolve to.",
+  online: "Peers seen within the mesh freshness window (synced).",
+};
+
+interface Row {
+  key: string;
+  peer: PeerInfo;
+  host: string;
+  online: boolean;
+  isSelf: boolean;
+  locationLabel: string;
+  plottable: boolean;
+  point?: MapPoint;
+}
+
+function hostOf(address: string | undefined): string {
+  if (!address) return "";
+  const trimmed = address.trim();
+  const bracket = trimmed.match(/^\[([^\]]+)\](?::\d+)?$/);
+  if (bracket) return bracket[1];
+  if ((trimmed.match(/:/g) || []).length === 1) return trimmed.split(":")[0];
+  return trimmed;
+}
+
+export default function GeoPage() {
+  const { data: peersData, isLoading } = usePeers();
+  const [hoveredId, setHoveredId] = useState<string | null>(null);
+
+  const rows: Row[] = useMemo(() => {
+    const peers = peersData?.peers ?? [];
+    return peers.map((peer, i): Row => {
+      const key = peer.node_id || peer.address || `peer-${i}`;
+      const host = hostOf(peer.address);
+      const online = Boolean(peer.synced);
+      const isSelf = Boolean(peer.is_self);
+      const loc = resolveLocation(peer.address);
+
+      let point: MapPoint | undefined;
+      if (loc.plottable && loc.lat != null && loc.lon != null) {
+        const { dLat, dLon } = jitterFor(host || key);
+        point = {
+          id: key,
+          lat: Math.max(-85, Math.min(85, loc.lat + dLat)),
+          lon: Math.max(-179, Math.min(179, loc.lon + dLon)),
+          label: `${host || "peer"} — ${loc.label}`,
+          online,
+          isSelf,
+        };
+      }
+
+      return {
+        key,
+        peer,
+        host,
+        online,
+        isSelf,
+        locationLabel: loc.label,
+        plottable: loc.plottable,
+        point,
+      };
+    });
+  }, [peersData]);
+
+  const points = useMemo(
+    () => rows.map((r) => r.point).filter((p): p is MapPoint => Boolean(p)),
+    [rows],
+  );
+
+  const plottedCount = points.length;
+  const onlineCount = rows.filter((r) => r.online).length;
+  const regionCount = useMemo(() => {
+    const set = new Set<string>();
+    rows.forEach((r) => {
+      if (r.point) set.add(r.locationLabel);
+    });
+    return set.size;
+  }, [rows]);
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        eyebrow="geo"
+        title="Peer map."
+        subtitle="Approximate geographic spread of the mesh peers this node knows, resolved offline from peer IP addresses."
+      />
+
+      {/* Stats */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <StatCard label="Peers" value={rows.length} tooltip={TOOLTIPS.peers} loading={isLoading} />
+        <StatCard label="Plotted" value={plottedCount} tooltip={TOOLTIPS.plotted} loading={isLoading} />
+        <StatCard label="Regions" value={regionCount} tooltip={TOOLTIPS.regions} loading={isLoading} />
+        <StatCard label="Online" value={`${onlineCount} / ${rows.length}`} tooltip={TOOLTIPS.online} loading={isLoading} />
+      </div>
+
+      {/* Resolution note */}
+      <div
+        className="flex items-start gap-3"
+        style={{
+          background: "var(--accent-weak)",
+          border: "1px solid var(--rule)",
+          borderRadius: "4px",
+          padding: "12px 14px",
+        }}
+      >
+        <Info size={16} strokeWidth={1.75} style={{ color: "var(--accent)", flexShrink: 0, marginTop: "1px" }} />
+        <p style={{ color: "var(--dim)", fontSize: "13px", lineHeight: 1.5 }}>
+          Locations are <strong style={{ color: "var(--fg)" }}>approximate, region-level</strong> placements. The
+          dashboard&apos;s offline posture forbids external map tiles and geolocation lookups, so each peer IP is
+          mapped locally via the IANA IPv4 registry to the Regional Internet Registry that administers its block
+          (ARIN, RIPE, APNIC, LACNIC, AFRINIC) and drawn at that region&apos;s centroid. Private, loopback, and
+          reserved addresses are listed but not plotted. Precise country/city geolocation would require a data
+          source the offline posture does not allow.
+        </p>
+      </div>
+
+      {/* Map */}
+      <SectionErrorBoundary section="Peer Map">
+        <Card>
+          <CardHeader title="World map" subtitle={`${plottedCount} of ${rows.length} peers plotted`} />
+          <WorldMap points={points} hoveredId={hoveredId} onHover={setHoveredId} />
+          {/* Legend */}
+          <div className="flex flex-wrap items-center gap-x-5 gap-y-2 mt-4" style={{ fontSize: "12px", color: "var(--dim)" }}>
+            <span className="inline-flex items-center gap-2">
+              <span style={{ width: 8, height: 8, borderRadius: "50%", background: "var(--green)", display: "inline-block" }} />
+              Online peer
+            </span>
+            <span className="inline-flex items-center gap-2">
+              <span style={{ width: 8, height: 8, borderRadius: "50%", background: "var(--red)", display: "inline-block" }} />
+              Offline / stale
+            </span>
+            <span className="inline-flex items-center gap-2">
+              <span style={{ width: 8, height: 8, borderRadius: "50%", background: "var(--accent)", display: "inline-block" }} />
+              This node
+            </span>
+          </div>
+        </Card>
+      </SectionErrorBoundary>
+
+      {/* Peer list */}
+      <SectionErrorBoundary section="Peer List">
+        <Card>
+          <CardHeader title="Peers" subtitle={`${rows.length} known`} />
+          {rows.length === 0 ? (
+            <p style={{ color: "var(--dim)", fontSize: "14px", padding: "8px 0" }}>
+              {isLoading ? "Loading peers…" : "No peers connected. Your node will discover peers automatically."}
+            </p>
+          ) : (
+            <div style={{ overflowX: "auto" }}>
+              <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "13px" }}>
+                <thead>
+                  <tr style={{ textAlign: "left", color: "var(--dim)" }}>
+                    <th style={{ padding: "8px 10px", fontWeight: 500 }}>Address</th>
+                    <th style={{ padding: "8px 10px", fontWeight: 500 }}>Resolved location</th>
+                    <th style={{ padding: "8px 10px", fontWeight: 500 }}>Status</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {rows.map((r) => {
+                    const active = hoveredId === r.key;
+                    return (
+                      <tr
+                        key={r.key}
+                        onMouseEnter={() => setHoveredId(r.key)}
+                        onMouseLeave={() => setHoveredId(null)}
+                        style={{
+                          borderTop: "1px solid var(--rule)",
+                          background: active ? "var(--accent-weak)" : "transparent",
+                        }}
+                      >
+                        <td style={{ padding: "8px 10px", fontFamily: "var(--font-mono)", color: "var(--fg)" }}>
+                          {r.host || "—"}
+                          {r.isSelf && (
+                            <span style={{ marginLeft: 8, color: "var(--accent)", fontSize: "11px" }}>this node</span>
+                          )}
+                        </td>
+                        <td style={{ padding: "8px 10px", color: r.plottable ? "var(--fg)" : "var(--dim)" }}>
+                          {r.locationLabel}
+                          {!r.plottable && (
+                            <span style={{ marginLeft: 8, color: "var(--fainter)", fontSize: "11px" }}>not plotted</span>
+                          )}
+                        </td>
+                        <td style={{ padding: "8px 10px" }}>
+                          <StatusDot
+                            status={r.online ? "online" : "warning"}
+                            label={r.online ? "Online" : "Stale"}
+                            size="sm"
+                          />
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </Card>
+      </SectionErrorBoundary>
+    </div>
+  );
+}

--- a/dashboard/src/components/geo/WorldMap.tsx
+++ b/dashboard/src/components/geo/WorldMap.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { CONTINENTS, MAP_HEIGHT, MAP_WIDTH, project, ringToPath } from "@/lib/geo/worldMap";
+
+export interface MapPoint {
+  id: string;
+  lat: number;
+  lon: number;
+  label: string;
+  online: boolean;
+  isSelf?: boolean;
+}
+
+interface WorldMapProps {
+  points: MapPoint[];
+  hoveredId?: string | null;
+  onHover?: (id: string | null) => void;
+}
+
+// Graticule every 30° longitude / 30° latitude for a subtle sense of scale.
+const LON_LINES = [-150, -120, -90, -60, -30, 0, 30, 60, 90, 120, 150];
+const LAT_LINES = [-60, -30, 0, 30, 60];
+
+/**
+ * Inline SVG equirectangular world map. All geometry is bundled (no tiles, no
+ * external requests) and every colour is a theme CSS variable so the map reads
+ * correctly in both light and dark themes.
+ */
+export function WorldMap({ points, hoveredId, onHover }: WorldMapProps) {
+  return (
+    <div style={{ width: "100%", overflowX: "auto" }}>
+      <svg
+        viewBox={`0 0 ${MAP_WIDTH} ${MAP_HEIGHT}`}
+        role="img"
+        aria-label="World map of mesh peer locations"
+        preserveAspectRatio="xMidYMid meet"
+        style={{
+          width: "100%",
+          height: "auto",
+          minWidth: "520px",
+          display: "block",
+          background: "var(--surface)",
+          border: "1px solid var(--rule)",
+          borderRadius: "4px",
+        }}
+      >
+        {/* Graticule */}
+        <g stroke="var(--rule)" strokeWidth={0.3} opacity={0.7}>
+          {LON_LINES.map((lon) => {
+            const [x] = project(lon, 0);
+            return <line key={`lon-${lon}`} x1={x} y1={0} x2={x} y2={MAP_HEIGHT} />;
+          })}
+          {LAT_LINES.map((lat) => {
+            const [, y] = project(0, lat);
+            return <line key={`lat-${lat}`} x1={0} y1={y} x2={MAP_WIDTH} y2={y} />;
+          })}
+        </g>
+
+        {/* Continents */}
+        <g fill="var(--rule-strong)" stroke="var(--fainter)" strokeWidth={0.35} opacity={0.9}>
+          {CONTINENTS.map((ring, i) => (
+            <path key={`land-${i}`} d={ringToPath(ring)} />
+          ))}
+        </g>
+
+        {/* Peer markers */}
+        <g>
+          {points.map((p) => {
+            const [x, y] = project(p.lon, p.lat);
+            const active = hoveredId === p.id;
+            const color = p.isSelf
+              ? "var(--accent)"
+              : p.online
+                ? "var(--green)"
+                : "var(--red)";
+            return (
+              <g
+                key={p.id}
+                onMouseEnter={() => onHover?.(p.id)}
+                onMouseLeave={() => onHover?.(null)}
+                style={{ cursor: "default" }}
+              >
+                {/* Halo */}
+                <circle cx={x} cy={y} r={active ? 6 : 4} fill={color} opacity={0.18} />
+                {/* Core dot */}
+                <circle
+                  cx={x}
+                  cy={y}
+                  r={active ? 2.6 : 2}
+                  fill={color}
+                  stroke="var(--surface)"
+                  strokeWidth={0.5}
+                />
+                <title>{`${p.label}${p.isSelf ? " (this node)" : ""}`}</title>
+              </g>
+            );
+          })}
+        </g>
+      </svg>
+    </div>
+  );
+}

--- a/dashboard/src/components/layout/Sidebar.tsx
+++ b/dashboard/src/components/layout/Sidebar.tsx
@@ -16,6 +16,7 @@ import {
   EyeOff,
   Skull,
   Globe,
+  MapPin,
   HeartPulse,
   ScrollText,
   Users,
@@ -62,6 +63,7 @@ const GROUPS: NavGroup[] = [
       { href: "/", label: "Overview", icon: <LayoutDashboard {...ICON} /> },
       { href: "/mempool", label: "Mempool", icon: <Activity {...ICON} /> },
       { href: "/capabilities", label: "Capabilities", icon: <ShieldCheck {...ICON} /> },
+      { href: "/geo", label: "Geo", icon: <MapPin {...ICON} /> },
     ],
   },
   {

--- a/dashboard/src/lib/geo/ipLocation.ts
+++ b/dashboard/src/lib/geo/ipLocation.ts
@@ -1,0 +1,205 @@
+/**
+ * Offline IP → geographic region resolution.
+ *
+ * The dashboard runs under a strict, offline CSP posture: no external map
+ * tiles, no CDN, and no third-party geolocation API calls are permitted. That
+ * rules out the usual "look the IP up in a GeoIP web service" approach and any
+ * bundled city-level GeoIP database (those are megabytes).
+ *
+ * What we CAN do offline, cheaply and deterministically, is map an address to
+ * the Regional Internet Registry (RIR) that administers its block. The IANA
+ * IPv4 /8 registry is a small, stable, authoritative table — one entry per
+ * first octet — so it costs almost nothing to bundle. RIR granularity is
+ * continent-scale, not country- or city-level: an address resolves to one of
+ * five service regions (ARIN, RIPE NCC, APNIC, LACNIC, AFRINIC). Private,
+ * loopback, and reserved ranges are detected and never plotted.
+ *
+ * LIMITATION (surfaced in the UI): locations are approximate, region-level
+ * placements at each RIR's service-area centroid — not precise coordinates.
+ * Sharpening this to country/city would require an external GeoIP data source,
+ * which the offline posture forbids.
+ */
+
+export type Rir = "ARIN" | "RIPE" | "APNIC" | "LACNIC" | "AFRINIC";
+
+export type LocationKind =
+  | "public" // routable, resolved to an RIR region
+  | "private" // RFC1918 LAN
+  | "cgnat" // RFC6598 carrier-grade NAT (100.64/10)
+  | "loopback" // 127/8
+  | "linklocal" // 169.254/16
+  | "reserved" // 0/8, multicast, future-use, broadcast
+  | "unknown"; // unparseable / unmapped
+
+export interface ResolvedLocation {
+  kind: LocationKind;
+  /** Human label for the resolved region, e.g. "Europe / M.East (RIPE)". */
+  label: string;
+  /** The administering RIR, when kind === "public". */
+  rir?: Rir;
+  /** Centroid latitude of the RIR service region (present only when plottable). */
+  lat?: number;
+  /** Centroid longitude of the RIR service region (present only when plottable). */
+  lon?: number;
+  /** Whether this location has coordinates and should be drawn on the map. */
+  plottable: boolean;
+}
+
+/** Representative service-area centroid + label for each RIR. */
+const RIR_REGION: Record<Rir, { label: string; lat: number; lon: number }> = {
+  ARIN: { label: "North America (ARIN)", lat: 40, lon: -100 },
+  RIPE: { label: "Europe / M.East (RIPE)", lat: 50, lon: 15 },
+  APNIC: { label: "Asia-Pacific (APNIC)", lat: 18, lon: 105 },
+  LACNIC: { label: "Latin America (LACNIC)", lat: -15, lon: -60 },
+  AFRINIC: { label: "Africa (AFRINIC)", lat: 2, lon: 21 },
+};
+
+/**
+ * IANA IPv4 /8 → RIR map, indexed by first octet. Built from range tuples for
+ * readability. Entries left null are unmapped; special-use blocks
+ * (private/loopback/reserved) are handled separately below, before this table
+ * is consulted.
+ *
+ * This is the standard /8-granularity approximation of the IANA registry. A
+ * handful of legacy /8s are sub-divided across RIRs at finer than /8; each such
+ * block is attributed to its dominant registry. Region-level accuracy makes
+ * that approximation immaterial to where the dot lands.
+ */
+function buildOctetTable(): (Rir | null)[] {
+  const table: (Rir | null)[] = new Array(256).fill(null);
+  const assign = (rir: Rir, ...spans: (number | [number, number])[]) => {
+    for (const span of spans) {
+      const [start, end] = Array.isArray(span) ? span : [span, span];
+      for (let o = start; o <= end; o++) table[o] = rir;
+    }
+  };
+
+  assign(
+    "ARIN",
+    [3, 9], [11, 13], [15, 24], 26, [28, 30], [32, 35], 38, 40, 44, 45, 47, 48, 50, 52,
+    54, 55, 56, [63, 76], [96, 100], 104, 107, 108, [128, 132], [134, 140], [142, 144],
+    [146, 149], 152, [155, 162], [164, 170], [172, 174], 184, 192, 198, 199, [204, 209],
+    [214, 216],
+  );
+  assign(
+    "RIPE",
+    2, 5, 25, 31, 37, 46, 51, 53, 57, 62, [77, 95], 109, 141, 145, 151, 176, 178, 185,
+    188, [193, 195], 212, 213, 217,
+  );
+  assign(
+    "APNIC",
+    1, 14, 27, 36, 39, 42, 43, 49, [58, 61], 101, 103, 106, [110, 126], 133, 150, 153,
+    163, 171, 175, 180, 182, 183, 202, 203, 210, 211, [218, 223],
+  );
+  assign("AFRINIC", 41, 102, 105, 154, 196, 197);
+  assign("LACNIC", 177, 179, 181, 186, 187, 189, 190, 191, 200, 201);
+
+  return table;
+}
+
+const OCTET_TABLE = buildOctetTable();
+
+function parseIPv4(ip: string): number[] | null {
+  const m = ip.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (!m) return null;
+  const octets = [m[1], m[2], m[3], m[4]].map((s) => Number(s));
+  if (octets.some((o) => o < 0 || o > 255)) return null;
+  return octets;
+}
+
+/** Strip a trailing `:port` and surrounding brackets so we resolve the host. */
+function extractHost(addressOrIp: string): string {
+  let host = addressOrIp.trim();
+  // Bracketed IPv6 with optional port: [2a00::1]:8555
+  const bracket = host.match(/^\[([^\]]+)\](?::\d+)?$/);
+  if (bracket) return bracket[1];
+  // IPv4 (or hostname) with a single trailing :port
+  if ((host.match(/:/g) || []).length === 1) host = host.split(":")[0];
+  return host;
+}
+
+function locateIPv6(host: string): ResolvedLocation {
+  const h = host.toLowerCase();
+  if (h === "::1") return special("loopback", "Loopback (::1)");
+  if (h.startsWith("fe80")) return special("linklocal", "Link-local (IPv6)");
+  if (h.startsWith("fc") || h.startsWith("fd")) return special("private", "Unique-local (IPv6)");
+  // Coarse RIR mapping from the leading hextet of the global-unicast 2000::/3
+  // block. Enough to place a dot on the right continent; honest about no more.
+  const first = h.split(":")[0];
+  const val = parseInt(first, 16);
+  let rir: Rir | null = null;
+  if (!Number.isNaN(val)) {
+    if (val >= 0x2a00 && val <= 0x2aff) rir = "RIPE";
+    else if (val >= 0x2400 && val <= 0x24ff) rir = "APNIC";
+    else if (val >= 0x2c00 && val <= 0x2cff) rir = "AFRINIC";
+    else if (val >= 0x2800 && val <= 0x28ff) rir = "LACNIC";
+    else if ((val >= 0x2600 && val <= 0x26ff) || val === 0x2620) rir = "ARIN";
+  }
+  if (rir) return fromRir(rir);
+  return special("unknown", "Unknown (IPv6)");
+}
+
+function fromRir(rir: Rir): ResolvedLocation {
+  const region = RIR_REGION[rir];
+  return {
+    kind: "public",
+    label: region.label,
+    rir,
+    lat: region.lat,
+    lon: region.lon,
+    plottable: true,
+  };
+}
+
+function special(kind: LocationKind, label: string): ResolvedLocation {
+  return { kind, label, plottable: false };
+}
+
+/**
+ * Resolve a peer address (bare IP or `host:port`, IPv4 or IPv6) to an
+ * approximate, region-level location. Never makes a network call.
+ */
+export function resolveLocation(addressOrIp: string | undefined | null): ResolvedLocation {
+  if (!addressOrIp) return special("unknown", "Unknown");
+  const host = extractHost(addressOrIp);
+
+  if (host.includes(":")) return locateIPv6(host);
+
+  const octets = parseIPv4(host);
+  if (!octets) return special("unknown", "Unknown");
+  const [a, b] = octets;
+
+  // Special-use IPv4 blocks (checked before the RIR table).
+  if (a === 0) return special("reserved", "Reserved (0.0.0.0/8)");
+  if (a === 10) return special("private", "Private LAN (10/8)");
+  if (a === 127) return special("loopback", "Loopback (127/8)");
+  if (a === 169 && b === 254) return special("linklocal", "Link-local (169.254/16)");
+  if (a === 172 && b >= 16 && b <= 31) return special("private", "Private LAN (172.16/12)");
+  if (a === 192 && b === 168) return special("private", "Private LAN (192.168/16)");
+  if (a === 100 && b >= 64 && b <= 127) return special("cgnat", "Carrier NAT (100.64/10)");
+  if (a >= 224 && a <= 239) return special("reserved", "Multicast (224/4)");
+  if (a >= 240) return special("reserved", "Reserved (240/4)");
+
+  const rir = OCTET_TABLE[a];
+  if (rir) return fromRir(rir);
+  return special("unknown", "Unmapped block");
+}
+
+/**
+ * Deterministic small offset (in degrees) so several peers in the same RIR
+ * region don't stack on one pixel. Seeded by the address string, so a peer
+ * always lands in the same spot. Bounded to roughly +/-9 degrees.
+ */
+export function jitterFor(seed: string): { dLat: number; dLon: number } {
+  let h = 2166136261;
+  for (let i = 0; i < seed.length; i++) {
+    h ^= seed.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  const a = (h >>> 0) % 1000;
+  const b = ((h >>> 10) >>> 0) % 1000;
+  return {
+    dLat: (a / 1000 - 0.5) * 12,
+    dLon: (b / 1000 - 0.5) * 18,
+  };
+}

--- a/dashboard/src/lib/geo/worldMap.ts
+++ b/dashboard/src/lib/geo/worldMap.ts
@@ -1,0 +1,86 @@
+/**
+ * Bundled, dependency-free world map geometry.
+ *
+ * The offline CSP posture forbids external map tiles, CDN-hosted GeoJSON, and
+ * mapping libraries pulled at runtime, and no mapping library is present in the
+ * bundle. So the map is a small set of hand-simplified continent outlines,
+ * expressed as [lon, lat] rings and rendered inline as SVG polygons under a
+ * plain equirectangular projection. It is a stylised silhouette — recognisable
+ * continents, not survey-grade coastlines — which is all a peer-region overview
+ * needs, and it adds no dependency and only a few KB.
+ *
+ * Projection (equirectangular): the SVG viewBox is `0 0 360 180`, one unit per
+ * degree, so a point projects to `x = lon + 180`, `y = 90 - lat`.
+ */
+
+export const MAP_WIDTH = 360;
+export const MAP_HEIGHT = 180;
+
+/** Project a [lon, lat] pair into viewBox coordinates. */
+export function project(lon: number, lat: number): [number, number] {
+  return [lon + 180, 90 - lat];
+}
+
+/** Build an SVG path `d` string for a closed ring of [lon, lat] points. */
+export function ringToPath(ring: [number, number][]): string {
+  return (
+    ring
+      .map(([lon, lat], i) => {
+        const [x, y] = project(lon, lat);
+        return `${i === 0 ? "M" : "L"}${x.toFixed(1)} ${y.toFixed(1)}`;
+      })
+      .join(" ") + " Z"
+  );
+}
+
+/**
+ * Simplified continent outlines as closed [lon, lat] rings. Coarse by design.
+ */
+export const CONTINENTS: [number, number][][] = [
+  // North America
+  [
+    [-168, 65], [-160, 71], [-140, 70], [-120, 72], [-95, 73], [-80, 73], [-62, 66],
+    [-56, 60], [-64, 47], [-70, 44], [-70, 41], [-75, 35], [-81, 25], [-90, 29],
+    [-97, 26], [-97, 22], [-105, 20], [-106, 23], [-114, 28], [-118, 33], [-122, 37],
+    [-124, 42], [-124, 48], [-132, 52], [-140, 59], [-150, 59], [-165, 60], [-168, 65],
+  ],
+  // Greenland
+  [
+    [-45, 60], [-30, 61], [-20, 70], [-25, 78], [-40, 83], [-58, 80], [-55, 70],
+    [-50, 64], [-45, 60],
+  ],
+  // South America
+  [
+    [-77, 8], [-72, 11], [-62, 10], [-52, 5], [-50, 0], [-42, -3], [-35, -6],
+    [-38, -13], [-48, -25], [-58, -35], [-62, -40], [-65, -45], [-69, -52], [-74, -52],
+    [-72, -45], [-73, -38], [-71, -30], [-71, -18], [-77, -12], [-81, -6], [-80, -2],
+    [-78, 2], [-77, 8],
+  ],
+  // Africa
+  [
+    [-17, 15], [-16, 21], [-10, 27], [-5, 32], [10, 34], [11, 37], [20, 32], [25, 32],
+    [32, 31], [34, 28], [43, 12], [51, 12], [43, 4], [41, -2], [40, -10], [35, -18],
+    [32, -26], [27, -33], [20, -35], [18, -28], [13, -17], [9, -2], [9, 4], [3, 6],
+    [-8, 4], [-13, 8], [-17, 15],
+  ],
+  // Europe (with a rough Scandinavia lobe)
+  [
+    [-10, 36], [-9, 43], [-2, 43], [-1, 49], [-5, 50], [2, 51], [4, 58], [8, 63],
+    [12, 66], [18, 69], [24, 66], [28, 60], [30, 55], [26, 46], [20, 42], [15, 40],
+    [18, 45], [12, 44], [8, 44], [3, 43], [-3, 36], [-10, 36],
+  ],
+  // Asia
+  [
+    [30, 55], [40, 62], [50, 68], [60, 70], [75, 73], [95, 76], [115, 74], [140, 73],
+    [160, 70], [178, 66], [170, 60], [160, 60], [142, 50], [135, 45], [129, 42],
+    [122, 40], [121, 31], [113, 22], [108, 21], [106, 16], [99, 8], [95, 16], [88, 22],
+    [80, 13], [73, 8], [67, 25], [57, 25], [48, 40], [41, 42], [37, 45], [30, 47],
+    [30, 55],
+  ],
+  // Australia
+  [
+    [114, -22], [122, -18], [130, -12], [137, -12], [143, -12], [147, -20], [153, -28],
+    [150, -37], [143, -39], [135, -35], [129, -32], [123, -34], [115, -34], [113, -26],
+    [114, -22],
+  ],
+];


### PR DESCRIPTION
## Summary

Adds a **Geo** page (`/geo`, in the **overview** nav group after Capabilities) that plots this node's mesh peers on an inline SVG world map, keyed by peer IP. Closes #234.

## Peer data source
Reuses the existing `usePeers` hook (`/api/v1/network/peers`). Each `PeerInfo` carries an `address` (the peer's IP), which is what we resolve and plot. Online status comes from the peer's `synced` flag.

## IP → location (offline)
The dashboard's strict offline CSP posture forbids external map tiles, CDN assets, and third-party geolocation APIs, and bundling a city-level GeoIP database would be megabytes. Instead, `src/lib/geo/ipLocation.ts` maps each address **entirely offline**:

- A small, bundled **IANA IPv4 `/8` → RIR table** (one entry per first octet) resolves routable IPs to their administering Regional Internet Registry — `ARIN`, `RIPE`, `APNIC`, `LACNIC`, `AFRINIC` — plotted at that region's service-area centroid.
- Coarse IPv6 handling via the leading hextet of the `2000::/3` global-unicast block.
- RFC1918 / CGNAT / loopback / link-local / reserved / multicast ranges are detected and **listed but not plotted**.
- A deterministic per-address jitter spreads peers that share a region so their dots don't stack.

**Limitation (stated on the page):** locations are **approximate, region-level** — continent-scale, not country/city. Sharpening would need an external GeoIP source the offline posture disallows. This is called out in an info banner on the page.

## Map
`src/lib/geo/worldMap.ts` bundles hand-simplified continent outlines as `[lon, lat]` rings, rendered by `src/components/geo/WorldMap.tsx` as inline SVG under an equirectangular projection. No mapping library or dependency added; geometry is a few KB. All colours are theme CSS variables, so the map reads correctly in light and dark.

## UI
- Stat row: Peers / Plotted / Regions / Online.
- World map card with a legend (online / offline / this-node).
- Peer list: address, resolved location, online status — cross-highlighted with the map on hover; non-routable addresses shown with a "not plotted" hint.
- Built from existing `PageHeader` / `Card` / `StatCard` / `StatusDot` / `SectionErrorBoundary` primitives.

## Checks
- `tsc --noEmit`: clean.
- `eslint` on new/changed files: clean (0 errors, 0 new warnings; the repo's pre-existing baseline warnings/errors are untouched).
- `next build`: succeeds; `/geo` prerenders as a static route.

No new dependencies. Not deployed.