### PR TITLE
backups: automatic scheduled encrypted backups

### DIFF
--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -7401,6 +7401,130 @@ async fn main() -> Result<()> {
     });
     info!("Database backup task started (daily)");
 
+    // Automatic scheduled encrypted-backup task. Secure-by-default: it idles and
+    // writes nothing until an operator enables `[backup]` in pool.toml (or via
+    // the dashboard). When enabled it reuses the SAME `Database::backup`
+    // (VACUUM INTO) routine the manual backup uses — so the artifact inherits
+    // the database's SQLCipher encryption — writing a timestamped file into the
+    // configured target dir, pruning to `retention`, and recording last-run
+    // status for the dashboard. The live schedule is re-read from the shared
+    // full_node_config each tick, so enable/interval/retention/target_dir edits
+    // take effect without a node restart.
+    {
+        let db_for_sched = Arc::clone(&db);
+        let state_for_sched = Arc::clone(&verification_state);
+        let mut sched_shutdown = shutdown_tx.subscribe();
+        tokio::spawn(async move {
+            // Coarse poll cadence: the loop wakes on this fixed interval and only
+            // runs a backup once the configured period has elapsed. 60s keeps the
+            // task off any hot path while still honouring hourly custom periods.
+            const CHECK_SECS: u64 = 60;
+            let mut interval =
+                tokio::time::interval(std::time::Duration::from_secs(CHECK_SECS));
+            // Let the node finish starting before the first check/run.
+            interval.tick().await;
+            loop {
+                tokio::select! {
+                    _ = interval.tick() => {
+                        // Snapshot the live schedule (may have changed via the API).
+                        let schedule = match state_for_sched.full_node_config.as_ref() {
+                            Some(cfg) => cfg.read().backup.clone(),
+                            None => continue,
+                        };
+                        if !schedule.enabled {
+                            continue;
+                        }
+                        let now_unix = std::time::SystemTime::now()
+                            .duration_since(std::time::UNIX_EPOCH)
+                            .map(|d| d.as_secs())
+                            .unwrap_or(0);
+                        let last_run = state_for_sched.backup_status.read().last_run_unix;
+                        if !ghost_common::config::backup_is_due(
+                            last_run,
+                            now_unix,
+                            schedule.interval.period_secs(),
+                        ) {
+                            continue;
+                        }
+
+                        let target_dir = std::path::PathBuf::from(&schedule.target_dir);
+                        let filename =
+                            ghost_common::config::BackupSchedule::artifact_filename(now_unix);
+                        let backup_path = target_dir.join(&filename);
+                        let retention = schedule.effective_retention();
+
+                        // Blocking DB + filesystem work off the async worker.
+                        let db_run = Arc::clone(&db_for_sched);
+                        let dir_run = target_dir.clone();
+                        let path_run = backup_path.clone();
+                        let result = tokio::task::spawn_blocking(
+                            move || -> Result<(), String> {
+                                std::fs::create_dir_all(&dir_run)
+                                    .map_err(|e| format!("create target dir: {e}"))?;
+                                db_run.backup(&path_run).map_err(|e| e.to_string())?;
+                                // Prune old artifacts down to the retention window.
+                                let mut names: Vec<String> = Vec::new();
+                                if let Ok(entries) = std::fs::read_dir(&dir_run) {
+                                    for entry in entries.flatten() {
+                                        if let Some(name) = entry.file_name().to_str() {
+                                            if name.starts_with("ghost-backup-")
+                                                && name.ends_with(".db")
+                                            {
+                                                names.push(name.to_string());
+                                            }
+                                        }
+                                    }
+                                }
+                                for stale in ghost_common::config::backups_to_prune(
+                                    names, retention,
+                                ) {
+                                    let _ = std::fs::remove_file(dir_run.join(stale));
+                                }
+                                Ok(())
+                            },
+                        )
+                        .await;
+
+                        let finished_unix = std::time::SystemTime::now()
+                            .duration_since(std::time::UNIX_EPOCH)
+                            .map(|d| d.as_secs())
+                            .unwrap_or(now_unix);
+                        let mut status = state_for_sched.backup_status.write();
+                        status.last_run_unix = Some(finished_unix);
+                        match result {
+                            Ok(Ok(())) => {
+                                status.last_success = Some(true);
+                                status.last_path =
+                                    Some(backup_path.to_string_lossy().to_string());
+                                status.last_error = None;
+                                tracing::info!(
+                                    path = ?backup_path,
+                                    "Scheduled encrypted backup complete"
+                                );
+                            }
+                            Ok(Err(e)) => {
+                                status.last_success = Some(false);
+                                status.last_error = Some(e.clone());
+                                tracing::warn!(error = %e, "Scheduled backup failed");
+                            }
+                            Err(e) => {
+                                let msg = format!("backup task join error: {e}");
+                                status.last_success = Some(false);
+                                status.last_error = Some(msg.clone());
+                                tracing::warn!(error = %msg, "Scheduled backup task failed");
+                            }
+                        }
+                    }
+                    _ = sched_shutdown.recv() => {
+                        tracing::info!("Scheduled backup task shutting down");
+                        break;
+                    }
+                }
+            }
+        });
+        info!("Scheduled encrypted-backup task started (idle until enabled)");
+    }
+
     // Clone ws_state for event handlers before moving verification_state
     let _verification_state_for_ws = Arc::clone(&verification_state);
 

