### PR TITLE
swarm: populate mesh-peer uptime/peers/L1/L2 telemetry + self L2 height (fixes #269)

### DIFF
--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -253,6 +253,54 @@ async fn notify_ghost_pay_finalize(
     Err(last_err)
 }
 
+/// Local ghost-pay L2 status endpoint (unsigned, loopback IPC). Same service as
+/// [`GHOST_PAY_FINALIZE_URL`]; returns this node's L2 virtual-block height.
+const GHOST_PAY_STATUS_URL: &str = "https://127.0.0.1:8800/verify/ghostpay?unsigned=true";
+
+/// Lightweight cache of the local ghost-pay L2 virtual-block height, refreshed
+/// by a background poller and read (a cheap atomic load) on the health-ping hot
+/// path so gossiping this node's L2 tip never blocks on a cross-process call.
+/// `known` stays false until the first successful poll; once set it retains the
+/// last good value across a failed poll, so peers see "—" only while we
+/// genuinely have no L2 height to report.
+#[derive(Default)]
+struct L2HeightCache {
+    height: std::sync::atomic::AtomicU64,
+    known: std::sync::atomic::AtomicBool,
+}
+
+impl L2HeightCache {
+    fn set(&self, height: u64) {
+        self.height
+            .store(height, std::sync::atomic::Ordering::Relaxed);
+        self.known.store(true, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    fn get(&self) -> Option<u64> {
+        self.known
+            .load(std::sync::atomic::Ordering::Relaxed)
+            .then(|| self.height.load(std::sync::atomic::Ordering::Relaxed))
+    }
+}
+
+/// Query the local ghost-pay service for its current L2 virtual-block height.
+/// ghost-pay serves identity-derived TLS on :8800, so this loopback IPC skips
+/// cert-chain validation (same rationale as [`notify_ghost_pay_finalize`]).
+/// Returns `None` when ghost-pay is unreachable or reports failure.
+async fn fetch_ghostpay_virtual_block(client: &reqwest::Client) -> Option<u64> {
+    let resp = client.get(GHOST_PAY_STATUS_URL).send().await.ok()?;
+    let json: serde_json::Value = resp.json().await.ok()?;
+    let inner = json.get("response")?;
+    if !inner
+        .get("success")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+    {
+        return None;
+    }
+    inner.get("virtual_block").and_then(|v| v.as_u64())
+}
+
 /// The ceremony position this node should target next, accounting for a node
 /// whose adopted head lags the recorded chain tip.
 ///
@@ -2678,6 +2726,61 @@ async fn main() -> Result<()> {
     mesh_inner.set_best_records_provider(Arc::new(move || {
         build_local_best_records(&db_for_best_records)
     }));
+
+    // Swarm-page telemetry gossiped so peers render each node's real state
+    // instead of a dash. These mirror exactly what the swarm SELF row reports.
+
+    // L1 (Bitcoin) block height — the same value the /health block_height uses.
+    let rm_for_l1_height = Arc::clone(&round_manager);
+    mesh_inner.set_l1_height_provider(Arc::new(move || rm_for_l1_height.current_height()));
+
+    // This node's own trailing-7-day uptime %, the qualification gatekeeper
+    // metric — the exact figure `get_uptime_percent` returns (GHOST-10
+    // time-based denominator), keyed by our own hex node id and converted to a
+    // percentage. `None` (→ "—") when there are no samples yet, never fabricated.
+    let db_for_uptime = Arc::clone(&db);
+    let uptime_node_id_hex = identity.node_id_hex();
+    mesh_inner.set_uptime_percent_provider(Arc::new(move || {
+        let since = chrono::Utc::now().timestamp()
+            - (ghost_common::constants::UPTIME_WINDOW_DAYS as i64 * 86_400);
+        db_for_uptime
+            .get_uptime_percent(&uptime_node_id_hex, since)
+            .ok()
+            .map(|ratio| ratio * 100.0)
+    }));
+
+    // Ghost Pay L2 virtual-block height, read from a lightweight cache refreshed
+    // by a background poller (below). Reading a cached atomic keeps the health-
+    // ping hot path free of the cross-process ghost-pay call.
+    let l2_height_cache = Arc::new(L2HeightCache::default());
+    let l2_cache_for_ping = Arc::clone(&l2_height_cache);
+    mesh_inner.set_l2_height_provider(Arc::new(move || l2_cache_for_ping.get()));
+
+    // Poll the local ghost-pay service (:8800) for the L2 tip and cache it, so
+    // both this node's gossiped L2 height and the cache stay warm. Only runs
+    // when ghost-pay is enabled; on failure the last good value is retained.
+    if config.ghost_pay_enabled() {
+        let l2_cache_for_poll = Arc::clone(&l2_height_cache);
+        tokio::spawn(async move {
+            let client = match reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(5))
+                .danger_accept_invalid_certs(true)
+                .build()
+            {
+                Ok(c) => c,
+                Err(e) => {
+                    tracing::warn!(error = %e, "L2 height poller: failed to build client");
+                    return;
+                }
+            };
+            loop {
+                if let Some(height) = fetch_ghostpay_virtual_block(&client).await {
+                    l2_cache_for_poll.set(height);
+                }
+                tokio::time::sleep(std::time::Duration::from_secs(15)).await;
+            }
+        });
+    }
 
     let mesh = Arc::new(mesh_inner);
 
@@ -5866,6 +5969,14 @@ async fn main() -> Result<()> {
                 max_capacity: p.max_capacity,
                 // get_connected_peers already filtered to Connected + fresh.
                 healthy: true,
+                // Swarm-page telemetry gossiped by each peer. L1 height 0 means
+                // "not reported" (older build) → None so the page shows "—"
+                // rather than a misleading 0; uptime/peer_count/L2 are already
+                // Option (None = not reported / not applicable).
+                l1_height: (p.block_height != 0).then_some(p.block_height),
+                uptime_percent: p.uptime_percent,
+                peer_count: p.peer_count,
+                l2_height: p.l2_height,
             })
             .collect()
     });

