### PR TITLE
dashboard: tooltip info-icon to the left of the label

### DIFF
--- a/dashboard/src/app/(dashboard)/page.tsx
+++ b/dashboard/src/app/(dashboard)/page.tsx
@@ -44,7 +44,7 @@ const SHARE_TIERS = [
 
 function InfoIcon() {
   return (
-    <svg className="w-3 h-3 text-gray-600 inline-block ml-1" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+    <svg className="w-3 h-3 text-gray-600 inline-block mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
       <circle cx="12" cy="12" r="10" />
       <path d="M12 16v-4M12 8h.01" />
     </svg>
@@ -79,7 +79,7 @@ function L1Card() {
       <div className="grid grid-cols-2 gap-3">
         <Tooltip content={TOOLTIPS.block_height}>
           <div className="p-3 bg-orange-900/10 rounded-lg">
-            <div className="text-xs text-gray-500 mb-1">Block Height <InfoIcon /></div>
+            <div className="text-xs text-gray-500 mb-1"><InfoIcon /> Block Height</div>
             <div className="text-lg font-mono font-semibold text-gray-100">
               {isLoading ? "..." : isSyncing
                 ? <span>{syncHeight.toLocaleString()} <span className="text-xs text-orange-400">/ {blockHeight.toLocaleString()}</span></span>
@@ -95,7 +95,7 @@ function L1Card() {
         </Tooltip>
         <Tooltip content={TOOLTIPS.l1_peers}>
           <div className="p-3 bg-orange-900/10 rounded-lg">
-            <div className="text-xs text-gray-500 mb-1">Mesh Peers <InfoIcon /></div>
+            <div className="text-xs text-gray-500 mb-1"><InfoIcon /> Mesh Peers</div>
             <div className="text-lg font-mono font-semibold text-gray-100">
               {isLoading ? "..." : `${status?.peer_count ?? 0} connected`}
             </div>
@@ -103,7 +103,7 @@ function L1Card() {
         </Tooltip>
         <Tooltip content={TOOLTIPS.network_hashrate}>
           <div className="p-3 bg-orange-900/10 rounded-lg">
-            <div className="text-xs text-gray-500 mb-1">Network Hashrate <InfoIcon /></div>
+            <div className="text-xs text-gray-500 mb-1"><InfoIcon /> Network Hashrate</div>
             <div className="text-lg font-mono font-semibold text-gray-100">
               {bestHashLoading ? "..." : bestHash?.network_hashrate ? formatHashrate(bestHash.network_hashrate) : "--"}
             </div>
@@ -111,7 +111,7 @@ function L1Card() {
         </Tooltip>
         <Tooltip content={TOOLTIPS.pool_hashrate}>
           <div className="p-3 bg-orange-900/10 rounded-lg">
-            <div className="text-xs text-gray-500 mb-1">Ghost Pool Hashrate <InfoIcon /></div>
+            <div className="text-xs text-gray-500 mb-1"><InfoIcon /> Ghost Pool Hashrate</div>
             <div className="text-lg font-mono font-semibold text-gray-100">
               {isLoading ? "..." : mining ? formatHashrate((mining.hashrate_th ?? 0) * 1e12) : "0 H/s"}
             </div>
@@ -119,7 +119,7 @@ function L1Card() {
         </Tooltip>
         <Tooltip content={TOOLTIPS.l1_hashrate}>
           <div className="p-3 bg-orange-900/10 rounded-lg">
-            <div className="text-xs text-gray-500 mb-1">Your Hashrate <InfoIcon /></div>
+            <div className="text-xs text-gray-500 mb-1"><InfoIcon /> Your Hashrate</div>
             <div className="text-lg font-mono font-semibold text-gray-100">
               {isLoading ? "..." : mining ? formatHashrate((mining.local_hashrate_th ?? 0) * 1e12) : "0 H/s"}
             </div>
@@ -171,7 +171,7 @@ function L2Card() {
       <div className="grid grid-cols-2 gap-3">
         <Tooltip content={TOOLTIPS.l2_height}>
           <div className="p-3 bg-purple-900/10 rounded-lg">
-            <div className="text-xs text-gray-500 mb-1">L2 Height <InfoIcon /></div>
+            <div className="text-xs text-gray-500 mb-1"><InfoIcon /> L2 Height</div>
             <div className="text-lg font-mono font-semibold text-gray-100">
               {isLoading ? "..." : isSyncing ? <span className="text-purple-400">Syncing...</span> : height}
             </div>
@@ -184,7 +184,7 @@ function L2Card() {
         </Tooltip>
         <Tooltip content={TOOLTIPS.l2_peers}>
           <div className="p-3 bg-purple-900/10 rounded-lg">
-            <div className="text-xs text-gray-500 mb-1">L2 Peers <InfoIcon /></div>
+            <div className="text-xs text-gray-500 mb-1"><InfoIcon /> L2 Peers</div>
             <div className="text-lg font-mono font-semibold text-gray-100">
               {isLoading ? "..." : `${gp?.peer_count ?? 0} connected`}
             </div>
@@ -192,7 +192,7 @@ function L2Card() {
         </Tooltip>
         <Tooltip content={TOOLTIPS.l2_wraith}>
           <div className="p-3 bg-purple-900/10 rounded-lg">
-            <div className="text-xs text-gray-500 mb-1">Wraith <InfoIcon /></div>
+            <div className="text-xs text-gray-500 mb-1"><InfoIcon /> Wraith</div>
             <div className="flex items-center gap-2">
               <StatusDot
                 status={wraithActive ? "online" : "offline"}
@@ -361,7 +361,7 @@ function PrivacySection() {
       <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3">
         <Tooltip content={TOOLTIPS.ghost_mode}>
           <div className="p-3 bg-red-900/10 rounded-lg">
-            <div className="text-xs text-gray-500 mb-1">Ghost Mode <InfoIcon /></div>
+            <div className="text-xs text-gray-500 mb-1"><InfoIcon /> Ghost Mode</div>
             <div className="flex items-center gap-2">
               <StatusDot
                 status={ghostModeActive ? "online" : "offline"}
@@ -373,7 +373,7 @@ function PrivacySection() {
         </Tooltip>
         <Tooltip content={TOOLTIPS.privacy_tor}>
           <div className="p-3 bg-red-900/10 rounded-lg">
-            <div className="text-xs text-gray-500 mb-1">Tor Mode <InfoIcon /></div>
+            <div className="text-xs text-gray-500 mb-1"><InfoIcon /> Tor Mode</div>
             <div className="flex items-center gap-2">
               <StatusDot
                 status={torActive ? "online" : "offline"}
@@ -385,7 +385,7 @@ function PrivacySection() {
         </Tooltip>
         <Tooltip content={TOOLTIPS.privacy_haze}>
           <div className="p-3 bg-red-900/10 rounded-lg">
-            <div className="text-xs text-gray-500 mb-1">Ghost Haze <InfoIcon /></div>
+            <div className="text-xs text-gray-500 mb-1"><InfoIcon /> Ghost Haze</div>
             <div className="flex items-center gap-2">
               <StatusDot
                 status={hazeActive ? "online" : "offline"}
@@ -397,7 +397,7 @@ function PrivacySection() {
         </Tooltip>
         <Tooltip content={TOOLTIPS.privacy_shroud}>
           <div className="p-3 bg-red-900/10 rounded-lg">
-            <div className="text-xs text-gray-500 mb-1">Ghost Shroud <InfoIcon /></div>
+            <div className="text-xs text-gray-500 mb-1"><InfoIcon /> Ghost Shroud</div>
             <div className="flex items-center gap-2">
               <StatusDot
                 status={shroudActive ? "online" : "offline"}
@@ -409,7 +409,7 @@ function PrivacySection() {
         </Tooltip>
         <Tooltip content={TOOLTIPS.privacy_wraith}>
           <div className="p-3 bg-red-900/10 rounded-lg">
-            <div className="text-xs text-gray-500 mb-1">Wraith <InfoIcon /></div>
+            <div className="text-xs text-gray-500 mb-1"><InfoIcon /> Wraith</div>
             <div className="flex items-center gap-2">
               <StatusDot
                 status={wraithActive ? "online" : "offline"}

--- a/dashboard/src/app/(dashboard)/swarm/page.tsx
+++ b/dashboard/src/app/(dashboard)/swarm/page.tsx
@@ -47,7 +47,7 @@ function formatHashrate(th: number): string {
 // is wrapped in a <Tooltip> that carries the explanatory copy.
 function InfoIcon() {
   return (
-    <svg className="w-3 h-3 text-gray-600 inline-block ml-1" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+    <svg className="w-3 h-3 text-gray-600 inline-block mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
       <circle cx="12" cy="12" r="10" />
       <path d="M12 16v-4M12 8h.01" />
     </svg>
@@ -458,7 +458,7 @@ export default function SwarmPage() {
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div className="p-3 bg-gray-800/50 rounded-lg">
                 <Tooltip content={TOOLTIPS.nodeId}>
-                  <div className="text-xs text-gray-500 uppercase tracking-wide mb-1 inline-block">Node ID <InfoIcon /></div>
+                  <div className="text-xs text-gray-500 uppercase tracking-wide mb-1 inline-block"><InfoIcon /> Node ID</div>
                 </Tooltip>
                 <div className="font-mono text-sm text-gray-100 break-all select-all">
                   {nodeInfo.node_id}
@@ -466,7 +466,7 @@ export default function SwarmPage() {
               </div>
               <div className="p-3 bg-gray-800/50 rounded-lg">
                 <Tooltip content={TOOLTIPS.connectionAddress}>
-                  <div className="text-xs text-gray-500 uppercase tracking-wide mb-1 inline-block">Connection Address <InfoIcon /></div>
+                  <div className="text-xs text-gray-500 uppercase tracking-wide mb-1 inline-block"><InfoIcon /> Connection Address</div>
                 </Tooltip>
                 <div className="font-mono text-sm text-gray-100 mb-2 select-all">
                   {swarmData?.self?.address
@@ -553,25 +553,25 @@ export default function SwarmPage() {
                 <div className="grid grid-cols-2 gap-2 text-xs mb-3">
                   <Tooltip content={TOOLTIPS.l1Height}>
                     <div>
-                      <span className="text-gray-500">L1: <InfoIcon /></span>{" "}
+                      <span className="text-gray-500"><InfoIcon /> L1:</span>{" "}
                       <span className="text-gray-300">{orDash(node.l1_height, (v) => v.toLocaleString())}</span>
                     </div>
                   </Tooltip>
                   <Tooltip content={TOOLTIPS.l2Height}>
                     <div>
-                      <span className="text-gray-500">L2: <InfoIcon /></span>{" "}
+                      <span className="text-gray-500"><InfoIcon /> L2:</span>{" "}
                       <span className="text-gray-300">{orDash(node.l2_height, (v) => v.toLocaleString())}</span>
                     </div>
                   </Tooltip>
                   <Tooltip content={TOOLTIPS.peers}>
                     <div>
-                      <span className="text-gray-500">Peers: <InfoIcon /></span>{" "}
+                      <span className="text-gray-500"><InfoIcon /> Peers:</span>{" "}
                       <span className="text-gray-300">{orDash(node.peer_count, (v) => String(v))}</span>
                     </div>
                   </Tooltip>
                   <Tooltip content={TOOLTIPS.shares}>
                     <div>
-                      <span className="text-gray-500">Shares: <InfoIcon /></span>{" "}
+                      <span className="text-gray-500"><InfoIcon /> Shares:</span>{" "}
                       <span className="text-gray-300">{node.shares ?? 0}/{node.max_shares ?? 15}</span>
                     </div>
                   </Tooltip>
@@ -659,7 +659,7 @@ export default function SwarmPage() {
                     </div>
                     <Tooltip content={TOOLTIPS.shares}>
                       <div className="text-sm text-gray-400 inline-block">
-                        {node.shares ?? 0}/{node.max_shares ?? 15} shares <InfoIcon />
+                        <InfoIcon /> {node.shares ?? 0}/{node.max_shares ?? 15} shares
                       </div>
                     </Tooltip>
                   </div>
@@ -668,7 +668,7 @@ export default function SwarmPage() {
                 <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mt-4 text-sm">
                   <Tooltip content={TOOLTIPS.uptime}>
                     <div>
-                      <span className="text-gray-500">Uptime <InfoIcon /></span>
+                      <span className="text-gray-500"><InfoIcon /> Uptime</span>
                       <div
                         className={`font-medium ${
                           node.uptime_percent === undefined || node.uptime_percent === null
@@ -686,19 +686,19 @@ export default function SwarmPage() {
                   </Tooltip>
                   <Tooltip content={TOOLTIPS.peers}>
                     <div>
-                      <span className="text-gray-500">Peers <InfoIcon /></span>
+                      <span className="text-gray-500"><InfoIcon /> Peers</span>
                       <div className="text-gray-100">{orDash(node.peer_count, (v) => String(v))}</div>
                     </div>
                   </Tooltip>
                   <Tooltip content={TOOLTIPS.l1Height}>
                     <div>
-                      <span className="text-gray-500">L1 Height <InfoIcon /></span>
+                      <span className="text-gray-500"><InfoIcon /> L1 Height</span>
                       <div className="text-gray-100 font-mono">{orDash(node.l1_height, (v) => v.toLocaleString())}</div>
                     </div>
                   </Tooltip>
                   <Tooltip content={TOOLTIPS.l2Height}>
                     <div>
-                      <span className="text-gray-500">L2 Height <InfoIcon /></span>
+                      <span className="text-gray-500"><InfoIcon /> L2 Height</span>
                       <div className="text-gray-100 font-mono">{orDash(node.l2_height, (v) => v.toLocaleString())}</div>
                     </div>
                   </Tooltip>


### PR DESCRIPTION
Overview + Swarm: move the `InfoIcon` before the label (was trailing), margin ml-1→mr-1. Frontend-only, tsc + eslint clean.