### PR TITLE
node: ghostd-flags bridge + daemon settings (mempool/connectivity/performance/BIP157/onlynet/I2P)

### DIFF
--- a/crates/ghost-common/src/config.rs
+++ b/crates/ghost-common/src/config.rs
@@ -144,16 +144,105 @@ pub struct NodeLaunchConfig {
     /// single flag is emitted. Requires a ghostd restart to take effect.
     #[serde(default)]
     pub tor_mode: bool,
+
+    // --- Mempool ---------------------------------------------------------
+    /// Keep the transaction mempool below this many megabytes (`-maxmempool`).
+    /// Unset → ghostd's default. Restart-required.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_mempool_mb: Option<u32>,
+    /// Drop mempool transactions older than this many hours (`-mempoolexpiry`).
+    /// Unset → ghostd's default. Restart-required.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mempool_expiry_hours: Option<u32>,
+
+    // --- Connectivity ----------------------------------------------------
+    /// Maximum automatic peer connections (`-maxconnections`). Unset → ghostd's
+    /// default. Restart-required.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_connections: Option<u32>,
+    /// Outbound-traffic ceiling per 24h (`-maxuploadtarget`). A unit-friendly
+    /// value: a bare number is megabytes, with optional suffix `[k|K|m|M|g|G|t|T]`
+    /// (lowercase = base-1000, uppercase = base-1024); `0` = no limit. Unset →
+    /// ghostd's default. Restart-required.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_upload_target_mb: Option<String>,
+
+    // --- Performance -----------------------------------------------------
+    /// Database cache size in megabytes (`-dbcache`). Unset → ghostd's default.
+    /// Restart-required.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dbcache_mb: Option<u32>,
+
+    // --- Indexes / BIP157 ------------------------------------------------
+    /// Build the basic block-filter index (`-blockfilterindex=1`). Enabling
+    /// triggers a one-time index build over the chain. Unset/false → ghostd's
+    /// default (off). Restart-required.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub block_filter_index: Option<bool>,
+    /// Serve BIP157 compact block filters to light clients (`-peerblockfilters=1`).
+    /// ghostd requires the block-filter index to also be enabled. Unset/false →
+    /// ghostd's default (off). Restart-required.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub peer_block_filters: Option<bool>,
+
+    // --- Privacy networking ---------------------------------------------
+    /// Restrict automatic outbound connections to these networks (`-onlynet`,
+    /// repeated once per entry). Valid values: `ipv4`, `ipv6`, `onion`, `i2p`,
+    /// `cjdns`. Empty → no restriction. Restart-required.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub onlynet: Vec<String>,
+    /// I2P SAM proxy `host:port` for reaching I2P peers (`-i2psam`). Unset → I2P
+    /// disabled. Restart-required.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub i2p_sam: Option<String>,
+    /// Accept inbound I2P connections (`-i2pacceptincoming=1`). Only effective
+    /// when `i2p_sam` is set. Unset/false → ghostd's default. Restart-required.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub i2p_accept_incoming: Option<bool>,
 }
 
 impl NodeLaunchConfig {
     /// The ghostd (Bitcoin Core) CLI flags that mirror these settings. Only
     /// non-default values are emitted, so a node with everything off adds nothing
     /// to ghostd's `ExecStart` and behaves exactly as before.
+    ///
+    /// Every flag here is read by ghostd only at startup, so changing any of
+    /// these requires a ghostd restart to take effect (see `ghostd_managed_dropin`
+    /// in `setup.rs`, which regenerates the drop-in idempotently).
     pub fn ghostd_flags(&self) -> Vec<String> {
         let mut flags = Vec::new();
         if self.tor_mode {
             flags.push("-tormode=1".to_string());
+        }
+        if let Some(mb) = self.max_mempool_mb {
+            flags.push(format!("-maxmempool={mb}"));
+        }
+        if let Some(hours) = self.mempool_expiry_hours {
+            flags.push(format!("-mempoolexpiry={hours}"));
+        }
+        if let Some(n) = self.max_connections {
+            flags.push(format!("-maxconnections={n}"));
+        }
+        if let Some(ref target) = self.max_upload_target_mb {
+            flags.push(format!("-maxuploadtarget={target}"));
+        }
+        if let Some(mb) = self.dbcache_mb {
+            flags.push(format!("-dbcache={mb}"));
+        }
+        if self.block_filter_index == Some(true) {
+            flags.push("-blockfilterindex=1".to_string());
+        }
+        if self.peer_block_filters == Some(true) {
+            flags.push("-peerblockfilters=1".to_string());
+        }
+        for net in &self.onlynet {
+            flags.push(format!("-onlynet={net}"));
+        }
+        if let Some(ref sam) = self.i2p_sam {
+            flags.push(format!("-i2psam={sam}"));
+        }
+        if self.i2p_accept_incoming == Some(true) {
+            flags.push("-i2pacceptincoming=1".to_string());
         }
         flags
     }
@@ -2552,5 +2641,83 @@ mod tests {
             result.is_ok(),
             "Signet should warn but allow world-readable config"
         );
+    }
+
+    // --- NodeLaunchConfig::ghostd_flags emission --------------------------
+
+    #[test]
+    fn test_node_launch_default_emits_nothing() {
+        // A node with everything off must add nothing to ghostd's ExecStart.
+        assert!(NodeLaunchConfig::default().ghostd_flags().is_empty());
+    }
+
+    #[test]
+    fn test_node_launch_each_field_maps_to_its_flag() {
+        let cfg = NodeLaunchConfig {
+            tor_mode: true,
+            max_mempool_mb: Some(600),
+            mempool_expiry_hours: Some(72),
+            max_connections: Some(40),
+            max_upload_target_mb: Some("500M".to_string()),
+            dbcache_mb: Some(2048),
+            block_filter_index: Some(true),
+            peer_block_filters: Some(true),
+            onlynet: vec!["onion".to_string(), "i2p".to_string()],
+            i2p_sam: Some("127.0.0.1:7656".to_string()),
+            i2p_accept_incoming: Some(true),
+        };
+        let flags = cfg.ghostd_flags();
+        assert!(flags.contains(&"-tormode=1".to_string()));
+        assert!(flags.contains(&"-maxmempool=600".to_string()));
+        assert!(flags.contains(&"-mempoolexpiry=72".to_string()));
+        assert!(flags.contains(&"-maxconnections=40".to_string()));
+        assert!(flags.contains(&"-maxuploadtarget=500M".to_string()));
+        assert!(flags.contains(&"-dbcache=2048".to_string()));
+        assert!(flags.contains(&"-blockfilterindex=1".to_string()));
+        assert!(flags.contains(&"-peerblockfilters=1".to_string()));
+        assert!(flags.contains(&"-onlynet=onion".to_string()));
+        assert!(flags.contains(&"-onlynet=i2p".to_string()));
+        assert!(flags.contains(&"-i2psam=127.0.0.1:7656".to_string()));
+        assert!(flags.contains(&"-i2pacceptincoming=1".to_string()));
+    }
+
+    #[test]
+    fn test_node_launch_none_and_false_fields_are_absent() {
+        // Some(false) bools and None scalars must not emit a flag.
+        let cfg = NodeLaunchConfig {
+            block_filter_index: Some(false),
+            peer_block_filters: Some(false),
+            i2p_accept_incoming: Some(false),
+            ..Default::default()
+        };
+        assert!(cfg.ghostd_flags().is_empty());
+    }
+
+    #[test]
+    fn test_node_launch_serde_back_compat_missing_fields() {
+        // An old pool.toml that predates the daemon fields (only tor_mode, or
+        // even an empty table) must still parse, with the new fields defaulting.
+        let old: NodeLaunchConfig = toml::from_str("tor_mode = true").unwrap();
+        assert!(old.tor_mode);
+        assert_eq!(old.max_mempool_mb, None);
+        assert!(old.onlynet.is_empty());
+        assert_eq!(old.i2p_accept_incoming, None);
+        assert_eq!(old.ghostd_flags(), vec!["-tormode=1".to_string()]);
+
+        let empty: NodeLaunchConfig = toml::from_str("").unwrap();
+        assert!(empty.ghostd_flags().is_empty());
+    }
+
+    #[test]
+    fn test_node_launch_round_trips_through_toml() {
+        let cfg = NodeLaunchConfig {
+            max_mempool_mb: Some(300),
+            onlynet: vec!["ipv4".to_string()],
+            block_filter_index: Some(true),
+            ..Default::default()
+        };
+        let s = toml::to_string(&cfg).unwrap();
+        let back: NodeLaunchConfig = toml::from_str(&s).unwrap();
+        assert_eq!(back.ghostd_flags(), cfg.ghostd_flags());
     }
 }

