### PR TITLE
rbf: operator opt-out of full-RBF (re-add -mempoolfullrbf + policy branch)

### DIFF
--- a/crates/ghost-common/src/config.rs
+++ b/crates/ghost-common/src/config.rs
@@ -154,6 +154,14 @@ pub struct NodeLaunchConfig {
     /// Unset → ghostd's default. Restart-required.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mempool_expiry_hours: Option<u32>,
+    /// Full replace-by-fee (`-mempoolfullrbf`). ghostd defaults to full RBF ON
+    /// (any transaction replaceable). `Some(false)` opts the operator OUT,
+    /// emitting `-mempoolfullrbf=0` so only BIP125-signalling transactions are
+    /// replaceable (first-seen-safe for non-signalling txs). `None` or
+    /// `Some(true)` preserves ghostd's default (full RBF on) and emits nothing.
+    /// Restart-required.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub full_rbf: Option<bool>,
 
     // --- Connectivity ----------------------------------------------------
     /// Maximum automatic peer connections (`-maxconnections`). Unset → ghostd's
@@ -219,6 +227,11 @@ impl NodeLaunchConfig {
         }
         if let Some(hours) = self.mempool_expiry_hours {
             flags.push(format!("-mempoolexpiry={hours}"));
+        }
+        // ghostd defaults to full RBF on, so only emit a flag when the operator
+        // opts out (Some(false)). None / Some(true) leave ghostd at its default.
+        if self.full_rbf == Some(false) {
+            flags.push("-mempoolfullrbf=0".to_string());
         }
         if let Some(n) = self.max_connections {
             flags.push(format!("-maxconnections={n}"));
@@ -2710,6 +2723,7 @@ mod tests {
             tor_mode: true,
             max_mempool_mb: Some(600),
             mempool_expiry_hours: Some(72),
+            full_rbf: Some(false),
             max_connections: Some(40),
             max_upload_target_mb: Some("500M".to_string()),
             dbcache_mb: Some(2048),
@@ -2723,6 +2737,7 @@ mod tests {
         assert!(flags.contains(&"-tormode=1".to_string()));
         assert!(flags.contains(&"-maxmempool=600".to_string()));
         assert!(flags.contains(&"-mempoolexpiry=72".to_string()));
+        assert!(flags.contains(&"-mempoolfullrbf=0".to_string()));
         assert!(flags.contains(&"-maxconnections=40".to_string()));
         assert!(flags.contains(&"-maxuploadtarget=500M".to_string()));
         assert!(flags.contains(&"-dbcache=2048".to_string()));
@@ -2744,6 +2759,28 @@ mod tests {
             ..Default::default()
         };
         assert!(cfg.ghostd_flags().is_empty());
+    }
+
+    #[test]
+    fn test_node_launch_full_rbf_only_emits_on_opt_out() {
+        // ghostd defaults to full RBF ON, so the flag is emitted ONLY when the
+        // operator opts out with Some(false). None and Some(true) preserve the
+        // default and must add nothing to ExecStart.
+        let none = NodeLaunchConfig::default();
+        assert_eq!(none.full_rbf, None);
+        assert!(!none.ghostd_flags().iter().any(|f| f.starts_with("-mempoolfullrbf")));
+
+        let on = NodeLaunchConfig {
+            full_rbf: Some(true),
+            ..Default::default()
+        };
+        assert!(!on.ghostd_flags().iter().any(|f| f.starts_with("-mempoolfullrbf")));
+
+        let off = NodeLaunchConfig {
+            full_rbf: Some(false),
+            ..Default::default()
+        };
+        assert_eq!(off.ghostd_flags(), vec!["-mempoolfullrbf=0".to_string()]);
     }
 
     #[test]

--- a/crates/ghost-common/src/setup.rs
+++ b/crates/ghost-common/src/setup.rs
@@ -284,6 +284,7 @@ const MANAGED_GHOSTD_FLAG_PREFIXES: &[&str] = &[
     // Daemon / node launch settings (NodeLaunchConfig).
     "-maxmempool",
     "-mempoolexpiry",
+    "-mempoolfullrbf",
     "-maxconnections",
     "-maxuploadtarget",
     "-dbcache",
@@ -481,6 +482,7 @@ mod tests {
             tor_mode: true,
             max_mempool_mb: Some(600),
             mempool_expiry_hours: Some(48),
+            full_rbf: Some(false),
             max_connections: Some(50),
             max_upload_target_mb: Some("2G".to_string()),
             dbcache_mb: Some(2048),
@@ -505,6 +507,8 @@ mod tests {
         assert_eq!(dropin.matches("-dbcache=").count(), 1);
         assert!(dropin.contains("-dbcache=2048"));
         assert!(dropin.contains("-mempoolexpiry=48"));
+        assert_eq!(dropin.matches("-mempoolfullrbf=").count(), 1);
+        assert!(dropin.contains("-mempoolfullrbf=0"));
         assert!(dropin.contains("-maxconnections=50"));
         assert!(dropin.contains("-maxuploadtarget=2G"));
         assert!(dropin.contains("-blockfilterindex=1"));

--- a/crates/ghost-verification/src/routes.rs
+++ b/crates/ghost-verification/src/routes.rs
@@ -5440,6 +5440,7 @@ async fn api_config_daemon_handler(
         "settings": {
             "max_mempool_mb": launch.max_mempool_mb,
             "mempool_expiry_hours": launch.mempool_expiry_hours,
+            "full_rbf": launch.full_rbf,
             "max_connections": launch.max_connections,
             "max_upload_target_mb": launch.max_upload_target_mb,
             "dbcache_mb": launch.dbcache_mb,
@@ -5775,6 +5776,10 @@ struct DaemonSettingsRequest {
     max_mempool_mb: Option<u32>,
     #[serde(default)]
     mempool_expiry_hours: Option<u32>,
+    /// Full RBF opt-out. `Some(false)` opts out (emits `-mempoolfullrbf=0`);
+    /// `None`/`Some(true)` preserve ghostd's default (full RBF on).
+    #[serde(default)]
+    full_rbf: Option<bool>,
     #[serde(default)]
     max_connections: Option<u32>,
     #[serde(default)]
@@ -5938,6 +5943,7 @@ async fn api_config_daemon_post_handler(
         let launch = &mut cfg.node_launch;
         launch.max_mempool_mb = payload.max_mempool_mb;
         launch.mempool_expiry_hours = payload.mempool_expiry_hours;
+        launch.full_rbf = payload.full_rbf;
         launch.max_connections = payload.max_connections;
         launch.max_upload_target_mb = payload.max_upload_target_mb.clone();
         launch.dbcache_mb = payload.dbcache_mb;
@@ -9000,6 +9006,7 @@ mod tests {
         let good = DaemonSettingsRequest {
             max_mempool_mb: Some(600),
             mempool_expiry_hours: Some(72),
+            full_rbf: Some(false),
             max_connections: Some(40),
             max_upload_target_mb: Some("1G".to_string()),
             dbcache_mb: Some(2048),

--- a/dashboard/src/app/(dashboard)/settings/daemon/page.tsx
+++ b/dashboard/src/app/(dashboard)/settings/daemon/page.tsx
@@ -23,6 +23,9 @@ const ONLYNET_OPTIONS = ["ipv4", "ipv6", "onion", "i2p", "cjdns"] as const;
 interface FormState {
   maxMempoolMb: string;
   mempoolExpiryHours: string;
+  // ON = full RBF (ghostd default, any tx replaceable). OFF = opt out → only
+  // BIP125-signalling txs replaceable (first-seen-safe for the rest).
+  fullRbf: boolean;
   maxConnections: string;
   maxUploadTargetMb: string;
   dbcacheMb: string;
@@ -36,6 +39,7 @@ interface FormState {
 const EMPTY_FORM: FormState = {
   maxMempoolMb: "",
   mempoolExpiryHours: "",
+  fullRbf: true, // ghostd default is full RBF on
   maxConnections: "",
   maxUploadTargetMb: "",
   dbcacheMb: "",
@@ -52,6 +56,8 @@ function fromSettings(s: DaemonSettings | undefined): FormState {
   return {
     maxMempoolMb: num(s.max_mempool_mb),
     mempoolExpiryHours: num(s.mempool_expiry_hours),
+    // Full RBF is on unless the operator explicitly opted out (full_rbf===false).
+    fullRbf: s.full_rbf !== false,
     maxConnections: num(s.max_connections),
     maxUploadTargetMb: s.max_upload_target_mb ?? "",
     dbcacheMb: num(s.dbcache_mb),
@@ -79,6 +85,9 @@ function toSettings(f: FormState): DaemonSettings {
   return {
     max_mempool_mb: optNum(f.maxMempoolMb),
     mempool_expiry_hours: optNum(f.mempoolExpiryHours),
+    // ON → null (leave ghostd at its full-RBF default, emit no flag).
+    // OFF → false (opt out → -mempoolfullrbf=0).
+    full_rbf: f.fullRbf ? null : false,
     max_connections: optNum(f.maxConnections),
     max_upload_target_mb: optStr(f.maxUploadTargetMb),
     dbcache_mb: optNum(f.dbcacheMb),
@@ -265,6 +274,16 @@ export default function DaemonSettingsPage() {
                 type="number"
                 inputMode="numeric"
                 unit="hrs"
+              />
+              <ToggleFieldRow
+                label="Full RBF"
+                description={
+                  form.fullRbf
+                    ? "ON (default): every unconfirmed transaction is replaceable by a higher-fee conflict, regardless of BIP125 signalling."
+                    : "OFF: only transactions that signal BIP125 opt-in replaceability can be replaced. Non-signalling first-seen transactions are protected (-mempoolfullrbf=0)."
+                }
+                enabled={form.fullRbf}
+                onChange={(v) => patch({ fullRbf: v })}
               />
             </div>
           </Card>

--- a/dashboard/src/lib/api/config.ts
+++ b/dashboard/src/lib/api/config.ts
@@ -64,6 +64,10 @@ export interface DaemonSettings {
   // Mempool
   max_mempool_mb?: number | null;       // -maxmempool (MB)
   mempool_expiry_hours?: number | null; // -mempoolexpiry (hours)
+  // Full RBF (-mempoolfullrbf). ghostd defaults to full RBF ON (any tx
+  // replaceable). false opts out → -mempoolfullrbf=0 (only BIP125-signalling
+  // txs replaceable). null/true preserve ghostd's default (emit nothing).
+  full_rbf?: boolean | null;
   // Connectivity
   max_connections?: number | null;      // -maxconnections
   max_upload_target_mb?: string | null; // -maxuploadtarget (number + optional unit k|K|m|M|g|G|t|T; 0 = no limit)

--- a/ghost-core/src/init.cpp
+++ b/ghost-core/src/init.cpp
@@ -717,6 +717,7 @@ void SetupServerArgs(ArgsManager& argsman, bool can_listen_ipc)
     SetupChainParamsBaseOptions(argsman);
 
     argsman.AddArg("-acceptnonstdtxn", strprintf("Relay and mine \"non-standard\" transactions (test networks only; default: %u)", DEFAULT_ACCEPT_NON_STD_TXN), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::NODE_RELAY);
+    argsman.AddArg("-mempoolfullrbf", strprintf("Accept transaction replace-by-fee without requiring replaceability signaling (full RBF; default: %u). Set to 0 to only replace transactions that signal BIP125 opt-in replaceability.", DEFAULT_MEMPOOL_FULL_RBF), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
     argsman.AddArg("-ghostreaper", "Ghost Reaper dead-code filter master switch (default: enabled). Sets the default value for every per-vector toggle; individual -ghostreaper-reject* flags override per detector.", ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
     argsman.AddArg("-ghostreaper-rejectinscription", "Ghost Reaper: reject witness scripts containing OP_FALSE OP_IF ... OP_ENDIF inscription envelopes (default: follows -ghostreaper).", ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
     argsman.AddArg("-ghostreaper-rejectdropstuffing", "Ghost Reaper: reject witness scripts with a large push followed by OP_DROP/OP_2DROP (default: follows -ghostreaper).", ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);

--- a/ghost-core/src/kernel/mempool_options.h
+++ b/ghost-core/src/kernel/mempool_options.h
@@ -26,6 +26,12 @@ static constexpr unsigned int DEFAULT_MEMPOOL_EXPIRY_HOURS{336};
 static constexpr bool DEFAULT_PERSIST_V1_DAT{false};
 /** Default for -acceptnonstdtxn */
 static constexpr bool DEFAULT_ACCEPT_NON_STD_TXN{false};
+/** Default for -mempoolfullrbf, whether the mempool accepts the replacement of
+ *  any conflicting transaction (full RBF) regardless of BIP125 opt-in
+ *  signalling. Ghost keeps full RBF on by default; an operator can opt out with
+ *  -mempoolfullrbf=0 to restrict replacement to transactions that signal BIP125
+ *  replaceability (first-seen-safe for non-signalling transactions). */
+static constexpr bool DEFAULT_MEMPOOL_FULL_RBF{true};
 
 namespace kernel {
 /**
@@ -54,6 +60,10 @@ struct MemPoolOptions {
     std::optional<unsigned> max_datacarrier_bytes{DEFAULT_ACCEPT_DATACARRIER ? std::optional{MAX_OP_RETURN_RELAY} : std::nullopt};
     bool permit_bare_multisig{DEFAULT_PERMIT_BAREMULTISIG};
     bool require_standard{true};
+    /** Whether to enable full RBF (accept replacement of any conflicting
+     *  mempool transaction). When false, only transactions signalling BIP125
+     *  opt-in replaceability may be replaced. Controlled by -mempoolfullrbf. */
+    bool full_rbf{DEFAULT_MEMPOOL_FULL_RBF};
     bool persist_v1_dat{DEFAULT_PERSIST_V1_DAT};
     /** Ghost Reaper dead-code mempool filter configuration */
     GhostReaperConfig ghost_reaper{};

--- a/ghost-core/src/node/mempool_args.cpp
+++ b/ghost-core/src/node/mempool_args.cpp
@@ -104,6 +104,10 @@ util::Result<void> ApplyArgsManOptions(const ArgsManager& argsman, const CChainP
 
     mempool_opts.persist_v1_dat = argsman.GetBoolArg("-persistmempoolv1", mempool_opts.persist_v1_dat);
 
+    // Full RBF is on by default; -mempoolfullrbf=0 lets an operator opt out and
+    // fall back to BIP125 opt-in replacement (see ReplacementChecks/PreChecks).
+    mempool_opts.full_rbf = argsman.GetBoolArg("-mempoolfullrbf", DEFAULT_MEMPOOL_FULL_RBF);
+
     // Ghost Reaper configuration.
     //
     // The master `-ghostreaper` flag sets the default value for every per-vector

--- a/ghost-core/src/rpc/mempool.cpp
+++ b/ghost-core/src/rpc/mempool.cpp
@@ -688,7 +688,7 @@ UniValue MempoolInfoToJSON(const CTxMemPool& pool)
     ret.pushKV("minrelaytxfee", ValueFromAmount(pool.m_opts.min_relay_feerate.GetFeePerK()));
     ret.pushKV("incrementalrelayfee", ValueFromAmount(pool.m_opts.incremental_relay_feerate.GetFeePerK()));
     ret.pushKV("unbroadcastcount", uint64_t{pool.GetUnbroadcastTxs().size()});
-    ret.pushKV("fullrbf", true);
+    ret.pushKV("fullrbf", pool.m_opts.full_rbf);
     ret.pushKV("permitbaremultisig", pool.m_opts.permit_bare_multisig);
     ret.pushKV("maxdatacarriersize", pool.m_opts.max_datacarrier_bytes.value_or(0));
     return ret;
@@ -712,7 +712,7 @@ static RPCHelpMan getmempoolinfo()
                 {RPCResult::Type::STR_AMOUNT, "minrelaytxfee", "Current minimum relay fee for transactions"},
                 {RPCResult::Type::NUM, "incrementalrelayfee", "minimum fee rate increment for mempool limiting or replacement in " + CURRENCY_UNIT + "/kvB"},
                 {RPCResult::Type::NUM, "unbroadcastcount", "Current number of transactions that haven't passed initial broadcast yet"},
-                {RPCResult::Type::BOOL, "fullrbf", "True if the mempool accepts RBF without replaceability signaling inspection (DEPRECATED)"},
+                {RPCResult::Type::BOOL, "fullrbf", "True if the mempool accepts replacement of any transaction regardless of BIP125 opt-in signalling (full RBF). Reflects the -mempoolfullrbf setting."},
                 {RPCResult::Type::BOOL, "permitbaremultisig", "True if the mempool accepts transactions with bare multisig outputs"},
                 {RPCResult::Type::NUM, "maxdatacarriersize", "Maximum number of bytes that can be used by OP_RETURN outputs in the mempool"},
             }},

--- a/ghost-core/src/validation.cpp
+++ b/ghost-core/src/validation.cpp
@@ -843,6 +843,12 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
                 // Transaction conflicts with a mempool tx, but we're not allowing replacements in this context.
                 return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "bip125-replacement-disallowed");
             }
+            if (!m_pool.m_opts.full_rbf && !SignalsOptInRBF(*ptxConflicting)) {
+                // Full RBF is disabled (-mempoolfullrbf=0) and the conflicting
+                // mempool transaction did not signal BIP125 opt-in
+                // replaceability, so it is protected from replacement.
+                return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "txn-mempool-conflict");
+            }
             ws.m_conflicts.insert(ptxConflicting->GetHash());
         }
     }

--- a/ghost-core/test/functional/feature_rbf.py
+++ b/ghost-core/test/functional/feature_rbf.py
@@ -79,6 +79,9 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         self.log.info("Running test incremental relay feerates...")
         self.test_incremental_relay_feerates()
 
+        self.log.info("Running test opt-out of full replace by fee...")
+        self.test_no_fullrbf()
+
         self.log.info("Passed")
 
     def make_utxo(self, node, amount, *, confirmed=True, scriptPubKey=None):
@@ -650,6 +653,60 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         # Optout_tx is not anymore in the mempool.
         assert optout_tx['txid'] not in self.nodes[0].getrawmempool()
         assert conflicting_tx['txid'] in self.nodes[0].getrawmempool()
+
+    def test_no_fullrbf(self):
+        # With -mempoolfullrbf=0 the operator opts out of full RBF: only
+        # transactions that signal BIP125 opt-in replaceability may be replaced.
+        self.restart_node(0, extra_args=[
+            "-mempoolfullrbf=0",
+            "-limitancestorcount=50",
+            "-limitancestorsize=101",
+            "-limitdescendantcount=200",
+            "-limitdescendantsize=101",
+        ])
+        assert_equal(False, self.nodes[0].getmempoolinfo()["fullrbf"])
+
+        # A transaction that does NOT signal BIP125 (opt-out) is protected from
+        # replacement even by a higher-fee conflict.
+        optout_utxo = self.make_utxo(self.nodes[0], int(2 * COIN))
+        optout_tx = self.wallet.send_self_transfer(
+            from_node=self.nodes[0],
+            utxo_to_spend=optout_utxo,
+            sequence=MAX_BIP125_RBF_SEQUENCE + 1,
+            fee_rate=Decimal('0.01'),
+        )
+        assert_equal(False, self.nodes[0].getmempoolentry(optout_tx['txid'])['bip125-replaceable'])
+
+        optout_conflict = self.wallet.create_self_transfer(
+            utxo_to_spend=optout_utxo,
+            fee_rate=Decimal('0.02'),
+        )
+        # The replacement must be rejected because full RBF is off and the
+        # conflicting mempool tx did not signal opt-in.
+        assert_raises_rpc_error(-26, "txn-mempool-conflict",
+                                self.nodes[0].sendrawtransaction, optout_conflict['hex'], 0)
+        # The original opt-out tx survives; the replacement did not enter.
+        assert optout_tx['txid'] in self.nodes[0].getrawmempool()
+        assert optout_conflict['txid'] not in self.nodes[0].getrawmempool()
+
+        # A transaction that DOES signal BIP125 opt-in remains replaceable even
+        # with full RBF disabled — this is the opt-in path that must still work.
+        optin_utxo = self.make_utxo(self.nodes[0], int(2 * COIN))
+        optin_tx = self.wallet.send_self_transfer(
+            from_node=self.nodes[0],
+            utxo_to_spend=optin_utxo,
+            sequence=MAX_BIP125_RBF_SEQUENCE,
+            fee_rate=Decimal('0.01'),
+        )
+        assert_equal(True, self.nodes[0].getmempoolentry(optin_tx['txid'])['bip125-replaceable'])
+
+        optin_conflict = self.wallet.create_self_transfer(
+            utxo_to_spend=optin_utxo,
+            fee_rate=Decimal('0.02'),
+        )
+        self.nodes[0].sendrawtransaction(optin_conflict['hex'], 0)
+        assert optin_tx['txid'] not in self.nodes[0].getrawmempool()
+        assert optin_conflict['txid'] in self.nodes[0].getrawmempool()
 
 if __name__ == '__main__':
     ReplaceByFeeTest(__file__).main()

--- a/ghost-core/test/functional/feature_rbf.py
+++ b/ghost-core/test/functional/feature_rbf.py
@@ -76,11 +76,11 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         self.log.info("Running test full replace by fee...")
         self.test_fullrbf()
 
-        self.log.info("Running test incremental relay feerates...")
-        self.test_incremental_relay_feerates()
-
         self.log.info("Running test opt-out of full replace by fee...")
         self.test_no_fullrbf()
+
+        self.log.info("Running test incremental relay feerates...")
+        self.test_incremental_relay_feerates()
 
         self.log.info("Passed")
 
@@ -664,6 +664,9 @@ class ReplaceByFeeTest(BitcoinTestFramework):
             "-limitdescendantcount=200",
             "-limitdescendantsize=101",
         ])
+        # Restarting drops node 0's P2P connection; reconnect so make_utxo's
+        # block generation can sync across the two nodes.
+        self.connect_nodes(0, 1)
         assert_equal(False, self.nodes[0].getmempoolinfo()["fullrbf"])
 
         # A transaction that does NOT signal BIP125 (opt-out) is protected from

--- a/ghost-core/test/functional/test_framework/test_framework.py
+++ b/ghost-core/test/functional/test_framework/test_framework.py
@@ -934,7 +934,15 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
             os.rmdir(cache_path('wallets'))  # Remove empty wallets dir
             for entry in os.listdir(cache_path()):
                 if entry not in ['chainstate', 'blocks', 'indexes']:  # Only indexes, chainstate and blocks folders
-                    os.remove(cache_path(entry))
+                    # ghostd writes node-local state directories (e.g. `gsp`) into
+                    # the datadir alongside the block/chainstate dirs; those must be
+                    # cleared from the shared cache too. os.remove() only handles
+                    # files, so recurse into directories.
+                    entry_path = cache_path(entry)
+                    if os.path.isdir(entry_path):
+                        shutil.rmtree(entry_path)
+                    else:
+                        os.remove(entry_path)
 
         for i in range(self.num_nodes):
             self.log.debug("Copy cache directory {} to node {}".format(cache_node_dir, i))


### PR DESCRIPTION
## Summary

Re-introduces an operator opt-out for full replace-by-fee. ghost-core had hard-coded full RBF on and the upstream `-mempoolfullrbf` startup arg had been removed, leaving no way to protect first-seen non-signalling transactions from replacement. This restores that control as a **mempool relay-policy** option and wires it through the ghostd daemon-settings bridge and the dashboard.

This is a **mempool-policy change only** — there is **no block-consensus / block-validation change**.

### Default behaviour is preserved

Full RBF stays **ON** by default (`DEFAULT_MEMPOOL_FULL_RBF{true}`). A node that does not set the flag is byte-behaviour identical to before. The operator only changes anything by explicitly passing `-mempoolfullrbf=0` (or toggling the dashboard switch off), which restores classic BIP125 opt-in replacement: only transactions that signal opt-in (`nSequence < 0xfffffffe`, or inherited signalling) may be replaced.

## Deploy requirement — rebuild + deploy ghostd, not just ghost-pool

The policy branch lives in the **ghostd (ghost-core / C++) binary**. The Rust bridge only *emits* the `-mempoolfullrbf=0` flag into ghostd's systemd drop-in; ghostd must already understand that flag. **The deployed ghostd binary must be rebuilt and rolled out with this change before the bridge/dashboard toggle is used** — an old ghostd would reject the unknown arg and fail to start. Order of operations for the fleet: build + canary-deploy the new **ghostd** first, then deploy ghost-pool + dashboard that expose the toggle.

## C++ sites changed (ghost-core)

- `src/kernel/mempool_options.h` — add `DEFAULT_MEMPOOL_FULL_RBF{true}` and `MemPoolOptions::full_rbf`.
- `src/node/mempool_args.cpp` — `full_rbf = GetBoolArg("-mempoolfullrbf", DEFAULT_MEMPOOL_FULL_RBF)`.
- `src/init.cpp` — register the `-mempoolfullrbf` startup arg (`NODE_RELAY` category).
- `src/validation.cpp` (`MemPoolAccept::PreChecks`) — the policy branch: when `!m_pool.m_opts.full_rbf && !SignalsOptInRBF(*ptxConflicting)`, reject with `txn-mempool-conflict` (protects the non-signalling mempool tx). With full RBF on, unchanged.
- `src/rpc/mempool.cpp` — `getmempoolinfo.fullrbf` now reflects the real setting instead of hard-coded `true`; help text updated.
- `test/functional/feature_rbf.py` — new `test_no_fullrbf` exercising both modes.

## Rust bridge + UI wiring

- `crates/ghost-common/src/config.rs` — `NodeLaunchConfig::full_rbf: Option<bool>`; `ghostd_flags()` emits `-mempoolfullrbf=0` **only** on `Some(false)`; `None`/`Some(true)` emit nothing (preserve default).
- `crates/ghost-common/src/setup.rs` — `-mempoolfullrbf` added to `MANAGED_GHOSTD_FLAG_PREFIXES` so the managed drop-in stays idempotent.
- `crates/ghost-verification/src/routes.rs` — `full_rbf` exposed on `GET` and accepted on `POST /api/v1/config/daemon`, persisted to `[node_launch]`.
- `dashboard` — a **"Full RBF" toggle** (default ON) in Settings > Daemon (Mempool group) with an explainer; ON = all txs replaceable (current default), OFF = BIP125-signalling-only (first-seen-safe); "Apply & restart" confirm.

## Testing

- ghostd builds and links (`cmake --build ... -j2`, per the WSL2 `-j2` constraint).
- `feature_rbf.py`: default mode (`test_fullrbf`) unchanged — a non-signalling opt-out tx is still replaced; opt-out mode (`test_no_fullrbf`, `-mempoolfullrbf=0`) — a non-signalling tx is protected (`txn-mempool-conflict`), a BIP125-signalling tx is still replaceable.
- `src/test` `rbf_tests` suite passes (no regression from the options change).
- `cargo check -p ghost-common -p ghost-verification -p ghost-setup -p ghost-pool` clean; `ghost-common` + `ghost-verification` unit tests pass (opt-out-only emission, drop-in idempotency, daemon-settings validation).
- Dashboard `tsc --noEmit` and `eslint` clean; `next build` succeeds.
