### PR TITLE
dashboard(geo): plot mesh nodes from mesh-nodes endpoint (fixes #268)

### DIFF
--- a/dashboard/src/app/(dashboard)/capacity/page.tsx
+++ b/dashboard/src/app/(dashboard)/capacity/page.tsx
@@ -1,18 +1,18 @@
 "use client";
 
-import { useQuery } from "@tanstack/react-query";
 import { PageHeader } from "@/components/ui/PageHeader";
 import { Card } from "@/components/ui/Card";
 import { Badge } from "@/components/ui/Badge";
 import { SkeletonCard } from "@/components/ui/Skeleton";
 import { SectionErrorBoundary } from "@/components/ui/SectionErrorBoundary";
-import { fetchApi } from "@/lib/api/client";
+import { useMeshNodes } from "@/hooks/queries";
+import type { MeshNode } from "@/lib/api/meshNodes";
 
 /**
  * Capacity & load-balancer view.
  *
  * Sourced from `/api/v1/pool/mesh-nodes` — the SAME live mesh-node list the
- * Swarm page and the deduped mesh-wide active-miner total (Watchdog's
+ * Swarm and Geo pages and the deduped mesh-wide active-miner total (Watchdog's
  * `mesh_active_miners`) are built from — so the table covers the WHOLE fleet,
  * not just the `public_mining` capacity reporters the load-balancer
  * `pool-nodes` path filtered to. Each node carries a `deduped_miner_count`
@@ -21,47 +21,6 @@ import { fetchApi } from "@/lib/api/client";
  * gossiped a capacity ceiling yet are shown with an "unknown" marker rather
  * than being dropped, keeping the visible node set == the deduped-total set.
  */
-
-interface MeshNodeCapabilities {
-  archive: boolean;
-  ghost_pay: boolean;
-  public_mining: boolean;
-  reaper: boolean;
-  elder: boolean;
-}
-
-interface MeshNode {
-  node_id: string;
-  address: string;
-  elder: boolean;
-  capabilities: MeshNodeCapabilities;
-  hashrate_th: number;
-  // Raw connection count — a load-balancer routing view that double-counts a
-  // miner failing over between nodes. Kept for reference; NOT summed.
-  miner_count: number;
-  // Deduplicated share of the mesh-wide active-miner total attributed to this
-  // node. Each unique miner is owned by exactly one node, so summing this
-  // across the list equals the deduped `mesh_active_miners` grand total the
-  // Watchdog reports.
-  deduped_miner_count: number;
-  // Hardware-derived capacity ceiling. 0 / absent = the node has not gossiped
-  // one yet (shown as "unknown", not a real ceiling).
-  max_capacity?: number;
-  healthy: boolean;
-  is_self: boolean;
-}
-
-interface MeshNodesResponse {
-  nodes: MeshNode[];
-  total: number;
-}
-
-async function fetchMeshNodes(): Promise<MeshNodesResponse> {
-  // Route through the proxy (fetchApi). `/api/v1/pool/mesh-nodes` is a public,
-  // no-auth endpoint that returns self + every connected peer, so the table
-  // reflects the whole mesh without a hard-coded node list.
-  return fetchApi<MeshNodesResponse>("/api/v1/pool/mesh-nodes");
-}
 
 // Utilisation from the DEDUPED miner count (the honest per-node figure) over
 // the node's capacity ceiling. Unknown capacity (0) yields 0% and renders "—".
@@ -120,11 +79,7 @@ function UtilisationBar({ pct, label }: { pct: number; label?: string }) {
 }
 
 export default function CapacityPage() {
-  const { data, isLoading, error } = useQuery<MeshNodesResponse>({
-    queryKey: ["mesh-nodes"],
-    queryFn: fetchMeshNodes,
-    refetchInterval: 30_000,
-  });
+  const { data, isLoading, error } = useMeshNodes();
 
   if (isLoading) {
     return (

--- a/dashboard/src/app/(dashboard)/geo/page.tsx
+++ b/dashboard/src/app/(dashboard)/geo/page.tsx
@@ -9,33 +9,24 @@ import { Card, CardHeader } from "@/components/ui/Card";
 import { StatusDot } from "@/components/ui/StatusDot";
 import { SectionErrorBoundary } from "@/components/ui/SectionErrorBoundary";
 import { WorldMap, type MapPoint } from "@/components/geo/WorldMap";
-import { usePeers, useGeoDb } from "@/hooks/queries";
-import { flagEmoji, type GeoResult } from "@/lib/geo/geoip";
-import type { PeerInfo } from "@/types/api";
+import { useMeshNodes, useGeoDb } from "@/hooks/queries";
+import { extractHost, flagEmoji, type GeoResult } from "@/lib/geo/geoip";
+import type { MeshNode } from "@/lib/api/meshNodes";
 
 const TOOLTIPS = {
-  peers: "Mesh peers this node currently knows, from the network peers endpoint.",
-  plotted: "Peers whose IP resolved to a country and are drawn on the map.",
-  countries: "Distinct countries your plotted peers resolve to.",
-  online: "Peers seen within the mesh freshness window (synced).",
+  nodes: "Mesh nodes this node knows — self plus every connected peer, from the mesh-nodes endpoint.",
+  plotted: "Nodes whose IP resolved to a country and are drawn on the map.",
+  countries: "Distinct countries your plotted nodes resolve to.",
+  online: "Nodes reporting healthy in the current mesh view.",
 };
 
 interface Row {
   key: string;
-  peer: PeerInfo;
+  node: MeshNode;
   host: string;
   online: boolean;
   isSelf: boolean;
   geo: GeoResult;
-}
-
-function hostOf(address: string | undefined): string {
-  if (!address) return "";
-  const trimmed = address.trim();
-  const bracket = trimmed.match(/^\[([^\]]+)\](?::\d+)?$/);
-  if (bracket) return bracket[1];
-  if ((trimmed.match(/:/g) || []).length === 1) return trimmed.split(":")[0];
-  return trimmed;
 }
 
 function toPoint(r: Row): MapPoint | null {
@@ -46,7 +37,7 @@ function toPoint(r: Row): MapPoint | null {
     lon: r.geo.lon,
     code: r.geo.code ?? "",
     name: r.geo.name ?? "",
-    label: `${r.host || "peer"} — ${r.geo.name ?? "peer"}`,
+    label: `${r.host || "node"} — ${r.geo.name ?? "node"}`,
     online: r.online,
     isSelf: r.isSelf,
     num: r.geo.num,
@@ -54,28 +45,28 @@ function toPoint(r: Row): MapPoint | null {
 }
 
 export default function GeoPage() {
-  const { data: peersData, isLoading: peersLoading } = usePeers();
+  const { data: meshData, isLoading: nodesLoading } = useMeshNodes();
   const { data: geoDb, isLoading: geoLoading, isError: geoError } = useGeoDb();
   const [hoveredId, setHoveredId] = useState<string | null>(null);
 
   const rows: Row[] = useMemo(() => {
-    const peers = peersData?.peers ?? [];
-    return peers.map((peer, i): Row => {
-      const key = peer.node_id || peer.address || `peer-${i}`;
-      const host = hostOf(peer.address);
+    const nodes = meshData?.nodes ?? [];
+    return nodes.map((node, i): Row => {
+      const key = node.node_id || node.address || `node-${i}`;
+      const host = extractHost(node.address);
       const geo: GeoResult = geoDb
-        ? geoDb.resolve(peer.address)
+        ? geoDb.resolve(node.address)
         : { kind: "unknown", label: geoLoading ? "Resolving…" : "Unresolved", plottable: false };
       return {
         key,
-        peer,
+        node,
         host,
-        online: Boolean(peer.synced),
-        isSelf: Boolean(peer.is_self),
+        online: Boolean(node.healthy),
+        isSelf: Boolean(node.is_self),
         geo,
       };
     });
-  }, [peersData, geoDb, geoLoading]);
+  }, [meshData, geoDb, geoLoading]);
 
   const points = useMemo(
     () => rows.map(toPoint).filter((p): p is MapPoint => p !== null),
@@ -102,22 +93,22 @@ export default function GeoPage() {
       .sort((a, b) => b.count - a.count);
   }, [rows]);
 
-  const loading = peersLoading || geoLoading;
+  const loading = nodesLoading || geoLoading;
 
   return (
     <div className="space-y-6">
       <PageHeader
         eyebrow="geo"
-        title="Peer map."
-        subtitle="Geographic spread of the mesh peers this node knows, resolved offline from peer IP addresses to country level."
+        title="Node map."
+        subtitle="Geographic spread of the mesh nodes this node knows, resolved offline from node IP addresses to country level."
       />
 
       {/* Stats */}
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-        <StatCard label="Peers" value={rows.length} tooltip={TOOLTIPS.peers} loading={peersLoading} />
+        <StatCard label="Nodes" value={rows.length} tooltip={TOOLTIPS.nodes} loading={nodesLoading} />
         <StatCard label="Plotted" value={points.length} tooltip={TOOLTIPS.plotted} loading={loading} />
         <StatCard label="Countries" value={countryCount} tooltip={TOOLTIPS.countries} loading={loading} />
-        <StatCard label="Online" value={`${onlineCount} / ${rows.length}`} tooltip={TOOLTIPS.online} loading={peersLoading} />
+        <StatCard label="Online" value={`${onlineCount} / ${rows.length}`} tooltip={TOOLTIPS.online} loading={nodesLoading} />
       </div>
 
       {/* Region chips */}
@@ -155,15 +146,15 @@ export default function GeoPage() {
         <Info size={16} strokeWidth={1.75} style={{ color: "var(--accent)", flexShrink: 0, marginTop: "1px" }} />
         <p style={{ color: "var(--dim)", fontSize: "13px", lineHeight: 1.5 }}>
           Locations are <strong style={{ color: "var(--fg)" }}>country-level</strong>, resolved entirely
-          offline. The dashboard&apos;s CSP forbids external map tiles and geolocation lookups, so each peer IP
+          offline. The dashboard&apos;s CSP forbids external map tiles and geolocation lookups, so each node IP
           is matched against a small bundled IP&#8209;to&#8209;country table (DB&#8209;IP Lite, CC&#8209;BY 4.0)
           and drawn at that country&apos;s centroid on a bundled Natural&nbsp;Earth vector map. Private,
-          loopback, carrier&#8209;NAT and reserved addresses are listed but not plotted. Per&#8209;peer ASN and
-          direction would need those fields added to the peers endpoint.
+          loopback, carrier&#8209;NAT and reserved addresses are listed but not plotted. This node is drawn in
+          the accent colour; peers are green when healthy and red when stale.
           {geoError && (
             <>
               {" "}
-              <strong style={{ color: "var(--red)" }}>The GeoIP dataset failed to load</strong>, so peers are
+              <strong style={{ color: "var(--red)" }}>The GeoIP dataset failed to load</strong>, so nodes are
               listed without country placement.
             </>
           )}
@@ -171,15 +162,15 @@ export default function GeoPage() {
       </div>
 
       {/* Map */}
-      <SectionErrorBoundary section="Peer Map">
+      <SectionErrorBoundary section="Node Map">
         <Card>
-          <CardHeader title="World map" subtitle={`${points.length} of ${rows.length} peers plotted`} />
+          <CardHeader title="World map" subtitle={`${points.length} of ${rows.length} nodes plotted`} />
           <WorldMap points={points} self={self} hoveredId={hoveredId} onHover={setHoveredId} />
           {/* Legend */}
           <div className="flex flex-wrap items-center gap-x-5 gap-y-2 mt-4" style={{ fontSize: "12px", color: "var(--dim)" }}>
             <span className="inline-flex items-center gap-2">
               <span style={{ width: 8, height: 8, borderRadius: "50%", background: "var(--green)", display: "inline-block" }} />
-              Online peer
+              Online node
             </span>
             <span className="inline-flex items-center gap-2">
               <span style={{ width: 8, height: 8, borderRadius: "50%", background: "var(--red)", display: "inline-block" }} />
@@ -193,13 +184,13 @@ export default function GeoPage() {
         </Card>
       </SectionErrorBoundary>
 
-      {/* Peer list */}
-      <SectionErrorBoundary section="Peer List">
+      {/* Node list */}
+      <SectionErrorBoundary section="Node List">
         <Card>
-          <CardHeader title="Peers" subtitle={`${rows.length} known`} />
+          <CardHeader title="Nodes" subtitle={`${rows.length} known`} />
           {rows.length === 0 ? (
             <p style={{ color: "var(--dim)", fontSize: "14px", padding: "8px 0" }}>
-              {peersLoading ? "Loading peers…" : "No peers connected. Your node will discover peers automatically."}
+              {nodesLoading ? "Loading nodes…" : "No mesh nodes connected. Your node will discover peers automatically."}
             </p>
           ) : (
             <div style={{ overflowX: "auto" }}>
@@ -208,7 +199,7 @@ export default function GeoPage() {
                   <tr style={{ textAlign: "left", color: "var(--dim)" }}>
                     <th style={{ padding: "8px 10px", fontWeight: 500 }}>Address</th>
                     <th style={{ padding: "8px 10px", fontWeight: 500 }}>Country</th>
-                    <th style={{ padding: "8px 10px", fontWeight: 500 }}>Latency</th>
+                    <th style={{ padding: "8px 10px", fontWeight: 500 }}>Role</th>
                     <th style={{ padding: "8px 10px", fontWeight: 500 }}>Status</th>
                   </tr>
                 </thead>
@@ -216,7 +207,6 @@ export default function GeoPage() {
                   {rows.map((r) => {
                     const active = hoveredId === r.key;
                     const flag = r.geo.code ? flagEmoji(r.geo.code) : "";
-                    const latency = r.peer.latency_ms;
                     return (
                       <tr
                         key={r.key}
@@ -243,8 +233,12 @@ export default function GeoPage() {
                             <span style={{ marginLeft: 8, color: "var(--fainter)", fontSize: "11px" }}>not plotted</span>
                           )}
                         </td>
-                        <td style={{ padding: "8px 10px", color: "var(--dim)", fontVariantNumeric: "tabular-nums" }}>
-                          {latency != null ? `${Math.round(latency)} ms` : "—"}
+                        <td style={{ padding: "8px 10px", color: "var(--dim)" }}>
+                          {r.node.elder ? (
+                            <span style={{ color: "var(--accent)" }}>Elder</span>
+                          ) : (
+                            "Node"
+                          )}
                         </td>
                         <td style={{ padding: "8px 10px" }}>
                           <StatusDot

--- a/dashboard/src/hooks/queries/useMeshQueries.ts
+++ b/dashboard/src/hooks/queries/useMeshQueries.ts
@@ -1,9 +1,11 @@
 import { useQuery } from '@tanstack/react-query';
 import { getMeshStatus, type MeshResponse } from '@/lib/api/mesh';
+import { fetchMeshNodes, type MeshNodesResponse } from '@/lib/api/meshNodes';
 
 export const meshKeys = {
   all: ['mesh'] as const,
   status: () => [...meshKeys.all, 'status'] as const,
+  nodes: () => [...meshKeys.all, 'nodes'] as const,
 };
 
 export function useMeshStatus() {
@@ -12,5 +14,19 @@ export function useMeshStatus() {
     queryFn: getMeshStatus,
     refetchInterval: 30000, // Refresh every 30 seconds
     staleTime: 10000,
+  });
+}
+
+/**
+ * Live mesh-node list from `/api/v1/pool/mesh-nodes` (self + every connected
+ * peer, each with its REAL public `address`). This is the source the Capacity
+ * and Geo pages share — unlike `/api/v1/network/peers`, whose `address` is
+ * empty.
+ */
+export function useMeshNodes(options?: { refetchInterval?: number }) {
+  return useQuery<MeshNodesResponse>({
+    queryKey: meshKeys.nodes(),
+    queryFn: fetchMeshNodes,
+    refetchInterval: options?.refetchInterval ?? 30_000,
   });
 }

--- a/dashboard/src/lib/api/meshNodes.ts
+++ b/dashboard/src/lib/api/meshNodes.ts
@@ -1,0 +1,48 @@
+// Mesh-nodes API client.
+//
+// `/api/v1/pool/mesh-nodes` is a public, no-auth endpoint that returns self +
+// every connected peer with its REAL public `address` ("ip:port"), unlike
+// `/api/v1/network/peers` whose `address` field is empty. This is the live
+// mesh-node list the Capacity and Geo pages are built from.
+
+import { fetchApi } from "./client";
+
+export interface MeshNodeCapabilities {
+  archive: boolean;
+  ghost_pay: boolean;
+  public_mining: boolean;
+  reaper: boolean;
+  elder: boolean;
+}
+
+export interface MeshNode {
+  node_id: string;
+  address: string;
+  elder: boolean;
+  capabilities: MeshNodeCapabilities;
+  hashrate_th: number;
+  // Raw connection count — a load-balancer routing view that double-counts a
+  // miner failing over between nodes. Kept for reference; NOT summed.
+  miner_count: number;
+  // Deduplicated share of the mesh-wide active-miner total attributed to this
+  // node. Each unique miner is owned by exactly one node, so summing this
+  // across the list equals the deduped `mesh_active_miners` grand total the
+  // Watchdog reports.
+  deduped_miner_count: number;
+  // Hardware-derived capacity ceiling. 0 / absent = the node has not gossiped
+  // one yet (shown as "unknown", not a real ceiling).
+  max_capacity?: number;
+  healthy: boolean;
+  is_self: boolean;
+}
+
+export interface MeshNodesResponse {
+  nodes: MeshNode[];
+  total: number;
+}
+
+export async function fetchMeshNodes(): Promise<MeshNodesResponse> {
+  // Route through the proxy (fetchApi). Returns self + every connected peer, so
+  // callers reflect the whole mesh without a hard-coded node list.
+  return fetchApi<MeshNodesResponse>("/api/v1/pool/mesh-nodes");
+}


### PR DESCRIPTION
## Problem

The dashboard Geo page plotted **0 peers**. It sourced nodes from `GET /api/v1/network/peers`, whose `address` field comes back empty (`{"address":"", "node_id":..., "port":8555}`). With no IP, the offline geoip resolver had nothing to look up, so nothing was ever placed on the map. Fixes #268.

## Fix (frontend-only, no new endpoint)

Repoint the Geo page to `GET /api/v1/pool/mesh-nodes` — the **same** live mesh-node list the Capacity (#258) and Swarm pages already use — which carries the real public `address` (`"212.147.227.108:8559"`).

- Extracted the mesh-nodes client + types (previously inline on the Capacity page) into `lib/api/meshNodes.ts` and a shared `useMeshNodes` hook in `useMeshQueries.ts`. The Capacity page now reuses them (no behaviour change there).
- Geo page now maps each node: `address` is host-extracted (reusing `extractHost` from `lib/geo/geoip.ts`, handling IPv6 bracket form), resolved offline to a country centroid, and plotted. `healthy` -> online status, `is_self` -> "this node" (accent-styled), `node_id` -> label, `elder` -> a Role column.
- Private / loopback / CGNAT / reserved addresses stay **listed but not plotted** (unchanged detection).
- Summary tiles and copy relabelled to the mesh-node set (self is included in the map and the counts, so the tile reads "Nodes"/"Online n / total" honestly). The explanatory note no longer references the peers endpoint.
- Fully offline / CSP-safe — no new external calls.

## Verification

`tsc --noEmit` clean, `eslint` clean on all changed files, `npm run build` succeeds (`/geo` + `/capacity` compile). (Three pre-existing lint errors remain in untouched files: `useWebSocket.ts`, `useOnboarding.ts`, `ThemeToggle.tsx`.)

A throwaway Node script ran the **same** parse + lookup logic as `lib/geo/geoip.ts` against `public/geo/geoip.bin` for the real production node IPs:

| IP | Resolved |
|----|----------|
| 83.136.251.162 | GB United Kingdom - plottable |
| 85.9.198.212 | US United States - plottable |
| 213.163.207.46 | SG Singapore - plottable |
| 95.111.221.169 | AU Australia - plottable |
| 212.147.227.108 | SE Sweden - plottable |
| 94.237.102.192 | DE Germany - plottable |

All six resolve to a real country and are plottable — the map will draw nodes, not just compile.