--- a/crates/ghost-common/src/setup.rs
+++ b/crates/ghost-common/src/setup.rs
@@ -271,11 +271,36 @@ pub fn apply_reaper(
     })
 }
 
+/// Every ghostd flag prefix this codebase owns via the drop-in. A token matching
+/// any of these is stripped from the inherited `ExecStart` before the current set
+/// is re-appended, which is what keeps regeneration idempotent: re-applying with
+/// the same config yields the same `ExecStart`, and toggling a setting off drops
+/// its flag entirely rather than leaving a stale copy behind. All are emitted by
+/// `ReaperSettings::ghostd_flags` / `NodeLaunchConfig::ghostd_flags`.
+const MANAGED_GHOSTD_FLAG_PREFIXES: &[&str] = &[
+    // Reaper (per-vector) + Tor.
+    "-ghostreaper",
+    "-tormode",
+    // Daemon / node launch settings (NodeLaunchConfig).
+    "-maxmempool",
+    "-mempoolexpiry",
+    "-maxconnections",
+    "-maxuploadtarget",
+    "-dbcache",
+    "-blockfilterindex",
+    "-peerblockfilters",
+    "-onlynet",
+    "-i2psam",
+    "-i2pacceptincoming",
+];
+
 /// True when `tok` is a ghostd flag that this codebase manages via the drop-in,
 /// so it must be stripped from the inherited `ExecStart` before the current set
 /// is re-appended (keeps regeneration idempotent).
 fn is_managed_ghostd_flag(tok: &str) -> bool {
-    tok.starts_with("-ghostreaper") || tok.starts_with("-tormode")
+    MANAGED_GHOSTD_FLAG_PREFIXES
+        .iter()
+        .any(|p| tok.starts_with(p))
 }
 
 /// Render a systemd drop-in for ghostd that applies the per-vector reaper
@@ -283,7 +308,8 @@ fn is_managed_ghostd_flag(tok: &str) -> bool {
 ///
 /// `exec_argv` is the daemon's resolved command line (e.g. the `argv[]` from
 /// `systemctl show ghostd -p ExecStart --value`). Any existing managed flags
-/// (`-ghostreaper*`, `-tormode`) are stripped and the current set is appended,
+/// (`-ghostreaper*`, `-tormode`, and the daemon flags in
+/// `MANAGED_GHOSTD_FLAG_PREFIXES`) are stripped and the current set is appended,
 /// wrapped in a drop-in that resets and replaces `ExecStart` (the systemd
 /// override idiom: an empty `ExecStart=` clears the inherited value before the
 /// new one is set). A single drop-in carries every ghost-managed flag so the
@@ -430,15 +456,83 @@ mod tests {
         let on = ghostd_managed_dropin(
             exec,
             &reaper,
-            &NodeLaunchConfig { tor_mode: true },
+            &NodeLaunchConfig { tor_mode: true, ..Default::default() },
         );
         assert_eq!(on.matches("-tormode=1").count(), 1);
 
         let off = ghostd_managed_dropin(
             exec,
             &reaper,
-            &NodeLaunchConfig { tor_mode: false },
+            &NodeLaunchConfig { tor_mode: false, ..Default::default() },
         );
         assert!(!off.contains("-tormode"));
+    }
+
+    #[test]
+    fn test_ghostd_managed_dropin_daemon_flags_coexist_and_idempotent() {
+        // A prior drop-in already carried Tor + reaper + a stale daemon flag set;
+        // re-applying with a new daemon config must strip the stale copies and
+        // emit each managed flag exactly once, alongside the reaper + tor flags.
+        let exec = "/opt/ghost/bin/ghostd -signet -datadir=/var/lib/bitcoin \
+                    -tormode=1 -ghostreaper=enabled -maxmempool=100 -dbcache=300 \
+                    -onlynet=ipv4 -port=38333";
+        let reaper = ReaperSettings::default();
+        let launch = NodeLaunchConfig {
+            tor_mode: true,
+            max_mempool_mb: Some(600),
+            mempool_expiry_hours: Some(48),
+            max_connections: Some(50),
+            max_upload_target_mb: Some("2G".to_string()),
+            dbcache_mb: Some(2048),
+            block_filter_index: Some(true),
+            peer_block_filters: Some(true),
+            onlynet: vec!["onion".to_string(), "i2p".to_string()],
+            i2p_sam: Some("127.0.0.1:7656".to_string()),
+            i2p_accept_incoming: Some(true),
+        };
+
+        let dropin = ghostd_managed_dropin(exec, &reaper, &launch);
+
+        // Base non-managed args survive.
+        assert!(dropin.contains("/opt/ghost/bin/ghostd"));
+        assert!(dropin.contains("-signet"));
+        assert!(dropin.contains("-datadir=/var/lib/bitcoin"));
+        assert!(dropin.contains("-port=38333"));
+
+        // Each managed daemon flag appears exactly once (stale values stripped).
+        assert_eq!(dropin.matches("-maxmempool=").count(), 1);
+        assert!(dropin.contains("-maxmempool=600"));
+        assert_eq!(dropin.matches("-dbcache=").count(), 1);
+        assert!(dropin.contains("-dbcache=2048"));
+        assert!(dropin.contains("-mempoolexpiry=48"));
+        assert!(dropin.contains("-maxconnections=50"));
+        assert!(dropin.contains("-maxuploadtarget=2G"));
+        assert!(dropin.contains("-blockfilterindex=1"));
+        assert!(dropin.contains("-peerblockfilters=1"));
+        assert!(dropin.contains("-i2psam=127.0.0.1:7656"));
+        assert!(dropin.contains("-i2pacceptincoming=1"));
+
+        // onlynet re-emitted per network, and the stale ipv4 is gone.
+        assert!(dropin.contains("-onlynet=onion"));
+        assert!(dropin.contains("-onlynet=i2p"));
+        assert!(!dropin.contains("-onlynet=ipv4"));
+        assert_eq!(dropin.matches("-onlynet=").count(), 2);
+
+        // Coexists with Tor + reaper, each once.
+        assert_eq!(dropin.matches("-tormode=1").count(), 1);
+        assert_eq!(dropin.matches("-ghostreaper=").count(), 1);
+
+        // Idempotence: feeding the generated ExecStart back in yields the same
+        // managed flag set.
+        let regen_exec = dropin
+            .lines()
+            .rev()
+            .find(|l| l.starts_with("ExecStart=/"))
+            .unwrap()
+            .trim_start_matches("ExecStart=");
+        let dropin2 = ghostd_managed_dropin(regen_exec, &reaper, &launch);
+        assert_eq!(dropin2.matches("-maxmempool=").count(), 1);
+        assert_eq!(dropin2.matches("-onlynet=").count(), 2);
+        assert_eq!(dropin2.matches("-tormode=1").count(), 1);
     }
 }