--- a/crates/ghost-common/src/config.rs
+++ b/crates/ghost-common/src/config.rs
@@ -130,6 +130,11 @@ pub struct NodeConfig {
     /// default; delivery is inert until an operator enables a channel.
     #[serde(default)]
     pub alerts: AlertsConfig,
+    /// Automatic scheduled encrypted-backup configuration. Off by default
+    /// (secure-by-default); the scheduler idles and writes nothing until an
+    /// operator enables it.
+    #[serde(default)]
+    pub backup: BackupSchedule,
 }
 
 /// ghostd launch-time flags that the dashboard can toggle. These are baked into
@@ -1897,6 +1902,202 @@ impl Default for AlertEvents {
     }
 }
 
+// ============================================================================
+// Scheduled encrypted backups
+// ============================================================================
+
+/// How often the scheduled-backup task runs.
+///
+/// Serialises to a single compact string so it round-trips cleanly through both
+/// pool.toml (`interval = "daily"`) and the dashboard JSON API: `Daily`→`"daily"`,
+/// `Weekly`→`"weekly"`, and a custom period →`"<n>h"` (e.g. `"6h"`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BackupInterval {
+    /// Every 24 hours.
+    Daily,
+    /// Every 7 days.
+    Weekly,
+    /// Every N hours (clamped to a 1-hour floor).
+    Hours(u32),
+}
+
+impl Default for BackupInterval {
+    fn default() -> Self {
+        BackupInterval::Daily
+    }
+}
+
+impl BackupInterval {
+    /// The period between runs, in whole hours (never zero).
+    pub fn period_hours(self) -> u32 {
+        match self {
+            BackupInterval::Daily => 24,
+            BackupInterval::Weekly => 24 * 7,
+            BackupInterval::Hours(h) => h.max(1),
+        }
+    }
+
+    /// The period between runs, in seconds (never zero).
+    pub fn period_secs(self) -> u64 {
+        self.period_hours() as u64 * 3600
+    }
+
+    /// Canonical string form used on the wire and on disk.
+    pub fn as_wire(self) -> String {
+        match self {
+            BackupInterval::Daily => "daily".to_string(),
+            BackupInterval::Weekly => "weekly".to_string(),
+            BackupInterval::Hours(h) => format!("{}h", h.max(1)),
+        }
+    }
+
+    /// Parse the canonical string form. Accepts `daily`/`weekly` (also `day`/
+    /// `week`), or an hours value written as `24` or `24h`. The 24- and 168-hour
+    /// values normalise back to `Daily`/`Weekly` so a round-trip is stable.
+    pub fn parse_wire(s: &str) -> Result<Self, String> {
+        let t = s.trim().to_lowercase();
+        match t.as_str() {
+            "daily" | "day" => Ok(BackupInterval::Daily),
+            "weekly" | "week" => Ok(BackupInterval::Weekly),
+            other => {
+                let digits = other.strip_suffix('h').unwrap_or(other);
+                match digits.parse::<u32>() {
+                    Ok(24) => Ok(BackupInterval::Daily),
+                    Ok(168) => Ok(BackupInterval::Weekly),
+                    Ok(h) => Ok(BackupInterval::Hours(h.max(1))),
+                    Err(_) => Err(format!("invalid backup interval: {s:?}")),
+                }
+            }
+        }
+    }
+}
+
+impl Serialize for BackupInterval {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.as_wire())
+    }
+}
+
+impl<'de> Deserialize<'de> for BackupInterval {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        BackupInterval::parse_wire(&s).map_err(serde::de::Error::custom)
+    }
+}
+
+fn default_backup_retention() -> u32 {
+    7
+}
+
+fn default_backup_target_dir() -> String {
+    "/home/ghost/.ghost/backups".to_string()
+}
+
+/// Automatic scheduled encrypted-backup configuration.
+///
+/// Secure-by-default: `enabled` is `false`, so the scheduler task idles and
+/// writes nothing until an operator turns it on. When enabled, the task runs
+/// the same `Database::backup` (VACUUM INTO) routine the manual backup uses —
+/// so the artifact inherits the database's SQLCipher encryption — writing a
+/// timestamped file into `target_dir` every `interval`, then pruning to the
+/// most recent `retention` files.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BackupSchedule {
+    /// Master switch. Off by default.
+    #[serde(default)]
+    pub enabled: bool,
+    /// How often a backup runs.
+    #[serde(default)]
+    pub interval: BackupInterval,
+    /// Keep only the most recent N artifacts in `target_dir`; older ones are
+    /// pruned after each successful run. Effective value has a floor of 1.
+    #[serde(default = "default_backup_retention")]
+    pub retention: u32,
+    /// Absolute directory the timestamped encrypted artifacts are written to.
+    #[serde(default = "default_backup_target_dir")]
+    pub target_dir: String,
+}
+
+impl Default for BackupSchedule {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            interval: BackupInterval::Daily,
+            retention: default_backup_retention(),
+            target_dir: default_backup_target_dir(),
+        }
+    }
+}
+
+impl BackupSchedule {
+    /// Retention clamped to a floor of 1 (never keep zero backups).
+    pub fn effective_retention(&self) -> u32 {
+        self.retention.max(1)
+    }
+
+    /// Timestamped artifact filename for a backup taken at `unix_secs` (UTC).
+    ///
+    /// Format `ghost-backup-YYYYMMDD-HHMMSS.db`, which is lexicographically
+    /// sortable — a plain string sort is chronological, which the prune logic
+    /// relies on. The `.db` extension matches what the backup-history endpoint
+    /// lists, so scheduled artifacts show up alongside manual ones.
+    pub fn artifact_filename(unix_secs: u64) -> String {
+        use chrono::{TimeZone, Utc};
+        let stamp = Utc
+            .timestamp_opt(unix_secs as i64, 0)
+            .single()
+            .map(|dt| dt.format("%Y%m%d-%H%M%S").to_string())
+            .unwrap_or_else(|| format!("{unix_secs:012}"));
+        format!("ghost-backup-{stamp}.db")
+    }
+}
+
+/// Whether a scheduled backup is due. Pure + testable.
+///
+/// Due when the task has never run this process (`last_run_unix` is `None`) or
+/// at least `period_secs` have elapsed since the last completed attempt.
+pub fn backup_is_due(last_run_unix: Option<u64>, now_unix: u64, period_secs: u64) -> bool {
+    match last_run_unix {
+        None => true,
+        Some(last) => now_unix.saturating_sub(last) >= period_secs,
+    }
+}
+
+/// Given the backup filenames currently in the target directory, return the
+/// ones to delete so only the most recent `retention` remain. Pure + testable.
+///
+/// Filenames are compared lexicographically, which is chronological for the
+/// `ghost-backup-YYYYMMDD-HHMMSS.db` naming produced by [`BackupSchedule::artifact_filename`].
+pub fn backups_to_prune(mut filenames: Vec<String>, retention: u32) -> Vec<String> {
+    let keep = retention.max(1) as usize;
+    // Newest first, then drop everything past the keep window.
+    filenames.sort();
+    filenames.reverse();
+    filenames.into_iter().skip(keep).collect()
+}
+
+/// Runtime status of the scheduled-backup task, surfaced to the dashboard.
+///
+/// Held in memory only (not persisted); it resets on node restart, which is
+/// why `last_run_unix` starting at `None` triggers a first run shortly after
+/// startup when the schedule is enabled.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct BackupRunStatus {
+    /// Unix seconds of the last completed attempt (success or failure).
+    /// `None` = the task has not run since startup.
+    #[serde(default)]
+    pub last_run_unix: Option<u64>,
+    /// Whether the most recent attempt succeeded.
+    #[serde(default)]
+    pub last_success: Option<bool>,
+    /// Absolute path of the most recently written artifact (on success).
+    #[serde(default)]
+    pub last_path: Option<String>,
+    /// Error detail from the most recent failed attempt.
+    #[serde(default)]
+    pub last_error: Option<String>,
+}
+
 /// Pool configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PoolConfig {
