### PR TITLE
dashboard(filtering): BUDS class pills on mining-policy presets

### DIFF
--- a/dashboard/src/app/(dashboard)/filtering/basic/page.tsx
+++ b/dashboard/src/app/(dashboard)/filtering/basic/page.tsx
@@ -6,9 +6,10 @@ import { Card, CardHeader } from "@/components/ui/Card";
 import { SectionErrorBoundary } from "@/components/ui/SectionErrorBoundary";
 import { fetchApi } from "@/lib/api/client";
 import { PolicyProfileSelector } from "@/components/filtering/PolicyProfileSelector";
+import { BUDS_TIER_COLORS, type BudsTierKey } from "@/lib/budsTiers";
 
 interface TierMeta {
-  key: "T0" | "T1" | "T2" | "T3";
+  key: BudsTierKey;
   name: string;
   short: string;
   color: string;
@@ -21,7 +22,7 @@ const TIERS: TierMeta[] = [
     key: "T0",
     name: "T0 · Financial",
     short: "Ordinary payments",
-    color: "#3fb950",
+    color: BUDS_TIER_COLORS.T0,
     blurb: "Plain money moving between people — the transactions Bitcoin exists for.",
     examples: "single-sig sends, change, consolidations",
   },
@@ -29,7 +30,7 @@ const TIERS: TierMeta[] = [
     key: "T1",
     name: "T1 · Extended",
     short: "Bigger financial",
-    color: "#58a6ff",
+    color: BUDS_TIER_COLORS.T1,
     blurb: "Still money, just more elaborate — multiple signers or time locks.",
     examples: "multisig, Lightning channels, timelocks",
   },
@@ -37,7 +38,7 @@ const TIERS: TierMeta[] = [
     key: "T2",
     name: "T2 · Data",
     short: "Small data carriers",
-    color: "#d29922",
+    color: BUDS_TIER_COLORS.T2,
     blurb: "Transactions that also carry a little standard data. Allowed, but not payments.",
     examples: "OP_RETURN ≤ 80 bytes, commitments",
   },
@@ -45,7 +46,7 @@ const TIERS: TierMeta[] = [
     key: "T3",
     name: "T3 · Abusive",
     short: "Heavy / abusive data",
-    color: "#f85149",
+    color: BUDS_TIER_COLORS.T3,
     blurb: "Transactions whose main purpose is stuffing data onto the chain.",
     examples: "inscriptions, runes, BRC-20, oversized data",
   },

--- a/dashboard/src/components/filtering/PolicyProfileSelector.tsx
+++ b/dashboard/src/components/filtering/PolicyProfileSelector.tsx
@@ -6,14 +6,55 @@ import { Button } from "@/components/ui/Button";
 import { useFullConfig } from "@/hooks/queries/useConfigQueries";
 import { setPolicyProfile, type PolicyProfileType } from "@/lib/api/config";
 import { useToast } from "@/components/ui/Toast";
+import { BUDS_TIER_COLORS, BUDS_TIER_KEYS, type BudsTierKey } from "@/lib/budsTiers";
 
 // The three real tier-policy presets (pool.toml [policy].profile), with
-// plain-English labels and descriptions true to what each actually mines.
-export const POLICY_PRESETS: { value: PolicyProfileType; label: string; desc: string }[] = [
-  { value: "strict", label: "Strict", desc: "Payments, multisig & timelocks only (T0+T1). Drops all data — no OP_RETURN, inscriptions or runes." },
-  { value: "permissive", label: "Standard", desc: "Adds small OP_RETURN / Lightning commitments (T0+T1+T2). Still drops inscriptions, runes & BRC-20 (T3)." },
-  { value: "full_open", label: "Everything", desc: "All valid transactions including inscriptions, runes & BRC-20 (T0–T3). Maximum fees, no tier filtering." },
+// plain-English labels, descriptions and the BUDS classes each actually mines.
+export const POLICY_PRESETS: {
+  value: PolicyProfileType;
+  label: string;
+  desc: string;
+  tiers: BudsTierKey[]; // BUDS classes this preset MINES (rest are dropped)
+}[] = [
+  { value: "strict", label: "Strict", tiers: ["T0", "T1"], desc: "Payments, multisig & timelocks only (T0+T1). Drops all data — no OP_RETURN, inscriptions or runes." },
+  { value: "permissive", label: "Standard", tiers: ["T0", "T1", "T2"], desc: "Adds small OP_RETURN / Lightning commitments (T0+T1+T2). Still drops inscriptions, runes & BRC-20 (T3)." },
+  { value: "full_open", label: "Everything", tiers: ["T0", "T1", "T2", "T3"], desc: "All valid transactions including inscriptions, runes & BRC-20 (T0–T3). Maximum fees, no tier filtering." },
 ];
+
+// A tight row of four BUDS-class pills. Mined classes are filled with the
+// class's BUDS colour; dropped classes are dimmed/outlined so the difference
+// is legible at a glance.
+function TierPills({ mined }: { mined: BudsTierKey[] }) {
+  return (
+    <div className="flex items-center" style={{ gap: "4px", marginBottom: "6px" }}>
+      {BUDS_TIER_KEYS.map((key) => {
+        const isMined = mined.includes(key);
+        const color = BUDS_TIER_COLORS[key];
+        return (
+          <span
+            key={key}
+            title={isMined ? `${key} mined` : `${key} dropped`}
+            style={{
+              fontFamily: "var(--font-mono, ui-monospace, monospace)",
+              fontSize: "11px",
+              fontWeight: 600,
+              lineHeight: 1,
+              letterSpacing: "0.02em",
+              padding: "3px 6px",
+              borderRadius: "4px",
+              border: `1px solid ${isMined ? color : "var(--rule)"}`,
+              background: isMined ? color : "transparent",
+              color: isMined ? "#0b0f14" : "var(--dim)",
+              opacity: isMined ? 1 : 0.55,
+            }}
+          >
+            {key}
+          </span>
+        );
+      })}
+    </div>
+  );
+}
 
 // Normalise the stored profile (legacy `bitcoin_pure` == `strict`).
 export function normalizeProfile(profile?: string): PolicyProfileType | undefined {
@@ -77,6 +118,7 @@ export function PolicyProfileSelector() {
                   <span style={{ color: "var(--accent)", fontSize: "11px", fontWeight: 600 }}>· current</span>
                 )}
               </div>
+              <TierPills mined={p.tiers} />
               <div style={{ color: "var(--dim)", fontSize: "12px", lineHeight: "1.5" }}>{p.desc}</div>
             </button>
           );

--- a/dashboard/src/lib/budsTiers.ts
+++ b/dashboard/src/lib/budsTiers.ts
@@ -1,0 +1,15 @@
+// Shared BUDS class (T0–T3) colours — the single source of truth reused by the
+// "four classes" cards, the "Your mempool by class" bar and the mining-policy
+// preset pills. Keep these in sync in ONE place so surfaces never drift.
+
+export type BudsTierKey = "T0" | "T1" | "T2" | "T3";
+
+export const BUDS_TIER_COLORS: Record<BudsTierKey, string> = {
+  T0: "#3fb950", // Financial — green
+  T1: "#58a6ff", // Extended — blue
+  T2: "#d29922", // Data — amber
+  T3: "#f85149", // Abusive — red
+};
+
+// Ordered list of the four BUDS classes for iterating pills/legends.
+export const BUDS_TIER_KEYS: BudsTierKey[] = ["T0", "T1", "T2", "T3"];


### PR DESCRIPTION
## Summary

Adds a row of four **BUDS class pills** (`T0`/`T1`/`T2`/`T3`) above the description on each mining-policy preset button (Strict / Standard / Everything), so operators can see at a glance which BUDS classes each preset mines.

- Classes a preset **mines** are shown as filled pills in that class's BUDS colour.
- Classes a preset **drops** are dimmed/outlined so the difference is obvious.

The `PolicyProfileSelector` is reused on both the Basic filtering page and Settings › Filtering, so the pills appear in both places.

## Per-preset tier mapping

| Preset | Profile key | Mined (coloured) | Dropped (dimmed) |
|--------|-------------|------------------|------------------|
| Strict | `strict` | T0, T1 | T2, T3 |
| Standard | `permissive` | T0, T1, T2 | T3 |
| Everything | `full_open` | T0, T1, T2, T3 | — |

The mapping lives as a `tiers` field on the existing `POLICY_PRESETS` config object.

## Colours — single source of truth

Extracted the existing T0–T3 class colours (T0 green `#3fb950`, T1 blue `#58a6ff`, T2 amber `#d29922`, T3 red `#f85149`) — previously inlined in the `TIERS` array in `filtering/basic/page.tsx` — into a shared `src/lib/budsTiers.ts` constant. The four-classes cards, the "Your mempool by class" bar and the new preset pills now all reference the same values, so nothing can drift. No new hex values were introduced.

## Verification

- Pill counts render as expected: Strict = 2 coloured + 2 dimmed, Standard = 3 + 1, Everything = 4 + 0.
- Click-to-select behaviour unchanged — the pills are non-interactive `<span>`s inside the existing button; the "current" badge and description line are unchanged and still sit below the pills.
- `tsc --noEmit` clean, `eslint` clean, `next build` succeeds.
- Theme-aware (uses `var(--rule)`/`var(--dim)` for dropped pills).