--- a/crates/ghost-verification/src/routes.rs
+++ b/crates/ghost-verification/src/routes.rs
@@ -353,6 +353,7 @@ pub fn create_router(state: Arc<VerificationState>) -> Router {
             get(api_config_template_profile_handler),
         )
         .route("/api/v1/config/reaper", get(api_config_reaper_handler))
+        .route("/api/v1/config/daemon", get(api_config_daemon_handler))
         .route("/api/v1/config/alerts", get(api_config_alerts_handler))
         .route(
             "/api/v1/config/ghost_pay",
@@ -487,6 +488,10 @@ pub fn create_router(state: Arc<VerificationState>) -> Router {
             post(api_config_reaper_post_handler),
         )
         .route("/api/v1/config/tor", post(api_config_tor_post_handler))
+        .route(
+            "/api/v1/config/daemon",
+            post(api_config_daemon_post_handler),
+        )
         .route(
             "/api/v1/config/alerts",
             post(api_config_alerts_post_handler),
@@ -5416,6 +5421,40 @@ async fn api_config_reaper_handler(
     }))
 }
 
+/// API v1 Config daemon handler — returns the ghostd launch / daemon settings
+/// from the full node config (pool.toml `[node_launch]`), plus the terminal
+/// result of the last ghostd apply so the dashboard can show whether the change
+/// was picked up. All of these are ghostd startup flags, so a change requires a
+/// ghostd restart (handled by the POST path).
+async fn api_config_daemon_handler(
+    State(state): State<Arc<VerificationState>>,
+) -> impl IntoResponse {
+    let launch = state
+        .full_node_config
+        .as_ref()
+        .map(|c| c.read().node_launch.clone())
+        .unwrap_or_default();
+    let apply = serde_json::to_value(&*state.ghostd_reaper_apply.read())
+        .unwrap_or_else(|_| serde_json::json!({}));
+    Json(serde_json::json!({
+        "settings": {
+            "max_mempool_mb": launch.max_mempool_mb,
+            "mempool_expiry_hours": launch.mempool_expiry_hours,
+            "max_connections": launch.max_connections,
+            "max_upload_target_mb": launch.max_upload_target_mb,
+            "dbcache_mb": launch.dbcache_mb,
+            "block_filter_index": launch.block_filter_index,
+            "peer_block_filters": launch.peer_block_filters,
+            "onlynet": launch.onlynet,
+            "i2p_sam": launch.i2p_sam,
+            "i2p_accept_incoming": launch.i2p_accept_incoming,
+        },
+        // Terminal result of the last automatic ghostd apply.
+        "ghostd_apply": apply,
+        "message": "ghostd daemon launch settings (restart-required)",
+    }))
+}
+
 /// API v1 Config ghost pay handler
 async fn api_config_ghost_pay_handler(
     State(state): State<Arc<VerificationState>>,
@@ -5722,6 +5761,223 @@ async fn api_config_tor_post_handler(
         } else {
             "Tor mode disabled. ghostd is restarting on clearnet; the pool will bounce once it settles."
         },
+    }))
+    .into_response()
+}
+
+/// Request body for the ghostd daemon-settings POST endpoint. Every field is an
+/// `Option`; a missing field clears the corresponding ghostd flag (falls back to
+/// ghostd's own default). Mirrors the `[node_launch]` daemon fields — `tor_mode`
+/// keeps its own `/config/tor` endpoint and is preserved here untouched.
+#[derive(Debug, Default, Deserialize)]
+struct DaemonSettingsRequest {
+    #[serde(default)]
+    max_mempool_mb: Option<u32>,
+    #[serde(default)]
+    mempool_expiry_hours: Option<u32>,
+    #[serde(default)]
+    max_connections: Option<u32>,
+    #[serde(default)]
+    max_upload_target_mb: Option<String>,
+    #[serde(default)]
+    dbcache_mb: Option<u32>,
+    #[serde(default)]
+    block_filter_index: Option<bool>,
+    #[serde(default)]
+    peer_block_filters: Option<bool>,
+    #[serde(default)]
+    onlynet: Option<Vec<String>>,
+    #[serde(default)]
+    i2p_sam: Option<String>,
+    #[serde(default)]
+    i2p_accept_incoming: Option<bool>,
+}
+
+/// Networks ghostd's `-onlynet` accepts (matches `GetNetworkNames()`).
+const VALID_ONLYNET: &[&str] = &["ipv4", "ipv6", "onion", "i2p", "cjdns"];
+
+/// Validate a `-maxuploadtarget` value: a non-negative integer with an optional
+/// single base-unit suffix `[k|K|m|M|g|G|t|T]`. `0` (no limit) is allowed.
+fn valid_upload_target(v: &str) -> bool {
+    if v.is_empty() {
+        return false;
+    }
+    let (num, _unit) = match v.chars().last() {
+        Some(c) if "kKmMgGtT".contains(c) => (&v[..v.len() - 1], Some(c)),
+        _ => (v, None),
+    };
+    !num.is_empty() && num.chars().all(|c| c.is_ascii_digit()) && num.parse::<u64>().is_ok()
+}
+
+/// Validate the incoming daemon settings, returning a human-readable reason on
+/// the first failure. Ranges are deliberately generous but reject nonsense that
+/// would make ghostd refuse to start or cripple this mining node.
+fn validate_daemon_settings(req: &DaemonSettingsRequest) -> Result<(), String> {
+    // Mempool must stay live for block templates; ghostd's floor is small but a
+    // few MB is the practical minimum. Cap well above any realistic value.
+    if let Some(mb) = req.max_mempool_mb {
+        if !(5..=100_000).contains(&mb) {
+            return Err(format!("max_mempool_mb must be 5..=100000 MB (got {mb})"));
+        }
+    }
+    if let Some(h) = req.mempool_expiry_hours {
+        if !(1..=8_760).contains(&h) {
+            return Err(format!(
+                "mempool_expiry_hours must be 1..=8760 hours (got {h})"
+            ));
+        }
+    }
+    // maxconnections=0 would disable listening/dnsseed — unacceptable for a
+    // mining node — so require a sane floor.
+    if let Some(n) = req.max_connections {
+        if !(8..=10_000).contains(&n) {
+            return Err(format!("max_connections must be 8..=10000 (got {n})"));
+        }
+    }
+    if let Some(ref t) = req.max_upload_target_mb {
+        if !valid_upload_target(t) {
+            return Err(format!(
+                "max_upload_target_mb must be a number with optional unit [k|K|m|M|g|G|t|T] (got {t:?})"
+            ));
+        }
+    }
+    if let Some(mb) = req.dbcache_mb {
+        if !(4..=1_000_000).contains(&mb) {
+            return Err(format!("dbcache_mb must be 4..=1000000 MB (got {mb})"));
+        }
+    }
+    if let Some(ref nets) = req.onlynet {
+        for net in nets {
+            let n = net.trim().to_ascii_lowercase();
+            if !VALID_ONLYNET.contains(&n.as_str()) {
+                return Err(format!(
+                    "onlynet entry {net:?} invalid; allowed: {}",
+                    VALID_ONLYNET.join(", ")
+                ));
+            }
+        }
+    }
+    // ghostd refuses to start with -peerblockfilters unless the block-filter
+    // index is also enabled, so reject that combination up front.
+    if req.peer_block_filters == Some(true) && req.block_filter_index != Some(true) {
+        return Err(
+            "peer_block_filters (BIP157) requires block_filter_index to be enabled too".to_string(),
+        );
+    }
+    // I2P SAM proxy must be host:port with a numeric port.
+    if let Some(ref sam) = req.i2p_sam {
+        let ok = sam
+            .rsplit_once(':')
+            .is_some_and(|(host, port)| !host.is_empty() && port.parse::<u16>().is_ok());
+        if !ok {
+            return Err(format!("i2p_sam must be host:port with a numeric port (got {sam:?})"));
+        }
+    }
+    if req.i2p_accept_incoming == Some(true) && req.i2p_sam.is_none() {
+        return Err("i2p_accept_incoming requires i2p_sam to be set".to_string());
+    }
+    Ok(())
+}
+
+/// API v1 Config daemon POST handler — sets ghostd launch flags (mempool,
+/// connectivity, performance, BIP157 indexes, onlynet, I2P).
+///
+/// ghostd reads all of these only at startup, so — exactly like `-tormode` and
+/// the `-ghostreaper` flags — this persists `[node_launch]` to pool.toml and
+/// then reuses `spawn_ghostd_reaper_apply`, which runs `ghost-setup apply-reaper`
+/// to regenerate the combined managed drop-in and RESTART ghostd, then bounces
+/// ghost-pool. The response returns promptly with the apply *initiated*; the
+/// terminal result lands on the `/config/daemon` GET endpoint's `ghostd_apply`.
+async fn api_config_daemon_post_handler(
+    State(state): State<Arc<VerificationState>>,
+    Json(payload): Json<DaemonSettingsRequest>,
+) -> impl IntoResponse {
+    // Validate before touching anything; reject nonsense with 400.
+    if let Err(reason) = validate_daemon_settings(&payload) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "success": false,
+                "error": reason,
+                "code": "INVALID_DAEMON_SETTINGS",
+            })),
+        )
+            .into_response();
+    }
+
+    // Require the full node config + a path to persist to; otherwise the change
+    // can't survive a restart, so fail-closed with SERVICE_UNAVAILABLE.
+    let Some(ref full) = state.full_node_config else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(serde_json::json!({
+                "success": false,
+                "error": "Config update API not available: full node config not loaded",
+                "code": "CONFIG_NOT_LOADED",
+            })),
+        )
+            .into_response();
+    };
+    let Some(ref path) = state.full_node_config_path else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(serde_json::json!({
+                "success": false,
+                "error": "Config update API not available: no node config path configured",
+                "code": "CONFIG_NOT_LOADED",
+            })),
+        )
+            .into_response();
+    };
+
+    {
+        let mut cfg = full.write();
+        // tor_mode is owned by /config/tor — preserve it. Overwrite the daemon
+        // fields wholesale from the request (a missing field clears the flag,
+        // reverting to ghostd's default), normalising onlynet entries.
+        let launch = &mut cfg.node_launch;
+        launch.max_mempool_mb = payload.max_mempool_mb;
+        launch.mempool_expiry_hours = payload.mempool_expiry_hours;
+        launch.max_connections = payload.max_connections;
+        launch.max_upload_target_mb = payload.max_upload_target_mb.clone();
+        launch.dbcache_mb = payload.dbcache_mb;
+        launch.block_filter_index = payload.block_filter_index;
+        launch.peer_block_filters = payload.peer_block_filters;
+        launch.onlynet = payload
+            .onlynet
+            .clone()
+            .unwrap_or_default()
+            .into_iter()
+            .map(|n| n.trim().to_ascii_lowercase())
+            .collect();
+        launch.i2p_sam = payload.i2p_sam.clone();
+        launch.i2p_accept_incoming = payload.i2p_accept_incoming;
+
+        if let Err(e) = cfg.save_atomic(path) {
+            error!(error = %e, "Failed to persist daemon settings");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({
+                    "success": false,
+                    "error": format!("Failed to persist daemon settings: {e}"),
+                    "code": "PERSIST_FAILED",
+                })),
+            )
+                .into_response();
+        }
+    }
+
+    // Apply the ghostd flags (restarts ghostd) then bounce the pool. Shares the
+    // reaper apply path because the drop-in carries all ghost-managed flags.
+    spawn_ghostd_reaper_apply(Arc::clone(&state));
+
+    let apply = serde_json::to_value(&*state.ghostd_reaper_apply.read())
+        .unwrap_or_else(|_| serde_json::json!({}));
+    Json(serde_json::json!({
+        "success": true,
+        "ghostd_apply": apply,
+        "restart_pending": true,
+        "message": "Daemon settings saved. ghostd is restarting to apply the new launch flags; the pool will bounce once it settles.",
     }))
     .into_response()
 }