@@ -1995,6 +2196,135 @@ impl Default for PoolConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ------------------------------------------------------------------
+    // Scheduled backups
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn backup_schedule_defaults_secure_by_default() {
+        let s = BackupSchedule::default();
+        assert!(!s.enabled, "scheduled backups must be OFF by default");
+        assert_eq!(s.interval, BackupInterval::Daily);
+        assert_eq!(s.retention, 7);
+        assert_eq!(s.target_dir, "/home/ghost/.ghost/backups");
+    }
+
+    #[test]
+    fn backup_schedule_serde_back_compat_missing_section() {
+        // A pool.toml written before this feature has no [backup] table at all;
+        // #[serde(default)] on the field must fill in the safe default.
+        #[derive(serde::Deserialize)]
+        struct Slice {
+            #[serde(default)]
+            backup: BackupSchedule,
+        }
+        let slice: Slice = toml::from_str("").expect("empty toml deserialises");
+        assert!(!slice.backup.enabled);
+        assert_eq!(slice.backup.interval, BackupInterval::Daily);
+        assert_eq!(slice.backup.retention, 7);
+    }
+
+    #[test]
+    fn backup_schedule_partial_fields_fill_defaults() {
+        // Only `enabled` provided; the rest fall back to defaults.
+        let s: BackupSchedule = toml::from_str("enabled = true\n").unwrap();
+        assert!(s.enabled);
+        assert_eq!(s.interval, BackupInterval::Daily);
+        assert_eq!(s.retention, 7);
+    }
+
+    #[test]
+    fn backup_interval_round_trips_toml_and_json() {
+        for iv in [
+            BackupInterval::Daily,
+            BackupInterval::Weekly,
+            BackupInterval::Hours(6),
+        ] {
+            let s = BackupSchedule {
+                enabled: true,
+                interval: iv,
+                retention: 3,
+                target_dir: "/var/lib/ghost/backups".to_string(),
+            };
+            let toml_s = toml::to_string(&s).unwrap();
+            let back: BackupSchedule = toml::from_str(&toml_s).unwrap();
+            assert_eq!(back.interval, iv, "toml round-trip: {toml_s}");
+            let json = serde_json::to_string(&s).unwrap();
+            let back_j: BackupSchedule = serde_json::from_str(&json).unwrap();
+            assert_eq!(back_j.interval, iv, "json round-trip: {json}");
+        }
+    }
+
+    #[test]
+    fn backup_interval_wire_forms() {
+        assert_eq!(BackupInterval::Daily.as_wire(), "daily");
+        assert_eq!(BackupInterval::Weekly.as_wire(), "weekly");
+        assert_eq!(BackupInterval::Hours(6).as_wire(), "6h");
+        // Aliases + hour equivalents normalise back.
+        assert_eq!(BackupInterval::parse_wire("daily").unwrap(), BackupInterval::Daily);
+        assert_eq!(BackupInterval::parse_wire("WEEK").unwrap(), BackupInterval::Weekly);
+        assert_eq!(BackupInterval::parse_wire("24h").unwrap(), BackupInterval::Daily);
+        assert_eq!(BackupInterval::parse_wire("168").unwrap(), BackupInterval::Weekly);
+        assert_eq!(BackupInterval::parse_wire("12h").unwrap(), BackupInterval::Hours(12));
+        assert!(BackupInterval::parse_wire("nonsense").is_err());
+    }
+
+    #[test]
+    fn backup_interval_period_secs() {
+        assert_eq!(BackupInterval::Daily.period_secs(), 86_400);
+        assert_eq!(BackupInterval::Weekly.period_secs(), 604_800);
+        assert_eq!(BackupInterval::Hours(6).period_secs(), 21_600);
+        // Zero hours is clamped to a one-hour floor (never a zero period).
+        assert_eq!(BackupInterval::Hours(0).period_secs(), 3_600);
+    }
+
+    #[test]
+    fn backup_is_due_next_run_computation() {
+        let period = BackupInterval::Daily.period_secs(); // 86_400
+        // Never run this process → due immediately.
+        assert!(backup_is_due(None, 1_000_000, period));
+        // Exactly a full period elapsed → due.
+        assert!(backup_is_due(Some(1_000_000), 1_000_000 + period, period));
+        // Just short of a period → not due.
+        assert!(!backup_is_due(Some(1_000_000), 1_000_000 + period - 1, period));
+        // Clock skew backwards → not due (saturating subtraction).
+        assert!(!backup_is_due(Some(2_000_000), 1_000_000, period));
+    }
+
+    #[test]
+    fn backups_to_prune_keeps_last_n() {
+        let files = vec![
+            "ghost-backup-20260101-000000.db".to_string(),
+            "ghost-backup-20260102-000000.db".to_string(),
+            "ghost-backup-20260103-000000.db".to_string(),
+            "ghost-backup-20260104-000000.db".to_string(),
+            "ghost-backup-20260105-000000.db".to_string(),
+        ];
+        let prune = backups_to_prune(files.clone(), 3);
+        // The two oldest are pruned; the three newest are kept.
+        assert_eq!(
+            prune,
+            vec![
+                "ghost-backup-20260102-000000.db".to_string(),
+                "ghost-backup-20260101-000000.db".to_string(),
+            ]
+        );
+        // Retention >= count keeps everything.
+        assert!(backups_to_prune(files.clone(), 5).is_empty());
+        assert!(backups_to_prune(files.clone(), 99).is_empty());
+        // Retention floored at 1 (never prune the whole set to zero).
+        assert_eq!(backups_to_prune(files, 0).len(), 4);
+    }
+
+    #[test]
+    fn backup_artifact_filename_is_sortable_and_dotted() {
+        let a = BackupSchedule::artifact_filename(1_700_000_000);
+        let b = BackupSchedule::artifact_filename(1_700_086_400);
+        assert!(a.starts_with("ghost-backup-"));
+        assert!(a.ends_with(".db"));
+        assert!(a < b, "later timestamp must sort after earlier: {a} vs {b}");
+    }
 
     #[test]
     fn test_default_config() {

--- a/crates/ghost-verification/src/routes.rs
+++ b/crates/ghost-verification/src/routes.rs
@@ -356,6 +356,10 @@ pub fn create_router(state: Arc<VerificationState>) -> Router {
         .route("/api/v1/config/daemon", get(api_config_daemon_handler))
         .route("/api/v1/config/alerts", get(api_config_alerts_handler))
         .route(
+            "/api/v1/config/backup_schedule",
+            get(api_config_backup_schedule_handler),
+        )
+        .route(
             "/api/v1/config/ghost_pay",
             get(api_config_ghost_pay_handler),
         )
@@ -495,6 +499,10 @@ pub fn create_router(state: Arc<VerificationState>) -> Router {
         .route(
             "/api/v1/config/alerts",
             post(api_config_alerts_post_handler),
+        )
+        .route(
+            "/api/v1/config/backup_schedule",
+            post(api_config_backup_schedule_post_handler),
         )
         .route("/api/v1/alerts/test", post(api_alerts_test_post_handler))
         .route(
@@ -6457,6 +6465,104 @@ async fn api_config_alerts_post_handler(
         );
     }
     Json(body)
+}
+
+/// Build the shared JSON body for the backup-schedule get/set endpoints:
+/// the persisted schedule plus the in-memory last-run status.
+fn backup_schedule_response_json(
+    schedule: &ghost_common::config::BackupSchedule,
+    status: &ghost_common::config::BackupRunStatus,
+) -> serde_json::Value {
+    serde_json::json!({
+        // `interval` serialises to its wire string ("daily" / "weekly" / "6h").
+        "enabled": schedule.enabled,
+        "interval": schedule.interval,
+        "retention": schedule.retention,
+        "target_dir": schedule.target_dir,
+        "status": status,
+    })
+}
+
+/// API v1 Config backup-schedule GET handler — returns the automatic scheduled
+/// encrypted-backup configuration plus the in-memory last-run status (time /
+/// result / path) so the dashboard can render the "Scheduled backups" card.
+async fn api_config_backup_schedule_handler(
+    State(state): State<Arc<VerificationState>>,
+) -> impl IntoResponse {
+    let schedule = state
+        .full_node_config
+        .as_ref()
+        .map(|c| c.read().backup.clone())
+        .unwrap_or_default();
+    let status = state.backup_status.read().clone();
+    let mut body = backup_schedule_response_json(&schedule, &status);
+    if let Some(obj) = body.as_object_mut() {
+        obj.insert(
+            "message".to_string(),
+            serde_json::Value::String(
+                "Automatic scheduled encrypted-backup configuration".to_string(),
+            ),
+        );
+    }
+    Json(body)
+}
+
+/// API v1 Config backup-schedule POST handler — persists the scheduled-backup
+/// config to pool.toml `[backup]`. Retention is floored at 1 and `target_dir`
+/// must be an absolute path (mirrors the M-15 backup-history guard), so an
+/// enabled schedule can never be pointed at a relative directory.
+async fn api_config_backup_schedule_post_handler(
+    State(state): State<Arc<VerificationState>>,
+    Json(payload): Json<ghost_common::config::BackupSchedule>,
+) -> impl IntoResponse {
+    let mut saved = payload;
+    // Never keep zero backups; clamp before persisting so what's stored matches
+    // what the scheduler enforces.
+    saved.retention = saved.retention.max(1);
+
+    // Reject a relative target dir up front (the scheduler and history endpoint
+    // both require an absolute path).
+    if !std::path::Path::new(&saved.target_dir).is_absolute() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "success": false,
+                "error": "target_dir must be an absolute path",
+                "code": "INVALID_TARGET_DIR",
+            })),
+        )
+            .into_response();
+    }
+
+    let mut persisted = false;
+    if let Some(ref full) = state.full_node_config {
+        let mut cfg = full.write();
+        cfg.backup = saved.clone();
+        if let Some(ref path) = state.full_node_config_path {
+            match cfg.save_atomic(path) {
+                Ok(()) => persisted = true,
+                Err(e) => error!(error = %e, "Failed to persist backup schedule config"),
+            }
+        }
+    }
+
+    let status = state.backup_status.read().clone();
+    let mut body = backup_schedule_response_json(&saved, &status);
+    if let Some(obj) = body.as_object_mut() {
+        obj.insert("success".to_string(), serde_json::Value::Bool(true));
+        obj.insert("persisted".to_string(), serde_json::Value::Bool(persisted));
+        obj.insert(
+            "message".to_string(),
+            serde_json::Value::String(
+                if persisted {
+                    "Backup schedule saved.".to_string()
+                } else {
+                    "Backup schedule received but no node config path is configured — changes were not persisted.".to_string()
+                },
+            ),
+        );
+    }
+    Json(body).into_response()
 }
 
 /// API v1 Alerts test-send POST handler — delivers a real test alert to every

