### PR TITLE
alerts: reorg-detected, stale-tip, and update-available events

### DIFF
--- a/bins/ghost-pool/src/alert_monitors.rs
+++ b/bins/ghost-pool/src/alert_monitors.rs
@@ -1,0 +1,323 @@
+//! Periodic operator-alert monitors.
+//!
+//! Two small background tasks that feed the existing operator-alert pipeline
+//! (`ghost_verification::alerts`) for conditions that have no natural
+//! event-driven trigger site:
+//!
+//! * **Behind-tip** — the node has fallen behind the network: either its local
+//!   height lags the best connected peer by more than [`BEHIND_TIP_LAG_BLOCKS`],
+//!   or no new block has arrived for [`BEHIND_TIP_MAX_AGE_SECS`] while a peer is
+//!   ahead. Edge-triggered: one alert on entering the behind state, re-armed on
+//!   recovery.
+//! * **Update-available** — a newer node release than the one installed is
+//!   published. The installed/latest versions come from the same files the
+//!   dashboard auto-update view reads (`/etc/ghost/version` and the updater
+//!   status file). Rate-limited to at most once per day.
+//!
+//! Both dispatch off the hot path (their own spawned tasks) and both honour the
+//! operator's per-event enable flag + master switch inside the dispatcher.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use ghost_verification::alerts::{AlertDispatcher, AlertEvent};
+use tokio::sync::broadcast;
+use tracing::{debug, info};
+
+/// How far the local height may lag the best peer before the node is "behind".
+/// `best_peer - local > K` (strictly greater) trips the alert.
+pub const BEHIND_TIP_LAG_BLOCKS: u64 = 3;
+
+/// How long the tip may stall (no new block) — while a peer is ahead — before
+/// the node is considered behind. ~30 minutes: comfortably longer than the
+/// ~10-minute target block interval, so ordinary variance never trips it.
+pub const BEHIND_TIP_MAX_AGE_SECS: u64 = 30 * 60;
+
+/// Cadence of the behind-tip check.
+pub const BEHIND_TIP_CHECK_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Cadence of the update-available check. The alert itself is separately
+/// rate-limited to [`UPDATE_ALERT_MIN_INTERVAL`], so this only bounds freshness.
+pub const UPDATE_CHECK_INTERVAL: Duration = Duration::from_secs(6 * 3600);
+
+/// Minimum interval between update-available alerts — at most once per day while
+/// an update remains available.
+pub const UPDATE_ALERT_MIN_INTERVAL: Duration = Duration::from_secs(24 * 3600);
+
+/// Default path to the installed-version marker (matches the dashboard route).
+const DEFAULT_VERSION_FILE: &str = "/etc/ghost/version";
+/// Default path to the updater status file carrying `latest_version`.
+const DEFAULT_STATUS_FILE: &str = "/var/lib/ghost/auto-update.status";
+
+/// Decide whether the node is behind the network tip, returning an
+/// operator-facing detail string when it is (and `None` when it is caught up).
+/// Pure — no I/O or clock access — so the threshold logic is unit-testable.
+///
+/// * `best_peer_height == 0` is treated as "no peer height reported" and never
+///   trips the alert (an isolated or just-started node must not false-positive).
+/// * lagging: `best_peer - local > lag_blocks_k`.
+/// * stalled: `tip_age_secs > max_tip_age_secs` AND a peer is strictly ahead.
+pub fn evaluate_behind_tip(
+    local_height: u64,
+    best_peer_height: u64,
+    tip_age_secs: u64,
+    lag_blocks_k: u64,
+    max_tip_age_secs: u64,
+) -> Option<String> {
+    if best_peer_height == 0 {
+        return None;
+    }
+    let lag = best_peer_height.saturating_sub(local_height);
+    if lag > lag_blocks_k {
+        return Some(format!(
+            "Node is {lag} blocks behind the network: local height {local_height}, \
+             best peer height {best_peer_height}."
+        ));
+    }
+    if tip_age_secs > max_tip_age_secs && best_peer_height > local_height {
+        return Some(format!(
+            "No new block for {} min while a peer is ahead: local height {local_height}, \
+             best peer height {best_peer_height}.",
+            tip_age_secs / 60
+        ));
+    }
+    None
+}
+
+/// Parse a dotted version ("1.10.20", "v1.2", "1.2.3-rc1") into its numeric
+/// components, ignoring any `-prerelease`/`+build` metadata and any non-digit
+/// suffix on a segment. Missing components compare as 0.
+fn parse_version(v: &str) -> Vec<u64> {
+    let v = v.trim().trim_start_matches(['v', 'V']);
+    let core = v.split(['-', '+']).next().unwrap_or(v);
+    core.split('.')
+        .map(|seg| {
+            let digits: String = seg.chars().take_while(char::is_ascii_digit).collect();
+            digits.parse::<u64>().unwrap_or(0)
+        })
+        .collect()
+}
+
+/// Whether `latest` is a strictly newer version than `installed`. Pure, so the
+/// comparison is unit-testable independent of the file reads.
+pub fn version_is_newer(latest: &str, installed: &str) -> bool {
+    let a = parse_version(latest);
+    let b = parse_version(installed);
+    let n = a.len().max(b.len());
+    for i in 0..n {
+        let x = a.get(i).copied().unwrap_or(0);
+        let y = b.get(i).copied().unwrap_or(0);
+        if x != y {
+            return x > y;
+        }
+    }
+    false
+}
+
+/// Read the installed version (from the version-marker file, falling back to the
+/// running binary's version) and the latest version (from the updater status
+/// file's `latest_version` field). Returns `None` when no latest version is
+/// available, so the caller simply skips this cycle. Paths are overridable via
+/// `GHOST_VERSION_FILE` / `GHOST_AUTOUPDATE_STATUS` (matching the dashboard).
+async fn read_versions(installed_fallback: &str) -> Option<(String, String)> {
+    let version_path =
+        std::env::var("GHOST_VERSION_FILE").unwrap_or_else(|_| DEFAULT_VERSION_FILE.to_string());
+    let status_path = std::env::var("GHOST_AUTOUPDATE_STATUS")
+        .unwrap_or_else(|_| DEFAULT_STATUS_FILE.to_string());
+
+    let installed = tokio::fs::read_to_string(&version_path)
+        .await
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| installed_fallback.to_string());
+
+    let latest = tokio::fs::read_to_string(&status_path)
+        .await
+        .ok()
+        .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
+        .and_then(|v| {
+            v.get("latest_version")
+                .and_then(|x| x.as_str())
+                .map(str::to_string)
+        })
+        .filter(|s| !s.is_empty())?;
+
+    Some((installed, latest))
+}
+
+/// Spawn the behind-tip monitor. `local_height` reads this node's current L1
+/// height; `best_peer_height` reads the highest L1 height reported by a
+/// connected mesh peer (0 when none is known). Runs until `shutdown` fires.
+pub fn spawn_behind_tip_monitor<L, P>(
+    alerts: Arc<AlertDispatcher>,
+    local_height: L,
+    best_peer_height: P,
+    mut shutdown: broadcast::Receiver<()>,
+) where
+    L: Fn() -> u64 + Send + 'static,
+    P: Fn() -> u64 + Send + 'static,
+{
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(BEHIND_TIP_CHECK_INTERVAL);
+        // Track when the local height last advanced, to derive tip age without a
+        // block-timestamp source.
+        let mut last_height = local_height();
+        let mut last_change = Instant::now();
+        info!("Behind-tip monitor started");
+        loop {
+            tokio::select! {
+                _ = interval.tick() => {
+                    let local = local_height();
+                    if local > last_height {
+                        last_height = local;
+                        last_change = Instant::now();
+                    }
+                    let best_peer = best_peer_height();
+                    let tip_age = last_change.elapsed().as_secs();
+                    let detail = evaluate_behind_tip(
+                        local,
+                        best_peer,
+                        tip_age,
+                        BEHIND_TIP_LAG_BLOCKS,
+                        BEHIND_TIP_MAX_AGE_SECS,
+                    );
+                    let active = detail.is_some();
+                    if active {
+                        debug!(local, best_peer, tip_age, "Node appears behind the tip");
+                    }
+                    alerts
+                        .fire_edge(
+                            AlertEvent::BehindTip,
+                            "tip",
+                            active,
+                            detail.as_deref().unwrap_or(""),
+                        )
+                        .await;
+                }
+                _ = shutdown.recv() => break,
+            }
+        }
+    });
+}
+
+/// Spawn the update-available monitor. `installed_fallback` is the running
+/// binary's version, used when the version-marker file is absent. Runs until
+/// `shutdown` fires.
+pub fn spawn_update_available_monitor(
+    alerts: Arc<AlertDispatcher>,
+    installed_fallback: String,
+    mut shutdown: broadcast::Receiver<()>,
+) {
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(UPDATE_CHECK_INTERVAL);
+        info!("Update-available monitor started");
+        loop {
+            tokio::select! {
+                _ = interval.tick() => {
+                    if let Some((installed, latest)) = read_versions(&installed_fallback).await {
+                        if version_is_newer(&latest, &installed) {
+                            let detail = format!(
+                                "A newer node release is available: installed {installed}, \
+                                 latest {latest}. See the dashboard to update."
+                            );
+                            alerts
+                                .fire_rate_limited(
+                                    AlertEvent::UpdateAvailable,
+                                    UPDATE_ALERT_MIN_INTERVAL,
+                                    &detail,
+                                )
+                                .await;
+                        }
+                    }
+                }
+                _ = shutdown.recv() => break,
+            }
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn behind_tip_none_when_no_peer_height() {
+        // best_peer == 0 means "unknown" — never alert.
+        assert!(evaluate_behind_tip(0, 0, 999_999, BEHIND_TIP_LAG_BLOCKS, BEHIND_TIP_MAX_AGE_SECS)
+            .is_none());
+        assert!(evaluate_behind_tip(
+            100,
+            0,
+            999_999,
+            BEHIND_TIP_LAG_BLOCKS,
+            BEHIND_TIP_MAX_AGE_SECS
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn behind_tip_fires_when_lagging_by_more_than_k() {
+        // local 100, peer 104 → lag 4 > K(3) → behind.
+        let d = evaluate_behind_tip(100, 104, 5, 3, BEHIND_TIP_MAX_AGE_SECS);
+        assert!(d.is_some());
+        assert!(d.unwrap().contains("4 blocks behind"));
+    }
+
+    #[test]
+    fn behind_tip_silent_when_lag_within_k() {
+        // lag exactly K is not "more than K"; recent tip → not stalled.
+        assert!(evaluate_behind_tip(100, 103, 5, 3, BEHIND_TIP_MAX_AGE_SECS).is_none());
+        // caught up / ahead.
+        assert!(evaluate_behind_tip(100, 100, 5, 3, BEHIND_TIP_MAX_AGE_SECS).is_none());
+        assert!(evaluate_behind_tip(105, 100, 5, 3, BEHIND_TIP_MAX_AGE_SECS).is_none());
+    }
+
+    #[test]
+    fn behind_tip_fires_on_stalled_tip_while_peer_ahead() {
+        // Only 1 block behind (within K) but the tip has been stale > max age
+        // and a peer is ahead → stalled alert.
+        let d = evaluate_behind_tip(100, 101, BEHIND_TIP_MAX_AGE_SECS + 1, 3, BEHIND_TIP_MAX_AGE_SECS);
+        assert!(d.is_some());
+        assert!(d.unwrap().contains("No new block"));
+    }
+
+    #[test]
+    fn behind_tip_no_stall_alert_when_caught_up_even_if_old() {
+        // Tip old but peer not ahead (we are at/above best peer) → healthy.
+        assert!(evaluate_behind_tip(
+            101,
+            101,
+            BEHIND_TIP_MAX_AGE_SECS + 100,
+            3,
+            BEHIND_TIP_MAX_AGE_SECS
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn version_newer_basic() {
+        assert!(version_is_newer("1.10.20", "1.10.6"));
+        assert!(version_is_newer("1.11.0", "1.10.20"));
+        assert!(version_is_newer("2.0.0", "1.99.99"));
+        assert!(!version_is_newer("1.10.6", "1.10.20"));
+        assert!(!version_is_newer("1.10.20", "1.10.20"));
+        assert!(!version_is_newer("1.10.20", "1.10.21"));
+    }
+
+    #[test]
+    fn version_newer_tolerates_prefixes_and_suffixes() {
+        assert!(version_is_newer("v1.10.20", "1.10.6"));
+        assert!(version_is_newer("1.10.20", "v1.10.6"));
+        assert!(version_is_newer("1.11.0-rc1", "1.10.20"));
+        // Same numeric core, one prerelease: numeric core equal → not "newer".
+        assert!(!version_is_newer("1.10.20-rc1", "1.10.20"));
+    }
+
+    #[test]
+    fn version_newer_handles_missing_components() {
+        assert!(version_is_newer("1.11", "1.10.20"));
+        assert!(!version_is_newer("1.10", "1.10.0"));
+        assert!(version_is_newer("1.10.1", "1.10"));
+    }
+}

--- a/bins/ghost-pool/src/lib.rs
+++ b/bins/ghost-pool/src/lib.rs
@@ -39,6 +39,9 @@
 //! - [`treasury`] - Treasury state and fee distribution tracking
 //! - [`validation`] - Input validation for miner credentials and shares
 
+/// Periodic operator-alert monitors (behind-tip / update-available).
+pub mod alert_monitors;
+
 /// Coinbase transaction verification against payout commitments.
 pub mod coinbase_verifier;
 

--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -6947,6 +6947,42 @@ async fn main() -> Result<()> {
         }
     });
 
+    // Start the behind-tip monitor. Edge-triggered `BehindTip` alert when this
+    // node's local height lags the best connected peer, or the tip stalls while
+    // a peer is ahead. Uses the same height/peer plumbing the /health + swarm
+    // views read; delivery + the enable flag are handled inside the dispatcher.
+    {
+        let rm_for_tip = Arc::clone(&round_manager);
+        let mesh_for_tip = Arc::clone(&mesh);
+        let alerts_for_tip = Arc::clone(&alert_dispatcher);
+        ghost_pool::alert_monitors::spawn_behind_tip_monitor(
+            alerts_for_tip,
+            move || rm_for_tip.current_height(),
+            move || {
+                // Highest L1 height reported by a fresh, connected mesh peer
+                // (0 when none is known → the monitor stays silent).
+                mesh_for_tip
+                    .peers()
+                    .get_connected_peers(120)
+                    .iter()
+                    .map(|p| p.block_height)
+                    .max()
+                    .unwrap_or(0)
+            },
+            shutdown_tx.subscribe(),
+        );
+    }
+
+    // Start the update-available monitor. Rate-limited `UpdateAvailable` alert
+    // (at most once/day) when the updater's published latest version is newer
+    // than the installed one — same version files the dashboard auto-update
+    // view reads.
+    ghost_pool::alert_monitors::spawn_update_available_monitor(
+        Arc::clone(&alert_dispatcher),
+        env!("CARGO_PKG_VERSION").to_string(),
+        shutdown_tx.subscribe(),
+    );
+
     // Start pool time-series sampler task.
     // Snapshots the mesh-wide pool hashrate + connected-miner count (the same
     // accessors the /api/v1/mining/status handler reads) into the bounded
@@ -7903,10 +7939,13 @@ async fn main() -> Result<()> {
             }
         });
 
-        // Start reorg handler (subscribes to block disconnect events)
+        // Start reorg handler (subscribes to block disconnect events). Wire the
+        // operator-alert dispatcher so the existing reorg-detection point also
+        // fires a `ReorgDetected` alert (gated on the operator's event flag).
         let block_events = zmq_subscriber.subscribe_block_events();
         let reorg_handler = ReorgHandler::new(Arc::clone(&db), ReorgConfig::default())
-            .with_vote_handler(Arc::clone(&vote_handler));
+            .with_vote_handler(Arc::clone(&vote_handler))
+            .with_alert_dispatcher(Arc::clone(&alert_dispatcher));
         reorg_handler.start(block_events);
 
         info!("ZMQ block watcher connected to {}", zmq_endpoint);

--- a/bins/ghost-pool/src/reorg.rs
+++ b/bins/ghost-pool/src/reorg.rs
@@ -46,6 +46,13 @@ use ghost_common::zmq::BlockEvent;
 use ghost_consensus::vote_handler::VoteHandler;
 use ghost_storage::models::PayoutStatus;
 use ghost_storage::Database;
+use ghost_verification::alerts::{AlertDispatcher, AlertEvent};
+use std::time::Duration;
+
+/// Debounce window for reorg alerts. A single reorg emits one `Disconnected`
+/// event per orphaned block, so without this a depth-N reorg would fire N
+/// alerts in a burst. One alert per window is enough to page the operator.
+const REORG_ALERT_MIN_INTERVAL: Duration = Duration::from_secs(60);
 
 /// Safely truncate a hash string for logging (returns up to 16 chars or full string if shorter)
 fn truncate_hash(hash: &str) -> &str {
@@ -109,6 +116,10 @@ impl ReorgConfig {
 pub struct ReorgHandler {
     db: Arc<Database>,
     vote_handler: Option<Arc<VoteHandler>>,
+    /// Operator-alert dispatcher. When set, a `ReorgDetected` alert fires (once
+    /// per debounce window, and only if the operator has the event enabled) at
+    /// the existing reorg-detection point.
+    alerts: Option<Arc<AlertDispatcher>>,
     config: ReorgConfig,
     /// Counter for consecutive reorgs (deep reorg detection)
     consecutive_reorgs: AtomicU32,
@@ -133,6 +144,7 @@ impl ReorgHandler {
         Self {
             db,
             vote_handler: None,
+            alerts: None,
             consecutive_reorgs: AtomicU32::new(0),
             stats: ReorgStatsInner {
                 total_reorgs: AtomicU64::new(0),
@@ -149,6 +161,12 @@ impl ReorgHandler {
     /// Set the vote handler for cancelling pending proposals
     pub fn with_vote_handler(mut self, vh: Arc<VoteHandler>) -> Self {
         self.vote_handler = Some(vh);
+        self
+    }
+
+    /// Wire the operator-alert dispatcher so reorgs page the operator.
+    pub fn with_alert_dispatcher(mut self, alerts: Arc<AlertDispatcher>) -> Self {
+        self.alerts = Some(alerts);
         self
     }
 
@@ -281,6 +299,26 @@ impl ReorgHandler {
             reorg_depth,
             "REORG DETECTED: Block disconnected from main chain"
         );
+
+        // Fire the operator alert at the detection point. Rate-limited so a
+        // multi-block reorg (one Disconnected event per orphaned block) pages
+        // once, not once per block; the dispatcher also gates on the master
+        // switch and the `reorg_detected` event flag. `old_tip` is the
+        // disconnected block hash; depth is the consecutive-disconnect count.
+        // The new tip is not carried on the ZMQ sequence event, so it is
+        // omitted from the message.
+        if let Some(alerts) = &self.alerts {
+            let detail = format!(
+                "Bitcoin chain reorg detected: block {hash_display} disconnected from the tip (depth {reorg_depth})."
+            );
+            alerts
+                .fire_rate_limited(
+                    AlertEvent::ReorgDetected,
+                    REORG_ALERT_MIN_INTERVAL,
+                    &detail,
+                )
+                .await;
+        }
 
         // 1. Mark affected rounds as orphaned
         match self.db.mark_rounds_orphaned_by_hash(block_hash) {

--- a/crates/ghost-common/src/config.rs
+++ b/crates/ghost-common/src/config.rs
@@ -1781,6 +1781,15 @@ pub struct AlertEvents {
     /// This node found a block.
     #[serde(default = "default_true")]
     pub block_found: bool,
+    /// A Bitcoin chain reorg was detected (a block disconnected from the tip).
+    #[serde(default = "default_true")]
+    pub reorg_detected: bool,
+    /// The node is behind the network tip (stale tip / lagging local height).
+    #[serde(default = "default_true")]
+    pub behind_tip: bool,
+    /// A newer node release is available than the one installed.
+    #[serde(default = "default_true")]
+    pub update_available: bool,
 }
 
 impl Default for AlertEvents {
@@ -1792,6 +1801,9 @@ impl Default for AlertEvents {
             restart_needed: true,
             peer_count_drop: true,
             block_found: true,
+            reorg_detected: true,
+            behind_tip: true,
+            update_available: true,
         }
     }
 }
@@ -1900,6 +1912,47 @@ mod tests {
         let config = NodeConfig::default();
         assert_eq!(config.network.sv2_port, SV2_STRATUM_PORT);
         assert_eq!(config.bitcoin.network, BitcoinNetwork::Signet);
+    }
+
+    #[test]
+    fn alert_events_default_all_on() {
+        let e = AlertEvents::default();
+        assert!(e.reorg_detected && e.behind_tip && e.update_available);
+    }
+
+    #[test]
+    fn alert_events_legacy_toml_still_parses_with_new_events_on() {
+        // A config written before the reorg/behind-tip/update events existed
+        // must still parse, and the three new events must default to ON via
+        // their `#[serde(default = "default_true")]` — so upgrading a node
+        // never silently disables the new alerts.
+        let legacy = r#"
+            node_offline = true
+            capability_drift = false
+            low_disk = true
+            restart_needed = true
+            peer_count_drop = true
+            block_found = true
+        "#;
+        let parsed: AlertEvents = toml::from_str(legacy).expect("legacy events parse");
+        assert!(!parsed.capability_drift, "explicit legacy value preserved");
+        assert!(
+            parsed.reorg_detected && parsed.behind_tip && parsed.update_available,
+            "new events default ON for old configs"
+        );
+    }
+
+    #[test]
+    fn alert_events_can_disable_new_events() {
+        let toml = r#"
+            reorg_detected = false
+            behind_tip = false
+            update_available = false
+        "#;
+        let parsed: AlertEvents = toml::from_str(toml).expect("parse");
+        assert!(!parsed.reorg_detected && !parsed.behind_tip && !parsed.update_available);
+        // Untouched events keep their default-ON.
+        assert!(parsed.node_offline && parsed.block_found);
     }
 
     #[test]

--- a/crates/ghost-verification/src/alerts.rs
+++ b/crates/ghost-verification/src/alerts.rs
@@ -55,6 +55,12 @@ pub enum AlertEvent {
     PeerCountDrop,
     /// This node found a block.
     BlockFound,
+    /// A Bitcoin chain reorg was detected (a block disconnected from the tip).
+    ReorgDetected,
+    /// The node is behind the network tip (stale tip / lagging local height).
+    BehindTip,
+    /// A newer node release is available than the one installed.
+    UpdateAvailable,
 }
 
 impl AlertEvent {
@@ -68,6 +74,9 @@ impl AlertEvent {
             AlertEvent::RestartNeeded => e.restart_needed,
             AlertEvent::PeerCountDrop => e.peer_count_drop,
             AlertEvent::BlockFound => e.block_found,
+            AlertEvent::ReorgDetected => e.reorg_detected,
+            AlertEvent::BehindTip => e.behind_tip,
+            AlertEvent::UpdateAvailable => e.update_available,
         }
     }
 
@@ -80,6 +89,9 @@ impl AlertEvent {
             AlertEvent::RestartNeeded => "Restart needed",
             AlertEvent::PeerCountDrop => "Peer count dropped",
             AlertEvent::BlockFound => "Block found",
+            AlertEvent::ReorgDetected => "Chain reorg detected",
+            AlertEvent::BehindTip => "Node behind tip",
+            AlertEvent::UpdateAvailable => "Update available",
         }
     }
 }
@@ -474,6 +486,9 @@ mod tests {
                 restart_needed: false,
                 peer_count_drop: false,
                 block_found: false,
+                reorg_detected: false,
+                behind_tip: false,
+                update_available: false,
             };
             pick(&mut events);
             c.events = events;

--- a/dashboard/src/app/(dashboard)/settings/alerts/page.tsx
+++ b/dashboard/src/app/(dashboard)/settings/alerts/page.tsx
@@ -29,6 +29,9 @@ const EVENT_META: { key: keyof AlertEvents; label: string; description: string }
   { key: "restart_needed", label: "Restart needed", description: "A change or update needs a node restart to apply." },
   { key: "peer_count_drop", label: "Peer count drop", description: "Connected mesh peers were lost (possible partition)." },
   { key: "block_found", label: "Block found", description: "This node found a block." },
+  { key: "reorg_detected", label: "Chain reorg detected", description: "A Bitcoin block was disconnected from the tip (chain reorganisation)." },
+  { key: "behind_tip", label: "Node behind tip", description: "The node fell behind the network — a stale tip or a lagging local height." },
+  { key: "update_available", label: "Update available", description: "A newer node release is available than the one installed." },
 ];
 
 export default function AlertsSettingsPage() {

--- a/dashboard/src/lib/api/alerts.ts
+++ b/dashboard/src/lib/api/alerts.ts
@@ -11,6 +11,9 @@ export interface AlertEvents {
   restart_needed: boolean;
   peer_count_drop: boolean;
   block_found: boolean;
+  reorg_detected: boolean;
+  behind_tip: boolean;
+  update_available: boolean;
 }
 
 export interface EmailChannel {
@@ -87,6 +90,9 @@ export const ALERTS_DEFAULTS: AlertsConfig = {
     restart_needed: true,
     peer_count_drop: true,
     block_found: true,
+    reorg_detected: true,
+    behind_tip: true,
+    update_available: true,
   },
 };
 


### PR DESCRIPTION
## Summary

Adds three new operator monitoring alerts to the existing alert pipeline, following the exact pattern of the current events (`AlertEvent` variant + `[alerts].events` bool + a fire/dispatch call at the detection site + a frontend toggle):

- **Reorg detected** — hooks the existing ZMQ reorg-detection point (`ReorgHandler::handle_reorg` in `bins/ghost-pool/src/reorg.rs`), where a `BlockEvent::Disconnected` marks a block orphaned. No new detection was built. The alert carries the disconnected block hash (old tip) and the consecutive-disconnect depth; it is rate-limited (60s window) so a depth-N reorg pages once rather than once per orphaned block.
- **Behind tip / stale tip** — a new periodic monitor (`bins/ghost-pool/src/alert_monitors.rs`, spawned alongside the WS health task in `main.rs`) that reads the same height/peer plumbing the `/health` and swarm views use: local height from the round manager, best peer height from connected mesh peers. Edge-triggered: fires when `best_peer - local > 3` blocks, **or** the tip has been stale for more than ~30 min while a peer is ahead. Re-arms on recovery.
- **Update available** — a periodic check (every 6h) that compares the installed version against the updater's published `latest_version` (the same `/etc/ghost/version` + auto-update status file the dashboard auto-update view reads), firing when latest is strictly newer. Rate-limited to at most once per day.

Each event respects its enable flag in `[alerts].events`; all dispatch happens off the hot path in spawned tasks; no secrets/tokens are logged.

## Frontend

The three events are added to Settings -> Alerts (`page.tsx` `EVENT_META`) and the alerts API client types + defaults (`lib/api/alerts.ts`), matching the existing toggle UI. The backend GET/POST handlers serialise the whole `AlertsConfig` via serde, so the new fields flow through with no handler changes.

## Backward compatibility

The three new `AlertEvents` fields use `#[serde(default = "default_true")]`, so pre-existing `pool.toml` configs still parse and gain the new alerts (default ON) on upgrade.

## Verification

- `cargo check -p ghost-common -p ghost-consensus -p ghost-verification -p ghost-pool -j2` — clean (no warnings from changed files).
- New unit tests: `ghost-common` serde default / backward-compat + disable (3), `ghost-pool` behind-tip threshold + version comparison (8), `ghost-verification` enable-flag gating updated for the new events (10). All pass.
- Dashboard: `tsc --noEmit` clean, `eslint` clean on changed files, `npm run build` succeeds.
