### PR TITLE
logs: multi-binary console via journald with strict allowlist (fixes #271)

### DIFF
--- a/crates/ghost-verification/src/journal.rs
+++ b/crates/ghost-verification/src/journal.rs
@@ -1,0 +1,422 @@
+//! Multi-binary log source backed by `journalctl`.
+//!
+//! The dashboard Logs console reads ghost-pool's own output from the in-process
+//! ring buffer (`crate::log_buffer`). This module extends that console to the
+//! *other* node binaries — ghostd, ghost-pay, the dashboard and the SV2 stack —
+//! whose logs live in the systemd journal rather than in ghost-pool's address
+//! space.
+//!
+//! ## Security model (STRICT allowlist + argv, zero injection)
+//!
+//! The dashboard sends a *logical* unit key (e.g. `ghostd`), never a systemd
+//! unit string. [`resolve_unit`] looks that key up in a fixed, compile-time
+//! [`ALLOWLIST`]; an unknown key is rejected before anything is executed. The
+//! resolved unit string is a hard-coded constant from this table — a client
+//! string is never interpolated into it.
+//!
+//! `journalctl` is invoked with an explicit `argv` (`Command::new("journalctl")
+//! .args([...])`), never through a shell, so there is no word-splitting, glob or
+//! metacharacter surface even in principle. The only non-constant arguments are
+//! (a) the allowlisted unit constant and (b) integers we format ourselves
+//! (`limit`, priority range) — neither is attacker-controlled.
+
+use std::collections::HashMap;
+
+use tokio::process::Command;
+
+/// A binary whose logs the dashboard may read.
+#[derive(Debug, Clone, Copy)]
+pub struct LogUnit {
+    /// Stable logical key the dashboard sends (`?unit=<key>`).
+    pub key: &'static str,
+    /// The real systemd unit string. Hard-coded — never built from input.
+    pub unit: &'static str,
+    /// Human label for the selector.
+    pub label: &'static str,
+    /// One-line description of what this binary is.
+    pub description: &'static str,
+    /// `true` for ghost-pool, which is served from the in-process ring buffer
+    /// rather than journald.
+    pub ring_buffer: bool,
+}
+
+/// The complete, fixed set of readable log sources. Seeded from the real unit
+/// names present on the production nodes (`systemctl list-units 'ghost*' 'sri*'`
+/// on ghost-vm1). Adding a binary here is the ONLY way to make it readable.
+pub const ALLOWLIST: &[LogUnit] = &[
+    LogUnit {
+        key: "ghost-pool",
+        unit: "ghost-pool.service",
+        label: "Ghost Pool",
+        description: "Mining pool node (this process) — in-memory ring buffer",
+        ring_buffer: true,
+    },
+    LogUnit {
+        key: "ghostd",
+        unit: "ghostd.service",
+        label: "Ghost Core",
+        description: "ghostd — Bitcoin Ghost Core daemon",
+        ring_buffer: false,
+    },
+    LogUnit {
+        key: "ghost-pay",
+        unit: "ghost-pay.service",
+        label: "Ghost Pay",
+        description: "L2 instant-payment service",
+        ring_buffer: false,
+    },
+    LogUnit {
+        key: "dashboard",
+        unit: "ghost-dashboard.service",
+        label: "Dashboard",
+        description: "Node dashboard web server",
+        ring_buffer: false,
+    },
+    LogUnit {
+        key: "sri-pool",
+        unit: "sri-pool.service",
+        label: "SV2 Pool",
+        description: "Stratum V2 pool (pool_sv2)",
+        ring_buffer: false,
+    },
+    LogUnit {
+        key: "sri-translator",
+        unit: "sri-translator.service",
+        label: "SV2 Translator",
+        description: "Stratum V1→V2 translator (translator_sv2)",
+        ring_buffer: false,
+    },
+];
+
+/// The default unit key (ghost-pool ring buffer), used when `?unit=` is absent.
+pub const DEFAULT_UNIT: &str = "ghost-pool";
+
+/// Resolve a logical key from the allowlist. Returns `None` for any key not in
+/// [`ALLOWLIST`] — the caller MUST reject (HTTP 400) without executing anything.
+pub fn resolve_unit(key: &str) -> Option<&'static LogUnit> {
+    ALLOWLIST.iter().find(|u| u.key == key)
+}
+
+/// Structured failure from reading a journald unit. Rendered to an honest error
+/// state in the UI — never converted into fake log lines.
+#[derive(Debug)]
+pub enum JournalError {
+    /// `journalctl` is not installed / not on `PATH`.
+    Unavailable,
+    /// The journal could not be read (typically the service user is not in the
+    /// `systemd-journal` group).
+    PermissionDenied,
+    /// Any other non-zero exit, carrying journalctl's stderr for the operator.
+    Command(String),
+}
+
+impl JournalError {
+    /// Operator-facing message shown in the Logs console.
+    pub fn message(&self) -> String {
+        match self {
+            JournalError::Unavailable => {
+                "journalctl is not available on this host, so logs for this binary cannot be read."
+                    .to_string()
+            }
+            JournalError::PermissionDenied => {
+                "Permission denied reading this binary's journal. The ghost-pool service needs to \
+                 be in the systemd-journal group (SupplementaryGroups=systemd-journal); this takes \
+                 effect on the next ghost-pool restart."
+                    .to_string()
+            }
+            JournalError::Command(stderr) => {
+                let trimmed = stderr.trim();
+                if trimmed.is_empty() {
+                    "journalctl exited with an error while reading this binary's log.".to_string()
+                } else {
+                    format!("journalctl error: {trimmed}")
+                }
+            }
+        }
+    }
+}
+
+/// Syslog priority filter passed to journalctl's `--priority a..b` for a minimum
+/// display level. `None` means "no filter" (show every level).
+fn priority_range(min_level: Option<&str>) -> Option<&'static str> {
+    match min_level {
+        None | Some("all") | Some("trace") | Some("debug") => None,
+        // journald has no dedicated trace level; 7 (debug) is the finest.
+        Some("info") => Some("0..6"),  // emerg..info
+        Some("warn") => Some("0..4"),  // emerg..warning
+        Some("error") => Some("0..3"), // emerg..err
+        Some(_) => None,
+    }
+}
+
+/// Map a syslog PRIORITY (0..7) to the dashboard's lowercase level string,
+/// matching the ring-buffer vocabulary (`error`/`warn`/`info`/`debug`/`trace`).
+fn priority_to_level(priority: Option<&str>) -> &'static str {
+    match priority.and_then(|p| p.trim().parse::<u8>().ok()) {
+        Some(0..=3) => "error",      // emerg, alert, crit, err
+        Some(4) => "warn",           // warning
+        Some(5) | Some(6) => "info", // notice, info
+        Some(7) => "debug",          // debug
+        _ => "info",                 // absent/unknown → info
+    }
+}
+
+/// Strip ANSI/VT escape sequences (colour, cursor moves) from a log message.
+///
+/// ghost-pay and some other binaries colour their `tracing` output, and journald
+/// stores those raw bytes. We render plain text, so drop every CSI/OSC/escape
+/// sequence. Implemented as a tiny state machine (no regex dependency).
+pub fn strip_ansi(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut chars = input.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c != '\u{1b}' {
+            out.push(c);
+            continue;
+        }
+        // ESC seen. Inspect the next byte to decide the sequence kind.
+        match chars.next() {
+            // CSI: ESC [ ... final-byte in 0x40..=0x7e
+            Some('[') => {
+                for f in chars.by_ref() {
+                    if ('\u{40}'..='\u{7e}').contains(&f) {
+                        break;
+                    }
+                }
+            }
+            // OSC: ESC ] ... terminated by BEL or ESC \
+            Some(']') => {
+                while let Some(f) = chars.next() {
+                    if f == '\u{07}' {
+                        break;
+                    }
+                    if f == '\u{1b}' {
+                        if matches!(chars.peek(), Some('\\')) {
+                            chars.next();
+                        }
+                        break;
+                    }
+                }
+            }
+            // Any other two-char escape (e.g. ESC c) — drop the escape + next.
+            Some(_) | None => {}
+        }
+    }
+    out
+}
+
+/// A journald MESSAGE (or any field) may arrive as a JSON string OR, when it
+/// contains non-UTF-8 or control bytes, as a JSON array of byte integers.
+/// Decode both shapes to a `String`.
+fn field_to_string(value: &serde_json::Value) -> Option<String> {
+    match value {
+        serde_json::Value::String(s) => Some(s.clone()),
+        serde_json::Value::Array(arr) => {
+            let bytes: Vec<u8> = arr
+                .iter()
+                .filter_map(|v| v.as_u64())
+                .map(|n| n as u8)
+                .collect();
+            Some(String::from_utf8_lossy(&bytes).into_owned())
+        }
+        _ => None,
+    }
+}
+
+/// Parse a single line of `journalctl -o json` output into the same
+/// `{ timestamp, level, target, message }` object the ring buffer emits.
+/// Returns `None` for blank lines or lines missing a MESSAGE.
+pub fn parse_journal_line(line: &str) -> Option<serde_json::Value> {
+    let obj: HashMap<String, serde_json::Value> = serde_json::from_str(line).ok()?;
+
+    // __REALTIME_TIMESTAMP is microseconds since the epoch, as a string.
+    let timestamp_ms = obj
+        .get("__REALTIME_TIMESTAMP")
+        .and_then(field_to_string)
+        .and_then(|s| s.trim().parse::<u64>().ok())
+        .map(|us| us / 1000)
+        .unwrap_or(0);
+
+    let level = priority_to_level(obj.get("PRIORITY").and_then(field_to_string).as_deref());
+
+    // Prefer SYSLOG_IDENTIFIER, else the systemd unit, as the "target" column.
+    let target = obj
+        .get("SYSLOG_IDENTIFIER")
+        .and_then(field_to_string)
+        .or_else(|| obj.get("_SYSTEMD_UNIT").and_then(field_to_string))
+        .unwrap_or_default();
+
+    let message = strip_ansi(&obj.get("MESSAGE").and_then(field_to_string)?);
+
+    Some(serde_json::json!({
+        "timestamp": timestamp_ms,
+        "level": level,
+        "target": target,
+        "message": message,
+    }))
+}
+
+/// Read up to `limit` recent journal records for an allowlisted `unit`,
+/// optionally filtered to a minimum severity, and return them oldest-first as
+/// the dashboard's log-line JSON objects.
+///
+/// `unit` MUST be the hard-coded unit string from an [`ALLOWLIST`] entry — never
+/// a raw client value. `journalctl` is executed with an explicit argv.
+pub async fn read_journal(
+    unit: &str,
+    limit: usize,
+    min_level: Option<&str>,
+) -> Result<Vec<serde_json::Value>, JournalError> {
+    let limit = limit.clamp(1, 5000);
+    let mut cmd = Command::new("journalctl");
+    cmd.args([
+        "--no-pager",
+        "-o",
+        "json",
+        "-u",
+        unit,
+        "-n",
+        &limit.to_string(),
+    ]);
+    if let Some(range) = priority_range(min_level) {
+        cmd.args(["--priority", range]);
+    }
+
+    let output = match cmd.output().await {
+        Ok(o) => o,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Err(JournalError::Unavailable);
+        }
+        Err(e) => return Err(JournalError::Command(e.to_string())),
+    };
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).to_lowercase();
+        if stderr.contains("permission")
+            || stderr.contains("not allowed")
+            || stderr.contains("access denied")
+        {
+            return Err(JournalError::PermissionDenied);
+        }
+        return Err(JournalError::Command(
+            String::from_utf8_lossy(&output.stderr).into_owned(),
+        ));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let entries: Vec<serde_json::Value> = stdout.lines().filter_map(parse_journal_line).collect();
+    Ok(entries)
+}
+
+/// Check whether a systemd unit is loaded on this host, so the dashboard only
+/// offers selectors for binaries that actually exist here. ghost-pool (ring
+/// buffer) is always available. Errors/absence are reported as `false`, never
+/// as a hard failure of the units listing.
+pub async fn unit_is_present(u: &LogUnit) -> bool {
+    if u.ring_buffer {
+        return true;
+    }
+    match Command::new("systemctl")
+        .args(["show", u.unit, "--property=LoadState", "--value"])
+        .output()
+        .await
+    {
+        Ok(out) if out.status.success() => {
+            let state = String::from_utf8_lossy(&out.stdout);
+            state.trim() == "loaded"
+        }
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn allowlist_rejects_unknown_units_without_exec() {
+        // Unknown / injection-shaped keys resolve to None → caller returns 400
+        // and NEVER reaches the journalctl exec path.
+        assert!(resolve_unit("ghostd").is_some());
+        assert!(resolve_unit("ghost-pool").is_some());
+        assert!(resolve_unit("does-not-exist").is_none());
+        assert!(resolve_unit("ghostd.service").is_none()); // must send the KEY
+        assert!(resolve_unit("ghostd; rm -rf /").is_none());
+        assert!(resolve_unit("$(reboot)").is_none());
+        assert!(resolve_unit("../../etc/passwd").is_none());
+        assert!(resolve_unit("").is_none());
+    }
+
+    #[test]
+    fn resolved_unit_string_is_a_fixed_constant() {
+        // The resolved unit is the hard-coded table value, not the input.
+        let u = resolve_unit("ghostd").unwrap();
+        assert_eq!(u.unit, "ghostd.service");
+        assert!(!u.ring_buffer);
+        let pool = resolve_unit("ghost-pool").unwrap();
+        assert!(pool.ring_buffer);
+    }
+
+    #[test]
+    fn strip_ansi_removes_colour_and_keeps_text() {
+        // SGR colour codes (ghost-pay style) are removed, text preserved.
+        assert_eq!(strip_ansi("\u{1b}[32mINFO\u{1b}[0m started"), "INFO started");
+        assert_eq!(strip_ansi("\u{1b}[1;31merror!\u{1b}[0m"), "error!");
+        // Plain text is untouched.
+        assert_eq!(strip_ansi("no escapes here"), "no escapes here");
+        // OSC sequence (ESC ] ... BEL) is removed.
+        assert_eq!(strip_ansi("a\u{1b}]0;title\u{07}b"), "ab");
+        // Bare ESC + following byte dropped without panicking.
+        assert_eq!(strip_ansi("x\u{1b}cy"), "xy");
+    }
+
+    #[test]
+    fn priority_maps_to_level() {
+        assert_eq!(priority_to_level(Some("0")), "error");
+        assert_eq!(priority_to_level(Some("3")), "error");
+        assert_eq!(priority_to_level(Some("4")), "warn");
+        assert_eq!(priority_to_level(Some("6")), "info");
+        assert_eq!(priority_to_level(Some("7")), "debug");
+        assert_eq!(priority_to_level(None), "info");
+        assert_eq!(priority_to_level(Some("garbage")), "info");
+    }
+
+    #[test]
+    fn priority_range_filter() {
+        assert_eq!(priority_range(None), None);
+        assert_eq!(priority_range(Some("all")), None);
+        assert_eq!(priority_range(Some("trace")), None);
+        assert_eq!(priority_range(Some("debug")), None);
+        assert_eq!(priority_range(Some("info")), Some("0..6"));
+        assert_eq!(priority_range(Some("warn")), Some("0..4"));
+        assert_eq!(priority_range(Some("error")), Some("0..3"));
+    }
+
+    #[test]
+    fn parses_journal_json_string_message() {
+        let line = r#"{"__REALTIME_TIMESTAMP":"1700000000000000","PRIORITY":"6","SYSLOG_IDENTIFIER":"ghostd","MESSAGE":"UpdateTip: new best block"}"#;
+        let v = parse_journal_line(line).unwrap();
+        assert_eq!(v["timestamp"], 1_700_000_000_000u64); // us → ms
+        assert_eq!(v["level"], "info");
+        assert_eq!(v["target"], "ghostd");
+        assert_eq!(v["message"], "UpdateTip: new best block");
+    }
+
+    #[test]
+    fn parses_journal_json_array_message_and_strips_ansi() {
+        // MESSAGE as a byte array carrying an ANSI colour sequence: bytes for
+        // ESC [ 3 2 m O K ESC [ 0 m
+        let line = r#"{"__REALTIME_TIMESTAMP":"1700000000000000","PRIORITY":"4","_SYSTEMD_UNIT":"ghost-pay.service","MESSAGE":[27,91,51,50,109,79,75,27,91,48,109]}"#;
+        let v = parse_journal_line(line).unwrap();
+        assert_eq!(v["level"], "warn");
+        assert_eq!(v["target"], "ghost-pay.service"); // fell back to unit
+        assert_eq!(v["message"], "OK"); // ANSI stripped from the byte array
+    }
+
+    #[test]
+    fn skips_lines_without_message_or_blank() {
+        assert!(parse_journal_line("").is_none());
+        assert!(parse_journal_line("not json").is_none());
+        assert!(parse_journal_line(r#"{"PRIORITY":"6"}"#).is_none());
+    }
+}

--- a/crates/ghost-verification/src/lib.rs
+++ b/crates/ghost-verification/src/lib.rs
@@ -43,6 +43,7 @@ pub mod challenge;
 pub mod client;
 pub mod config;
 pub mod handlers;
+pub mod journal;
 pub mod log_buffer;
 pub mod pool_series;
 pub mod qualification;

--- a/crates/ghost-verification/src/routes.rs
+++ b/crates/ghost-verification/src/routes.rs
@@ -543,8 +543,9 @@ pub fn create_router(state: Arc<VerificationState>) -> Router {
             "/api/v1/backup/delete/:filename",
             delete(api_backup_delete_handler),
         )
-        // Dashboard: Logs endpoint (ring buffer)
+        // Dashboard: Logs endpoint (ring buffer + allowlisted journald units)
         .route("/api/v1/logs", get(api_logs_handler))
+        .route("/api/v1/logs/units", get(api_logs_units_handler))
         // Dashboard: Nickname management
         .route("/api/v1/node/nickname", post(api_nickname_post_handler))
         // Dashboard: Swarm node management CRUD
@@ -7866,28 +7867,99 @@ async fn api_node_restart_handler(
 struct LogsQuery {
     limit: Option<usize>,
     level: Option<String>,
+    /// Logical binary key (see `crate::journal::ALLOWLIST`). Absent → ghost-pool
+    /// ring buffer (unchanged default behaviour).
+    unit: Option<String>,
 }
 
-/// API v1 Logs handler — returns recent ghost-pool log entries from the
-/// in-process ring buffer (`crate::log_buffer`).
+/// API v1 Logs handler — returns recent log entries for the selected binary.
 ///
-/// ghost-pool's `tracing` layer mirrors every emitted event into the buffer, so
-/// each entry carries the real structured message, target and level. This
-/// replaces the previous `journalctl`-backed implementation, which (a) exposed
-/// host journal output (HIGH-4) and (b) frequently returned empty `message`
-/// fields because journald stored the ANSI-coloured formatted line as a byte
-/// array that failed the JSON string decode (issue #246). The buffer is process-
-/// local so no host log daemon or elevated privileges are required.
+/// `unit=ghost-pool` (the default) short-circuits to ghost-pool's in-process
+/// ring buffer (`crate::log_buffer`): its `tracing` layer mirrors every emitted
+/// event into the buffer so each entry carries the real structured message,
+/// target and level, with no host log daemon or elevated privileges required.
+///
+/// Any other allowlisted binary (ghostd / ghost-pay / dashboard / SV2 stack) is
+/// read from the systemd journal via `crate::journal`. The client sends only a
+/// LOGICAL key, which is resolved through a strict compile-time allowlist to a
+/// hard-coded unit string; `journalctl` is then exec'd with an explicit argv, so
+/// there is no shell and no way to interpolate a client string into the command.
+/// An unknown key is rejected with 400 before anything is executed. journald
+/// failures (missing binary, permission denied, empty) return an honest
+/// structured `error`/empty state — never fabricated log lines.
 async fn api_logs_handler(
     State(_state): State<Arc<VerificationState>>,
     Query(params): Query<LogsQuery>,
 ) -> impl IntoResponse {
     let limit = params.limit.unwrap_or(100).min(1000);
-    let entries = crate::log_buffer::recent(limit, params.level.as_deref());
+    let level = params.level.as_deref();
+    let key = params
+        .unit
+        .as_deref()
+        .unwrap_or(crate::journal::DEFAULT_UNIT);
 
-    Json(serde_json::json!({
-        "entries": entries
-    }))
+    // STRICT allowlist: an unknown key is rejected here, before any exec.
+    let Some(unit) = crate::journal::resolve_unit(key) else {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "entries": [],
+                "unit": key,
+                "error": format!("Unknown log unit '{key}'"),
+            })),
+        )
+            .into_response();
+    };
+
+    // ghost-pool → in-process ring buffer (unchanged behaviour).
+    if unit.ring_buffer {
+        let entries = crate::log_buffer::recent(limit, level);
+        return Json(serde_json::json!({
+            "entries": entries,
+            "unit": unit.key,
+            "source": "ring-buffer",
+            "error": serde_json::Value::Null,
+        }))
+        .into_response();
+    }
+
+    // All other allowlisted binaries → journald, via an argv exec.
+    match crate::journal::read_journal(unit.unit, limit, level).await {
+        Ok(entries) => Json(serde_json::json!({
+            "entries": entries,
+            "unit": unit.key,
+            "source": "journald",
+            "error": serde_json::Value::Null,
+        }))
+        .into_response(),
+        Err(e) => Json(serde_json::json!({
+            "entries": [],
+            "unit": unit.key,
+            "source": "journald",
+            "error": e.message(),
+        }))
+        .into_response(),
+    }
+}
+
+/// API v1 Logs Units handler — lists the binaries whose logs this node can
+/// serve, so the dashboard builds its selector from what is actually allowlisted
+/// AND present on this host. ghost-pool is always available (ring buffer); other
+/// units report `available` from their systemd `LoadState`.
+async fn api_logs_units_handler(
+    State(_state): State<Arc<VerificationState>>,
+) -> impl IntoResponse {
+    let mut units = Vec::with_capacity(crate::journal::ALLOWLIST.len());
+    for u in crate::journal::ALLOWLIST {
+        units.push(serde_json::json!({
+            "key": u.key,
+            "label": u.label,
+            "description": u.description,
+            "source": if u.ring_buffer { "ring-buffer" } else { "journald" },
+            "available": crate::journal::unit_is_present(u).await,
+        }));
+    }
+    Json(serde_json::json!({ "units": units, "default": crate::journal::DEFAULT_UNIT }))
 }
 
 /// Nickname POST body