--- a/crates/ghost-verification/src/server.rs
+++ b/crates/ghost-verification/src/server.rs
@@ -1341,6 +1341,11 @@ pub struct VerificationState {
     /// endpoint so the dashboard can report whether the ghostd mempool reaper
     /// picked up the last change (the apply runs off the request path).
     pub ghostd_reaper_apply: Arc<parking_lot::RwLock<GhostdReaperApply>>,
+    /// Last-run status of the scheduled encrypted-backup task (in bins/ghost-pool).
+    /// Updated by that task after each run and read by the backup-schedule GET
+    /// endpoint so the dashboard can show the last time/result/path. In-memory
+    /// only — resets on restart. Shared by cloning the `Arc` into the task.
+    pub backup_status: Arc<parking_lot::RwLock<ghost_common::config::BackupRunStatus>>,
     /// L-28: Debug endpoints enabled flag - IMMUTABLE after server start
     ///
     /// This is set from DashboardConfig during construction and can be modified
@@ -1529,6 +1534,9 @@ impl VerificationState {
             require_internal_auth: true,
             restart_signal: Arc::new(AtomicBool::new(false)),
             ghostd_reaper_apply: Arc::new(parking_lot::RwLock::new(GhostdReaperApply::default())),
+            backup_status: Arc::new(parking_lot::RwLock::new(
+                ghost_common::config::BackupRunStatus::default(),
+            )),
             // L-28: Debug endpoints flag frozen from DashboardConfig
             debug_endpoints_frozen: AtomicBool::new(debug_enabled),
             max_capacity: AtomicU32::new(0),

--- a/dashboard/src/app/(dashboard)/system/page.tsx
+++ b/dashboard/src/app/(dashboard)/system/page.tsx
@@ -36,6 +36,7 @@ import {
 import { getBackupDownloadUrl } from "@/lib/api/backup";
 import { useToast } from "@/components/ui/Toast";
 import { AutoUpdateSection } from "@/components/settings/AutoUpdateSection";
+import { ScheduledBackupsCard } from "@/components/settings/ScheduledBackupsCard";
 import type { UpdateStatus } from "@/lib/api/system";
 import type { PruneProfile } from "@/types/api";
 import type { VerifyBackupResponse } from "@/types/api";
@@ -992,6 +993,13 @@ export default function SystemPage() {
             </div>
           </div>
         </Card>
+      </SectionErrorBoundary>
+
+      {/* ----------------------------------------------------------------- */}
+      {/* Scheduled Backups                                                  */}
+      {/* ----------------------------------------------------------------- */}
+      <SectionErrorBoundary section="Scheduled Backups">
+        <ScheduledBackupsCard />
       </SectionErrorBoundary>
 
       {/* ================================================================= */}

--- a/dashboard/src/components/settings/ScheduledBackupsCard.tsx
+++ b/dashboard/src/components/settings/ScheduledBackupsCard.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+import { useState } from "react";
+import { Badge } from "@/components/ui/Badge";
+import { Button } from "@/components/ui/Button";
+import { Card, CardHeader } from "@/components/ui/Card";
+import { Input } from "@/components/ui/Input";
+import { Toggle } from "@/components/ui/Toggle";
+import { useToast } from "@/components/ui/Toast";
+import {
+  useBackupSchedule,
+  useSetBackupSchedule,
+} from "@/hooks/queries/useBackupScheduleQueries";
+import {
+  BACKUP_SCHEDULE_DEFAULTS,
+  type BackupScheduleResponse,
+} from "@/lib/api/backupSchedule";
+
+type IntervalKind = "daily" | "weekly" | "custom";
+
+// Split the compact wire interval ("daily" | "weekly" | "<n>h") into the UI's
+// kind + custom-hours pair.
+function parseInterval(wire: string): { kind: IntervalKind; hours: number } {
+  const t = (wire ?? "").trim().toLowerCase();
+  if (t === "daily" || t === "24h" || t === "24") return { kind: "daily", hours: 24 };
+  if (t === "weekly" || t === "168h" || t === "168") return { kind: "weekly", hours: 168 };
+  const n = parseInt(t.replace(/h$/, ""), 10);
+  return { kind: "custom", hours: Number.isFinite(n) && n > 0 ? n : 12 };
+}
+
+function toWire(kind: IntervalKind, hours: number): string {
+  if (kind === "daily") return "daily";
+  if (kind === "weekly") return "weekly";
+  const h = Number.isFinite(hours) && hours > 0 ? Math.floor(hours) : 1;
+  return `${h}h`;
+}
+
+function formatUnix(unix?: number | null): string {
+  if (!unix) return "—";
+  return new Date(unix * 1000).toLocaleString();
+}
+
+/**
+ * Settings card for automatic scheduled encrypted backups. Sits alongside the
+ * manual Backup & Restore surface on the System page. The schedule is persisted
+ * to pool.toml `[backup]`; the node's background task reuses the same encrypted
+ * backup routine the manual export uses, writes timestamped artifacts to the
+ * target directory, and prunes to the retention window.
+ */
+export function ScheduledBackupsCard() {
+  const { data, isLoading } = useBackupSchedule();
+  const save = useSetBackupSchedule();
+  const { success, error } = useToast();
+
+  const [enabled, setEnabled] = useState(BACKUP_SCHEDULE_DEFAULTS.enabled);
+  const [intervalKind, setIntervalKind] = useState<IntervalKind>("daily");
+  const [customHours, setCustomHours] = useState(12);
+  const [retention, setRetention] = useState(BACKUP_SCHEDULE_DEFAULTS.retention);
+  const [targetDir, setTargetDir] = useState(BACKUP_SCHEDULE_DEFAULTS.target_dir);
+
+  // Hydrate local form once per distinct server response (the same "adjust
+  // state while rendering" pattern the alerts settings page uses).
+  const [hydratedFrom, setHydratedFrom] = useState<BackupScheduleResponse | null>(null);
+  if (data && hydratedFrom !== data) {
+    setHydratedFrom(data);
+    setEnabled(data.enabled);
+    const parsed = parseInterval(data.interval);
+    setIntervalKind(parsed.kind);
+    setCustomHours(parsed.hours);
+    setRetention(data.retention);
+    setTargetDir(data.target_dir);
+  }
+
+  const status = data?.status;
+
+  const handleSave = async () => {
+    const trimmedDir = targetDir.trim();
+    if (!trimmedDir.startsWith("/")) {
+      error("Invalid directory", "Target directory must be an absolute path.");
+      return;
+    }
+    try {
+      const res = await save.mutateAsync({
+        enabled,
+        interval: toWire(intervalKind, customHours),
+        retention: Math.max(1, Math.floor(retention) || 1),
+        target_dir: trimmedDir,
+      });
+      if (res.persisted) {
+        success("Backup schedule saved", res.message);
+      } else {
+        error("Not persisted", res.message);
+      }
+    } catch (err) {
+      error("Save failed", err instanceof Error ? err.message : "Unknown error");
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader
+        title="Scheduled Backups"
+        subtitle="Automatically create encrypted backups on a schedule and keep the most recent copies."
+      />
+
+      <div className="space-y-6">
+        {/* Enable */}
+        <div className="flex items-center justify-between p-4 bg-gray-800/50 rounded-lg">
+          <div>
+            <div className="text-gray-100 font-medium">Enable scheduled backups</div>
+            <p className="text-sm text-gray-400">
+              Off by default. When on, the node writes an encrypted backup to the target
+              directory on each interval and prunes old copies automatically.
+            </p>
+          </div>
+          <div className="flex items-center gap-3">
+            <Badge variant={enabled ? "success" : "default"}>{enabled ? "On" : "Off"}</Badge>
+            <Toggle label="Enable scheduled backups" enabled={enabled} onChange={setEnabled} />
+          </div>
+        </div>
+
+        {/* Settings */}
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div className="space-y-1">
+            <label className="block text-sm font-medium text-gray-300">Interval</label>
+            <select
+              value={intervalKind}
+              onChange={(e) => setIntervalKind(e.target.value as IntervalKind)}
+              disabled={!enabled}
+              className="w-full px-3 py-2 text-sm bg-gray-800 border border-gray-700 rounded-lg text-gray-100 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-transparent disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <option value="daily">Daily (every 24h)</option>
+              <option value="weekly">Weekly (every 7 days)</option>
+              <option value="custom">Custom (hours)</option>
+            </select>
+            <p className="text-xs text-gray-500">How often a backup is created.</p>
+          </div>
+
+          {intervalKind === "custom" && (
+            <Input
+              label="Custom interval (hours)"
+              type="number"
+              min={1}
+              value={String(customHours)}
+              disabled={!enabled}
+              onChange={(e) => setCustomHours(parseInt(e.target.value, 10) || 1)}
+              helperText="Minimum 1 hour."
+            />
+          )}
+
+          <Input
+            label="Retention (keep last N)"
+            type="number"
+            min={1}
+            value={String(retention)}
+            disabled={!enabled}
+            onChange={(e) => setRetention(parseInt(e.target.value, 10) || 1)}
+            helperText="Older backups beyond this count are deleted after each run."
+          />
+
+          <Input
+            label="Target directory"
+            value={targetDir}
+            disabled={!enabled}
+            onChange={(e) => setTargetDir(e.target.value)}
+            helperText="Absolute path where encrypted backups are written."
+            className="sm:col-span-2"
+          />
+        </div>
+
+        {/* Last run status */}
+        <div className="p-4 bg-gray-800/50 rounded-lg border border-gray-700">
+          <div className="flex items-center justify-between mb-2">
+            <h4 className="text-sm font-medium text-gray-300">Last run</h4>
+            {status?.last_success === true && <Badge variant="success">Success</Badge>}
+            {status?.last_success === false && <Badge variant="error">Failed</Badge>}
+            {status?.last_run_unix == null && <Badge variant="default">Never run</Badge>}
+          </div>
+          <div className="text-sm text-gray-400 space-y-1">
+            <div>Time: {formatUnix(status?.last_run_unix)}</div>
+            {status?.last_path && (
+              <div className="break-all">Path: {status.last_path}</div>
+            )}
+            {status?.last_error && (
+              <div className="text-red-400 break-all">Error: {status.last_error}</div>
+            )}
+          </div>
+        </div>
+
+        <div className="flex items-center gap-3">
+          <Button
+            variant="primary"
+            onClick={handleSave}
+            loading={save.isPending}
+            disabled={isLoading}
+          >
+            Save schedule
+          </Button>
+          <span className="text-xs text-gray-500">
+            Backups inherit the database encryption; store the target directory securely.
+          </span>
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/dashboard/src/hooks/queries/index.ts
+++ b/dashboard/src/hooks/queries/index.ts
@@ -28,6 +28,9 @@ export * from './useLogsQuery';
 // Backup queries
 export * from './useBackupQueries';
 
+// Scheduled-backup config queries
+export * from './useBackupScheduleQueries';
+
 // Watchdog queries
 export * from './useWatchdogQueries';
 

--- a/dashboard/src/hooks/queries/useBackupScheduleQueries.ts
+++ b/dashboard/src/hooks/queries/useBackupScheduleQueries.ts
@@ -1,0 +1,29 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  getBackupSchedule,
+  setBackupSchedule,
+  type BackupSchedule,
+} from "@/lib/api/backupSchedule";
+
+export const backupScheduleKeys = {
+  all: ["backupSchedule"] as const,
+  config: () => [...backupScheduleKeys.all, "config"] as const,
+};
+
+export function useBackupSchedule() {
+  return useQuery({
+    queryKey: backupScheduleKeys.config(),
+    queryFn: getBackupSchedule,
+    staleTime: 30_000,
+  });
+}
+
+export function useSetBackupSchedule() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (config: BackupSchedule) => setBackupSchedule(config),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: backupScheduleKeys.all });
+    },
+  });
+}

