### PR TITLE
dashboard: geoip middleware matcher + GhostIdWizard lint fix

### DIFF
--- a/dashboard/src/app/(dashboard)/settings/wizards/GhostIdWizard.tsx
+++ b/dashboard/src/app/(dashboard)/settings/wizards/GhostIdWizard.tsx
@@ -19,14 +19,25 @@ export default function GhostIdWizard({ isOpen, onClose }: GhostIdWizardProps) {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
+  const [prevOpen, setPrevOpen] = useState(false);
+
+  // Reset the transient UI state the moment the dialog opens, during render
+  // (guarded on the open transition so it can't loop) rather than in the effect.
+  // This is React's recommended alternative to a setState-in-effect for derived
+  // resets; the effect below is left to do only the async fetch.
+  if (isOpen !== prevOpen) {
+    setPrevOpen(isOpen);
+    if (isOpen) {
+      setIsLoading(true);
+      setError(null);
+      setCopied(false);
+    }
+  }
 
   useEffect(() => {
     if (!isOpen) return;
 
     let cancelled = false;
-    setIsLoading(true);
-    setError(null);
-    setCopied(false);
 
     getGhostId()
       .then((result) => {

--- a/dashboard/src/middleware.ts
+++ b/dashboard/src/middleware.ts
@@ -100,5 +100,9 @@ function redirectToLogin(request: NextRequest, pathname: string): NextResponse {
 }
 
 export const config = {
-  matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"],
+  // `geo/geoip.bin` is a large static binary served from /public; exclude it so
+  // the middleware never runs for it and it is delivered directly (same treatment
+  // as `_next/static`). This is the asset only — the `/geo` PAGE is still matched
+  // and stays behind the JWT session gate.
+  matcher: ["/((?!_next/static|_next/image|favicon.ico|geo/geoip\\.bin).*)"],
 };


### PR DESCRIPTION
Two small frontend fixes for the node dashboard.

## #261 — geoip.bin auth-middleware matcher
The middleware matcher \`/((?!_next/static|_next/image|favicon.ico).*)\` caught \`/geo/geoip.bin\`, so unauthenticated requests for the static geoip binary were 307-redirected to \`/login\`. Added \`geo/geoip\.bin\` to the negative lookahead so the asset is served directly, the same treatment as \`_next/static\`.

The exclusion is scoped to the asset only:
- \`/geo/geoip.bin\` → middleware skipped, served directly
- \`/geo\` (the page) → still matched, still behind the JWT session gate
- \`/geo/*\` (any other geo route) → still matched, still gated

Verified the regex against \`/geo\`, \`/geo/geoip.bin\`, \`/geo/other\`, \`/geobogus\`, \`/system\`: only \`/geo/geoip.bin\` is skipped; everything else still runs the auth middleware.

## #262 — GhostIdWizard lint error
\`GhostIdWizard.tsx\` had a \`react-hooks/set-state-in-effect\` error: the fetch effect called \`setState\` synchronously to reset the transient UI state. Moved those resets into a guarded render-time adjust keyed on the open transition — the render-time pattern already used in \`ReaperControls\` — leaving the effect to do only the async \`getGhostId\` fetch. Behaviour is unchanged (spinner/error/copied reset on open exactly as before).

## Status
- \`tsc --noEmit\`: clean
- \`eslint\` on both changed files: 0 errors
- \`npm run build\`: succeeds

Refs #261, #262