--- a/dashboard/src/app/(dashboard)/logs/page.tsx
+++ b/dashboard/src/app/(dashboard)/logs/page.tsx
@@ -5,11 +5,13 @@ import { PageHeader } from "@/components/ui/PageHeader";
 import { Card } from "@/components/ui/Card";
 import { Button } from "@/components/ui/Button";
 import { SectionErrorBoundary } from "@/components/ui/SectionErrorBoundary";
-import { useLogs } from "@/hooks/queries";
-import type { LogEntry } from "@/types/api";
+import { useLogs, useLogUnits } from "@/hooks/queries";
+import type { LogEntry, LogUnit } from "@/types/api";
 
 const LEVELS = ["all", "error", "warn", "info", "debug", "trace"] as const;
 type Level = (typeof LEVELS)[number];
+
+const DEFAULT_UNIT = "ghost-pool";
 
 const LEVEL_COLOR: Record<LogEntry["level"], string> = {
   error: "#f85149",
@@ -19,7 +21,19 @@ const LEVEL_COLOR: Record<LogEntry["level"], string> = {
   trace: "var(--fainter)",
 };
 
-// Ring-buffer timestamps are Unix seconds; guard for ms just in case.
+// Fallback selector entry so the page renders before /logs/units resolves.
+const FALLBACK_UNITS: LogUnit[] = [
+  {
+    key: DEFAULT_UNIT,
+    label: "Ghost Pool",
+    description: "Mining pool node (this process) — in-memory ring buffer",
+    source: "ring-buffer",
+    available: true,
+  },
+];
+
+// Ring-buffer timestamps are Unix seconds; journald entries are Unix ms. Guard
+// for both by treating anything below ~year-2001-in-ms as seconds.
 function formatTs(ts: number): string {
   const ms = ts < 1e12 ? ts * 1000 : ts;
   const d = new Date(ms);
@@ -29,13 +43,27 @@ function formatTs(ts: number): string {
 
 export default function LogsPage() {
   const [level, setLevel] = useState<Level>("all");
+  const [unit, setUnit] = useState<string>(DEFAULT_UNIT);
   const [limit] = useState(500);
+
+  const { data: unitsData } = useLogUnits();
+  const units = unitsData?.units?.length ? unitsData.units : FALLBACK_UNITS;
+
   const { data, isLoading, isError, error, refetch, isFetching } = useLogs({
     limit,
     level: level === "all" ? undefined : level,
+    unit,
   });
 
   const entries = data?.entries ?? [];
+  // Honest structured error surfaced by the backend (e.g. journald permission
+  // denied) — returned with HTTP 200 so the selector stays usable.
+  const structuredError = data?.error ?? null;
+
+  const activeUnit = units.find((u) => u.key === unit);
+  const subtitle = activeUnit
+    ? `Recent logs for ${activeUnit.label}. ${activeUnit.description}.`
+    : "Recent node logs. Select a binary to inspect its output.";
 
   const copyAll = () => {
     const text = entries
@@ -46,16 +74,40 @@ export default function LogsPage() {
 
   return (
     <div className="space-y-6">
-      <PageHeader
-        eyebrow="system"
-        title="Logs."
-        subtitle="Recent ghost-pool logs from the node's in-memory ring buffer. This is ghost-pool's own output, not the full journald firehose of every binary."
-        subtitleFullWidth
-      />
+      <PageHeader eyebrow="system" title="Logs." subtitle={subtitle} subtitleFullWidth />
 
       <SectionErrorBoundary section="Logs">
         <Card>
-          {/* Controls */}
+          {/* Binary selector */}
+          <div className="flex items-center gap-2 flex-wrap" style={{ marginBottom: "12px" }}>
+            {units.map((u) => {
+              const active = unit === u.key;
+              const disabled = !u.available;
+              return (
+                <button
+                  key={u.key}
+                  onClick={() => !disabled && setUnit(u.key)}
+                  disabled={disabled}
+                  title={disabled ? `${u.label} is not present on this node` : u.description}
+                  style={{
+                    padding: "5px 12px",
+                    fontSize: "12px",
+                    borderRadius: "4px",
+                    border: `1px solid ${active ? "var(--accent)" : "var(--rule)"}`,
+                    background: active ? "var(--accent-weak)" : "transparent",
+                    color: disabled ? "var(--fainter)" : active ? "var(--fg)" : "var(--dim)",
+                    cursor: disabled ? "not-allowed" : "pointer",
+                    opacity: disabled ? 0.5 : 1,
+                    fontWeight: active ? 600 : 400,
+                  }}
+                >
+                  {u.label}
+                </button>
+              );
+            })}
+          </div>
+
+          {/* Level controls */}
           <div className="flex items-center justify-between gap-3 flex-wrap" style={{ marginBottom: "12px" }}>
             <div className="flex items-center gap-2 flex-wrap">
               {LEVELS.map((lv) => (
@@ -112,8 +164,10 @@ export default function LogsPage() {
               <div style={{ color: "#f85149" }}>
                 Couldn&apos;t load logs{error instanceof Error ? `: ${error.message}` : "."}
               </div>
+            ) : structuredError ? (
+              <div style={{ color: "#d29922" }}>{structuredError}</div>
             ) : entries.length === 0 ? (
-              <div style={{ color: "var(--dim)" }}>No log entries in the buffer for this level.</div>
+              <div style={{ color: "var(--dim)" }}>No log entries for this binary at this level.</div>
             ) : (
               entries.map((e, i) => (
                 <div key={i} style={{ whiteSpace: "pre-wrap", wordBreak: "break-word", display: "flex", gap: "10px" }}>

--- a/dashboard/src/hooks/queries/useLogsQuery.ts
+++ b/dashboard/src/hooks/queries/useLogsQuery.ts
@@ -1,15 +1,25 @@
 import { useQuery } from '@tanstack/react-query';
-import { getLogs } from '@/lib/api/logs';
+import { getLogs, getLogUnits } from '@/lib/api/logs';
 
 export const logsKeys = {
   all: ['logs'] as const,
-  list: (params?: { limit?: number; level?: string }) => [...logsKeys.all, 'list', params] as const,
+  list: (params?: { limit?: number; level?: string; unit?: string }) =>
+    [...logsKeys.all, 'list', params] as const,
+  units: () => [...logsKeys.all, 'units'] as const,
 };
 
-export function useLogs(params?: { limit?: number; level?: string }) {
+export function useLogs(params?: { limit?: number; level?: string; unit?: string }) {
   return useQuery({
     queryKey: logsKeys.list(params),
-    queryFn: () => getLogs(params?.limit, params?.level),
+    queryFn: () => getLogs(params?.limit, params?.level, params?.unit),
     refetchInterval: false, // Manual refresh or WebSocket
+  });
+}
+
+export function useLogUnits() {
+  return useQuery({
+    queryKey: logsKeys.units(),
+    queryFn: () => getLogUnits(),
+    staleTime: 5 * 60 * 1000, // Unit list changes rarely.
   });
 }

--- a/dashboard/src/lib/api/logs.ts
+++ b/dashboard/src/lib/api/logs.ts
@@ -1,11 +1,20 @@
 // Logs API endpoints
 import { fetchApi } from './client';
-import type { LogsResponse } from '@/types/api';
+import type { LogsResponse, LogUnitsResponse } from '@/types/api';
 
-export async function getLogs(limit?: number, level?: string): Promise<LogsResponse> {
+export async function getLogs(
+  limit?: number,
+  level?: string,
+  unit?: string,
+): Promise<LogsResponse> {
   const params = new URLSearchParams();
   if (limit) params.set('limit', limit.toString());
   if (level) params.set('level', level);
+  if (unit) params.set('unit', unit);
   const query = params.toString();
   return fetchApi<LogsResponse>(`/api/v1/logs${query ? `?${query}` : ''}`);
+}
+
+export async function getLogUnits(): Promise<LogUnitsResponse> {
+  return fetchApi<LogUnitsResponse>('/api/v1/logs/units');
 }

--- a/dashboard/src/types/api.ts
+++ b/dashboard/src/types/api.ts
@@ -538,6 +538,25 @@ export interface LogEntry {
 
 export interface LogsResponse {
   entries: LogEntry[];
+  // Present on multi-binary responses; absent on legacy ring-buffer-only shape.
+  unit?: string;
+  source?: "ring-buffer" | "journald";
+  // Honest structured error (e.g. journald permission denied); null on success.
+  error?: string | null;
+}
+
+// A selectable log source (binary) reported by /api/v1/logs/units.
+export interface LogUnit {
+  key: string;
+  label: string;
+  description: string;
+  source: "ring-buffer" | "journald";
+  available: boolean;
+}
+
+export interface LogUnitsResponse {
+  units: LogUnit[];
+  default: string;
 }
 
 // Wraith types

--- a/scripts/install-node.sh
+++ b/scripts/install-node.sh
@@ -1086,6 +1086,19 @@ cat > /etc/systemd/system/ghost-pool.service.d/genesis-anchor.conf <<EOF
 Environment=ZK_GENESIS_PARAMS_HASH=${ZK_GENESIS_PARAMS_HASH}
 EOF
 
+# Journal access — the dashboard Logs console reads the OTHER node binaries'
+# logs (ghostd / ghost-pay / dashboard / SV2 stack) out of the systemd journal
+# via journalctl, which requires membership of the `systemd-journal` group.
+# Written as a sibling drop-in (merged with the base unit like genesis-anchor.conf
+# above) so it can ship to existing nodes without rewriting the whole unit; the
+# later `systemctl daemon-reload` picks it up and it takes effect on the next
+# ghost-pool restart. ghost-pool's own logs come from its in-process ring buffer
+# and need no privilege.
+cat > /etc/systemd/system/ghost-pool.service.d/journal-access.conf <<EOF
+[Service]
+SupplementaryGroups=systemd-journal
+EOF
+
 # ghost-pay L2 service (also serves the Wraith bond ledger on 8800). Only
 # installed when Ghost Pay is enabled. GHOST_PAY_BOND_LEDGER_TOKEN is the SAME
 # secret written into pool.toml's [coordinator] bond_ledger_token above, so the


### PR DESCRIPTION
Fixes #271.

The Logs page only ever showed ghost-pool's in-process ring buffer. This adds a binary selector so operators can also read `ghostd`, `ghost-pay`, the dashboard and the SV2 stack (`sri-pool` / `sri-translator`) from the systemd journal, without loosening the security posture that removed the old journalctl endpoint (HIGH-4).

## Backend

- `GET /api/v1/logs` gains an optional `?unit=<key>` parameter.
  - `unit=ghost-pool` (the default when absent) short-circuits to the existing ring buffer — **behaviour unchanged**.
  - Other allowlisted keys are read via `journalctl -u <unit> -o json -n <limit> [--priority a..b]`, parsed into the **same** `{ timestamp, level, target, message }` shape the ring buffer returns.
- New `GET /api/v1/logs/units` lists the allowlisted binaries and whether each is actually present on this host (via `systemctl show ... LoadState`), so the frontend builds its selector from what exists.
- journald `MESSAGE` is decoded from both the JSON-string and JSON byte-array shapes, and **ANSI/VT escape sequences are stripped** (ghost-pay colours its output) with a small state machine — no new dependency.
- syslog `PRIORITY` is mapped to the dashboard's `error`/`warn`/`info`/`debug` vocabulary.
- journald failures (binary missing, permission denied, empty) return an **honest structured** `error`/empty state — never fabricated log lines.

### How injection is prevented

- **Strict allowlist:** a fixed compile-time table maps a *logical* key (e.g. `ghostd`) to a hard-coded unit string (`ghostd.service`). The client only ever sends the key; the unit string is a constant looked up from the table. An unknown key is rejected with `400` **before anything is executed**.
- **argv, never a shell:** `Command::new("journalctl").args([...])` — the only non-constant arguments are the allowlisted unit constant and integers we format ourselves (`limit`, priority range). No shell, no interpolation of any client string. Zero injection surface.

## Permissions

Reading other units' journals requires the `systemd-journal` group. Added a `ghost-pool.service.d/journal-access.conf` drop-in (sibling of the existing `genesis-anchor.conf`) with `SupplementaryGroups=systemd-journal` to the installer, so new nodes get it and it can ship to existing nodes without rewriting the base unit. **Takes effect on the ghost-pool restart that ships with a deploy.** (The reaper/tor managed drop-in in `setup.rs` targets `ghostd`'s `ExecStart` and is deliberately left untouched.)

## Frontend

Binary selector (segmented buttons) above the level filters, populated from `/api/v1/logs/units` with unavailable units greyed out. The selected unit is threaded through the logs query; Copy, Refresh and the level filters all work per-binary. The page subtitle now reflects the selected binary (no longer "ghost-pool only"), and journald permission/empty states render clearly.

## Verification

- `cargo check -p ghost-verification -p ghost-common -p ghost-pool -j2` — clean.
- 8 new unit tests pass: allowlist rejects unknown/injection-shaped keys without exec, resolved unit is a fixed constant, journald JSON→line parsing (string + byte-array MESSAGE), ANSI strip, priority→level and priority-range mapping, blank/malformed line skipping.
- Dashboard `tsc --noEmit`, `eslint` (changed files) and `npm run build` — all clean.
- Verified the JSON shape against real `journalctl -o json` output from a production node (`__REALTIME_TIMESTAMP` in µs, `PRIORITY`, string `MESSAGE`, `_SYSTEMD_UNIT` fallback for `target`).

Discovered unit allowlist (seeded from the real units on the nodes): `ghost-pool.service` (ring buffer), `ghostd.service`, `ghost-pay.service`, `ghost-dashboard.service`, `sri-pool.service`, `sri-translator.service`.