--- a/dashboard/src/lib/api/backupSchedule.ts
+++ b/dashboard/src/lib/api/backupSchedule.ts
@@ -1,0 +1,58 @@
+// Automatic scheduled encrypted backups — configuration persisted to pool.toml
+// `[backup]` by ghost-pool. The scheduled task reuses the same encrypted-backup
+// routine the manual backup uses. These calls route through the HMAC-signed
+// proxy like the operator-alerts config.
+import { fetchApi } from "./client";
+
+// `interval` is a compact wire string: "daily", "weekly", or "<n>h" for a
+// custom period in hours (e.g. "6h"). Matches the Rust `BackupInterval` form.
+export type BackupInterval = string;
+
+export interface BackupSchedule {
+  enabled: boolean;
+  interval: BackupInterval;
+  // Keep only the most recent N artifacts; older ones are pruned after a run.
+  retention: number;
+  // Absolute directory the timestamped encrypted artifacts are written to.
+  target_dir: string;
+}
+
+// In-memory last-run status reported by the node (resets on restart).
+export interface BackupRunStatus {
+  last_run_unix?: number | null;
+  last_success?: boolean | null;
+  last_path?: string | null;
+  last_error?: string | null;
+}
+
+export interface BackupScheduleResponse extends BackupSchedule {
+  status: BackupRunStatus;
+  message?: string;
+}
+
+export interface BackupScheduleSaveResponse extends BackupSchedule {
+  status: BackupRunStatus;
+  success: boolean;
+  persisted: boolean;
+  message: string;
+}
+
+export const BACKUP_SCHEDULE_DEFAULTS: BackupSchedule = {
+  enabled: false,
+  interval: "daily",
+  retention: 7,
+  target_dir: "/home/ghost/.ghost/backups",
+};
+
+export async function getBackupSchedule(): Promise<BackupScheduleResponse> {
+  return fetchApi<BackupScheduleResponse>("/api/v1/config/backup_schedule");
+}
+
+export async function setBackupSchedule(
+  config: BackupSchedule,
+): Promise<BackupScheduleSaveResponse> {
+  return fetchApi<BackupScheduleSaveResponse>("/api/v1/config/backup_schedule", {
+    method: "POST",
+    body: JSON.stringify(config),
+  });
+}


