### PR TITLE
dashboard: PageHeader subtitles full-width by default (fixes #265)

### DIFF
--- a/dashboard/src/components/ui/PageHeader.tsx
+++ b/dashboard/src/components/ui/PageHeader.tsx
@@ -6,7 +6,8 @@ interface PageHeaderProps {
   eyebrow?: string;
   title: string;
   subtitle?: string;
-  /** Let the subtitle span the full container width instead of the 60ch reading measure. */
+  /** Subtitles span the full container width by default. Pass `false` for the
+   *  narrow 60ch reading measure on the rare page that wants it. */
   subtitleFullWidth?: boolean;
   actions?: ReactNode;
   className?: string;
@@ -17,7 +18,7 @@ interface PageHeaderProps {
  * rhythm: an orange uppercase mono "eyebrow" line above a large light-weight
  * title. Subtitle stays as supporting prose.
  */
-export function PageHeader({ eyebrow, title, subtitle, subtitleFullWidth = false, actions, className = '' }: PageHeaderProps) {
+export function PageHeader({ eyebrow, title, subtitle, subtitleFullWidth = true, actions, className = '' }: PageHeaderProps) {
   return (
     <div className={`flex items-start justify-between gap-4 mb-8 ${className}`}>
       <div className="flex-1 min-w-0">


### PR DESCRIPTION
Flip `subtitleFullWidth` default to `true` in `PageHeader`, so subtitles span the container everywhere by default — no per-page opt-in, no regression on new pages (Sync/Geo/Pool/Connect/etc.). Root fix for the recurring clipping. `tsc` clean. Fixes #265.