--- a/crates/ghost-common/src/types.rs
+++ b/crates/ghost-common/src/types.rs
@@ -475,6 +475,28 @@ pub struct HealthPing {
     /// `#[serde(default)]` for backward compatibility.
     #[serde(default)]
     pub coordinator_sessions: u32,
+    /// This node's own trailing-7-day uptime, as a PERCENTAGE (0-100) — the
+    /// qualification gatekeeper metric (>=95% before capabilities count).
+    /// Gossiped so the dashboard Swarm page can render each mesh peer's uptime
+    /// instead of a dash. `Option` (not a plain `f64` defaulting to 0.0) so an
+    /// older peer that omits it — or one with no uptime samples yet — is shown
+    /// as "—" rather than a misleading 0.0%. `#[serde(default)]` → `None` when
+    /// absent, keeping the wire change additive for a mixed-version fleet.
+    #[serde(default)]
+    pub uptime_percent: Option<f64>,
+    /// The number of mesh peers THIS node currently sees (its own deduplicated
+    /// peer count). Gossiped so the Swarm page can show each peer's connectivity.
+    /// `Option` so absence (older peer) renders as "—", never a misleading 0.
+    /// `#[serde(default)]` for backward compatibility.
+    #[serde(default)]
+    pub peer_count: Option<u32>,
+    /// This node's Ghost Pay L2 virtual-block height, when it runs ghost-pay.
+    /// Gossiped so the Swarm page can show each mesh peer's L2 tip. `None` for
+    /// nodes that don't run ghost-pay (or older peers that predate this field),
+    /// so the frontend renders "—" instead of a fabricated 0. `#[serde(default)]`
+    /// for backward compatibility.
+    #[serde(default)]
+    pub l2_height: Option<u64>,
 }
 
 /// One node's best (rarest) valid share in a public records window.
@@ -1078,7 +1100,42 @@ mod tests {
             }],
             coordinator_endpoint: None,
             coordinator_sessions: 0,
+            uptime_percent: Some(99.5),
+            peer_count: Some(3),
+            l2_height: Some(12_345),
         }