### PR DESCRIPTION
## Summary

Adds an opt-in **automatic scheduled encrypted-backup** feature to the node. The manual encrypted-backup surface already existed; this adds a schedule on top of it, reusing the exact same backup routine rather than reimplementing backup/encryption.

The scheduled task calls the existing `Database::backup` (SQLite `VACUUM INTO`) routine — the same one the daily backup task already used — so every artifact inherits the database's SQLCipher encryption. Secure-by-default: the whole feature is **off until an operator enables it**.

## Backend

- **`ghost-common` (`config.rs`)** — new `BackupSchedule` struct on `NodeConfig` (`#[serde(default)]`, so pre-existing `pool.toml` files stay valid):
  - `enabled` (default `false`), `interval` (`BackupInterval`: `daily` / `weekly` / custom `<n>h`), `retention` (keep last N, default 7), `target_dir` (default `/home/ghost/.ghost/backups`).
  - `BackupInterval` serialises to a compact wire string (`"daily"` / `"weekly"` / `"6h"`) that round-trips through both TOML and JSON.
  - `BackupRunStatus` (last run time / result / path / error) and pure, unit-tested helpers: `backup_is_due`, `backups_to_prune`, `artifact_filename`.
- **`ghost-verification`** — a shared `backup_status` handle on `VerificationState`, and a `GET`/`POST /api/v1/config/backup_schedule` pair (POST on the internal HMAC router, mirroring the alerts handler). GET returns the schedule plus live last-run status; POST validates (retention floor 1, absolute `target_dir`) and persists via `save_atomic`.
- **`ghost-pool` (`main.rs`)** — a background scheduler task next to the other periodic tasks. When enabled it re-reads the live schedule each tick, writes a timestamped artifact (`ghost-backup-YYYYMMDD-HHMMSS.db`) to the target dir on the configured interval, prunes to `retention`, and records last-run status. DB/filesystem work runs on `spawn_blocking`; failures are logged and surfaced in status.

## Frontend

- A **Scheduled Backups** card on the System page, alongside the manual Backup & Restore surface: enable toggle, interval selector (daily / weekly / custom hours), retention, target directory, and last-run status. Reuses the existing Card/Toggle/Input primitives and the config get/set mutation pattern through the HMAC-signed proxy.

## Verification

- `cargo check -p ghost-common -p ghost-verification -p ghost-pool -j2` — clean.
- `cargo test -p ghost-common` backup tests — 9 passed (serde default/back-compat, interval round-trip + period, next-run computation, retention prune, filename sortability).
- `tsc --noEmit`, `eslint` on changed files, and `npm run build` — all clean.
