### PR TITLE
dashboard: nav reorg + geo note placement (5 tweaks)

### DIFF
--- a/dashboard/src/app/(dashboard)/geo/page.tsx
+++ b/dashboard/src/app/(dashboard)/geo/page.tsx
@@ -133,7 +133,30 @@ export default function GeoPage() {
         </div>
       )}
 
-      {/* Resolution note */}
+      {/* Map */}
+      <SectionErrorBoundary section="Node Map">
+        <Card>
+          <CardHeader title="World map" subtitle={`${points.length} of ${rows.length} nodes plotted`} />
+          <WorldMap points={points} self={self} hoveredId={hoveredId} onHover={setHoveredId} />
+          {/* Legend */}
+          <div className="flex flex-wrap items-center gap-x-5 gap-y-2 mt-4" style={{ fontSize: "12px", color: "var(--dim)" }}>
+            <span className="inline-flex items-center gap-2">
+              <span style={{ width: 8, height: 8, borderRadius: "50%", background: "var(--green)", display: "inline-block" }} />
+              Online node
+            </span>
+            <span className="inline-flex items-center gap-2">
+              <span style={{ width: 8, height: 8, borderRadius: "50%", background: "var(--red)", display: "inline-block" }} />
+              Offline / stale
+            </span>
+            <span className="inline-flex items-center gap-2">
+              <span style={{ width: 8, height: 8, borderRadius: "50%", background: "var(--accent)", display: "inline-block" }} />
+              This node
+            </span>
+          </div>
+        </Card>
+      </SectionErrorBoundary>
+
+      {/* Resolution note (below the map) */}
       <div
         className="flex items-start gap-3"
         style={{
@@ -160,29 +183,6 @@ export default function GeoPage() {
           )}
         </p>
       </div>
-
-      {/* Map */}
-      <SectionErrorBoundary section="Node Map">
-        <Card>
-          <CardHeader title="World map" subtitle={`${points.length} of ${rows.length} nodes plotted`} />
-          <WorldMap points={points} self={self} hoveredId={hoveredId} onHover={setHoveredId} />
-          {/* Legend */}
-          <div className="flex flex-wrap items-center gap-x-5 gap-y-2 mt-4" style={{ fontSize: "12px", color: "var(--dim)" }}>
-            <span className="inline-flex items-center gap-2">
-              <span style={{ width: 8, height: 8, borderRadius: "50%", background: "var(--green)", display: "inline-block" }} />
-              Online node
-            </span>
-            <span className="inline-flex items-center gap-2">
-              <span style={{ width: 8, height: 8, borderRadius: "50%", background: "var(--red)", display: "inline-block" }} />
-              Offline / stale
-            </span>
-            <span className="inline-flex items-center gap-2">
-              <span style={{ width: 8, height: 8, borderRadius: "50%", background: "var(--accent)", display: "inline-block" }} />
-              This node
-            </span>
-          </div>
-        </Card>
-      </SectionErrorBoundary>
 
       {/* Node list */}
       <SectionErrorBoundary section="Node List">

--- a/dashboard/src/components/layout/Sidebar.tsx
+++ b/dashboard/src/components/layout/Sidebar.tsx
@@ -63,9 +63,14 @@ const GROUPS: NavGroup[] = [
     label: "overview",
     items: [
       { href: "/", label: "Overview", icon: <LayoutDashboard {...ICON} /> },
-      { href: "/mempool", label: "Mempool", icon: <Activity {...ICON} /> },
       { href: "/sync", label: "Sync", icon: <RefreshCw {...ICON} /> },
       { href: "/geo", label: "Geo", icon: <MapPin {...ICON} /> },
+    ],
+  },
+  {
+    label: "identity",
+    items: [
+      { href: "/elders", label: "Elders & MPC", icon: <Users {...ICON} /> },
     ],
   },
   {
@@ -80,6 +85,7 @@ const GROUPS: NavGroup[] = [
     label: "ghost pool",
     items: [
       { href: "/mining", label: "Mining", icon: <Pickaxe {...ICON} /> },
+      { href: "/mempool", label: "Mempool", icon: <Activity {...ICON} /> },
       { href: "/capacity", label: "Capacity", icon: <Gauge {...ICON} /> },
       { href: "/pool", label: "Node Pool", icon: <Boxes {...ICON} /> },
     ],
@@ -102,13 +108,7 @@ const GROUPS: NavGroup[] = [
     ],
   },
   {
-    label: "identity",
-    items: [
-      { href: "/elders", label: "Elders & MPC", icon: <Users {...ICON} /> },
-    ],
-  },
-  {
-    label: "treasury",
+    label: "financial",
     items: [
       { href: "/payouts", label: "Payouts", icon: <Banknote {...ICON} /> },
       { href: "/treasury", label: "Treasury", icon: <CreditCard {...ICON} /> },

--- a/dashboard/src/components/layout/Sidebar.tsx
+++ b/dashboard/src/components/layout/Sidebar.tsx
@@ -74,7 +74,7 @@ const GROUPS: NavGroup[] = [
     ],
   },
   {
-    label: "filtering",
+    label: "tx filtering",
     items: [
       { href: "/filtering", label: "Overview", icon: <Filter {...ICON} /> },
       { href: "/filtering/basic", label: "Basic", icon: <Layers {...ICON} /> },


### PR DESCRIPTION
Frontend-only: geo resolution note moved below the world map; Mempool → Ghost Pool group; Identity moved below Overview; Treasury category → Financial; Filtering category → TX Filtering. tsc + eslint clean.