### PR TITLE
alerts: mempool-congestion, fee-spike, and failed-login events

### DIFF
--- a/bins/ghost-pool/src/alert_monitors.rs
+++ b/bins/ghost-pool/src/alert_monitors.rs
@@ -1,6 +1,6 @@
 //! Periodic operator-alert monitors.
 //!
-//! Two small background tasks that feed the existing operator-alert pipeline
+//! Small background tasks that feed the existing operator-alert pipeline
 //! (`ghost_verification::alerts`) for conditions that have no natural
 //! event-driven trigger site:
 //!
@@ -13,13 +13,22 @@
 //!   published. The installed/latest versions come from the same files the
 //!   dashboard auto-update view reads (`/etc/ghost/version` and the updater
 //!   status file). Rate-limited to at most once per day.
+//! * **Mempool-congestion** — ghostd's mempool `usage` is near its `maxmempool`
+//!   ceiling (from `getmempoolinfo`). Edge-triggered with hysteresis: fires when
+//!   usage crosses [`MEMPOOL_CONGESTION_HIGH_PCT`], re-arms once it falls back
+//!   below [`MEMPOOL_CONGESTION_REARM_PCT`].
+//! * **Fee-spike** — the next-block fee rate (from `estimatesmartfee`) crosses
+//!   [`FEE_SPIKE_ABS_SAT_VB`] or jumps to [`FEE_SPIKE_JUMP_FACTOR`]× a rolling
+//!   baseline. Rate-limited to [`FEE_SPIKE_ALERT_MIN_INTERVAL`] so sustained
+//!   high fees don't spam.
 //!
-//! Both dispatch off the hot path (their own spawned tasks) and both honour the
+//! All dispatch off the hot path (their own spawned tasks) and honour the
 //! operator's per-event enable flag + master switch inside the dispatcher.
 
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use ghost_common::rpc::BitcoinRpc;
 use ghost_verification::alerts::{AlertDispatcher, AlertEvent};
 use tokio::sync::broadcast;
 use tracing::{debug, info};
@@ -237,6 +246,268 @@ pub fn spawn_update_available_monitor(
     });
 }
 