@@ -8726,6 +8982,81 @@ mod tests {
                 "malformed new_hash {bad:?} must fall back to current"
             );
         }
+    }
+
+    #[test]
+    fn test_valid_upload_target() {
+        for ok in ["0", "500", "500M", "2G", "1t", "100k"] {
+            assert!(valid_upload_target(ok), "{ok:?} should be valid");
+        }
+        for bad in ["", "M", "5x", "-1", "1.5G", "5 M", "GG"] {
+            assert!(!valid_upload_target(bad), "{bad:?} should be rejected");
+        }
+    }
+
+    #[test]
+    fn test_validate_daemon_settings_accepts_sane_and_rejects_nonsense() {
+        // A fully-populated, sane request passes.
+        let good = DaemonSettingsRequest {
+            max_mempool_mb: Some(600),
+            mempool_expiry_hours: Some(72),
+            max_connections: Some(40),
+            max_upload_target_mb: Some("1G".to_string()),
+            dbcache_mb: Some(2048),
+            block_filter_index: Some(true),
+            peer_block_filters: Some(true),
+            onlynet: Some(vec!["onion".to_string(), "IPv4".to_string()]),
+            i2p_sam: Some("127.0.0.1:7656".to_string()),
+            i2p_accept_incoming: Some(true),
+        };
+        assert!(validate_daemon_settings(&good).is_ok());
+
+        // An all-None request (clear everything back to ghostd defaults) passes.
+        assert!(validate_daemon_settings(&DaemonSettingsRequest::default()).is_ok());
+
+        // Out-of-range scalars are rejected.
+        assert!(validate_daemon_settings(&DaemonSettingsRequest {
+            max_mempool_mb: Some(1),
+            ..Default::default()
+        })
+        .is_err());
+        assert!(validate_daemon_settings(&DaemonSettingsRequest {
+            max_connections: Some(0),
+            ..Default::default()
+        })
+        .is_err());
+        assert!(validate_daemon_settings(&DaemonSettingsRequest {
+            mempool_expiry_hours: Some(0),
+            ..Default::default()
+        })
+        .is_err());
+
+        // Unknown onlynet value rejected.
+        assert!(validate_daemon_settings(&DaemonSettingsRequest {
+            onlynet: Some(vec!["moonnet".to_string()]),
+            ..Default::default()
+        })
+        .is_err());
+
+        // BIP157: peerblockfilters without blockfilterindex is rejected.
+        assert!(validate_daemon_settings(&DaemonSettingsRequest {
+            peer_block_filters: Some(true),
+            block_filter_index: None,
+            ..Default::default()
+        })
+        .is_err());
+
+        // I2P: accept-incoming without a SAM proxy, and a malformed SAM address.
+        assert!(validate_daemon_settings(&DaemonSettingsRequest {
+            i2p_accept_incoming: Some(true),
+            ..Default::default()
+        })
+        .is_err());
+        assert!(validate_daemon_settings(&DaemonSettingsRequest {
+            i2p_sam: Some("no-port".to_string()),
+            ..Default::default()
+        })
+        .is_err());
     }
 
     #[test]