+    }
+
+    #[test]
+    fn health_ping_telemetry_roundtrip() {
+        // The new Swarm telemetry fields survive a round-trip.
+        let ping = sample_health_ping();
+        let back: HealthPing =
+            serde_json::from_str(&serde_json::to_string(&ping).unwrap()).unwrap();
+        assert_eq!(back.uptime_percent, Some(99.5));
+        assert_eq!(back.peer_count, Some(3));
+        assert_eq!(back.l2_height, Some(12_345));
+    }
+
+    #[test]
+    fn health_ping_deserializes_without_telemetry_fields() {
+        // Emulate an OLDER node's ping that predates the Swarm telemetry fields:
+        // serialize, strip each new field, and confirm every one defaults to
+        // `None` (rendered as "—", never a fabricated 0). Proves the wire change
+        // is additive so a mixed-version rolling deploy stays compatible.
+        let ping = sample_health_ping();
+        let mut v = serde_json::to_value(&ping).unwrap();
+        let obj = v.as_object_mut().unwrap();
+        assert!(obj.remove("uptime_percent").is_some());
+        assert!(obj.remove("peer_count").is_some());
+        assert!(obj.remove("l2_height").is_some());
+        let back: HealthPing = serde_json::from_value(v).unwrap();
+        assert_eq!(back.uptime_percent, None);
+        assert_eq!(back.peer_count, None);
+        assert_eq!(back.l2_height, None);
+        // Unrelated fields are unaffected.
+        assert_eq!(back.miner_count, 2);
+        assert_eq!(back.active_miner_id_hashes.len(), 2);
     }
 
     #[test]

