### PR TITLE
backend: swarm uptime, alert triggers, pool time-series + leaderboard

### DIFF
--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -6311,6 +6311,15 @@ async fn main() -> Result<()> {
         Ok(())
     });
 
+    // Shared slot for the operator-alert dispatcher. The block_found callback is
+    // registered here (before `verification_state` is wrapped in an `Arc`, which
+    // the dispatcher's live-config closure needs), so it can't capture the
+    // dispatcher directly. Instead it captures this slot, which is populated
+    // once the dispatcher is built (just after the `Arc::new` below). BlockFound
+    // is the one trigger site on a pre-Arc, synchronous callback path.
+    let alert_slot: Arc<std::sync::OnceLock<Arc<ghost_verification::alerts::AlertDispatcher>>> =
+        Arc::new(std::sync::OnceLock::new());
+
     // Configure block_found callback: triggers payout proposal BEFORE block submission.
     // This breaks the bootstrap deadlock where:
     //   1. submitblock requires an approved coinbase commitment
@@ -6326,6 +6335,7 @@ async fn main() -> Result<()> {
         let db_for_bf = Arc::clone(&db);
         let solo_payout_address_for_bf = config.network.solo_payout_address.clone();
         let metrics_for_bf = Arc::clone(&metrics);
+        let alert_slot_for_bf = Arc::clone(&alert_slot);
 
         verification_state = verification_state.with_block_found_callback(move |block_info| {
             let round_id = rm_for_bf.current_round_id();
@@ -6338,6 +6348,22 @@ async fn main() -> Result<()> {
                 solo_mode = is_solo_mode,
                 "Block-difficulty share found, creating pre-submission payout proposal..."
             );
+
+            // Fire the BlockFound operator alert (async, non-blocking — never
+            // holds up the payout-proposal hot path). Enable-flag + delivery are
+            // handled inside the dispatcher. Discrete event: no debounce needed.
+            if let Some(dispatcher) = alert_slot_for_bf.get() {
+                let dispatcher = Arc::clone(dispatcher);
+                let detail = format!(
+                    "Block-difficulty share found in round {round_id} (share {}, miner {}).",
+                    block_info.share_hash, block_info.miner_id
+                );
+                tokio::spawn(async move {
+                    dispatcher
+                        .fire(ghost_verification::alerts::AlertEvent::BlockFound, &detail)
+                        .await;
+                });
+            }
 
             // Use the share hash as block hash — the share met block difficulty,
             // so this IS the candidate block hash. Can't use [0u8;32] because
@@ -6705,6 +6731,26 @@ async fn main() -> Result<()> {
 
     let verification_state = Arc::new(verification_state);
 
+    // Build the operator-alert dispatcher now that the state is an `Arc`. Its
+    // config closure reads `full_node_config` on every dispatch, so live edits
+    // to `[alerts]` via the config API apply without a restart. All async
+    // trigger sites below clone this `Arc`; the block_found callback (registered
+    // pre-Arc) reads it via `alert_slot`, populated here.
+    let alert_dispatcher = {
+        let state_for_alerts = Arc::clone(&verification_state);
+        Arc::new(ghost_verification::alerts::AlertDispatcher::new(
+            verification_state.node_id.clone(),
+            move || {
+                state_for_alerts
+                    .full_node_config
+                    .as_ref()
+                    .map(|c| c.read().alerts.clone())
+                    .unwrap_or_default()
+            },
+        ))
+    };
+    let _ = alert_slot.set(Arc::clone(&alert_dispatcher));
+
     // Get restart signal for monitoring (config update API)
     let restart_signal = verification_state.restart_signal();
 
@@ -6712,12 +6758,23 @@ async fn main() -> Result<()> {
     // When config is updated via API, this triggers graceful shutdown
     let restart_signal_for_monitor = Arc::clone(&restart_signal);
     let shutdown_tx_for_restart = shutdown_tx.clone();
+    let alert_dispatcher_for_restart = Arc::clone(&alert_dispatcher);
+    let restart_node_id = verification_state.node_id.clone();
     tokio::spawn(async move {
         let mut interval = tokio::time::interval(std::time::Duration::from_secs(1));
         loop {
             interval.tick().await;
             if restart_signal_for_monitor.load(std::sync::atomic::Ordering::SeqCst) {
                 info!("Restart signal received (config update). Initiating graceful shutdown...");
+                // Fire the RestartNeeded alert BEFORE broadcasting shutdown so
+                // the HTTPS delivery isn't cut short by the graceful-exit path.
+                // Fires once (the loop breaks immediately after).
+                alert_dispatcher_for_restart
+                    .fire(
+                        ghost_verification::alerts::AlertEvent::RestartNeeded,
+                        &format!("Node {} is restarting to apply a configuration change.", &restart_node_id[..8.min(restart_node_id.len())]),
+                    )
+                    .await;
                 let _ = shutdown_tx_for_restart.send(());
                 break;
             }
@@ -6731,8 +6788,12 @@ async fn main() -> Result<()> {
     let mesh_for_ws = Arc::clone(&mesh);
     let start_time = std::time::Instant::now();
     let mut ws_shutdown = shutdown_tx.subscribe();
+    let alert_dispatcher_for_ws = Arc::clone(&alert_dispatcher);
     tokio::spawn(async move {
         let mut interval = tokio::time::interval(std::time::Duration::from_secs(5));
+        // Track the previous peer count so we can alert on a DROP (a decrease),
+        // not on every tick. `None` until the first observation.
+        let mut last_peer_count: Option<u32> = None;
         loop {
             tokio::select! {
                 _ = interval.tick() => {
@@ -6740,14 +6801,35 @@ async fn main() -> Result<()> {
                         .round_stats(rm_for_ws.current_round_id())
                         .map(|s| s.miner_count as u32)
                         .unwrap_or(0);
+                    let peer_count = mesh_for_ws.peers().unique_peer_count() as u32;
                     let event = ghost_verification::WsEvent::HealthUpdate {
                         block_height: rm_for_ws.current_height(),
                         round_id: rm_for_ws.current_round_id() as u64,
                         miner_count,
-                        peer_count: mesh_for_ws.peers().unique_peer_count() as u32,
+                        peer_count,
                         uptime_secs: start_time.elapsed().as_secs(),
                     };
                     ws_state.broadcast(event);
+
+                    // PeerCountDrop alert: fire when the connected-peer count
+                    // decreases. Rate-limited (at most once per 5 min) so a
+                    // flapping mesh doesn't spam the operator; delivery + the
+                    // enable flag are handled inside the dispatcher.
+                    if let Some(prev) = last_peer_count {
+                        if peer_count < prev {
+                            let detail = format!(
+                                "Connected peer count dropped from {prev} to {peer_count}."
+                            );
+                            alert_dispatcher_for_ws
+                                .fire_rate_limited(
+                                    ghost_verification::alerts::AlertEvent::PeerCountDrop,
+                                    std::time::Duration::from_secs(300),
+                                    &detail,
+                                )
+                                .await;
+                        }
+                    }
+                    last_peer_count = Some(peer_count);
                 }
                 _ = ws_shutdown.recv() => break,
             }
@@ -6836,6 +6918,7 @@ async fn main() -> Result<()> {
         let vh_for_revoke = Arc::clone(&vote_handler);
         let hh_for_revoke = Arc::clone(&health_handler);
         let mesh_for_revoke = Arc::clone(&mesh);
+        let alert_dispatcher_for_revoke = Arc::clone(&alert_dispatcher);
         let mut revoke_shutdown = shutdown_tx.subscribe();
         tokio::spawn(async move {
             let mut interval = tokio::time::interval(std::time::Duration::from_secs(3600));
@@ -6860,6 +6943,43 @@ async fn main() -> Result<()> {
 
                         // 2. Detect which are offline > 7 days
                         let offline = hh_for_revoke.detect_offline_elders(&elder_ids);
+
+                        // NodeOffline alerts: this is the node's only periodic
+                        // peer-liveness signal (self can't alert while it's the
+                        // one that's down). Edge-trigger per elder so an elder
+                        // that stays offline doesn't re-alert every hour, and
+                        // re-arm elders that are no longer offline so a later
+                        // outage alerts again. Keyed by the offline peer's id.
+                        {
+                            use std::collections::HashSet;
+                            let offline_ids: HashSet<[u8; 32]> =
+                                offline.iter().map(|(id, _)| *id).collect();
+                            for (elder_hex, _) in &elders {
+                                let is_offline = hex::decode(elder_hex)
+                                    .ok()
+                                    .and_then(|b| <[u8; 32]>::try_from(b.as_slice()).ok())
+                                    .map(|id| offline_ids.contains(&id))
+                                    .unwrap_or(false);
+                                let days = offline
+                                    .iter()
+                                    .find(|(id, _)| hex::encode(id) == *elder_hex)
+                                    .map(|(_, d)| *d)
+                                    .unwrap_or(0);
+                                let detail = format!(
+                                    "Elder node {} has been offline for {} day(s).",
+                                    &elder_hex[..8.min(elder_hex.len())],
+                                    days
+                                );
+                                alert_dispatcher_for_revoke
+                                    .fire_edge(
+                                        ghost_verification::alerts::AlertEvent::NodeOffline,
+                                        elder_hex,
+                                        is_offline,
+                                        &detail,
+                                    )
+                                    .await;
+                            }
+                        }
 
                         // 3. For each offline elder, propose revocation vote
                         for (node_id, offline_days) in offline {
@@ -7228,7 +7348,12 @@ async fn main() -> Result<()> {
     // auto-demote claims; the verification mesh catches false claims at the
     // consensus layer. `self_check` was constructed earlier so the HTTP
     // handler shares this exact snapshot; here we start its probe loop.
-    self_check.clone().spawn_loop(Arc::new(config.clone()));
+    // Pass the alert dispatcher so the self-check loop fires CapabilityDrift
+    // (a claimed capability's prerequisite regressing pass→fail) and LowDisk
+    // (data partition crossing the low-free threshold) as edge-triggered alerts.
+    self_check
+        .clone()
+        .spawn_loop(Arc::new(config.clone()), Some(Arc::clone(&alert_dispatcher)));
     info!("Capability self-check loop started (30s interval)");
 
     // Subscribe to template events BEFORE starting the processor to avoid race condition

--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -6836,6 +6836,38 @@ async fn main() -> Result<()> {
         }
     });
 
+    // Start pool time-series sampler task.
+    // Snapshots the mesh-wide pool hashrate + connected-miner count (the same
+    // accessors the /api/v1/mining/status handler reads) into the bounded
+    // in-memory ring on VerificationState every 30s, so /api/v1/pool/series can
+    // serve real server-side history instead of a client-side session buffer.
+    {
+        let state_for_series = Arc::clone(&verification_state);
+        let mut series_shutdown = shutdown_tx.subscribe();
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(std::time::Duration::from_secs(30));
+            loop {
+                tokio::select! {
+                    _ = interval.tick() => {
+                        let mesh_hashrate_th = state_for_series
+                            .mesh_total_hashrate()
+                            .or_else(|| state_for_series.local_hashrate())
+                            .unwrap_or(0.0);
+                        let sample = ghost_verification::pool_series::PoolSample {
+                            t: chrono::Utc::now().timestamp(),
+                            mesh_hashrate_th,
+                            local_hashrate_th: state_for_series.local_hashrate().unwrap_or(0.0),
+                            miners: state_for_series.mesh_active_miners().unwrap_or(0),
+                        };
+                        state_for_series.pool_series.push(sample);
+                    }
+                    _ = series_shutdown.recv() => break,
+                }
+            }
+        });
+        info!("Pool time-series sampler started (30s interval, 24h retention)");
+    }
+
     // Start self-uptime recording task
     // Records our own uptime so we can be qualified for payouts
     // This is necessary because verification results are stored by OTHER nodes about us,

--- a/bins/ghost-pool/src/self_check.rs
+++ b/bins/ghost-pool/src/self_check.rs
@@ -17,12 +17,17 @@ use std::time::Duration;
 use tracing::{debug, info};
 
 use ghost_common::config::{MiningMode, NodeConfig};
+use ghost_verification::alerts::{AlertDispatcher, AlertEvent};
 
 /// Run all four checks every 30s. Cheap (sub-second total) and covers most
 /// operator drift scenarios without flooding logs.
 const TICK_INTERVAL: Duration = Duration::from_secs(30);
 /// Minimum free disk space for a meaningful Archive claim (700 GB).
 const ARCHIVE_MIN_FREE_BYTES: u64 = 700 * 1024 * 1024 * 1024;
+/// Free-space floor for the general LowDisk operator alert on the data
+/// partition (independent of the Archive claim). A node needs headroom for the
+/// growing SQLite DB + WAL; dropping below this warrants operator attention.
+const LOW_DISK_MIN_FREE_BYTES: u64 = 5 * 1024 * 1024 * 1024;
 
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct CapabilityCheck {
@@ -70,8 +75,10 @@ impl SelfCheck {
 
     /// Run all probes once and update internal state. Logs at INFO when a
     /// capability transitions between passed/failed; doesn't spam on
-    /// stable state.
-    pub async fn run_once(&self, config: &NodeConfig) {
+    /// stable state. When `alerts` is provided, also fires edge-triggered
+    /// CapabilityDrift / LowDisk operator alerts (the dispatcher debounces, so
+    /// each is delivered once per transition, not every tick).
+    pub async fn run_once(&self, config: &NodeConfig, alerts: Option<&Arc<AlertDispatcher>>) {
         let public_mining = check_public_mining(config).await;
         let archive = check_archive(config);
         let ghost_pay = check_ghost_pay(config).await;
@@ -86,22 +93,86 @@ impl SelfCheck {
 
         let prev = self.snapshot();
         log_transitions(&prev, &next);
+
+        if let Some(alerts) = alerts {
+            fire_capability_drift_alerts(alerts, &next).await;
+            fire_low_disk_alert(alerts, config).await;
+        }
+
         *self.state.write() = next;
     }
 
     /// Spawn a background task that re-runs all probes every TICK_INTERVAL.
-    /// The handle is detached — caller doesn't await it.
-    pub fn spawn_loop(self, config: Arc<NodeConfig>) {
+    /// The handle is detached — caller doesn't await it. `alerts` (when set)
+    /// wires the loop into the operator alert pipeline.
+    pub fn spawn_loop(self, config: Arc<NodeConfig>, alerts: Option<Arc<AlertDispatcher>>) {
         tokio::spawn(async move {
             // Run once immediately so the dashboard has something to show.
-            self.run_once(&config).await;
+            self.run_once(&config, alerts.as_ref()).await;
             let mut interval = tokio::time::interval(TICK_INTERVAL);
             interval.tick().await; // consume the immediate tick
             loop {
                 interval.tick().await;
-                self.run_once(&config).await;
+                self.run_once(&config, alerts.as_ref()).await;
             }
         });
+    }
+}
+
+/// Fire a CapabilityDrift alert for every capability that is claimed in config
+/// but whose prerequisite probe is currently failing. Edge-triggered inside the
+/// dispatcher (keyed by capability name): one alert per pass→fail transition,
+/// re-armed when the prerequisite recovers.
+async fn fire_capability_drift_alerts(alerts: &Arc<AlertDispatcher>, next: &SelfCheckState) {
+    for (name, check) in [
+        ("public_mining", &next.public_mining),
+        ("archive", &next.archive),
+        ("ghost_pay", &next.ghost_pay),
+        ("reaper", &next.reaper),
+    ] {
+        let active = check.claimed && !check.passed;
+        let detail = format!(
+            "Capability '{name}' is claimed but its prerequisite check is failing: {}",
+            check.reason.as_deref().unwrap_or("unknown")
+        );
+        alerts
+            .fire_edge(AlertEvent::CapabilityDrift, name, active, &detail)
+            .await;
+    }
+}
+
+/// Fire a LowDisk alert when free space on the data partition drops below
+/// [`LOW_DISK_MIN_FREE_BYTES`]. Edge-triggered: one alert on crossing the
+/// threshold, re-armed when free space recovers. A stat failure is treated as
+/// "unknown" (no alert either way) to avoid false positives.
+async fn fire_low_disk_alert(alerts: &Arc<AlertDispatcher>, config: &NodeConfig) {
+    let probe_path = data_probe_path(config);
+    let Some(free) = free_bytes(&probe_path) else {
+        return;
+    };
+    let active = free < LOW_DISK_MIN_FREE_BYTES;
+    let detail = format!(
+        "Low disk space: only {} GiB free at {} (alert threshold {} GiB).",
+        free / (1024 * 1024 * 1024),
+        probe_path.display(),
+        LOW_DISK_MIN_FREE_BYTES / (1024 * 1024 * 1024)
+    );
+    alerts
+        .fire_edge(AlertEvent::LowDisk, "data_dir", active, &detail)
+        .await;
+}
+
+/// Resolve a stat-able path for the data partition: the configured `db_path`
+/// if it exists, else its parent (the DB may not be created yet), else `/`.
+fn data_probe_path(config: &NodeConfig) -> std::path::PathBuf {
+    let configured = config.storage.db_path.as_path();
+    if configured.exists() {
+        configured.to_path_buf()
+    } else {
+        configured
+            .parent()
+            .map(|p| p.to_path_buf())
+            .unwrap_or_else(|| std::path::PathBuf::from("/"))
     }
 }
 
@@ -203,14 +274,7 @@ fn check_archive(config: &NodeConfig) -> CapabilityCheck {
     // wants something that exists. Fall back to its parent so we still report
     // disk-free of the partition that will hold the archive.
     let configured = config.storage.db_path.as_path();
-    let probe_path = if configured.exists() {
-        configured.to_path_buf()
-    } else {
-        configured
-            .parent()
-            .map(|p| p.to_path_buf())
-            .unwrap_or_else(|| std::path::PathBuf::from("/"))
-    };
+    let probe_path = data_probe_path(config);
     let free = free_bytes(&probe_path);
     let passed = match free {
         Some(b) if b >= ARCHIVE_MIN_FREE_BYTES => true,
@@ -481,6 +545,44 @@ mod tests {
         if !r.passed {
             assert!(r.reason.as_ref().unwrap().contains("ghost-pay"));
         }
+    }
+
+    #[tokio::test]
+    async fn run_once_fires_capability_drift_for_failing_claim() {
+        use ghost_common::config::AlertsConfig;
+        // Enabled alert config, drift event on, channels default-disabled so no
+        // network I/O — we only assert the trigger reached the dispatcher.
+        let dispatcher = Arc::new(AlertDispatcher::new("node".into(), || {
+            let mut c = AlertsConfig::default();
+            c.enabled = true;
+            c.events.capability_drift = true;
+            c
+        }));
+        let mut cfg = NodeConfig::default();
+        // Claim public mining but omit the address/signing-key so the probe
+        // fails -> a genuine claimed-but-failing drift.
+        cfg.network.mining_mode = MiningMode::PublicPool;
+        cfg.network.public_address = None;
+        cfg.network.signing_key = None;
+
+        let sc = SelfCheck::new();
+        sc.run_once(&cfg, Some(&dispatcher)).await;
+
+        // The self-check loop reached fire_edge for the drifting capability.
+        assert!(dispatcher.is_edge_active(AlertEvent::CapabilityDrift, "public_mining"));
+        // A capability that is not claimed must NOT arm a drift edge.
+        assert!(!dispatcher.is_edge_active(AlertEvent::CapabilityDrift, "ghost_pay"));
+    }
+
+    #[tokio::test]
+    async fn run_once_without_dispatcher_is_a_noop_for_alerts() {
+        // Passing None must not panic and must still update the snapshot.
+        let cfg = NodeConfig::default();
+        let sc = SelfCheck::new();
+        sc.run_once(&cfg, None).await;
+        // State was written (last_checked_unix set on at least one probe).
+        let snap = sc.snapshot();
+        assert!(snap.reaper.last_checked_unix > 0);
     }
 
     #[tokio::test]

--- a/crates/ghost-verification/src/alerts.rs
+++ b/crates/ghost-verification/src/alerts.rs
@@ -35,12 +35,13 @@
 
 use ghost_common::config::AlertsConfig;
 use serde::Serialize;
-use std::time::Duration;
+use std::collections::{HashMap, HashSet};
+use std::time::{Duration, Instant};
 use tracing::{debug, warn};
 
 /// A watched node event. `label`/`title` produce operator-facing copy; the
 /// caller supplies a free-form `detail` string at the trigger site.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum AlertEvent {
     /// Node became unreachable / unhealthy.
     NodeOffline,
@@ -163,6 +164,129 @@ pub async fn dispatch_event(
     }
     let msg = AlertMessage::for_event(event, node_id, detail);
     Some(deliver(cfg, &msg).await)
+}
+
+/// Debouncing dispatcher that owns the self node id and a live view of the
+/// operator's `AlertsConfig`, so trigger sites can fire watched events without
+/// re-reading config or open-coding their own anti-spam. One shared instance
+/// (`Arc<AlertDispatcher>`) is cloned into every trigger site.
+///
+/// Three fire modes suit the shapes the trigger sites actually have:
+///
+/// * [`AlertDispatcher::fire_edge`] — edge-triggered: dispatches only when a
+///   condition (keyed by an arbitrary sub-key, e.g. a peer id or capability
+///   name) first becomes true, and re-arms when it clears. For level signals
+///   that persist across polling ticks (low disk, capability drift, a peer
+///   staying offline). Without this, a periodic check re-fires every tick.
+/// * [`AlertDispatcher::fire_rate_limited`] — dispatches at most once per
+///   `min_interval` per event. For repeating conditions with no natural
+///   "cleared" edge (a dropping peer count).
+/// * [`AlertDispatcher::fire`] — dispatches unconditionally. For naturally
+///   discrete one-shot events (block found, restart requested).
+///
+/// The config closure is evaluated on every dispatch so live edits to
+/// `[alerts]` (via the config API, which mutates `full_node_config`) take
+/// effect immediately — no stale startup snapshot.
+pub struct AlertDispatcher {
+    node_id: String,
+    config: Box<dyn Fn() -> AlertsConfig + Send + Sync>,
+    /// Currently-active edge conditions, keyed by `(event, sub-key)`.
+    edges: parking_lot::Mutex<HashSet<(AlertEvent, String)>>,
+    /// Last dispatch instant per event, for rate limiting.
+    rate: parking_lot::Mutex<HashMap<AlertEvent, Instant>>,
+}
+
+impl AlertDispatcher {
+    /// Build a dispatcher for this node. `config` is called on every dispatch
+    /// to read the current `[alerts]` config (wire it to the live
+    /// `full_node_config` so operator edits apply without a restart).
+    pub fn new(
+        node_id: String,
+        config: impl Fn() -> AlertsConfig + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            node_id,
+            config: Box::new(config),
+            edges: parking_lot::Mutex::new(HashSet::new()),
+            rate: parking_lot::Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Update the edge state for `(event, key)` and report whether a dispatch
+    /// should happen now (i.e. the condition *just* became active). Pure — no
+    /// I/O — so the debounce is unit-testable on its own.
+    fn arm_edge(&self, event: AlertEvent, key: &str, active: bool) -> bool {
+        let mut edges = self.edges.lock();
+        if active {
+            // `insert` returns true only if it was not already present, i.e.
+            // this is the rising edge.
+            edges.insert((event, key.to_string()))
+        } else {
+            edges.remove(&(event, key.to_string()));
+            false
+        }
+    }
+
+    /// Update the rate-limit clock for `event`; report whether `min_interval`
+    /// has elapsed since the last dispatch. Pure — no I/O.
+    fn arm_rate(&self, event: AlertEvent, min_interval: Duration) -> bool {
+        let mut rate = self.rate.lock();
+        let now = Instant::now();
+        match rate.get(&event) {
+            Some(&last) if now.duration_since(last) < min_interval => false,
+            _ => {
+                rate.insert(event, now);
+                true
+            }
+        }
+    }
+
+    /// Edge-triggered dispatch. Fires once when `active` first becomes true for
+    /// `(event, key)`, and re-arms when `active` returns to false. Returns
+    /// whether an alert was actually delivered.
+    pub async fn fire_edge(
+        &self,
+        event: AlertEvent,
+        key: &str,
+        active: bool,
+        detail: &str,
+    ) -> bool {
+        if !self.arm_edge(event, key, active) {
+            return false;
+        }
+        dispatch_event(&(self.config)(), event, &self.node_id, detail)
+            .await
+            .is_some()
+    }
+
+    /// Rate-limited dispatch. Fires at most once per `min_interval` per event.
+    pub async fn fire_rate_limited(
+        &self,
+        event: AlertEvent,
+        min_interval: Duration,
+        detail: &str,
+    ) -> bool {
+        if !self.arm_rate(event, min_interval) {
+            return false;
+        }
+        dispatch_event(&(self.config)(), event, &self.node_id, detail)
+            .await
+            .is_some()
+    }
+
+    /// Unconditional dispatch for naturally-discrete events.
+    pub async fn fire(&self, event: AlertEvent, detail: &str) -> bool {
+        dispatch_event(&(self.config)(), event, &self.node_id, detail)
+            .await
+            .is_some()
+    }
+
+    /// Whether the edge condition for `(event, key)` is currently marked active.
+    /// Read-only introspection for diagnostics and for tests that assert a
+    /// trigger site reached `fire_edge`.
+    pub fn is_edge_active(&self, event: AlertEvent, key: &str) -> bool {
+        self.edges.lock().contains(&(event, key.to_string()))
+    }
 }
 
 async fn deliver_telegram(
@@ -333,5 +457,91 @@ mod tests {
         let m = AlertMessage::for_event(AlertEvent::LowDisk, "abcdef0123456789", "");
         assert!(m.title.contains("Low disk"));
         assert!(!m.body.is_empty());
+    }
+
+    /// A config that is on and enables one event, with all channels disabled —
+    /// so `dispatch_event` returns `Some` (it fired) but no network I/O happens
+    /// (every channel is skipped). Lets us assert the trigger→dispatch wiring
+    /// deterministically without HTTP.
+    fn enabled_for(pick: impl Fn(&mut AlertEvents)) -> impl Fn() -> AlertsConfig {
+        move || {
+            let mut c = base();
+            // Start from all-off so the test only exercises the event we pick.
+            let mut events = AlertEvents {
+                node_offline: false,
+                capability_drift: false,
+                low_disk: false,
+                restart_needed: false,
+                peer_count_drop: false,
+                block_found: false,
+            };
+            pick(&mut events);
+            c.events = events;
+            c
+        }
+    }
+
+    #[tokio::test]
+    async fn edge_fires_once_then_suppresses_until_rearmed() {
+        let d = AlertDispatcher::new("node".into(), enabled_for(|e| e.low_disk = true));
+        // Rising edge -> dispatched.
+        assert!(d.fire_edge(AlertEvent::LowDisk, "/", true, "d").await);
+        // Still active -> suppressed (no spam).
+        assert!(!d.fire_edge(AlertEvent::LowDisk, "/", true, "d").await);
+        // Condition clears -> no dispatch, re-arms.
+        assert!(!d.fire_edge(AlertEvent::LowDisk, "/", false, "d").await);
+        // Rising edge again -> dispatched.
+        assert!(d.fire_edge(AlertEvent::LowDisk, "/", true, "d").await);
+    }
+
+    #[tokio::test]
+    async fn edge_keys_are_independent() {
+        let d = AlertDispatcher::new("node".into(), enabled_for(|e| e.node_offline = true));
+        // Two different peers offline -> two independent alerts.
+        assert!(d.fire_edge(AlertEvent::NodeOffline, "peerA", true, "d").await);
+        assert!(d.fire_edge(AlertEvent::NodeOffline, "peerB", true, "d").await);
+        // Re-reporting peerA -> suppressed.
+        assert!(!d.fire_edge(AlertEvent::NodeOffline, "peerA", true, "d").await);
+    }
+
+    #[tokio::test]
+    async fn edge_respects_master_and_event_flags() {
+        // Master off -> never dispatches even on a rising edge.
+        let d = AlertDispatcher::new("node".into(), || {
+            let mut c = base();
+            c.enabled = false;
+            c
+        });
+        assert!(!d.fire_edge(AlertEvent::LowDisk, "/", true, "d").await);
+
+        // Master on but this event disabled -> no dispatch.
+        let d = AlertDispatcher::new("node".into(), enabled_for(|e| e.block_found = true));
+        assert!(!d.fire_edge(AlertEvent::LowDisk, "/", true, "d").await);
+    }
+
+    #[tokio::test]
+    async fn rate_limit_suppresses_within_window() {
+        let d = AlertDispatcher::new("node".into(), enabled_for(|e| e.peer_count_drop = true));
+        assert!(
+            d.fire_rate_limited(AlertEvent::PeerCountDrop, Duration::from_secs(60), "d")
+                .await
+        );
+        // Second call inside the window -> suppressed.
+        assert!(
+            !d.fire_rate_limited(AlertEvent::PeerCountDrop, Duration::from_secs(60), "d")
+                .await
+        );
+        // A zero window always allows.
+        assert!(
+            d.fire_rate_limited(AlertEvent::PeerCountDrop, Duration::from_secs(0), "d")
+                .await
+        );
+    }
+
+    #[tokio::test]
+    async fn fire_unconditional_dispatches_each_call() {
+        let d = AlertDispatcher::new("node".into(), enabled_for(|e| e.block_found = true));
+        assert!(d.fire(AlertEvent::BlockFound, "block 1").await);
+        assert!(d.fire(AlertEvent::BlockFound, "block 2").await);
     }
 }

--- a/crates/ghost-verification/src/lib.rs
+++ b/crates/ghost-verification/src/lib.rs
@@ -44,6 +44,7 @@ pub mod client;
 pub mod config;
 pub mod handlers;
 pub mod log_buffer;
+pub mod pool_series;
 pub mod qualification;
 pub mod routes;
 pub mod server;

--- a/crates/ghost-verification/src/pool_series.rs
+++ b/crates/ghost-verification/src/pool_series.rs
@@ -1,0 +1,121 @@
+//! In-memory rolling time-series for pool-wide mining metrics.
+//!
+//! The dashboard Node Pool page charts pool hashrate + connected miners, but
+//! the backend historically exposed only *current* values, so the page had to
+//! accumulate history in a client-side session buffer that resets on every
+//! reload. This module keeps a bounded, process-local ring of periodic samples
+//! (fed by a sampler task in `bins/ghost-pool`) so the page can fetch real
+//! server-side history from `GET /api/v1/pool/series`.
+//!
+//! It mirrors the bounded-`VecDeque` shape of `log_buffer`, but hangs off
+//! `VerificationState` (Arc-shared) instead of a process `static` so the
+//! sampler task and the route handler share one instance.
+
+use parking_lot::RwLock;
+use serde::Serialize;
+use std::collections::VecDeque;
+
+/// One periodic sample of pool-wide metrics.
+#[derive(Debug, Clone, Serialize)]
+pub struct PoolSample {
+    /// Unix timestamp (seconds) the sample was taken.
+    pub t: i64,
+    /// Mesh-wide pool hashrate (TH/s) — sum of every node's realized hashrate.
+    pub mesh_hashrate_th: f64,
+    /// This node's own realized hashrate (TH/s).
+    pub local_hashrate_th: f64,
+    /// Mesh-wide deduplicated connected-miner count.
+    pub miners: u32,
+}
+
+/// Bounded FIFO ring of [`PoolSample`], shared between the sampler task and the
+/// `/api/v1/pool/series` handler. Cheap reads/writes behind a single `RwLock`.
+pub struct PoolSeries {
+    inner: RwLock<VecDeque<PoolSample>>,
+    capacity: usize,
+}
+
+impl PoolSeries {
+    /// Create a ring holding at most `capacity` samples.
+    pub fn new(capacity: usize) -> Self {
+        let capacity = capacity.max(1);
+        Self {
+            // Cap the pre-allocation so a large retention window doesn't reserve
+            // a huge buffer up front; it grows as samples arrive.
+            inner: RwLock::new(VecDeque::with_capacity(capacity.min(512))),
+            capacity,
+        }
+    }
+
+    /// Append a sample, evicting the oldest when at capacity (FIFO).
+    pub fn push(&self, sample: PoolSample) {
+        let mut buf = self.inner.write();
+        while buf.len() >= self.capacity {
+            buf.pop_front();
+        }
+        buf.push_back(sample);
+    }
+
+    /// All samples with `t >= cutoff`, oldest first.
+    pub fn since(&self, cutoff: i64) -> Vec<PoolSample> {
+        self.inner
+            .read()
+            .iter()
+            .filter(|s| s.t >= cutoff)
+            .cloned()
+            .collect()
+    }
+
+    /// Number of samples currently retained.
+    pub fn len(&self) -> usize {
+        self.inner.read().len()
+    }
+
+    /// Whether the ring holds no samples yet.
+    pub fn is_empty(&self) -> bool {
+        self.inner.read().is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample(t: i64) -> PoolSample {
+        PoolSample {
+            t,
+            mesh_hashrate_th: t as f64,
+            local_hashrate_th: 0.0,
+            miners: 1,
+        }
+    }
+
+    #[test]
+    fn evicts_oldest_at_capacity() {
+        let s = PoolSeries::new(3);
+        for t in 0..5 {
+            s.push(sample(t));
+        }
+        assert_eq!(s.len(), 3);
+        // Oldest two (t=0,1) evicted; t=2,3,4 retained.
+        let all = s.since(i64::MIN);
+        assert_eq!(all.iter().map(|x| x.t).collect::<Vec<_>>(), vec![2, 3, 4]);
+    }
+
+    #[test]
+    fn since_filters_by_cutoff() {
+        let s = PoolSeries::new(100);
+        for t in 0..10 {
+            s.push(sample(t));
+        }
+        let recent = s.since(7);
+        assert_eq!(recent.iter().map(|x| x.t).collect::<Vec<_>>(), vec![7, 8, 9]);
+    }
+
+    #[test]
+    fn empty_series_reports_empty() {
+        let s = PoolSeries::new(10);
+        assert!(s.is_empty());
+        assert!(s.since(0).is_empty());
+    }
+}

--- a/crates/ghost-verification/src/routes.rs
+++ b/crates/ghost-verification/src/routes.rs
@@ -232,6 +232,17 @@ pub fn create_router(state: Arc<VerificationState>) -> Router {
         // website render the node list from one node instead of a hard-coded
         // VM set, so new nodes appear automatically.
         .route("/api/v1/pool/mesh-nodes", get(api_pool_mesh_nodes_handler))
+        // Rolling server-side time-series of pool hashrate + connected miners,
+        // sampled every 30s (24h retention). `?window=1h|24h`. Lets the pool
+        // page chart real history instead of a client-side session buffer.
+        .route("/api/v1/pool/series", get(api_pool_series_handler))
+        // Mesh-wide leaderboard: node-ranked (self + peers by hashrate) plus the
+        // mesh-wide best-share records per window, aggregated from existing mesh
+        // data with no new gossip. Replaces the pool page's this-node-only list.
+        .route(
+            "/api/v1/pool/mesh-leaderboard",
+            get(api_pool_mesh_leaderboard_handler),
+        )
         // Read-only decentralised-coordinator election view. Returns
         // `{enabled:false}` unless the operator turns on
         // `[coordinator] wraith_election_enabled`.
@@ -1853,6 +1864,13 @@ struct PoolLeaderboardQuery {
     limit: Option<u32>,
 }
 
+/// Query parameters for the pool time-series endpoint.
+/// `window` is `1h | 24h` (defaults to `1h`, anything else is treated as `1h`).
+#[derive(Debug, Deserialize)]
+struct PoolSeriesQuery {
+    window: Option<String>,
+}
+
 #[derive(Debug, Deserialize)]
 struct MinerHistoryQuery {
     miner_id: Option<String>,
@@ -2893,6 +2911,185 @@ async fn api_pool_records_handler(
             "difficulty": share_difficulty_from_hash_hex(&share_hash),
             "assigned_difficulty": winning_assigned_diff,
         }
+    }))
+}
+
+/// Rolling server-side time-series of pool hashrate + connected miners.
+///
+/// The sampler task in `bins/ghost-pool` snapshots the same mesh accessors the
+/// mining-status endpoint uses (`mesh_total_hashrate` / `local_hashrate` /
+/// `mesh_active_miners`) every 30s into a bounded in-memory ring. This endpoint
+/// returns the samples within the requested `window` (`1h` or `24h`, default
+/// `1h`), oldest first. Empty until the first sample lands after startup — the
+/// dashboard keeps its client-side session buffer as a fallback in that case.
+async fn api_pool_series_handler(
+    State(state): State<Arc<VerificationState>>,
+    Query(params): Query<PoolSeriesQuery>,
+) -> impl IntoResponse {
+    // Only 1h and 24h are offered; anything else falls back to 1h.
+    let (window_label, window_secs): (&str, i64) = match params.window.as_deref() {
+        Some("24h") => ("24h", 24 * 3600),
+        _ => ("1h", 3600),
+    };
+    let cutoff = chrono::Utc::now().timestamp() - window_secs;
+    let samples = state.pool_series.since(cutoff);
+    Json(serde_json::json!({
+        "window": window_label,
+        "window_secs": window_secs,
+        "sample_interval_secs": 30,
+        "count": samples.len(),
+        "samples": samples,
+    }))
+}
+
+/// Mesh-wide leaderboard for the pool page — aggregated across the whole mesh
+/// WITHOUT any new gossip, from data every node already holds:
+///
+/// * `nodes` — every mesh node (self + connected peers) ranked by realized
+///   hashrate. This is the mesh-wide replacement for the pool page's old
+///   this-node-only miner list.
+/// * `records` — the mesh-wide best (rarest) share per window (block/day/week/
+///   month), merging this node's local DB best with peers' gossiped
+///   `best_records` (already reduced to one winner per window), each attributed
+///   to its redacted miner id.
+///
+/// LIMIT: a true mesh-wide *per-miner top-N* leaderboard (every miner on every
+/// node ranked by hashrate or shares) is NOT computable from a single node
+/// without new gossip — peers gossip per-node aggregates and one best-share
+/// record per window, never their full per-miner tables. The public website
+/// builds that by fanning out to every node and merging client-side. `records`
+/// is the widest mesh-wide per-miner surface available server-side here.
+async fn api_pool_mesh_leaderboard_handler(
+    State(state): State<Arc<VerificationState>>,
+) -> impl IntoResponse {
+    let health = state.get_health().await;
+
+    // --- Node-ranked leaderboard: self + every connected peer ---
+    let self_name = {
+        let config = state.dashboard_config.read();
+        let addr = match config.stratum_host.clone() {
+            Some(host) if host.contains(':') => host,
+            Some(host) => format!("{host}:{}", config.http_port.unwrap_or(8080)),
+            None => String::new(),
+        };
+        config
+            .node_name
+            .clone()
+            .filter(|n| !n.trim().is_empty())
+            .unwrap_or_else(|| mesh_node_name(&addr, &health.node_id))
+    };
+    let self_caps = &health.capabilities;
+    let mut nodes = vec![serde_json::json!({
+        "node_id": health.node_id.clone(),
+        "name": self_name,
+        "hashrate_th": state.local_hashrate().unwrap_or(0.0),
+        "miner_count": health.miner_count,
+        "shares": mesh_capability_shares(
+            self_caps.archive_mode,
+            self_caps.ghost_pay,
+            self_caps.public_mining,
+            self_caps.reaper,
+            self_caps.elder_status,
+        ),
+        "elder": self_caps.elder_status,
+        "healthy": health.healthy,
+        "is_self": true,
+    })];
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    seen.insert(health.node_id.clone());
+    for peer in state.mesh_nodes() {
+        if !seen.insert(peer.node_id.clone()) {
+            continue;
+        }
+        nodes.push(serde_json::json!({
+            "node_id": peer.node_id,
+            "name": mesh_node_name(&peer.address, &peer.node_id),
+            "hashrate_th": peer.hashrate_th,
+            "miner_count": peer.miner_count,
+            "shares": mesh_capability_shares(
+                peer.cap_archive,
+                peer.cap_ghost_pay,
+                peer.cap_public_mining,
+                peer.cap_reaper,
+                peer.cap_elder,
+            ),
+            "elder": peer.cap_elder,
+            "healthy": peer.healthy,
+            "is_self": false,
+        }));
+    }
+    // Rank by realized hashrate, highest first.
+    nodes.sort_by(|a, b| {
+        let ha = a.get("hashrate_th").and_then(|v| v.as_f64()).unwrap_or(0.0);
+        let hb = b.get("hashrate_th").and_then(|v| v.as_f64()).unwrap_or(0.0);
+        hb.partial_cmp(&ha).unwrap_or(std::cmp::Ordering::Equal)
+    });
+    let node_count = nodes.len();
+
+    // --- Mesh-wide best-share records per window ---
+    // Merge this node's local DB best with the peers' gossiped winners (already
+    // one per window). Same rarity rule as /api/v1/pool/records: fixed-width
+    // zero-padded hex, so string `<` matches numeric order (smaller = rarer).
+    let now_s = chrono::Utc::now().timestamp();
+    let mesh_records = state.mesh_best_records();
+    let mut records = Vec::new();
+    for (window_name, window_secs) in [
+        ("block", 600i64),
+        ("day", 86_400),
+        ("week", 604_800),
+        ("month", 2_592_000),
+    ] {
+        let since_ts = now_s - window_secs;
+        let mut winning_hash: Option<String> = None;
+        let mut winning_redacted = String::new();
+        let mut winning_timestamp: i64 = 0;
+
+        if let Some(ref db) = state.database {
+            if let Ok(Some(best)) = db.get_best_share_since(since_ts) {
+                winning_hash = Some(best.share_hash.clone());
+                winning_redacted = redact_miner_id(&best.miner_id);
+                winning_timestamp = best.timestamp;
+            }
+        }
+        if let Some(ref recs) = mesh_records {
+            for rec in recs {
+                if rec.window != window_name || rec.share_hash.is_empty() {
+                    continue;
+                }
+                let beats = winning_hash
+                    .as_ref()
+                    .map(|w| rec.share_hash < *w)
+                    .unwrap_or(true);
+                if beats {
+                    winning_hash = Some(rec.share_hash.clone());
+                    winning_redacted = rec.miner_id_redacted.clone();
+                    winning_timestamp = rec.timestamp;
+                }
+            }
+        }
+
+        if let Some(share_hash) = winning_hash {
+            let leading_hex_zeros = share_hash.chars().take_while(|c| *c == '0').count();
+            records.push(serde_json::json!({
+                "window": window_name,
+                "share_hash": share_hash.clone(),
+                "leading_zero_bits": leading_hex_zeros * 4,
+                "leading_hex_zeros": leading_hex_zeros,
+                "miner_id_redacted": winning_redacted,
+                "timestamp": winning_timestamp,
+                "difficulty": share_difficulty_from_hash_hex(&share_hash),
+            }));
+        }
+    }
+
+    Json(serde_json::json!({
+        "nodes": nodes,
+        "node_count": node_count,
+        "records": records,
+        "limit_note": "Node-ranked leaderboard + mesh-wide best-share records \
+            per window, aggregated from existing mesh data (no new gossip). A \
+            per-miner top-N hashrate/shares leaderboard across the whole mesh \
+            requires client-side fan-out to every node.",
     }))
 }
 

--- a/crates/ghost-verification/src/routes.rs
+++ b/crates/ghost-verification/src/routes.rs
@@ -1489,11 +1489,27 @@ async fn api_node_shares_handler(State(state): State<Arc<VerificationState>>) ->
         total += 1;
     }
 
+    // Real trailing-7-day uptime for THIS node (the qualification gatekeeper
+    // metric), read from the self-recorded uptime samples via the same query
+    // the qualification layer uses. `uptime_qualified` reflects the true >=95%
+    // gate rather than an unconditional `true`. Falls back to null/false when
+    // no DB is attached (never a fabricated 99.9%).
+    let self_uptime_percent: Option<f64> = state.database.as_ref().and_then(|db| {
+        let since = chrono::Utc::now().timestamp()
+            - (ghost_common::constants::UPTIME_WINDOW_DAYS as i64 * 86_400);
+        db.get_uptime_percent(&state.node_id, since)
+            .ok()
+            .map(|ratio| ratio * 100.0)
+    });
+    let uptime_qualified = self_uptime_percent
+        .map(|p| p >= ghost_common::constants::UPTIME_GATEKEEPER_THRESHOLD)
+        .unwrap_or(false);
+
     Json(serde_json::json!({
         "total": total,
         "max_shares": 15,
-        "uptime_qualified": true,
-        "uptime_percent": 99.9,
+        "uptime_qualified": uptime_qualified,
+        "uptime_percent": self_uptime_percent,
         "archive_mode": config.archive_mode,
         "ghost_pay": config.ghost_pay,
         "public_mining": config.public_mining,
@@ -3434,10 +3450,25 @@ async fn api_swarm_handler(State(state): State<Arc<VerificationState>>) -> impl 
 
     // The per-peer uptime %, peer count and L1/L2 heights are not gossiped, so
     // they render as "—" for mesh peers — but THIS node knows its own locally,
-    // so populate them here. (uptime_percent is the trailing-7-day qualification
-    // metric and isn't available on the health snapshot; left unset for now.)
+    // so populate them here.
     let self_l2_height =
         check_ghostpay_local(&state).and_then(|gp| (gp.sync_state != "disabled").then_some(gp.virtual_block));
+
+    // This node's own trailing-7-day uptime %, the qualification gatekeeper
+    // metric (>=95% before capabilities count). It's the exact figure the
+    // qualification layer reads (`get_uptime_percent`, GHOST-10 time-based
+    // denominator) over the self-recorded samples — the self-uptime task
+    // records under `identity.node_id_hex()`, which is `state.node_id` /
+    // `health.node_id`. Returned as a percentage (0-100) to match the
+    // peer-gossiped `uptime_percent` the frontend already renders. Left as
+    // `None` (frontend "—") only when there's no DB attached.
+    let self_uptime_percent = state.database.as_ref().and_then(|db| {
+        let since = chrono::Utc::now().timestamp()
+            - (ghost_common::constants::UPTIME_WINDOW_DAYS as i64 * 86_400);
+        db.get_uptime_percent(&health.node_id, since)
+            .ok()
+            .map(|ratio| ratio * 100.0)
+    });
 
     let self_node = serde_json::json!({
         "node_id": health.node_id.clone(),
@@ -3461,6 +3492,7 @@ async fn api_swarm_handler(State(state): State<Arc<VerificationState>>) -> impl 
         "peer_count": health.peer_count,
         "l1_height": health.block_height,
         "l2_height": self_l2_height,
+        "uptime_percent": self_uptime_percent,
     });
 
     let mut nodes = vec![self_node];

--- a/crates/ghost-verification/src/server.rs
+++ b/crates/ghost-verification/src/server.rs
@@ -1369,6 +1369,11 @@ pub struct VerificationState {
     stratum_verify_cache: parking_lot::Mutex<
         std::collections::HashMap<(StratumProtocol, u16), (Instant, StratumResponse)>,
     >,
+    /// Rolling in-memory time-series of pool-wide hashrate + connected miners,
+    /// fed by a periodic sampler task in `bins/ghost-pool` and exposed via
+    /// `GET /api/v1/pool/series`. Bounded ring; empty until the first sample
+    /// (the dashboard keeps its client-side session buffer as a fallback).
+    pub pool_series: crate::pool_series::PoolSeries,
 }
 
 /// TTL for cached stratum self-verification results. Verification cycles run
@@ -1521,6 +1526,8 @@ impl VerificationState {
             glyph_registered_relay_fn: None,
             l2_tree_state_fn: None,
             stratum_verify_cache: parking_lot::Mutex::new(std::collections::HashMap::new()),
+            // 24h of history at the sampler's 30s cadence (2880 samples).
+            pool_series: crate::pool_series::PoolSeries::new(2880),
         }
     }
 

--- a/dashboard/src/app/(dashboard)/pool/page.tsx
+++ b/dashboard/src/app/(dashboard)/pool/page.tsx
@@ -17,9 +17,10 @@ import {
   useMiners,
   useRewardsCurrent,
   useNodePayoutHistory,
+  usePoolMeshLeaderboard,
 } from "@/hooks/queries";
 import { usePoolSeries } from "@/hooks/usePoolSeries";
-import type { BestHashEntry, MinerInfo, NodePayoutEntry } from "@/types/api";
+import type { BestHashEntry, MinerInfo, NodePayoutEntry, MeshLeaderboardNode } from "@/types/api";
 
 const TOOLTIPS = {
   pool_hashrate: "Combined hashrate of every node in the Ghost mesh pool, aggregated across the whole network.",
@@ -98,15 +99,19 @@ function BestShareCard({ title, entry }: { title: string; entry: BestHashEntry |
   );
 }
 
-// One chart panel: title + "live (session)" tag + the plot.
+// One chart panel: title + source tag + the plot. The tag shows whether the
+// series is backed by the server-side ring ("history") or the in-browser
+// session buffer ("live (session)").
 function ChartCard({
   title,
   subtitle,
   children,
+  serverBacked = false,
 }: {
   title: string;
   subtitle?: string;
   children: React.ReactNode;
+  serverBacked?: boolean;
 }) {
   return (
     <Card>
@@ -119,7 +124,7 @@ function ChartCard({
             <p style={{ color: "var(--dim)", fontSize: "12px", marginTop: "2px" }}>{subtitle}</p>
           )}
         </div>
-        <Badge variant="default">live (session)</Badge>
+        <Badge variant="default">{serverBacked ? "history" : "live (session)"}</Badge>
       </div>
       {children}
     </Card>
@@ -133,6 +138,7 @@ export default function NodePoolPage() {
   const { data: minersData } = useMiners();
   const { data: rewards } = useRewardsCurrent();
   const { data: payouts } = useNodePayoutHistory("7d");
+  const { data: meshLeaderboard } = usePoolMeshLeaderboard();
   const series = usePoolSeries();
 
   const meshTh = status?.hashrate_th ?? status?.total_hashrate ?? 0;
@@ -206,6 +212,63 @@ export default function NodePoolPage() {
     [],
   );
 
+  // Mesh-wide leaderboard: every node in the mesh ranked by hashrate. The
+  // backend returns nodes already ranked; render them as-is.
+  const meshNodes = meshLeaderboard?.nodes ?? [];
+  const meshRecords = meshLeaderboard?.records ?? [];
+
+  const meshNodeColumns = useMemo<ColumnDef<MeshLeaderboardNode>[]>(
+    () => [
+      {
+        id: "rank",
+        header: "#",
+        cell: ({ row }) => <span style={{ color: "var(--fainter)" }}>{row.index + 1}</span>,
+      },
+      {
+        id: "node",
+        header: "Node",
+        accessorFn: (n) => n.name || n.node_id.slice(0, 10),
+        cell: ({ row }) => (
+          <span className="truncate" style={{ fontFamily: "var(--font-mono)", fontSize: "12px" }}>
+            {row.original.name || row.original.node_id.slice(0, 10)}
+            {row.original.is_self && (
+              <Badge variant="default" className="ml-2">
+                this node
+              </Badge>
+            )}
+          </span>
+        ),
+      },
+      {
+        id: "hashrate",
+        header: "Hashrate",
+        accessorFn: (n) => n.hashrate_th ?? 0,
+        cell: ({ getValue }) => formatHashrate((getValue() as number) * 1e12),
+      },
+      {
+        id: "miners",
+        header: "Miners",
+        accessorFn: (n) => n.miner_count ?? 0,
+        cell: ({ getValue }) => (getValue() as number).toLocaleString(),
+      },
+      {
+        id: "shares",
+        header: "Shares",
+        accessorFn: (n) => n.shares ?? 0,
+        cell: ({ getValue }) => `${getValue() as number} / 15`,
+      },
+      {
+        id: "status",
+        header: "Status",
+        accessorFn: (n) => (n.healthy ? "online" : "offline"),
+        cell: ({ getValue }) => (
+          <Badge variant={getValue() === "online" ? "success" : "error"}>{String(getValue())}</Badge>
+        ),
+      },
+    ],
+    [],
+  );
+
   const payoutColumns = useMemo<ColumnDef<NodePayoutEntry>[]>(
     () => [
       {
@@ -253,16 +316,27 @@ export default function NodePoolPage() {
         subtitle="Live pool stats and graphs for this node and the Ghost mesh — hashrate, miners, shares, best shares, round progress and payouts."
       />
 
-      {/* Live-session note: the node only exposes current values, so the graphs
-          are built from a rolling in-browser buffer that resets on reload. */}
+      {/* Chart source note: the hashrate/miner charts use the node's server-side
+          time-series ring when it has data, falling back to an in-browser
+          session buffer on a freshly-started node. */}
       <div
         className="rounded-lg p-3 text-sm"
         style={{ background: "var(--accent-weak)", border: "1px solid var(--rule)", color: "var(--dim)" }}
       >
-        Graphs are drawn from a live in-browser buffer of the polled pool values
-        ({series.sampleCount} sample{series.sampleCount === 1 ? "" : "s"} this session) and reset on reload.
-        The node API exposes current values only — persisting server-side roll-ups would let these charts
-        survive reloads and cover longer windows.
+        {series.serverBacked ? (
+          <>
+            Hashrate and miner charts are drawn from the node&apos;s server-side history
+            (sampled every 30s, up to 24h) so they survive reloads. The share accept-rate chart
+            is a live in-browser buffer ({series.sampleCount} sample
+            {series.sampleCount === 1 ? "" : "s"} this session).
+          </>
+        ) : (
+          <>
+            Graphs are drawn from a live in-browser buffer of the polled pool values
+            ({series.sampleCount} sample{series.sampleCount === 1 ? "" : "s"} this session) and reset on reload.
+            The node&apos;s server-side history will back these charts once it has accumulated a few samples.
+          </>
+        )}
       </div>
 
       {/* Headline stats */}
@@ -314,25 +388,37 @@ export default function NodePoolPage() {
       {/* Hashrate + miners time-series */}
       <SectionErrorBoundary section="Pool Graphs">
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-          <ChartCard title="Pool Hashrate" subtitle="Mesh-wide, aggregated across all nodes">
+          <ChartCard
+            title="Pool Hashrate"
+            subtitle="Mesh-wide, aggregated across all nodes"
+            serverBacked={series.serverBacked}
+          >
             <TimeSeriesChart
               data={series.meshHashrate}
-              ariaLabel="Pool hashrate over the session"
+              ariaLabel="Pool hashrate over time"
               formatValue={(v) => formatHashrate(v, 1)}
             />
           </ChartCard>
-          <ChartCard title="Connected Miners" subtitle="Active miners across the mesh pool">
+          <ChartCard
+            title="Connected Miners"
+            subtitle="Active miners across the mesh pool"
+            serverBacked={series.serverBacked}
+          >
             <TimeSeriesChart
               data={series.miners}
               color="var(--green)"
-              ariaLabel="Connected miners over the session"
+              ariaLabel="Connected miners over time"
               formatValue={(v) => Math.round(v).toString()}
             />
           </ChartCard>
-          <ChartCard title="This Node Hashrate" subtitle="Miners connected to this node only">
+          <ChartCard
+            title="This Node Hashrate"
+            subtitle="Miners connected to this node only"
+            serverBacked={series.serverBacked}
+          >
             <TimeSeriesChart
               data={series.nodeHashrate}
-              ariaLabel="This node hashrate over the session"
+              ariaLabel="This node hashrate over time"
               formatValue={(v) => formatHashrate(v, 1)}
             />
           </ChartCard>
@@ -445,12 +531,60 @@ export default function NodePoolPage() {
         </Card>
       </SectionErrorBoundary>
 
-      {/* Leaderboard */}
-      <SectionErrorBoundary section="Miner Leaderboard">
+      {/* Mesh leaderboard: every node in the pool ranked by hashrate, plus the
+          mesh-wide best-share records per window. Aggregated by the backend
+          across the whole mesh (no client fan-out). */}
+      <SectionErrorBoundary section="Mesh Leaderboard">
         <Card>
           <CardHeader
-            title="Miner Leaderboard"
-            subtitle="Top miners connected to this node, ranked by hashrate"
+            title="Mesh Leaderboard"
+            subtitle="Every node in the Ghost pool, ranked by hashrate across the whole mesh"
+          />
+          <DataTable
+            columns={meshNodeColumns}
+            data={meshNodes}
+            showPagination={false}
+            emptyMessage="No mesh nodes reporting yet"
+            loadingRows={4}
+          />
+          {meshRecords.length > 0 && (
+            <div className="mt-5">
+              <div style={{ color: "var(--dim)", fontSize: "12px", marginBottom: "8px" }}>
+                Mesh best-share records
+              </div>
+              <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+                {meshRecords.map((r) => (
+                  <div key={r.window}>
+                    <div style={{ color: "var(--dim)", fontSize: "11px", textTransform: "capitalize" }}>
+                      {r.window}
+                    </div>
+                    <div style={{ color: "var(--fg)", fontSize: "16px", fontWeight: 600 }}>
+                      {formatDifficulty(r.difficulty)}
+                    </div>
+                    <div style={{ color: "var(--fainter)", fontSize: "11px" }}>
+                      {r.leading_zero_bits} zero bits · {r.miner_id_redacted || "—"}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+          {meshLeaderboard?.limit_note && (
+            <p style={{ color: "var(--fainter)", fontSize: "11px", marginTop: "12px" }}>
+              {meshLeaderboard.limit_note}
+            </p>
+          )}
+        </Card>
+      </SectionErrorBoundary>
+
+      {/* This node's miners: the per-miner detail this node can see locally.
+          A true mesh-wide per-miner leaderboard needs client fan-out to every
+          node (see the mesh leaderboard note above). */}
+      <SectionErrorBoundary section="This Node's Miners">
+        <Card>
+          <CardHeader
+            title="This Node's Miners"
+            subtitle="Miners connected to this node's stratum port, ranked by hashrate"
           />
           {minersRedacted ? (
             <div style={{ color: "var(--dim)", fontSize: "13px" }}>

--- a/dashboard/src/hooks/queries/useMiningQueries.ts
+++ b/dashboard/src/hooks/queries/useMiningQueries.ts
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { getMiningStatus, getMiners, getBestHash, getPublicMiningNodes, setPrivateMining, setPublicMining, setPayoutAddress } from '@/lib/api/mining';
+import { getMiningStatus, getMiners, getBestHash, getPublicMiningNodes, setPrivateMining, setPublicMining, setPayoutAddress, getPoolSeries, getPoolMeshLeaderboard } from '@/lib/api/mining';
 
 export const miningKeys = {
   all: ['mining'] as const,
@@ -7,7 +7,30 @@ export const miningKeys = {
   miners: () => [...miningKeys.all, 'miners'] as const,
   bestHash: () => [...miningKeys.all, 'best-hash'] as const,
   publicNodes: () => [...miningKeys.all, 'public-nodes'] as const,
+  poolSeries: (window: string) => [...miningKeys.all, 'pool-series', window] as const,
+  meshLeaderboard: () => [...miningKeys.all, 'mesh-leaderboard'] as const,
 };
+
+// Server-side pool time-series (hashrate + miners) for the Node Pool charts.
+export function usePoolSeriesHistory(
+  window: '1h' | '24h' = '1h',
+  options?: { refetchInterval?: number },
+) {
+  return useQuery({
+    queryKey: miningKeys.poolSeries(window),
+    queryFn: () => getPoolSeries(window),
+    refetchInterval: options?.refetchInterval ?? 30_000,
+  });
+}
+
+// Mesh-wide leaderboard (node-ranked + mesh best-share records).
+export function usePoolMeshLeaderboard(options?: { refetchInterval?: number }) {
+  return useQuery({
+    queryKey: miningKeys.meshLeaderboard(),
+    queryFn: getPoolMeshLeaderboard,
+    refetchInterval: options?.refetchInterval ?? 15_000,
+  });
+}
 
 export function useMiningStatus(options?: { refetchInterval?: number }) {
   return useQuery({

--- a/dashboard/src/hooks/usePoolSeries.ts
+++ b/dashboard/src/hooks/usePoolSeries.ts
@@ -1,26 +1,29 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
-import { useMiningStatus, usePoolStatus, miningKeys, networkKeys } from '@/hooks/queries';
+import {
+  useMiningStatus,
+  usePoolStatus,
+  usePoolSeriesHistory,
+  miningKeys,
+  networkKeys,
+} from '@/hooks/queries';
 import type { MiningStatus, PoolStatus } from '@/types/api';
 
 /**
- * Session-scoped rolling time-series for the Node Pool page.
+ * Rolling time-series for the Node Pool page.
  *
- * The node API exposes only *current* pool values (hashrate, miner count,
- * share tallies) — there is no historical time-series endpoint. So the graphs
- * are driven from a client-side rolling buffer: every time the mining-status
- * query refetches (~5s) we append the latest reading. The buffer lives for the
- * session only (it resets on reload) and is labelled "live (session)" in the UI.
+ * Preferred source is the backend `GET /api/v1/pool/series` endpoint, a
+ * server-side ring sampled every 30s (survives reloads, covers up to 24h). When
+ * that ring is still empty (fresh node / just-restarted) the hook falls back to
+ * a client-side session buffer: every time the mining-status query refetches
+ * (~5s) we append the latest reading. Session accumulation is driven by
+ * subscribing to the react-query cache (an external system) — the idiomatic
+ * pattern for syncing external updates into state.
  *
- * Accumulation is driven by subscribing to the react-query cache (an external
- * system) and appending in the subscription callback — the idiomatic pattern
- * for syncing external updates into state.
- *
- * Backend follow-up: persisting these series server-side (e.g. 1-minute
- * roll-ups of pool hashrate / miner count / accept-rate) would let the charts
- * survive reloads and show longer windows than a single session.
+ * Share accept-rate has no backend series (the node exposes cumulative counters,
+ * not a rate history) so that chart is always session-derived.
  */
 
 export interface SeriesPoint {
@@ -35,22 +38,35 @@ export interface PoolSeries {
   nodeHashrate: SeriesPoint[];
   /** Connected miners across the mesh. */
   miners: SeriesPoint[];
-  /** Share accept-rate, 0–100. */
+  /** Share accept-rate, 0–100 (always session-derived). */
   acceptRate: SeriesPoint[];
-  /** Number of samples collected this session. */
+  /** Number of samples collected this session (session buffer). */
   sampleCount: number;
+  /** True when the hashrate/miner charts are backed by server-side history. */
+  serverBacked: boolean;
 }
 
 const MAX_POINTS = 240; // ~20 min at a 5s poll
+
+interface SessionSeries {
+  meshHashrate: SeriesPoint[];
+  nodeHashrate: SeriesPoint[];
+  miners: SeriesPoint[];
+  acceptRate: SeriesPoint[];
+  sampleCount: number;
+}
 
 export function usePoolSeries(): PoolSeries {
   // Keep the underlying queries active (and shared via the react-query cache)
   // so there is always fresh data to sample.
   useMiningStatus();
   usePoolStatus();
+  // Server-side history (1h window). Falls back silently to the session buffer
+  // when the endpoint is empty or unavailable on older nodes.
+  const { data: history } = usePoolSeriesHistory('1h');
 
   const queryClient = useQueryClient();
-  const [series, setSeries] = useState<PoolSeries>({
+  const [session, setSession] = useState<SessionSeries>({
     meshHashrate: [],
     nodeHashrate: [],
     miners: [],
@@ -91,7 +107,7 @@ export function usePoolSeries(): PoolSeries {
         return next.length > MAX_POINTS ? next.slice(next.length - MAX_POINTS) : next;
       };
 
-      setSeries((prev) => ({
+      setSession((prev) => ({
         meshHashrate: push(prev.meshHashrate, meshTh * 1e12),
         nodeHashrate: push(prev.nodeHashrate, nodeTh * 1e12),
         miners: push(prev.miners, miners),
@@ -106,5 +122,23 @@ export function usePoolSeries(): PoolSeries {
     return unsubscribe;
   }, [queryClient]);
 
-  return series;
+  // Merge: prefer the server ring for hashrate/miner charts once it has enough
+  // points to draw a meaningful line; otherwise use the session buffer. Chart
+  // values are H/s (TH/s * 1e12) to match the session buffer's units.
+  return useMemo<PoolSeries>(() => {
+    const samples = history?.samples ?? [];
+    const serverBacked = samples.length >= 2;
+    if (serverBacked) {
+      return {
+        meshHashrate: samples.map((s) => ({ t: s.t, v: s.mesh_hashrate_th * 1e12 })),
+        nodeHashrate: samples.map((s) => ({ t: s.t, v: s.local_hashrate_th * 1e12 })),
+        miners: samples.map((s) => ({ t: s.t, v: s.miners })),
+        // No backend accept-rate series — keep the session-derived one.
+        acceptRate: session.acceptRate,
+        sampleCount: session.sampleCount,
+        serverBacked: true,
+      };
+    }
+    return { ...session, serverBacked: false };
+  }, [history, session]);
 }

--- a/dashboard/src/lib/api/mining.ts
+++ b/dashboard/src/lib/api/mining.ts
@@ -1,9 +1,30 @@
 // Mining API endpoints
 import { fetchApi } from './client';
-import type { MiningStatus, MinersResponse, BestHashResponse } from '@/types/api';
+import type {
+  MiningStatus,
+  MinersResponse,
+  BestHashResponse,
+  PoolSeriesResponse,
+  MeshLeaderboardResponse,
+} from '@/types/api';
 
 export async function getMiningStatus(): Promise<MiningStatus> {
   return fetchApi<MiningStatus>('/api/v1/mining/status');
+}
+
+// Rolling server-side time-series of pool hashrate + connected miners.
+// `window` is '1h' or '24h'. Empty samples until the node has been up long
+// enough to accumulate history (the pool page falls back to its session buffer).
+export async function getPoolSeries(
+  window: '1h' | '24h' = '1h',
+): Promise<PoolSeriesResponse> {
+  return fetchApi<PoolSeriesResponse>(`/api/v1/pool/series?window=${window}`);
+}
+
+// Mesh-wide leaderboard: nodes ranked by hashrate across the whole mesh, plus
+// mesh-wide best-share records per window.
+export async function getPoolMeshLeaderboard(): Promise<MeshLeaderboardResponse> {
+  return fetchApi<MeshLeaderboardResponse>('/api/v1/pool/mesh-leaderboard');
 }
 
 export async function getMiners(): Promise<MinersResponse> {

--- a/dashboard/src/types/api.ts
+++ b/dashboard/src/types/api.ts
@@ -310,6 +310,58 @@ export interface MinersResponse {
   total_shares_submitted?: number;
 }
 
+// Pool time-series (GET /api/v1/pool/series) — rolling server-side history of
+// pool hashrate + connected miners, sampled every 30s (24h retention).
+export interface PoolSeriesSample {
+  /** Unix timestamp (seconds). */
+  t: number;
+  /** Mesh-wide pool hashrate (TH/s). */
+  mesh_hashrate_th: number;
+  /** This node's own realized hashrate (TH/s). */
+  local_hashrate_th: number;
+  /** Mesh-wide deduplicated connected-miner count. */
+  miners: number;
+}
+
+export interface PoolSeriesResponse {
+  window: string;
+  window_secs: number;
+  sample_interval_secs: number;
+  count: number;
+  samples: PoolSeriesSample[];
+}
+
+// Mesh-wide leaderboard (GET /api/v1/pool/mesh-leaderboard) — node-ranked
+// leaderboard + mesh-wide best-share records per window, aggregated with no new
+// gossip.
+export interface MeshLeaderboardNode {
+  node_id: string;
+  name: string;
+  hashrate_th: number;
+  miner_count: number;
+  shares: number;
+  elder: boolean;
+  healthy: boolean;
+  is_self: boolean;
+}
+
+export interface MeshLeaderboardRecord {
+  window: string;
+  share_hash: string;
+  leading_zero_bits: number;
+  leading_hex_zeros: number;
+  miner_id_redacted: string;
+  timestamp: number;
+  difficulty: number;
+}
+
+export interface MeshLeaderboardResponse {
+  nodes: MeshLeaderboardNode[];
+  node_count: number;
+  records: MeshLeaderboardRecord[];
+  limit_note: string;
+}
+
 // Best Hash types
 export interface BestHashEntry {
   hash?: string | null;


### PR DESCRIPTION
Completes three backend-centric dashboard follow-ups. Reuses existing patterns; no stubs or fabricated data. `cargo check` (`-j2`), `tsc` and `eslint` all clean; new unit tests pass.

## #219 — swarm self-node `uptime_percent`
The `/api/v1/swarm` self node omitted `uptime_percent` (frontend showed a dash) and `/api/v1/node/shares` hardcoded `99.9%` with `uptime_qualified: true`.

Both now report this node's **real trailing-7-day uptime**, read from the self-recorded uptime samples via the same `get_uptime_percent` query the qualification gatekeeper uses (GHOST-10 time-based denominator), keyed by the node's own hex id (`state.node_id`, which is where the self-uptime task records). `node/shares` now reflects the true `>=95%` gate instead of an unconditional `true`. Falls back to `null` (never a fabricated value) when no DB is attached.

- `crates/ghost-verification/src/routes.rs` — swarm self node + `api_node_shares_handler`.

## #259 — wire alert auto-fire triggers
`dispatch_event` existed but nothing fired it. Added `AlertDispatcher` (owns the self node id + a **live** view of `[alerts]` read from `full_node_config`, so operator edits apply without a restart) with debouncing so events don't spam: edge-triggered (fire once on a rising condition, re-arm on clear), rate-limited, and one-shot. All dispatch is async / off the hot paths; all six events respect their per-event enable flags.

Trigger sites (all in `bins/ghost-pool`):
- **NodeOffline** — elder-offline detection loop (edge per peer; re-arms when a peer recovers).
- **CapabilityDrift** — capability self-check, when a claimed capability's prerequisite regresses pass→fail.
- **LowDisk** — self-check data-partition free-space probe (edge).
- **RestartNeeded** — restart-signal monitor (fires before the shutdown broadcast).
- **PeerCountDrop** — WS health loop (rate-limited on a peer-count decrease).
- **BlockFound** — the `block_found` callback (async spawn; discrete event).

Tests: 5 dispatcher debounce/flag tests + a self-check trigger→dispatch wiring test.

- `crates/ghost-verification/src/alerts.rs`, `bins/ghost-pool/src/{main.rs,self_check.rs}`.

## #260 — pool time-series + mesh leaderboard
**(a) Time-series** — bounded in-memory ring (`PoolSeries` on `VerificationState`) sampled every 30s (24h retention) by a ghost-pool task from the same mesh accessors the mining-status endpoint uses, exposed via `GET /api/v1/pool/series?window=1h|24h`. The pool page charts real server-side history and keeps the client session buffer as a fallback until the ring fills.

**(b) Mesh leaderboard** — `GET /api/v1/pool/mesh-leaderboard` returns a node-ranked leaderboard (self + peers by hashrate) plus mesh-wide best-share records per window, aggregated from existing mesh data (`mesh_nodes` + `mesh_best_records`) with **no new gossip**. The pool page leaderboard is now mesh-wide; the this-node per-miner table is kept below it.

**Limit (documented in the response `limit_note`):** a true per-miner top-N across the whole mesh is not computable from a single node without new gossip — peers gossip per-node aggregates and one best-share record per window, not full per-miner tables. The public site builds that by fanning out to every node client-side.

- `crates/ghost-verification/src/{pool_series.rs,server.rs,routes.rs,lib.rs}`, `bins/ghost-pool/src/main.rs`, `dashboard/src/…` (pool page, `usePoolSeries`, mining queries/api, types).

## Build / test status
- `cargo check -p ghost-verification -p ghost-pool -j2` — clean (only pre-existing `wraith-protocol` warnings, unrelated).
- `tsc --noEmit` — clean. `eslint` on changed files — clean (repo has pre-existing baseline lint errors in `useWebSocket.ts`, untouched here).
- Tests: alerts 10 passed, pool_series 3 passed, self_check 13 passed.

No deploy, no merge.