+// ============================================================================
+// Mempool-congestion monitor
+// ============================================================================
+
+/// Usage (as a % of `maxmempool`) at which the mempool-congestion alert trips.
+pub const MEMPOOL_CONGESTION_HIGH_PCT: f64 = 90.0;
+
+/// Usage % the mempool must fall back below before the alert re-arms. The gap to
+/// [`MEMPOOL_CONGESTION_HIGH_PCT`] is hysteresis: it stops a mempool hovering
+/// right at the threshold from flapping the alert on every check.
+pub const MEMPOOL_CONGESTION_REARM_PCT: f64 = 80.0;
+
+/// Cadence of the mempool-congestion check.
+pub const MEMPOOL_CHECK_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Mempool `usage` as a percentage of `maxmempool`. Returns 0 when `maxmempool`
+/// is 0 (unknown / not reported) so a missing bound never trips the alert. Pure.
+pub fn mempool_usage_pct(usage_bytes: u64, maxmempool_bytes: u64) -> f64 {
+    if maxmempool_bytes == 0 {
+        return 0.0;
+    }
+    (usage_bytes as f64 / maxmempool_bytes as f64) * 100.0
+}
+
+/// Decide whether the mempool is congested at or above `high_pct` of its
+/// capacity, returning an operator-facing detail string when it is. Pure — no
+/// I/O — so the threshold logic is unit-testable independent of the RPC read.
+/// `maxmempool_bytes == 0` (unknown) never trips.
+pub fn evaluate_mempool_congestion(
+    usage_bytes: u64,
+    maxmempool_bytes: u64,
+    high_pct: f64,
+) -> Option<String> {
+    if maxmempool_bytes == 0 {
+        return None;
+    }
+    let pct = mempool_usage_pct(usage_bytes, maxmempool_bytes);
+    if pct >= high_pct {
+        const MIB: f64 = 1024.0 * 1024.0;
+        return Some(format!(
+            "Mempool is {pct:.0}% full: {:.0} MiB of {:.0} MiB in use (usage vs maxmempool).",
+            usage_bytes as f64 / MIB,
+            maxmempool_bytes as f64 / MIB,
+        ));
+    }
+    None
+}
+
+/// Spawn the mempool-congestion monitor. Reads ghostd `getmempoolinfo` via the
+/// pool's shared RPC client and fires an edge-triggered [`AlertEvent::MempoolCongestion`]
+/// when `usage` crosses [`MEMPOOL_CONGESTION_HIGH_PCT`] of `maxmempool`, re-arming
+/// once it falls back below [`MEMPOOL_CONGESTION_REARM_PCT`] (hysteresis).
+/// Delivery + the enable flag are handled inside the dispatcher. Runs until
+/// `shutdown` fires.
+pub fn spawn_mempool_congestion_monitor(
+    alerts: Arc<AlertDispatcher>,
+    rpc: Arc<BitcoinRpc>,
+    mut shutdown: broadcast::Receiver<()>,
+) {
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(MEMPOOL_CHECK_INTERVAL);
+        // Latched congestion state, for hysteresis across ticks.
+        let mut congested = false;
+        info!("Mempool-congestion monitor started");
+        loop {
+            tokio::select! {
+                _ = interval.tick() => {
+                    match rpc.get_mempool_info().await {
+                        Ok(info) => {
+                            let pct = mempool_usage_pct(info.usage, info.maxmempool);
+                            // Enter congested at HIGH; once congested, stay until
+                            // usage falls below REARM.
+                            let now_congested = if congested {
+                                info.maxmempool > 0 && pct >= MEMPOOL_CONGESTION_REARM_PCT
+                            } else {
+                                info.maxmempool > 0 && pct >= MEMPOOL_CONGESTION_HIGH_PCT
+                            };
+                            // Detail is only consumed on the rising edge; build it there.
+                            let detail = if now_congested && !congested {
+                                debug!(
+                                    pct,
+                                    usage = info.usage,
+                                    maxmempool = info.maxmempool,
+                                    "Mempool near capacity"
+                                );
+                                evaluate_mempool_congestion(
+                                    info.usage,
+                                    info.maxmempool,
+                                    MEMPOOL_CONGESTION_HIGH_PCT,
+                                )
+                                .unwrap_or_default()
+                            } else {
+                                String::new()
+                            };
+                            congested = now_congested;
+                            alerts
+                                .fire_edge(
+                                    AlertEvent::MempoolCongestion,
+                                    "mempool",
+                                    now_congested,
+                                    &detail,
+                                )
+                                .await;
+                        }
+                        Err(e) => {
+                            debug!(error = %e, "getmempoolinfo failed; skipping congestion check");
+                        }
+                    }
+                }
+                _ = shutdown.recv() => break,
+            }
+        }
+    });
+}
+
+// ============================================================================
+// Fee-spike monitor
+// ============================================================================
+
+/// Absolute next-block fee rate (sat/vB) at or above which a fee spike is
+/// reported regardless of the recent baseline — the fee environment is simply
+/// expensive.
+pub const FEE_SPIKE_ABS_SAT_VB: f64 = 100.0;
+
+/// A fee rate this many times the rolling baseline is a relative spike.
+pub const FEE_SPIKE_JUMP_FACTOR: f64 = 3.0;
+
+/// A relative (baseline-multiple) spike is only reported when the current rate
+/// is at least this high, so ordinary churn around a tiny baseline
+/// (e.g. 1 → 4 sat/vB) never pages the operator.
+pub const FEE_SPIKE_JUMP_FLOOR_SAT_VB: f64 = 20.0;
+
+/// EMA smoothing factor for the rolling fee baseline (weight of the newest
+/// sample). Small, so the baseline tracks the recent-normal slowly and a sudden
+/// jump still reads as a spike before it is absorbed.
+pub const FEE_SPIKE_BASELINE_ALPHA: f64 = 0.2;
+
+/// `estimatesmartfee` confirmation target used for the fee signal: the fee rate
+/// to get into the next block.
+pub const FEE_SPIKE_CONF_TARGET: u32 = 1;
+
+/// Cadence of the fee-spike check.
+pub const FEE_SPIKE_CHECK_INTERVAL: Duration = Duration::from_secs(120);
+
+/// Minimum interval between fee-spike alerts, so a sustained high-fee period
+/// pages once rather than every check.
+pub const FEE_SPIKE_ALERT_MIN_INTERVAL: Duration = Duration::from_secs(30 * 60);
+
+/// Convert a Bitcoin Core fee rate (BTC per 1000 vBytes, as `estimatesmartfee`
+/// reports) to sat/vB. 1 BTC/kvB = 1e8 sat / 1000 vB = 1e5 sat/vB. Pure.
+pub fn feerate_btc_kvb_to_sat_vb(feerate_btc_kvb: f64) -> f64 {
+    feerate_btc_kvb * 100_000.0
+}
+
+/// Decide whether the fee environment has spiked, returning an operator-facing
+/// detail string when it has. Pure — no I/O or clock access — so the threshold
+/// logic is unit-testable like [`evaluate_behind_tip`].
+///
+/// * absolute: `current >= abs_threshold` → spike (fees are simply high).
+/// * relative: a known `baseline > 0`, `current >= jump_floor`, and
+///   `current >= baseline * jump_factor` → spike (a sharp jump vs recent normal).
+/// * `current <= 0` never trips (no usable signal).
+pub fn evaluate_fee_spike(
+    current_sat_vb: f64,
+    baseline_sat_vb: Option<f64>,
+    abs_threshold_sat_vb: f64,
+    jump_factor: f64,
+    jump_floor_sat_vb: f64,
+) -> Option<String> {
+    if current_sat_vb <= 0.0 {
+        return None;
+    }
+    if current_sat_vb >= abs_threshold_sat_vb {
+        return Some(format!(
+            "Next-block fee rate is {current_sat_vb:.1} sat/vB, at or above the \
+             {abs_threshold_sat_vb:.0} sat/vB alert threshold."
+        ));
+    }
+    if let Some(base) = baseline_sat_vb {
+        if base > 0.0
+            && current_sat_vb >= jump_floor_sat_vb
+            && current_sat_vb >= base * jump_factor
+        {
+            return Some(format!(
+                "Next-block fee rate jumped to {current_sat_vb:.1} sat/vB, {:.1}x the \
+                 recent baseline of {base:.1} sat/vB.",
+                current_sat_vb / base
+            ));
+        }
+    }
+    None
+}
+
+/// Update the rolling fee baseline (EMA) with a new sample. Pure. The first
+/// sample seeds the baseline; later samples blend in at [`FEE_SPIKE_BASELINE_ALPHA`].
+pub fn update_fee_baseline(baseline: Option<f64>, sample_sat_vb: f64) -> f64 {
+    match baseline {
+        Some(b) => b * (1.0 - FEE_SPIKE_BASELINE_ALPHA) + sample_sat_vb * FEE_SPIKE_BASELINE_ALPHA,
+        None => sample_sat_vb,
+    }
+}
+
+/// Spawn the fee-spike monitor. Reads ghostd `estimatesmartfee` (next-block
+/// target) via the pool's shared RPC client, maintains a rolling baseline, and
+/// fires a rate-limited [`AlertEvent::FeeSpike`] when the rate crosses
+/// [`FEE_SPIKE_ABS_SAT_VB`] or jumps to [`FEE_SPIKE_JUMP_FACTOR`]× the baseline.
+/// Delivery + the enable flag are handled inside the dispatcher. Runs until
+/// `shutdown` fires.
+pub fn spawn_fee_spike_monitor(
+    alerts: Arc<AlertDispatcher>,
+    rpc: Arc<BitcoinRpc>,
+    mut shutdown: broadcast::Receiver<()>,
+) {
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(FEE_SPIKE_CHECK_INTERVAL);
+        let mut baseline: Option<f64> = None;
+        info!("Fee-spike monitor started");
+        loop {
+            tokio::select! {
+                _ = interval.tick() => {
+                    match rpc.estimate_smart_fee(FEE_SPIKE_CONF_TARGET).await {
+                        Ok(est) => {
+                            let Some(btc_kvb) = est.feerate else {
+                                debug!("estimatesmartfee returned no feerate; skipping fee-spike check");
+                                continue;
+                            };
+                            let sat_vb = feerate_btc_kvb_to_sat_vb(btc_kvb);
+                            if sat_vb <= 0.0 {
+                                continue;
+                            }
+                            if let Some(detail) = evaluate_fee_spike(
+                                sat_vb,
+                                baseline,
+                                FEE_SPIKE_ABS_SAT_VB,
+                                FEE_SPIKE_JUMP_FACTOR,
+                                FEE_SPIKE_JUMP_FLOOR_SAT_VB,
+                            ) {
+                                debug!(sat_vb, ?baseline, "Fee environment spiked");
+                                alerts
+                                    .fire_rate_limited(
+                                        AlertEvent::FeeSpike,
+                                        FEE_SPIKE_ALERT_MIN_INTERVAL,
+                                        &detail,
+                                    )
+                                    .await;
+                            }
+                            // Fold the sample into the rolling baseline AFTER
+                            // evaluating, so a spike is measured against the
+                            // pre-spike normal.
+                            baseline = Some(update_fee_baseline(baseline, sat_vb));
+                        }
+                        Err(e) => {
+                            debug!(error = %e, "estimatesmartfee failed; skipping fee-spike check");
+                        }
+                    }
+                }
+                _ = shutdown.recv() => break,
+            }
+        }
+    });
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -319,5 +590,143 @@ mod tests {
         assert!(version_is_newer("1.11", "1.10.20"));
         assert!(!version_is_newer("1.10", "1.10.0"));
         assert!(version_is_newer("1.10.1", "1.10"));
+    }
+
+    // ---- Mempool congestion ------------------------------------------------
+
+    #[test]
+    fn mempool_pct_is_zero_when_max_unknown() {
+        assert_eq!(mempool_usage_pct(100, 0), 0.0);
+        assert!((mempool_usage_pct(45, 100) - 45.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn congestion_none_when_below_threshold() {
+        // 80% full, threshold 90% → not congested.
+        assert!(evaluate_mempool_congestion(80, 100, MEMPOOL_CONGESTION_HIGH_PCT).is_none());
+    }
+
+    #[test]
+    fn congestion_fires_at_or_above_threshold() {
+        // Exactly at the threshold trips (>=).
+        let d = evaluate_mempool_congestion(90, 100, MEMPOOL_CONGESTION_HIGH_PCT);
+        assert!(d.is_some());
+        assert!(d.unwrap().contains("90% full"));
+        // Well over the threshold trips too.
+        assert!(evaluate_mempool_congestion(99, 100, MEMPOOL_CONGESTION_HIGH_PCT).is_some());
+    }
+
+    #[test]
+    fn congestion_never_fires_when_max_unknown() {
+        // maxmempool == 0 (not reported) must never trip, even with huge usage.
+        assert!(evaluate_mempool_congestion(u64::MAX, 0, MEMPOOL_CONGESTION_HIGH_PCT).is_none());
+    }
+
+    #[test]
+    fn congestion_rearm_is_below_high() {
+        // Sanity: hysteresis band is non-empty and ordered.
+        assert!(MEMPOOL_CONGESTION_REARM_PCT < MEMPOOL_CONGESTION_HIGH_PCT);
+    }
+
+    // ---- Fee spike ---------------------------------------------------------
+
+    #[test]
+    fn feerate_conversion_btc_kvb_to_sat_vb() {
+        // Min-relay 0.00001 BTC/kvB == 1 sat/vB.
+        assert!((feerate_btc_kvb_to_sat_vb(0.00001) - 1.0).abs() < 1e-6);
+        // 0.001 BTC/kvB == 100 sat/vB.
+        assert!((feerate_btc_kvb_to_sat_vb(0.001) - 100.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn fee_spike_fires_on_absolute_threshold() {
+        // At/above the absolute threshold fires regardless of baseline.
+        let d = evaluate_fee_spike(
+            120.0,
+            Some(110.0),
+            FEE_SPIKE_ABS_SAT_VB,
+            FEE_SPIKE_JUMP_FACTOR,
+            FEE_SPIKE_JUMP_FLOOR_SAT_VB,
+        );
+        assert!(d.is_some());
+        assert!(d.unwrap().contains("120.0 sat/vB"));
+    }
+
+    #[test]
+    fn fee_spike_fires_on_relative_jump() {
+        // 30 sat/vB vs a 5 sat/vB baseline = 6x (>= 3x) and above the floor → spike.
+        let d = evaluate_fee_spike(
+            30.0,
+            Some(5.0),
+            FEE_SPIKE_ABS_SAT_VB,
+            FEE_SPIKE_JUMP_FACTOR,
+            FEE_SPIKE_JUMP_FLOOR_SAT_VB,
+        );
+        assert!(d.is_some());
+        assert!(d.unwrap().contains("baseline"));
+    }
+
+    #[test]
+    fn fee_spike_silent_below_jump_floor() {
+        // 5x jump but the current rate (10) is below the 20 sat/vB floor → silent,
+        // so ordinary churn around a tiny baseline never pages.
+        assert!(evaluate_fee_spike(
+            10.0,
+            Some(2.0),
+            FEE_SPIKE_ABS_SAT_VB,
+            FEE_SPIKE_JUMP_FACTOR,
+            FEE_SPIKE_JUMP_FLOOR_SAT_VB,
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn fee_spike_silent_when_no_baseline_and_below_abs() {
+        // First reading (no baseline) below the absolute threshold → no alert.
+        assert!(evaluate_fee_spike(
+            25.0,
+            None,
+            FEE_SPIKE_ABS_SAT_VB,
+            FEE_SPIKE_JUMP_FACTOR,
+            FEE_SPIKE_JUMP_FLOOR_SAT_VB,
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn fee_spike_silent_within_normal_variation() {
+        // 25 vs 20 baseline = 1.25x (< 3x) and below abs → not a spike.
+        assert!(evaluate_fee_spike(
+            25.0,
+            Some(20.0),
+            FEE_SPIKE_ABS_SAT_VB,
+            FEE_SPIKE_JUMP_FACTOR,
+            FEE_SPIKE_JUMP_FLOOR_SAT_VB,
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn fee_spike_ignores_nonpositive_rate() {
+        assert!(evaluate_fee_spike(
+            0.0,
+            Some(5.0),
+            FEE_SPIKE_ABS_SAT_VB,
+            FEE_SPIKE_JUMP_FACTOR,
+            FEE_SPIKE_JUMP_FLOOR_SAT_VB,
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn fee_baseline_seeds_then_smooths() {
+        // First sample seeds the baseline exactly.
+        let b0 = update_fee_baseline(None, 10.0);
+        assert!((b0 - 10.0).abs() < 1e-9);
+        // Next sample blends toward the new value but stays between old and new.
+        let b1 = update_fee_baseline(Some(10.0), 30.0);
+        assert!(b1 > 10.0 && b1 < 30.0);
+        // Explicit EMA value: 10*0.8 + 30*0.2 = 14.
+        assert!((b1 - 14.0).abs() < 1e-9);
     }
 }

--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -6862,6 +6862,11 @@ async fn main() -> Result<()> {
     };
     let _ = alert_slot.set(Arc::clone(&alert_dispatcher));
 
+    // Register the dispatcher on the verification state so the internal
+    // failed-login endpoint (signalled by the dashboard login route) can
+    // dispatch the `FailedLogin` alert through the same debouncing dispatcher.
+    verification_state.set_alert_dispatcher(Arc::clone(&alert_dispatcher));
+
     // Get restart signal for monitoring (config update API)
     let restart_signal = verification_state.restart_signal();
 
@@ -6980,6 +6985,24 @@ async fn main() -> Result<()> {
     ghost_pool::alert_monitors::spawn_update_available_monitor(
         Arc::clone(&alert_dispatcher),
         env!("CARGO_PKG_VERSION").to_string(),
+        shutdown_tx.subscribe(),
+    );
+
+    // Start the mempool-congestion monitor. Edge-triggered `MempoolCongestion`
+    // alert (with hysteresis) when ghostd's mempool `usage` nears `maxmempool`,
+    // read via the pool's shared RPC client (`getmempoolinfo`).
+    ghost_pool::alert_monitors::spawn_mempool_congestion_monitor(
+        Arc::clone(&alert_dispatcher),
+        Arc::clone(&rpc),
+        shutdown_tx.subscribe(),
+    );
+
+    // Start the fee-spike monitor. Rate-limited `FeeSpike` alert when the
+    // next-block fee rate (`estimatesmartfee`) crosses an absolute threshold or
+    // jumps sharply versus a rolling baseline, read via the same RPC client.
+    ghost_pool::alert_monitors::spawn_fee_spike_monitor(
+        Arc::clone(&alert_dispatcher),
+        Arc::clone(&rpc),
         shutdown_tx.subscribe(),
     );
 

--- a/crates/ghost-common/src/config.rs
+++ b/crates/ghost-common/src/config.rs
@@ -1879,6 +1879,16 @@ pub struct AlertEvents {
     /// A newer node release is available than the one installed.
     #[serde(default = "default_true")]
     pub update_available: bool,
+    /// The mempool is near its capacity (usage close to `maxmempool`).
+    #[serde(default = "default_true")]
+    pub mempool_congestion: bool,
+    /// The fee environment spiked (fee rate crossed a threshold or jumped
+    /// sharply versus the recent baseline).
+    #[serde(default = "default_true")]
+    pub fee_spike: bool,
+    /// A burst of consecutive failed dashboard login attempts was detected.
+    #[serde(default = "default_true")]
+    pub failed_login: bool,
 }
 
 impl Default for AlertEvents {
@@ -1893,6 +1903,9 @@ impl Default for AlertEvents {
             reorg_detected: true,
             behind_tip: true,
             update_available: true,
+            mempool_congestion: true,
+            fee_spike: true,
+            failed_login: true,
         }
     }
 }
@@ -2007,14 +2020,16 @@ mod tests {
     fn alert_events_default_all_on() {
         let e = AlertEvents::default();
         assert!(e.reorg_detected && e.behind_tip && e.update_available);
+        assert!(e.mempool_congestion && e.fee_spike && e.failed_login);
     }
 
     #[test]
     fn alert_events_legacy_toml_still_parses_with_new_events_on() {
-        // A config written before the reorg/behind-tip/update events existed
-        // must still parse, and the three new events must default to ON via
-        // their `#[serde(default = "default_true")]` — so upgrading a node
-        // never silently disables the new alerts.
+        // A config written before the reorg/behind-tip/update and the
+        // congestion/fee-spike/failed-login events existed must still parse, and
+        // every newer event must default to ON via its
+        // `#[serde(default = "default_true")]` — so upgrading a node never
+        // silently disables the new alerts.
         let legacy = r#"
             node_offline = true
             capability_drift = false
@@ -2027,7 +2042,11 @@ mod tests {
         assert!(!parsed.capability_drift, "explicit legacy value preserved");
         assert!(
             parsed.reorg_detected && parsed.behind_tip && parsed.update_available,
-            "new events default ON for old configs"
+            "reorg/behind-tip/update events default ON for old configs"
+        );
+        assert!(
+            parsed.mempool_congestion && parsed.fee_spike && parsed.failed_login,
+            "congestion/fee-spike/failed-login events default ON for old configs"
         );
     }
 
@@ -2037,9 +2056,13 @@ mod tests {
             reorg_detected = false
             behind_tip = false
             update_available = false
+            mempool_congestion = false
+            fee_spike = false
+            failed_login = false
         "#;
         let parsed: AlertEvents = toml::from_str(toml).expect("parse");
         assert!(!parsed.reorg_detected && !parsed.behind_tip && !parsed.update_available);
+        assert!(!parsed.mempool_congestion && !parsed.fee_spike && !parsed.failed_login);
         // Untouched events keep their default-ON.
         assert!(parsed.node_offline && parsed.block_found);
     }

--- a/crates/ghost-verification/src/alerts.rs
+++ b/crates/ghost-verification/src/alerts.rs
@@ -61,6 +61,13 @@ pub enum AlertEvent {
     BehindTip,
     /// A newer node release is available than the one installed.
     UpdateAvailable,
+    /// The mempool is near its capacity (usage close to `maxmempool`).
+    MempoolCongestion,
+    /// The fee environment spiked (fee rate crossed a threshold or jumped
+    /// sharply versus the recent baseline).
+    FeeSpike,
+    /// A burst of consecutive failed dashboard login attempts was detected.
+    FailedLogin,
 }
 
 impl AlertEvent {
@@ -77,6 +84,9 @@ impl AlertEvent {
             AlertEvent::ReorgDetected => e.reorg_detected,
             AlertEvent::BehindTip => e.behind_tip,
             AlertEvent::UpdateAvailable => e.update_available,
+            AlertEvent::MempoolCongestion => e.mempool_congestion,
+            AlertEvent::FeeSpike => e.fee_spike,
+            AlertEvent::FailedLogin => e.failed_login,
         }
     }
 
@@ -92,6 +102,9 @@ impl AlertEvent {
             AlertEvent::ReorgDetected => "Chain reorg detected",
             AlertEvent::BehindTip => "Node behind tip",
             AlertEvent::UpdateAvailable => "Update available",
+            AlertEvent::MempoolCongestion => "Mempool congestion",
+            AlertEvent::FeeSpike => "Fee spike",
+            AlertEvent::FailedLogin => "Failed login attempts",
         }
     }
 }
@@ -489,6 +502,9 @@ mod tests {
                 reorg_detected: false,
                 behind_tip: false,
                 update_available: false,
+                mempool_congestion: false,
+                fee_spike: false,
+                failed_login: false,
             };
             pick(&mut events);
             c.events = events;
@@ -558,5 +574,56 @@ mod tests {
         let d = AlertDispatcher::new("node".into(), enabled_for(|e| e.block_found = true));
         assert!(d.fire(AlertEvent::BlockFound, "block 1").await);
         assert!(d.fire(AlertEvent::BlockFound, "block 2").await);
+    }
+
+    #[tokio::test]
+    async fn mempool_congestion_respects_enable_flag() {
+        // Enabled → edge dispatches on the rising edge.
+        let d = AlertDispatcher::new("node".into(), enabled_for(|e| e.mempool_congestion = true));
+        assert!(
+            d.fire_edge(AlertEvent::MempoolCongestion, "mempool", true, "90% full")
+                .await
+        );
+        // A different event enabled, congestion disabled → no dispatch.
+        let d = AlertDispatcher::new("node".into(), enabled_for(|e| e.fee_spike = true));
+        assert!(
+            !d.fire_edge(AlertEvent::MempoolCongestion, "mempool", true, "90% full")
+                .await
+        );
+    }
+
+    #[tokio::test]
+    async fn fee_spike_respects_enable_flag() {
+        let d = AlertDispatcher::new("node".into(), enabled_for(|e| e.fee_spike = true));
+        assert!(
+            d.fire_rate_limited(AlertEvent::FeeSpike, Duration::from_secs(60), "120 sat/vB")
+                .await
+        );
+        let d = AlertDispatcher::new("node".into(), enabled_for(|e| e.block_found = true));
+        assert!(
+            !d.fire_rate_limited(AlertEvent::FeeSpike, Duration::from_secs(60), "120 sat/vB")
+                .await
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_login_respects_enable_flag() {
+        let d = AlertDispatcher::new("node".into(), enabled_for(|e| e.failed_login = true));
+        assert!(
+            d.fire_rate_limited(AlertEvent::FailedLogin, Duration::from_secs(60), "5 attempts")
+                .await
+        );
+        let d = AlertDispatcher::new("node".into(), enabled_for(|e| e.node_offline = true));
+        assert!(
+            !d.fire_rate_limited(AlertEvent::FailedLogin, Duration::from_secs(60), "5 attempts")
+                .await
+        );
+    }
+
+    #[test]
+    fn new_event_titles_are_set() {
+        assert_eq!(AlertEvent::MempoolCongestion.title(), "Mempool congestion");
+        assert_eq!(AlertEvent::FeeSpike.title(), "Fee spike");
+        assert_eq!(AlertEvent::FailedLogin.title(), "Failed login attempts");
     }
 }

--- a/crates/ghost-verification/src/routes.rs
+++ b/crates/ghost-verification/src/routes.rs
@@ -498,6 +498,10 @@ pub fn create_router(state: Arc<VerificationState>) -> Router {
         )
         .route("/api/v1/alerts/test", post(api_alerts_test_post_handler))
         .route(
+            "/api/v1/alerts/internal/failed-login",
+            post(api_alerts_failed_login_post_handler),
+        )
+        .route(
             "/api/v1/config/ghost_pay",
             post(api_config_ghost_pay_post_handler),
         )
@@ -6495,6 +6499,95 @@ async fn api_alerts_test_post_handler(
         "results": results,
         "message": message,
     }))
+}
+
+/// Pool-side rate limit for failed-login alerts. The dashboard already
+/// edge-triggers (it only signals when its failure counter first crosses the
+/// threshold within the window), so this is a defensive second layer against a
+/// burst of signals — at most one `FailedLogin` alert per this interval.
+const FAILED_LOGIN_ALERT_MIN_INTERVAL: std::time::Duration =
+    std::time::Duration::from_secs(5 * 60);
+
+/// Body of the internal failed-login signal from the dashboard login route.
+/// Carries only the failed-attempt count (and the window it was measured over) —
+/// never the attempted password or any credential material.
+#[derive(Debug, Deserialize)]
+struct FailedLoginSignal {
+    /// Number of consecutive failed dashboard login attempts observed.
+    attempts: u32,
+    /// Window (seconds) over which the attempts were counted, for the message.
+    #[serde(default)]
+    window_secs: Option<u64>,
+}
+
+/// API v1 internal failed-login signal handler — dispatches a `FailedLogin`
+/// operator alert through the shared dispatcher.
+///
+/// This is a CROSS-LAYER bridge: dashboard password auth lives in the Next.js
+/// layer, which counts consecutive failed attempts in-process and, on crossing
+/// its threshold, calls this endpoint. The login route runs pre-session (there
+/// is no operator cookie yet), so it cannot use the authenticated dashboard
+/// proxy; instead it signs this call with the shared internal-auth secret
+/// (`INTERNAL_AUTH_KEY`, the same HMAC the proxy uses). We therefore VERIFY that
+/// HMAC here (`X-Ghost-Signature` + `X-Ghost-Timestamp` over the raw body) when
+/// internal auth is configured, so only a holder of the secret can raise this
+/// alert. The message includes the attempt count, never the attempted password.
+async fn api_alerts_failed_login_post_handler(
+    State(state): State<Arc<VerificationState>>,
+    headers: HeaderMap,
+    body: axum::body::Bytes,
+) -> impl IntoResponse {
+    // Require a valid internal HMAC when configured (production). Verify over the
+    // exact raw bytes, matching the dashboard proxy's signing scheme.
+    if let Some(auth) = state.internal_auth.as_ref() {
+        if let Err((code, _)) = verify_internal_auth(auth, &headers, &body) {
+            return (
+                code,
+                Json(serde_json::json!({ "success": false, "message": "unauthorized" })),
+            )
+                .into_response();
+        }
+    }
+
+    let payload: FailedLoginSignal = match serde_json::from_slice(&body) {
+        Ok(p) => p,
+        Err(_) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({ "success": false, "message": "invalid request body" })),
+            )
+                .into_response();
+        }
+    };
+
+    let detail = match payload.window_secs {
+        Some(w) if w >= 60 => format!(
+            "{} consecutive failed dashboard login attempts within {} minutes.",
+            payload.attempts,
+            w / 60
+        ),
+        _ => format!(
+            "{} consecutive failed dashboard login attempts.",
+            payload.attempts
+        ),
+    };
+
+    // Dispatch through the shared dispatcher: honours the master switch, the
+    // `failed_login` event flag, and applies a pool-side rate limit. No-op if
+    // the dispatcher was never wired (minimal/test servers).
+    let dispatched = if let Some(dispatcher) = state.alert_dispatcher.get() {
+        dispatcher
+            .fire_rate_limited(
+                crate::alerts::AlertEvent::FailedLogin,
+                FAILED_LOGIN_ALERT_MIN_INTERVAL,
+                &detail,
+            )
+            .await
+    } else {
+        false
+    };
+
+    Json(serde_json::json!({ "success": true, "dispatched": dispatched })).into_response()
 }
 
 /// API v1 Config ghost_pay POST handler

--- a/crates/ghost-verification/src/server.rs
+++ b/crates/ghost-verification/src/server.rs
@@ -1387,6 +1387,13 @@ pub struct VerificationState {
     /// `GET /api/v1/pool/series`. Bounded ring; empty until the first sample
     /// (the dashboard keeps its client-side session buffer as a fallback).
     pub pool_series: crate::pool_series::PoolSeries,
+    /// Operator-alert dispatcher, late-bound after startup. Populated by
+    /// `bins/ghost-pool` once the dispatcher is built (its live-config closure
+    /// needs this `Arc<VerificationState>`), so the internal failed-login
+    /// endpoint can dispatch a `FailedLogin` alert through the same debouncing
+    /// dispatcher every other trigger site uses. Empty on servers that never
+    /// wire it (e.g. minimal/test servers) — the endpoint then no-ops.
+    pub alert_dispatcher: std::sync::OnceLock<Arc<crate::alerts::AlertDispatcher>>,
 }
 
 /// TTL for cached stratum self-verification results. Verification cycles run
@@ -1541,7 +1548,15 @@ impl VerificationState {
             stratum_verify_cache: parking_lot::Mutex::new(std::collections::HashMap::new()),
             // 24h of history at the sampler's 30s cadence (2880 samples).
             pool_series: crate::pool_series::PoolSeries::new(2880),
+            alert_dispatcher: std::sync::OnceLock::new(),
         }
+    }
+
+    /// Late-bind the operator-alert dispatcher (see the field docs). Idempotent:
+    /// a second call is ignored. Takes `&self` because the state is shared behind
+    /// an `Arc` by the time the dispatcher exists.
+    pub fn set_alert_dispatcher(&self, dispatcher: Arc<crate::alerts::AlertDispatcher>) {
+        let _ = self.alert_dispatcher.set(dispatcher);
     }
 
     /// Set the L2 NoteSpend submission callback

--- a/dashboard/src/app/(dashboard)/settings/alerts/page.tsx
+++ b/dashboard/src/app/(dashboard)/settings/alerts/page.tsx
@@ -32,6 +32,9 @@ const EVENT_META: { key: keyof AlertEvents; label: string; description: string }
   { key: "reorg_detected", label: "Chain reorg detected", description: "A Bitcoin block was disconnected from the tip (chain reorganisation)." },
   { key: "behind_tip", label: "Node behind tip", description: "The node fell behind the network — a stale tip or a lagging local height." },
   { key: "update_available", label: "Update available", description: "A newer node release is available than the one installed." },
+  { key: "mempool_congestion", label: "Mempool congestion", description: "The mempool is near its capacity (usage close to maxmempool)." },
+  { key: "fee_spike", label: "Fee spike", description: "The next-block fee rate crossed a high threshold or jumped sharply." },
+  { key: "failed_login", label: "Failed login attempts", description: "A burst of consecutive failed dashboard login attempts was detected." },
 ];
 
 export default function AlertsSettingsPage() {

--- a/dashboard/src/app/api/auth/login/route.ts
+++ b/dashboard/src/app/api/auth/login/route.ts
@@ -5,6 +5,7 @@ import {
   signSession,
   timingSafeEqualStr,
 } from "@/lib/jwt";
+import { BACKEND_URL, internalAuthHeaders } from "@/lib/internal-auth";
 
 // ---------------------------------------------------------------------------
 // Per-client login rate limiting (Finding 8)
@@ -71,6 +72,85 @@ function sweepExpired(now: number): void {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Failed-login alert signal (cross-layer: dashboard -> ghost-pool)
+// ---------------------------------------------------------------------------
+// Dashboard password auth lives here in the Next.js layer, not in ghost-pool.
+// To surface a brute-force attempt as an operator alert, we count CONSECUTIVE
+// failed password checks in-process and, when the streak first crosses
+// FAILED_LOGIN_ALERT_THRESHOLD within FAILED_LOGIN_WINDOW_MS, signal ghost-pool
+// to dispatch a `FailedLogin` alert. The signal carries ONLY the attempt count
+// (never the attempted password). We edge-trigger (the `alerted` flag) so a
+// single burst pages once; a successful login clears the streak.
+// ---------------------------------------------------------------------------
+
+const FAILED_LOGIN_ALERT_THRESHOLD = 5;
+const FAILED_LOGIN_WINDOW_MS = 10 * 60 * 1000; // 10 minutes
+
+interface FailStreak {
+  count: number;
+  resetAt: number;
+  alerted: boolean;
+}
+
+const failedLogins = new Map<string, FailStreak>();
+
+/** Record one failed login; report the streak count and whether to alert now. */
+function recordFailedLogin(key: string): { count: number; shouldAlert: boolean } {
+  const now = Date.now();
+  const existing = failedLogins.get(key);
+
+  if (!existing || now >= existing.resetAt) {
+    failedLogins.set(key, { count: 1, resetAt: now + FAILED_LOGIN_WINDOW_MS, alerted: false });
+    return { count: 1, shouldAlert: false };
+  }
+
+  existing.count += 1;
+  if (existing.count >= FAILED_LOGIN_ALERT_THRESHOLD && !existing.alerted) {
+    existing.alerted = true; // edge: only the first crossing fires.
+    return { count: existing.count, shouldAlert: true };
+  }
+  return { count: existing.count, shouldAlert: false };
+}
+
+function clearFailedLogins(key: string): void {
+  failedLogins.delete(key);
+}
+
+/**
+ * Signal ghost-pool to dispatch a `FailedLogin` alert. Runs pre-session (no
+ * operator cookie exists on a failed login), so it cannot use the authenticated
+ * dashboard proxy; it signs the call directly with the shared internal-auth
+ * secret (the same HMAC the proxy uses). No-ops when INTERNAL_AUTH_KEY is
+ * unset. Never sends or logs the attempted password.
+ */
+async function signalFailedLoginBurst(attempts: number): Promise<void> {
+  const body = JSON.stringify({
+    attempts,
+    window_secs: Math.floor(FAILED_LOGIN_WINDOW_MS / 1000),
+  });
+  const authHeaders = internalAuthHeaders(body);
+  if (!("X-Ghost-Signature" in authHeaders)) {
+    // No signing key configured — we cannot authenticate the signal, so skip it
+    // rather than send an unauthenticated (and rejected) request.
+    return;
+  }
+  const url = new URL("/api/v1/alerts/internal/failed-login", BACKEND_URL);
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 3000);
+    await fetch(url.toString(), {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...authHeaders },
+      body,
+      signal: controller.signal,
+    });
+    clearTimeout(timeout);
+  } catch {
+    // Best-effort: a failed-login alert must never break the login response.
+  }
+}
+
 export async function POST(request: NextRequest) {
   const key = clientKey(request);
   sweepExpired(Date.now());
@@ -91,6 +171,14 @@ export async function POST(request: NextRequest) {
   }
 
   if (!timingSafeEqualStr(password ?? "", dashboardPassword)) {
+    // Track the consecutive-failure streak and, on crossing the threshold,
+    // signal ghost-pool to raise a `FailedLogin` operator alert. Awaited (a
+    // fast loopback call, guarded by a timeout) so the signal completes before
+    // the response returns; it never carries or logs the attempted password.
+    const { count, shouldAlert } = recordFailedLogin(key);
+    if (shouldAlert) {
+      await signalFailedLoginBurst(count);
+    }
     return NextResponse.json({ error: "Invalid password" }, { status: 401 });
   }
 
@@ -100,8 +188,10 @@ export async function POST(request: NextRequest) {
   }
 
   // Successful auth — reset this client's attempt counter so a legitimate
-  // operator isn't throttled by their own earlier typos.
+  // operator isn't throttled by their own earlier typos, and clear the
+  // failed-login streak so an occasional typo never accumulates toward an alert.
   clearAttempts(key);
+  clearFailedLogins(key);
 
   const ttl = resolveTtlSecs();
   const token = await signSession("operator", secret, ttl);

--- a/dashboard/src/app/api/proxy/[...path]/route.ts
+++ b/dashboard/src/app/api/proxy/[...path]/route.ts
@@ -1,29 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createHmac } from "crypto";
-
-// The node's local API is always reachable on loopback:8080. Default to it so a
-// fresh install works with no configuration; honour NEXT_PUBLIC_API_URL when set.
-const BACKEND_URL = process.env.NEXT_PUBLIC_API_URL || "http://127.0.0.1:8080";
-
-function signRequest(body: string): { signature: string; timestamp: string } {
-  const key = process.env.INTERNAL_AUTH_KEY;
-  if (!key) {
-    return { signature: "", timestamp: "" };
-  }
-
-  const timestamp = Math.floor(Date.now() / 1000);
-  const keyBytes = Buffer.from(key, "hex");
-
-  // Match Rust HMAC: HMAC-SHA256(secret, timestamp_le_bytes || body)
-  const hmac = createHmac("sha256", keyBytes);
-  const timestampBuf = Buffer.alloc(8);
-  timestampBuf.writeBigUInt64LE(BigInt(timestamp));
-  hmac.update(timestampBuf);
-  hmac.update(body);
-  const signature = hmac.digest("hex");
-
-  return { signature, timestamp: timestamp.toString() };
-}
+import { BACKEND_URL, signInternalRequest } from "@/lib/internal-auth";
 
 async function proxyRequest(request: NextRequest, params: Promise<{ path: string[] }>) {
   const { path } = await params;
@@ -45,14 +21,14 @@ async function proxyRequest(request: NextRequest, params: Promise<{ path: string
     body = await request.text();
 
     // Sign mutating requests with HMAC if key is configured
-    const { signature, timestamp } = signRequest(body);
+    const { signature, timestamp } = signInternalRequest(body);
     if (signature) {
       headers["X-Ghost-Signature"] = signature;
       headers["X-Ghost-Timestamp"] = timestamp;
     }
   } else {
     // Sign GET requests to internal endpoints too (empty body)
-    const { signature, timestamp } = signRequest("");
+    const { signature, timestamp } = signInternalRequest("");
     if (signature) {
       headers["X-Ghost-Signature"] = signature;
       headers["X-Ghost-Timestamp"] = timestamp;

--- a/dashboard/src/lib/api/alerts.ts
+++ b/dashboard/src/lib/api/alerts.ts
@@ -14,6 +14,9 @@ export interface AlertEvents {
   reorg_detected: boolean;
   behind_tip: boolean;
   update_available: boolean;
+  mempool_congestion: boolean;
+  fee_spike: boolean;
+  failed_login: boolean;
 }
 
 export interface EmailChannel {
@@ -93,6 +96,9 @@ export const ALERTS_DEFAULTS: AlertsConfig = {
     reorg_detected: true,
     behind_tip: true,
     update_available: true,
+    mempool_congestion: true,
+    fee_spike: true,
+    failed_login: true,
   },
 };
 

--- a/dashboard/src/lib/internal-auth.ts
+++ b/dashboard/src/lib/internal-auth.ts
@@ -1,0 +1,49 @@
+import { createHmac } from "crypto";
+
+// The node's local API is always reachable on loopback:8080. Default to it so a
+// fresh install works with no configuration; honour NEXT_PUBLIC_API_URL when set.
+export const BACKEND_URL = process.env.NEXT_PUBLIC_API_URL || "http://127.0.0.1:8080";
+
+export interface InternalSignature {
+  signature: string;
+  timestamp: string;
+}
+
+// Sign a request body for the node's internal (mesh-authenticated) endpoints.
+//
+// Matches the Rust `InternalAuth` scheme in `ghost-verification`:
+//   HMAC-SHA256(secret, timestamp_le_bytes(8) || body)
+// where `secret` is the hex-decoded `INTERNAL_AUTH_KEY` and `timestamp` is the
+// current Unix time in seconds. Returns empty strings when no key is configured,
+// so callers can detect that and skip the signed call.
+export function signInternalRequest(body: string): InternalSignature {
+  const key = process.env.INTERNAL_AUTH_KEY;
+  if (!key) {
+    return { signature: "", timestamp: "" };
+  }
+
+  const timestamp = Math.floor(Date.now() / 1000);
+  const keyBytes = Buffer.from(key, "hex");
+
+  const hmac = createHmac("sha256", keyBytes);
+  const timestampBuf = Buffer.alloc(8);
+  timestampBuf.writeBigUInt64LE(BigInt(timestamp));
+  hmac.update(timestampBuf);
+  hmac.update(body);
+  const signature = hmac.digest("hex");
+
+  return { signature, timestamp: timestamp.toString() };
+}
+
+// Build the internal-auth headers for a signed request body, or an empty object
+// when no signing key is configured.
+export function internalAuthHeaders(body: string): Record<string, string> {
+  const { signature, timestamp } = signInternalRequest(body);
+  if (!signature) {
+    return {};
+  }
+  return {
+    "X-Ghost-Signature": signature,
+    "X-Ghost-Timestamp": timestamp,
+  };
+}


### PR DESCRIPTION
Extends the operator-alert pipeline (same pattern as the reorg/behind-tip/update-available events added in #279) with three more events. All dispatch off the hot path, respect their per-event enable flag plus the master switch, and default ON via `serde(default = "default_true")` so existing `pool.toml` configs keep parsing and gain the alerts on upgrade.

## Events

### 1. `MempoolCongestion`
A periodic monitor reads ghostd `getmempoolinfo` via the pool's shared RPC client and compares `usage` to `maxmempool`. Edge-triggered with hysteresis: fires when usage crosses **90%** of `maxmempool`, and re-arms only once it falls back below **80%** so a mempool hovering at the boundary can't flap the alert. The message includes the usage percentage and size in MiB. Threshold logic is a pure, unit-tested function.

### 2. `FeeSpike`
A periodic monitor reads ghostd `estimatesmartfee` at a next-block confirmation target (the fee rate to enter the next block) via the same RPC client. Fires when the rate crosses an absolute threshold (**100 sat/vB**) or jumps to **3x** a rolling EMA baseline (only above a 20 sat/vB floor, so churn around a tiny baseline never pages). Rate-limited to once per 30 min so sustained high fees don't spam. The message includes the fee rate. The decision logic is pure and unit-tested like `evaluate_behind_tip`.

### 3. `FailedLogin` (cross-layer)
Dashboard password auth lives in the Next.js layer, not ghost-pool. The login route now counts **consecutive** failed attempts in-process and, when the streak first crosses **5 within 10 minutes**, signals ghost-pool over a new internal endpoint `POST /api/v1/alerts/internal/failed-login`. Because a failed login has no operator session, the route can't use the authenticated dashboard proxy — it signs the call directly with the shared internal-auth secret (`INTERNAL_AUTH_KEY`), reusing a signing helper factored out of the API proxy. The pool endpoint verifies that HMAC over the raw body and dispatches `FailedLogin` through the shared dispatcher (with a pool-side rate limit as a second anti-spam layer). The message carries only the attempt count — never the attempted password, which is never sent or logged.

## Verification
- `cargo check -p ghost-common -p ghost-verification -p ghost-pool -j2`: clean.
- Rust unit tests: enable-flag gating for the three new events; congestion threshold + hysteresis ordering; fee-spike absolute/relative/floor/no-baseline cases + EMA baseline; serde back-compat (legacy config parses, new flags default ON, all disable-able). All pass.
- `tsc --noEmit`, `eslint` on changed dashboard files, and `npm run build`: all clean.