--- a/crates/ghost-consensus/src/health_handler.rs
+++ b/crates/ghost-consensus/src/health_handler.rs
@@ -872,6 +872,17 @@ impl HealthPingHandler {
         // Hardware-derived capacity used by the LB for utilisation routing.
         self.peers
             .update_max_capacity(&envelope.sender, ping.max_capacity);
+        // Swarm-page telemetry: L1 height, trailing-7-day uptime %, this peer's
+        // own peer count, and Ghost Pay L2 height. Older peers omit the Option
+        // fields (→ None) and report block_height 0, all handled inside the
+        // updater so the mesh stays backward-compatible.
+        self.peers.update_node_telemetry(
+            &envelope.sender,
+            ping.block_height,
+            ping.uptime_percent,
+            ping.peer_count,
+            ping.l2_height,
+        );
         // Best (rarest) share per records window — merged with the local DB
         // best so `/api/v1/pool/records` returns the mesh-wide rarest record.
         self.peers

--- a/crates/ghost-consensus/src/mesh.rs
+++ b/crates/ghost-consensus/src/mesh.rs
@@ -249,6 +249,18 @@ pub struct MeshNetwork {
     /// converge on the mesh-wide rarest record per window.
     best_records_fn:
         Option<Arc<dyn Fn() -> Vec<ghost_common::types::WindowBestRecord> + Send + Sync>>,
+    /// Application-provided callback returning this node's current L1 (Bitcoin)
+    /// block height, gossiped in health pings so peers can show it on the Swarm
+    /// page. `None` → the ping reports height 0 (rendered "—" upstream).
+    l1_height_fn: Option<Arc<dyn Fn() -> u64 + Send + Sync>>,
+    /// Application-provided callback returning this node's own trailing-7-day
+    /// uptime as a percentage (0-100), gossiped in health pings. Returns `None`
+    /// when there are no samples yet; absent provider → `None` in the ping.
+    uptime_percent_fn: Option<Arc<dyn Fn() -> Option<f64> + Send + Sync>>,
+    /// Application-provided callback returning this node's Ghost Pay L2
+    /// virtual-block height, gossiped in health pings. `None` when ghost-pay
+    /// isn't running / the tip is unknown; absent provider → `None` in the ping.
+    l2_height_fn: Option<Arc<dyn Fn() -> Option<u64> + Send + Sync>>,
     /// Hardware-derived effective capacity advertised in health pings.
     /// `0` means we haven't computed it yet (mesh started before capacity
     /// init); peers treat it as unknown and skip utilisation routing for us.
@@ -1067,6 +1079,9 @@ impl MeshNetwork {
             active_miner_hashes_fn: None,
             local_hashrate_fn: None,
             best_records_fn: None,
+            l1_height_fn: None,
+            uptime_percent_fn: None,
+            l2_height_fn: None,
             max_capacity: AtomicU32::new(0),
             coordinator_sessions: AtomicU32::new(0),
         })
@@ -1171,6 +1186,29 @@ impl MeshNetwork {
         f: Arc<dyn Fn() -> Vec<ghost_common::types::WindowBestRecord> + Send + Sync>,
     ) {
         self.best_records_fn = Some(f);
+    }
+
+    /// Set a callback providing this node's current L1 (Bitcoin) block height,
+    /// gossiped in health pings for the Swarm page. Without this, pings report 0.
+    pub fn set_l1_height_provider(&mut self, f: Arc<dyn Fn() -> u64 + Send + Sync>) {
+        self.l1_height_fn = Some(f);
+    }
+
+    /// Set a callback providing this node's own trailing-7-day uptime percentage
+    /// (0-100), gossiped in health pings so peers render it on the Swarm page.
+    /// Returns `None` when there are no samples yet.
+    pub fn set_uptime_percent_provider(
+        &mut self,
+        f: Arc<dyn Fn() -> Option<f64> + Send + Sync>,
+    ) {
+        self.uptime_percent_fn = Some(f);
+    }
+
+    /// Set a callback providing this node's Ghost Pay L2 virtual-block height,
+    /// gossiped in health pings. Returns `None` when ghost-pay isn't running or
+    /// the L2 tip isn't known yet.
+    pub fn set_l2_height_provider(&mut self, f: Arc<dyn Fn() -> Option<u64> + Send + Sync>) {
+        self.l2_height_fn = Some(f);
     }
 
     /// Collect the best (rarest) record per window across the mesh: every
@@ -2924,11 +2962,19 @@ impl MeshNetwork {
                 .as_ref()
                 .map(|f| f())
                 .unwrap_or_default();
+            // Swarm-page telemetry gossiped for peers to render. L1 height comes
+            // from a provider (fallback 0 = "unknown"); uptime % and L2 height
+            // are Option (None when unavailable); peer_count is this node's own
+            // deduplicated view, matching the self figure the swarm endpoint uses.
+            let block_height = self.l1_height_fn.as_ref().map(|f| f()).unwrap_or(0);
+            let uptime_percent = self.uptime_percent_fn.as_ref().and_then(|f| f());
+            let l2_height = self.l2_height_fn.as_ref().and_then(|f| f());
+            let peer_count = Some(self.peers.unique_peer_count() as u32);
             let ping = ghost_common::types::HealthPing {
                 node_id: self.identity.node_id(),
                 public_address: String::new(), // S-7: Don't broadcast IP in cleartext ZMQ
-                block_height: 0,               // Would track actual height
-                round_id: 0,                   // Would track current round
+                block_height,
+                round_id: 0, // Would track current round
                 capabilities: *self.capabilities.read(),
                 miner_count: self
                     .miner_count_fn
@@ -2945,6 +2991,9 @@ impl MeshNetwork {
                 // mutated at runtime), so reading from self.config is fine.
                 coordinator_endpoint: self.config.advertised_coordinator_endpoint.clone(),
                 coordinator_sessions: self.coordinator_sessions.load(Ordering::Relaxed),
+                uptime_percent,
+                peer_count,
+                l2_height,
             };
 
             match self.create_envelope(

--- a/crates/ghost-consensus/src/peer.rs
+++ b/crates/ghost-consensus/src/peer.rs
@@ -204,6 +204,20 @@ impl PeerManager {
             if merged.coordinator_sessions == 0 {
                 merged.coordinator_sessions = existing.coordinator_sessions;
             }
+            // Preserve the health-ping telemetry a re-announce (Peer::new) carries
+            // at its defaults, so the Swarm figures don't blank out between pings.
+            if merged.block_height == 0 {
+                merged.block_height = existing.block_height;
+            }
+            if merged.uptime_percent.is_none() {
+                merged.uptime_percent = existing.uptime_percent;
+            }
+            if merged.peer_count.is_none() {
+                merged.peer_count = existing.peer_count;
+            }
+            if merged.l2_height.is_none() {
+                merged.l2_height = existing.l2_height;
+            }
             merged.first_seen = merged.first_seen.min(existing.first_seen);
             peers.insert(merged.node_id, merged);
             return;
@@ -347,6 +361,41 @@ impl PeerManager {
             // upsert/re-announce path preserves it instead, so a bare re-announce
             // can't reset it to 0 between pings.
             peer.coordinator_sessions = coordinator_sessions;
+        }
+    }
+
+    /// Update a peer's Swarm-page telemetry (L1 height, trailing-7-day uptime %,
+    /// its own peer count, and Ghost Pay L2 height) from its most recent health
+    /// ping. Each field is only overwritten when the ping carries a real value,
+    /// so a peer momentarily omitting one (older build / no L2) never blanks out
+    /// a figure the Swarm view already knows.
+    pub fn update_node_telemetry(
+        &self,
+        node_id: &NodeId,
+        block_height: u64,
+        uptime_percent: Option<f64>,
+        peer_count: Option<u32>,
+        l2_height: Option<u64>,
+    ) {
+        if let Some(peer) = self.peers.write().get_mut(node_id) {
+            // L1 height is a live gauge — take the latest reported value. `0`
+            // means the peer didn't report (older build), so don't clobber a
+            // known height with it.
+            if block_height != 0 {
+                peer.block_height = block_height;
+            }
+            // Uptime / peer-count / L2 are Option: only overwrite with a real
+            // value, never blank out a known figure with a peer's momentary
+            // omission (keeps the Swarm display stable between pings).
+            if uptime_percent.is_some() {
+                peer.uptime_percent = uptime_percent;
+            }
+            if peer_count.is_some() {
+                peer.peer_count = peer_count;
+            }
+            if l2_height.is_some() {
+                peer.l2_height = l2_height;
+            }
         }
     }
 
@@ -504,6 +553,20 @@ pub struct Peer {
     /// eligible set at the epoch boundary to size the seat count. 0 when idle or
     /// not a coordinator.
     pub coordinator_sessions: u32,
+    /// This peer's L1 (Bitcoin) block height, from its most recent health ping.
+    /// Surfaced on the Swarm page. `0` for older peers that hardcoded it (or
+    /// haven't reported yet) — treated as "unknown" and rendered "—" upstream.
+    pub block_height: u64,
+    /// This peer's own trailing-7-day uptime percentage (0-100), from its most
+    /// recent health ping. `None` for older peers that don't report it (or peers
+    /// with no samples yet) — rendered "—" on the Swarm page, never a fake 0.
+    pub uptime_percent: Option<f64>,
+    /// The number of mesh peers this peer itself reported seeing, from its most
+    /// recent health ping. `None` for older peers that don't report it.
+    pub peer_count: Option<u32>,
+    /// This peer's Ghost Pay L2 virtual-block height, from its most recent health
+    /// ping. `None` for peers that don't run ghost-pay (or older peers).
+    pub l2_height: Option<u64>,
 }
 
 impl Peer {
@@ -530,6 +593,10 @@ impl Peer {
             best_records: Vec::new(),
             coordinator_endpoint: None,
             coordinator_sessions: 0,
+            block_height: 0,
+            uptime_percent: None,
+            peer_count: None,
+            l2_height: None,
         }
     }
 

--- a/crates/ghost-verification/src/routes.rs
+++ b/crates/ghost-verification/src/routes.rs
@@ -2548,6 +2548,12 @@ fn mesh_node_to_json(node: &MeshNodeInfo) -> serde_json::Value {
         // Peer's hardware-derived capacity ceiling (0 = not yet gossiped →
         // the Capacity page renders it as "unknown", not a real ceiling).
         "max_capacity": node.max_capacity,
+        // Swarm-page telemetry gossiped per peer. `None` serialises to JSON null,
+        // which the frontend renders as "—" (never a misleading 0).
+        "l1_height": node.l1_height,
+        "uptime_percent": node.uptime_percent,
+        "peer_count": node.peer_count,
+        "l2_height": node.l2_height,
         "healthy": node.healthy,
         "is_self": false,
     })
@@ -3645,11 +3651,25 @@ async fn api_swarm_handler(State(state): State<Arc<VerificationState>>) -> impl 
         self_caps.elder_status,
     );
 
-    // The per-peer uptime %, peer count and L1/L2 heights are not gossiped, so
-    // they render as "—" for mesh peers — but THIS node knows its own locally,
-    // so populate them here.
-    let self_l2_height =
-        check_ghostpay_local(&state).and_then(|gp| (gp.sync_state != "disabled").then_some(gp.virtual_block));
+    // THIS node's own L2 (Ghost Pay) virtual-block height. `check_ghostpay_local`
+    // reads the in-process handler, which production ghost-pool does NOT wire —
+    // ghost-pay runs as a separate service on :8800 — so it returns `None` and
+    // the self row's L2 showed "—". Mirror the ghostpay status endpoint: on that
+    // `None`, fall back to querying the local :8800 service. `Some(disabled)`
+    // (ghost-pay off) still resolves to `None` → "—", never a fabricated value.
+    let self_l2_height = match check_ghostpay_local(&state) {
+        Some(gp) if gp.sync_state == "disabled" => None,
+        Some(gp) => Some(gp.virtual_block),
+        None => match tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            tokio::spawn(fetch_ghostpay_from_service()),
+        )
+        .await
+        {
+            Ok(Ok(Some(status))) => Some(status.virtual_block),
+            _ => None,
+        },
+    };
 
     // This node's own trailing-7-day uptime %, the qualification gatekeeper
     // metric (>=95% before capabilities count). It's the exact figure the
@@ -3734,6 +3754,13 @@ async fn api_swarm_handler(State(state): State<Arc<VerificationState>>) -> impl 
             "public_mining": peer.cap_public_mining,
             "reaper": peer.cap_reaper,
             "elder": peer.cap_elder,
+            // Gossiped Swarm telemetry — `None` → JSON null → "—" on the page,
+            // so a peer running an older build (that doesn't gossip these) shows
+            // a dash rather than a fabricated 0 until the fleet is updated.
+            "uptime_percent": peer.uptime_percent,
+            "peer_count": peer.peer_count,
+            "l1_height": peer.l1_height,
+            "l2_height": peer.l2_height,
         }));
     }
 