--- a/dashboard/src/app/(dashboard)/settings/daemon/page.tsx
+++ b/dashboard/src/app/(dashboard)/settings/daemon/page.tsx
@@ -1,0 +1,417 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Card, CardHeader } from "@/components/ui/Card";
+import { Input } from "@/components/ui/Input";
+import { Button } from "@/components/ui/Button";
+import { Badge } from "@/components/ui/Badge";
+import { Toggle } from "@/components/ui/Toggle";
+import { ConfirmDialog } from "@/components/ui/Dialog";
+import { SectionErrorBoundary } from "@/components/ui/SectionErrorBoundary";
+import { useToast } from "@/components/ui/Toast";
+import {
+  useDaemonSettings,
+  useSetDaemonSettings,
+  type DaemonSettings,
+} from "@/hooks/queries/useConfigQueries";
+
+// The networks ghostd's -onlynet accepts (mirrors GetNetworkNames()).
+const ONLYNET_OPTIONS = ["ipv4", "ipv6", "onion", "i2p", "cjdns"] as const;
+
+// Local form state: numeric flags are held as strings so an empty box means
+// "unset" (clears the flag → ghostd default). Booleans are plain toggles.
+interface FormState {
+  maxMempoolMb: string;
+  mempoolExpiryHours: string;
+  maxConnections: string;
+  maxUploadTargetMb: string;
+  dbcacheMb: string;
+  blockFilterIndex: boolean;
+  peerBlockFilters: boolean;
+  onlynet: string[];
+  i2pSam: string;
+  i2pAcceptIncoming: boolean;
+}
+
+const EMPTY_FORM: FormState = {
+  maxMempoolMb: "",
+  mempoolExpiryHours: "",
+  maxConnections: "",
+  maxUploadTargetMb: "",
+  dbcacheMb: "",
+  blockFilterIndex: false,
+  peerBlockFilters: false,
+  onlynet: [],
+  i2pSam: "",
+  i2pAcceptIncoming: false,
+};
+
+function fromSettings(s: DaemonSettings | undefined): FormState {
+  if (!s) return EMPTY_FORM;
+  const num = (v: number | null | undefined) => (v === null || v === undefined ? "" : String(v));
+  return {
+    maxMempoolMb: num(s.max_mempool_mb),
+    mempoolExpiryHours: num(s.mempool_expiry_hours),
+    maxConnections: num(s.max_connections),
+    maxUploadTargetMb: s.max_upload_target_mb ?? "",
+    dbcacheMb: num(s.dbcache_mb),
+    blockFilterIndex: s.block_filter_index ?? false,
+    peerBlockFilters: s.peer_block_filters ?? false,
+    onlynet: s.onlynet ?? [],
+    i2pSam: s.i2p_sam ?? "",
+    i2pAcceptIncoming: s.i2p_accept_incoming ?? false,
+  };
+}
+
+// A blank field → null (clears the flag). A filled numeric field → the parsed
+// integer. The backend validates ranges/enum and rejects nonsense with a 400.
+function toSettings(f: FormState): DaemonSettings {
+  const optNum = (v: string): number | null => {
+    const t = v.trim();
+    if (t === "") return null;
+    const n = Number(t);
+    return Number.isFinite(n) ? Math.trunc(n) : null;
+  };
+  const optStr = (v: string): string | null => {
+    const t = v.trim();
+    return t === "" ? null : t;
+  };
+  return {
+    max_mempool_mb: optNum(f.maxMempoolMb),
+    mempool_expiry_hours: optNum(f.mempoolExpiryHours),
+    max_connections: optNum(f.maxConnections),
+    max_upload_target_mb: optStr(f.maxUploadTargetMb),
+    dbcache_mb: optNum(f.dbcacheMb),
+    block_filter_index: f.blockFilterIndex,
+    peer_block_filters: f.peerBlockFilters,
+    onlynet: f.onlynet,
+    i2p_sam: optStr(f.i2pSam),
+    i2p_accept_incoming: f.i2pAcceptIncoming,
+  };
+}
+
+// A labelled numeric/text field row, matching the settings card layout.
+function FieldRow({
+  label,
+  description,
+  value,
+  onChange,
+  placeholder,
+  type = "text",
+  unit,
+  inputMode,
+}: {
+  label: string;
+  description: string;
+  value: string;
+  onChange: (v: string) => void;
+  placeholder?: string;
+  type?: string;
+  unit?: string;
+  inputMode?: "numeric" | "text";
+}) {
+  return (
+    <div className="flex items-center justify-between gap-4 p-3 bg-gray-800/50 rounded-lg">
+      <div className="flex-1 min-w-0">
+        <div className="text-gray-100 font-medium">{label}</div>
+        <div className="text-sm text-gray-400">{description}</div>
+      </div>
+      <div className="flex items-center gap-2 shrink-0">
+        <Input
+          type={type}
+          inputMode={inputMode}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={placeholder ?? "default"}
+          className="w-28 text-right"
+        />
+        {unit && <span className="text-gray-400 text-sm w-10">{unit}</span>}
+      </div>
+    </div>
+  );
+}
+
+function ToggleFieldRow({
+  label,
+  description,
+  enabled,
+  onChange,
+  disabled = false,
+  badge,
+}: {
+  label: string;
+  description: string;
+  enabled: boolean;
+  onChange: (v: boolean) => void;
+  disabled?: boolean;
+  badge?: React.ReactNode;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-4 p-3 bg-gray-800/50 rounded-lg">
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2">
+          <span className="text-gray-100 font-medium">{label}</span>
+          {badge}
+        </div>
+        <div className="text-sm text-gray-400">{description}</div>
+      </div>
+      <Toggle enabled={enabled} onChange={onChange} label={label} disabled={disabled} />
+    </div>
+  );
+}
+
+export default function DaemonSettingsPage() {
+  const { data, isLoading } = useDaemonSettings();
+  const setDaemon = useSetDaemonSettings();
+  const { success, error } = useToast();
+
+  const [form, setForm] = useState<FormState>(EMPTY_FORM);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  // Seed the form once the current settings load / change.
+  const loaded = data?.settings;
+  useEffect(() => {
+    setForm(fromSettings(loaded));
+  }, [loaded]);
+
+  const applyState = data?.ghostd_apply?.state;
+  const applyMessage = data?.ghostd_apply?.message;
+
+  // Client-side guard mirroring the backend's BIP157 dependency, so we can warn
+  // inline before the operator even opens the confirm dialog.
+  const bip157Invalid = form.peerBlockFilters && !form.blockFilterIndex;
+  const i2pIncomingInvalid = form.i2pAcceptIncoming && form.i2pSam.trim() === "";
+
+  const patch = (p: Partial<FormState>) => setForm((f) => ({ ...f, ...p }));
+
+  const toggleNet = (net: string) =>
+    setForm((f) => ({
+      ...f,
+      onlynet: f.onlynet.includes(net)
+        ? f.onlynet.filter((n) => n !== net)
+        : [...f.onlynet, net],
+    }));
+
+  const canApply = useMemo(
+    () => !bip157Invalid && !i2pIncomingInvalid && !setDaemon.isPending,
+    [bip157Invalid, i2pIncomingInvalid, setDaemon.isPending]
+  );
+
+  const handleApply = async () => {
+    try {
+      const res = await setDaemon.mutateAsync(toSettings(form));
+      setConfirmOpen(false);
+      success("Applying", res.message ?? "ghostd is restarting to apply the new launch flags.");
+    } catch (err) {
+      setConfirmOpen(false);
+      error("Failed", err instanceof Error ? err.message : "Unknown error");
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader
+          title="Daemon / Node"
+          subtitle="ghostd launch flags for this node. Every setting here is read only at startup, so applying any change restarts ghostd (and briefly bounces the pool)."
+        />
+        <div className="flex items-center gap-2 text-sm text-gray-400">
+          <span>Last apply:</span>
+          {applyState ? (
+            <Badge
+              variant={
+                applyState === "applied"
+                  ? "success"
+                  : applyState === "failed"
+                  ? "error"
+                  : applyState === "applying"
+                  ? "warning"
+                  : "default"
+              }
+            >
+              {applyState}
+            </Badge>
+          ) : (
+            <Badge variant="default">idle</Badge>
+          )}
+          {applyMessage && <span className="text-gray-500 truncate">{applyMessage}</span>}
+        </div>
+      </Card>
+
+      {isLoading ? (
+        <Card>
+          <p className="text-gray-400 text-sm">Loading daemon settings…</p>
+        </Card>
+      ) : (
+        <SectionErrorBoundary section="Daemon settings">
+          {/* Mempool */}
+          <Card>
+            <CardHeader title="Mempool" subtitle="Transaction pool size and expiry (-maxmempool / -mempoolexpiry)." />
+            <div className="space-y-3">
+              <FieldRow
+                label="Max mempool size"
+                description="Keep the transaction memory pool below this size. Blank = ghostd default."
+                value={form.maxMempoolMb}
+                onChange={(v) => patch({ maxMempoolMb: v })}
+                type="number"
+                inputMode="numeric"
+                unit="MB"
+              />
+              <FieldRow
+                label="Mempool expiry"
+                description="Drop transactions older than this. Blank = ghostd default."
+                value={form.mempoolExpiryHours}
+                onChange={(v) => patch({ mempoolExpiryHours: v })}
+                type="number"
+                inputMode="numeric"
+                unit="hrs"
+              />
+            </div>
+          </Card>
+
+          {/* Connectivity */}
+          <Card>
+            <CardHeader title="Connectivity" subtitle="Peer connection and upload limits (-maxconnections / -maxuploadtarget)." />
+            <div className="space-y-3">
+              <FieldRow
+                label="Max connections"
+                description="Maximum automatic peer connections (8–10000). Blank = ghostd default."
+                value={form.maxConnections}
+                onChange={(v) => patch({ maxConnections: v })}
+                type="number"
+                inputMode="numeric"
+              />
+              <FieldRow
+                label="Max upload target / 24h"
+                description="Outbound traffic ceiling. Number with optional unit k/K/m/M/g/G/t/T (0 = no limit). Blank = ghostd default."
+                value={form.maxUploadTargetMb}
+                onChange={(v) => patch({ maxUploadTargetMb: v })}
+                placeholder="e.g. 500M"
+              />
+            </div>
+          </Card>
+
+          {/* Performance */}
+          <Card>
+            <CardHeader title="Performance" subtitle="Database cache size (-dbcache)." />
+            <div className="space-y-3">
+              <FieldRow
+                label="Database cache"
+                description="UTXO/db cache in megabytes. Larger speeds up sync at the cost of RAM. Blank = ghostd default."
+                value={form.dbcacheMb}
+                onChange={(v) => patch({ dbcacheMb: v })}
+                type="number"
+                inputMode="numeric"
+                unit="MB"
+              />
+            </div>
+          </Card>
+
+          {/* Indexes / BIP157 */}
+          <Card>
+            <CardHeader title="Indexes (BIP157)" subtitle="Compact block filters for light clients (-blockfilterindex / -peerblockfilters)." />
+            <div className="space-y-3">
+              <ToggleFieldRow
+                label="Block filter index"
+                description="Build the basic block-filter index. Enabling triggers a one-time index build over the whole chain, which takes time and disk."
+                enabled={form.blockFilterIndex}
+                onChange={(v) => patch({ blockFilterIndex: v, peerBlockFilters: v ? form.peerBlockFilters : false })}
+              />
+              <ToggleFieldRow
+                label="Serve compact filters (peer block filters)"
+                description="Serve BIP157 compact block filters to connecting light clients. Requires the block filter index above."
+                enabled={form.peerBlockFilters}
+                onChange={(v) => patch({ peerBlockFilters: v })}
+                disabled={!form.blockFilterIndex}
+              />
+              {bip157Invalid && (
+                <p className="text-xs text-red-400 px-1">
+                  Peer block filters need the block filter index enabled too.
+                </p>
+              )}
+            </div>
+          </Card>
+
+          {/* Privacy networking */}
+          <Card>
+            <CardHeader title="Privacy networking" subtitle="Restrict outbound networks and reach I2P peers (-onlynet / -i2psam)." />
+            <div className="space-y-3">
+              <div className="p-3 bg-gray-800/50 rounded-lg">
+                <div className="text-gray-100 font-medium">Only connect via networks</div>
+                <div className="text-sm text-gray-400 mb-3">
+                  Restrict automatic outbound connections to the selected networks. None selected = no restriction.
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  {ONLYNET_OPTIONS.map((net) => {
+                    const on = form.onlynet.includes(net);
+                    return (
+                      <button
+                        key={net}
+                        type="button"
+                        onClick={() => toggleNet(net)}
+                        className={`px-3 py-1 rounded-lg text-sm border transition-colors ${
+                          on
+                            ? "bg-orange-600 text-white border-orange-500"
+                            : "bg-transparent text-gray-300 border-gray-600 hover:bg-gray-800"
+                        }`}
+                      >
+                        {net}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+              <FieldRow
+                label="I2P SAM proxy"
+                description="host:port of an I2P SAM proxy to reach I2P peers. Blank = I2P disabled."
+                value={form.i2pSam}
+                onChange={(v) => patch({ i2pSam: v, i2pAcceptIncoming: v.trim() === "" ? false : form.i2pAcceptIncoming })}
+                placeholder="127.0.0.1:7656"
+              />
+              <ToggleFieldRow
+                label="Accept inbound I2P connections"
+                description="Allow inbound I2P connections through the SAM proxy. Requires an I2P SAM proxy above."
+                enabled={form.i2pAcceptIncoming}
+                onChange={(v) => patch({ i2pAcceptIncoming: v })}
+                disabled={form.i2pSam.trim() === ""}
+              />
+              {i2pIncomingInvalid && (
+                <p className="text-xs text-red-400 px-1">
+                  Accepting inbound I2P needs an I2P SAM proxy address.
+                </p>
+              )}
+            </div>
+          </Card>
+
+          {/* Apply */}
+          <Card>
+            <div className="flex items-center justify-between gap-4">
+              <div className="text-sm text-gray-400">
+                Applying these changes restarts ghostd and briefly bounces ghost-pool.
+              </div>
+              <Button
+                variant="primary"
+                disabled={!canApply}
+                loading={setDaemon.isPending}
+                onClick={() => setConfirmOpen(true)}
+              >
+                Apply &amp; restart
+              </Button>
+            </div>
+          </Card>
+        </SectionErrorBoundary>
+      )}
+
+      <ConfirmDialog
+        isOpen={confirmOpen}
+        onClose={() => setConfirmOpen(false)}
+        onConfirm={handleApply}
+        title="Apply daemon settings & restart ghostd?"
+        message="ghostd will restart with the new launch flags and ghost-pool will bounce once it settles. Mining pauses for a few seconds during the restart. Continue?"
+        confirmLabel="Apply & restart"
+        variant="danger"
+        loading={setDaemon.isPending}
+      />
+    </div>
+  );
+}

--- a/dashboard/src/app/(dashboard)/settings/layout.tsx
+++ b/dashboard/src/app/(dashboard)/settings/layout.tsx
@@ -80,6 +80,15 @@ const NAV_ITEMS = [
     ),
   },
   {
+    href: "/settings/daemon",
+    label: "Daemon",
+    icon: (
+      <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2m-2-4h.01M17 16h.01" />
+      </svg>
+    ),
+  },
+  {
     href: "/settings/alerts",
     label: "Alerts",
     icon: (

--- a/dashboard/src/hooks/queries/useConfigQueries.ts
+++ b/dashboard/src/hooks/queries/useConfigQueries.ts
@@ -8,6 +8,9 @@ import {
   setReaper,
   getReaper,
   type ReaperSettings,
+  getDaemonSettings,
+  setDaemonSettings,
+  type DaemonSettings,
   setMempoolProfile,
   setTemplateProfile,
   getMempoolProfiles,
@@ -110,6 +113,28 @@ export function useSetReaper() {
     mutationFn: (input: ReaperSettings | boolean) => setReaper(input),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: configKeys.all });
+    },
+  });
+}
+
+export function useDaemonSettings() {
+  return useQuery({
+    queryKey: [...configKeys.all, 'daemon'] as const,
+    queryFn: getDaemonSettings,
+    staleTime: 30_000,
+  });
+}
+
+export function useSetDaemonSettings() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (settings: DaemonSettings) => setDaemonSettings(settings),
+    onSuccess: () => {
+      // Config changed; the live daemon state flips once ghostd finishes
+      // restarting — refresh both the config views and node status.
+      queryClient.invalidateQueries({ queryKey: configKeys.all });
+      queryClient.invalidateQueries({ queryKey: nodeKeys.status() });
     },
   });
 }