@@ -9665,6 +9692,10 @@ mod tests {
             deduped_miner_count: 2,
             max_capacity: 500,
             healthy: true,
+            l1_height: Some(912_345),
+            uptime_percent: Some(99.7),
+            peer_count: Some(3),
+            l2_height: Some(4_567),
         };
 
         let v = mesh_node_to_json(&node);
@@ -9676,6 +9707,11 @@ mod tests {
         assert_eq!(v["deduped_miner_count"], 2);
         assert_eq!(v["max_capacity"], 500);
         assert_eq!(v["healthy"], true);
+        // Gossiped Swarm telemetry surfaces on the peer JSON.
+        assert_eq!(v["l1_height"], 912_345);
+        assert_eq!(v["uptime_percent"], 99.7);
+        assert_eq!(v["peer_count"], 3);
+        assert_eq!(v["l2_height"], 4_567);
         // Peers are never self.
         assert_eq!(v["is_self"], false);
         // Capabilities are nested exactly as the website expects.
@@ -9705,6 +9741,10 @@ mod tests {
             deduped_miner_count: 0,
             max_capacity: 0,
             healthy: false,
+            l1_height: None,
+            uptime_percent: None,
+            peer_count: None,
+            l2_height: None,
         };
 
         let v = mesh_node_to_json(&node);
@@ -9714,6 +9754,12 @@ mod tests {
         assert_eq!(v["deduped_miner_count"], 0);
         assert_eq!(v["max_capacity"], 0);
         assert_eq!(v["healthy"], false);
+        // Unreported telemetry serialises to JSON null → "—" on the page, never
+        // a fabricated 0.
+        assert!(v["l1_height"].is_null());
+        assert!(v["uptime_percent"].is_null());
+        assert!(v["peer_count"].is_null());
+        assert!(v["l2_height"].is_null());
         assert!(v["capabilities"].is_object());
     }
 

--- a/crates/ghost-verification/src/server.rs
+++ b/crates/ghost-verification/src/server.rs
@@ -1147,6 +1147,19 @@ pub struct MeshNodeInfo {
     pub deduped_miner_count: u32,
     /// Whether the node is considered healthy/reachable on the mesh.
     pub healthy: bool,
+    /// This node's L1 (Bitcoin) block height, from its most recent health ping.
+    /// `None` when the peer hasn't reported it (older build) so the Swarm page
+    /// renders "—" instead of a misleading 0.
+    pub l1_height: Option<u64>,
+    /// This node's trailing-7-day uptime percentage (0-100), from its health
+    /// ping. `None` when not reported (older peer / no samples) → "—".
+    pub uptime_percent: Option<f64>,
+    /// The number of mesh peers this node itself reported seeing. `None` when
+    /// not reported (older peer) → "—".
+    pub peer_count: Option<u32>,
+    /// This node's Ghost Pay L2 virtual-block height. `None` when the node
+    /// doesn't run ghost-pay (or is an older peer) → "—".
+    pub l2_height: Option<u64>,
 }
 
 /// Outcome of the most recent automatic `ghost-setup apply-reaper` run.


### PR DESCRIPTION
Fixes #269.

On the Swarm page, mesh-peer nodes showed `—` for Uptime, Peers, L1 Height and L2 Height (only the self row populated those), and the self row's L2 Height was also `—`.

## Diagnosis — case (B): not gossiped

The `HealthPing` gossip payload carried capabilities, miner count, hashrate, elder status, max capacity, node id and address — but no `uptime_percent`, `peer_count` or `l2_height`, and it **hardcoded `block_height` to 0** (`// Would track actual height`). So even L1 was never really gossiped. The swarm SELF row populated all four from local calls (added in #219/#227), but peers had nothing to surface, so they rendered `—`.

## Root fix (additive, backward-compatible gossip)

- **`HealthPing`** (`ghost-common`): three new optional `#[serde(default)]` fields — `uptime_percent: Option<f64>`, `peer_count: Option<u32>`, `l2_height: Option<u64>` — and the existing `block_height` is now populated from a provider (real L1 height).
- **Sender** (`ghost-consensus` mesh): populates each from its own real values — L1 from the round manager's current height, uptime from the same `get_uptime_percent` the qualification gatekeeper uses (#219 precedent), peer count from its own deduplicated `unique_peer_count`, and L2 from a small cache refreshed by a background poller of the local ghost-pay service.
- **Receiver**: stored on `Peer` via a new `update_node_telemetry`, preserved across re-announces in the `upsert_peer` merge, threaded through `MeshNodeInfo`, and surfaced in `/api/v1/pool/mesh-nodes` + the `/api/v1/swarm` peer rows.

**Backward compatibility:** the fields are additive JSON with serde defaults, so an older peer that omits them deserialises to `None` (rendered `—`, never a fabricated 0) and an older node ignores the extra fields on a newer ping. The envelope signature covers the raw payload bytes (verified over received bytes, not a re-serialisation), so mixed-version gossip still verifies. No share/vote/checkpoint payload is touched — this is telemetry only.

> **Fleet note:** because this is case (B), peer telemetry only fully populates once peers run this build fleet-wide. The **self** row populates immediately.

## Self L2 height `—` — root cause + fix

`check_ghostpay_local` reads the in-process ghost-pay handler, but production ghost-pool never calls `with_ghostpay_handler` — ghost-pay runs as a separate service on `:8800` — so `get_ghostpay_status()` returned `None` and self L2 showed `—`. The L2 status card works only because it falls back to querying `:8800`; the swarm handler lacked that fallback. Fixed by mirroring the ghostpay status endpoint: on `None`, fall back to the local `:8800` service. A disabled ghost-pay still resolves to `—`, never a fabricated value (respecting the #219 precedent).

## Frontend

No dashboard change needed — `SwarmNode` already declares these fields and the Swarm page already renders them via `orDash` (`—` on null). This PR makes the backend actually emit them.

## Verification

- `cargo check -p ghost-consensus -p ghost-verification -p ghost-pool -j2` — clean.
- New serde back-compat unit tests: new node reads an old payload → fields `None`; new/old-shaped payloads still parse (`health_ping_telemetry_roundtrip`, `health_ping_deserializes_without_telemetry_fields`) plus updated `mesh_node_to_json` shape tests (populated + null).
- Lib tests green: ghost-common 243, ghost-consensus 262, ghost-verification 170, ghost-pool 240.
- `tsc --noEmit` clean; eslint on the swarm files shows only 2 pre-existing warnings (unchanged files), 0 errors.