@@ -359,4 +384,4 @@ export function useSetPublicMiningConfig() {
 }
 
 // Re-export types for convenience
-export type { CustomMempoolProfile, CustomTemplateProfile };
+export type { CustomMempoolProfile, CustomTemplateProfile, DaemonSettings };

--- a/dashboard/src/lib/api/config.ts
+++ b/dashboard/src/lib/api/config.ts
@@ -57,6 +57,53 @@ export async function setTor(enabled: boolean): Promise<TorToggleResult> {
   });
 }
 
+// ghostd daemon / node launch settings (pool.toml [node_launch]). Every field
+// maps to a ghostd startup flag, so a change requires a ghostd restart. A field
+// left undefined/null clears the flag (reverts to ghostd's own default).
+export interface DaemonSettings {
+  // Mempool
+  max_mempool_mb?: number | null;       // -maxmempool (MB)
+  mempool_expiry_hours?: number | null; // -mempoolexpiry (hours)
+  // Connectivity
+  max_connections?: number | null;      // -maxconnections
+  max_upload_target_mb?: string | null; // -maxuploadtarget (number + optional unit k|K|m|M|g|G|t|T; 0 = no limit)
+  // Performance
+  dbcache_mb?: number | null;           // -dbcache (MB)
+  // Indexes / BIP157
+  block_filter_index?: boolean | null;  // -blockfilterindex=1 (triggers an index build)
+  peer_block_filters?: boolean | null;  // -peerblockfilters=1 (requires block_filter_index)
+  // Privacy networking
+  onlynet?: string[];                    // -onlynet (repeated): ipv4|ipv6|onion|i2p|cjdns
+  i2p_sam?: string | null;               // -i2psam host:port
+  i2p_accept_incoming?: boolean | null;  // -i2pacceptincoming=1 (needs i2p_sam)
+}
+
+export interface DaemonConfigResponse {
+  settings: DaemonSettings;
+  ghostd_apply?: GhostdApplyStatus;
+  message: string;
+}
+
+export interface DaemonUpdateResponse {
+  success: boolean;
+  restart_pending?: boolean;
+  ghostd_apply?: GhostdApplyStatus;
+  message: string;
+}
+
+export async function getDaemonSettings(): Promise<DaemonConfigResponse> {
+  return fetchApi<DaemonConfigResponse>('/api/v1/config/daemon');
+}
+
+// Persist [node_launch] daemon settings and apply them: ghostd's launch-flag
+// drop-in is regenerated and ghostd is RESTARTED, then ghost-pool bounces.
+export async function setDaemonSettings(settings: DaemonSettings): Promise<DaemonUpdateResponse> {
+  return fetchApi<DaemonUpdateResponse>('/api/v1/config/daemon', {
+    method: 'POST',
+    body: JSON.stringify(settings),
+  });
+}
+
 export async function setArchiveMode(enabled: boolean): Promise<NodeConfig> {
   return fetchApi<NodeConfig>('/api/v1/config/archive_mode', {
     method: 'POST',


### PR DESCRIPTION
## What

Extends the existing ghostd launch-flag bridge (the same mechanism Tor uses) so operator daemon settings actually reach `ghostd`, and adds a set of real daemon toggles through it. All new flags are ghostd **startup** flags, so — exactly like `-tormode` — applying any of them regenerates the managed systemd drop-in and **restarts ghostd**, then bounces ghost-pool.

No deploy, no merge intended by this PR.

## Flags added (all verified present in `ghost-core/src/init.cpp`)

| Field (`[node_launch]`) | ghostd flag | init.cpp |
|---|---|---|
| `max_mempool_mb` | `-maxmempool=<MB>` | :555 |
| `mempool_expiry_hours` | `-mempoolexpiry=<hours>` | :558 |
| `max_connections` | `-maxconnections=<n>` | :599 |
| `max_upload_target_mb` | `-maxuploadtarget=<val>` (unit-friendly) | :602 |
| `dbcache_mb` | `-dbcache=<MB>` | :551 |
| `block_filter_index` | `-blockfilterindex=1` | :580 |
| `peer_block_filters` | `-peerblockfilters=1` (BIP157) | :613 |
| `onlynet` (list) | repeated `-onlynet=<net>` | :610 |
| `i2p_sam` | `-i2psam=<addr>` | :608 |
| `i2p_accept_incoming` | `-i2pacceptincoming=1` | :609 |

`-blocksonly` is deliberately **not** added — it is incompatible with a mining node, which needs a live mempool for templates.

## How it stays additive / idempotent

- Every field is `Option`/serde-default, so existing `pool.toml` files parse unchanged, and `ghostd_flags()` emits a flag only when set (a node with everything off adds nothing to `ExecStart`).
- `is_managed_ghostd_flag` now matches every managed prefix (reaper + tor + the new daemon flags), so `ghostd_managed_dropin` strips and re-appends the full ghost-managed set — regeneration is idempotent and coexists with `-tormode` / `-ghostreaper*`. `ghost-setup apply-reaper` already reads `[node_launch]`, so no change was needed there.

## Endpoint

`GET/POST /api/v1/config/daemon` on the internal HMAC router, mirroring `/config/tor`. POST validates ranges/enum and rejects nonsense with 400 — including the ghostd-enforced dependencies (`peerblockfilters` needs `blockfilterindex`; I2P accept-incoming needs `i2psam`). Persists via `save_atomic` (preserving `tor_mode`), then reuses `spawn_ghostd_reaper_apply`.

## Frontend

New **Settings › Daemon** page grouping the flags (Mempool / Connectivity / Performance / Indexes / Privacy networking), each with an **Apply & restart** confirm. Notes that enabling the block filter index triggers a one-time index build. Client + hooks + types added.

## Tests / build

- `cargo check -p ghost-common -p ghost-verification -p ghost-setup -p ghost-pool -j2` clean.
- New unit tests: `ghostd_flags()` per-field emission + None/false absence + serde back-compat; `ghostd_managed_dropin` daemon-flag round-trip (strip + re-append once, coexists with tor/reaper); endpoint input validation. All pass.
- `tsc --noEmit` + `eslint` clean on changed files; `npm run build` succeeds (`/settings/daemon` route generated).
