### PR TITLE
dashboard(pool): this-node-miners chart, rename Pool Connected Miners, banner to bottom, best-shares audit

### DIFF
--- a/dashboard/src/app/(dashboard)/pool/page.tsx
+++ b/dashboard/src/app/(dashboard)/pool/page.tsx
@@ -316,29 +316,6 @@ export default function NodePoolPage() {
         subtitle="Live pool stats and graphs for this node and the Ghost mesh — hashrate, miners, shares, best shares, round progress and payouts."
       />
 
-      {/* Chart source note: the hashrate/miner charts use the node's server-side
-          time-series ring when it has data, falling back to an in-browser
-          session buffer on a freshly-started node. */}
-      <div
-        className="rounded-lg p-3 text-sm"
-        style={{ background: "var(--accent-weak)", border: "1px solid var(--rule)", color: "var(--dim)" }}
-      >
-        {series.serverBacked ? (
-          <>
-            Hashrate and miner charts are drawn from the node&apos;s server-side history
-            (sampled every 30s, up to 24h) so they survive reloads. The share accept-rate chart
-            is a live in-browser buffer ({series.sampleCount} sample
-            {series.sampleCount === 1 ? "" : "s"} this session).
-          </>
-        ) : (
-          <>
-            Graphs are drawn from a live in-browser buffer of the polled pool values
-            ({series.sampleCount} sample{series.sampleCount === 1 ? "" : "s"} this session) and reset on reload.
-            The node&apos;s server-side history will back these charts once it has accumulated a few samples.
-          </>
-        )}
-      </div>
-
       {/* Headline stats */}
       <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4">
         <StatCard
@@ -400,14 +377,14 @@ export default function NodePoolPage() {
             />
           </ChartCard>
           <ChartCard
-            title="Connected Miners"
+            title="Pool Connected Miners"
             subtitle="Active miners across the mesh pool"
             serverBacked={series.serverBacked}
           >
             <TimeSeriesChart
               data={series.miners}
               color="var(--green)"
-              ariaLabel="Connected miners over time"
+              ariaLabel="Pool connected miners over time"
               formatValue={(v) => Math.round(v).toString()}
             />
           </ChartCard>
@@ -422,12 +399,12 @@ export default function NodePoolPage() {
               formatValue={(v) => formatHashrate(v, 1)}
             />
           </ChartCard>
-          <ChartCard title="Share Accept Rate" subtitle="Accepted shares as a percentage of submitted">
+          <ChartCard title="This Node Connected Miners" subtitle="Miners connected to this node only">
             <TimeSeriesChart
-              data={series.acceptRate}
+              data={series.nodeMiners}
               color="var(--green)"
-              ariaLabel="Share accept rate over the session"
-              formatValue={(v) => `${v.toFixed(1)}%`}
+              ariaLabel="This node connected miners over time"
+              formatValue={(v) => Math.round(v).toString()}
             />
           </ChartCard>
         </div>
@@ -623,6 +600,30 @@ export default function NodePoolPage() {
           />
         </Card>
       </SectionErrorBoundary>
+
+      {/* Chart source note: the mesh hashrate/miner charts use the node's
+          server-side time-series ring when it has data, falling back to an
+          in-browser session buffer on a freshly-started node. The this-node
+          connected-miners chart is always a session buffer. */}
+      <div
+        className="rounded-lg p-3 text-sm"
+        style={{ background: "var(--accent-weak)", border: "1px solid var(--rule)", color: "var(--dim)" }}
+      >
+        {series.serverBacked ? (
+          <>
+            Mesh hashrate and miner charts are drawn from the node&apos;s server-side history
+            (sampled every 30s, up to 24h) so they survive reloads. The this-node connected-miners
+            chart is a live in-browser buffer ({series.sampleCount} sample
+            {series.sampleCount === 1 ? "" : "s"} this session).
+          </>
+        ) : (
+          <>
+            Graphs are drawn from a live in-browser buffer of the polled pool values
+            ({series.sampleCount} sample{series.sampleCount === 1 ? "" : "s"} this session) and reset on reload.
+            The node&apos;s server-side history will back the mesh charts once it has accumulated a few samples.
+          </>
+        )}
+      </div>
     </div>
   );
 }

--- a/dashboard/src/hooks/usePoolSeries.ts
+++ b/dashboard/src/hooks/usePoolSeries.ts
@@ -22,8 +22,9 @@ import type { MiningStatus, PoolStatus } from '@/types/api';
  * subscribing to the react-query cache (an external system) — the idiomatic
  * pattern for syncing external updates into state.
  *
- * Share accept-rate has no backend series (the node exposes cumulative counters,
- * not a rate history) so that chart is always session-derived.
+ * This node's own connected-miner count has no backend series (the `/pool/series`
+ * ring only carries the mesh-wide miner count) so that chart is always
+ * session-derived.
  */
 
 export interface SeriesPoint {
@@ -38,8 +39,8 @@ export interface PoolSeries {
   nodeHashrate: SeriesPoint[];
   /** Connected miners across the mesh. */
   miners: SeriesPoint[];
-  /** Share accept-rate, 0–100 (always session-derived). */
-  acceptRate: SeriesPoint[];
+  /** This node's own connected-miner count (always session-derived). */
+  nodeMiners: SeriesPoint[];
   /** Number of samples collected this session (session buffer). */
   sampleCount: number;
   /** True when the hashrate/miner charts are backed by server-side history. */
@@ -52,7 +53,7 @@ interface SessionSeries {
   meshHashrate: SeriesPoint[];
   nodeHashrate: SeriesPoint[];
   miners: SeriesPoint[];
-  acceptRate: SeriesPoint[];
+  nodeMiners: SeriesPoint[];
   sampleCount: number;
 }
 
@@ -70,7 +71,7 @@ export function usePoolSeries(): PoolSeries {
     meshHashrate: [],
     nodeHashrate: [],
     miners: [],
-    acceptRate: [],
+    nodeMiners: [],
     sampleCount: 0,
   });
 
@@ -98,9 +99,9 @@ export function usePoolSeries(): PoolSeries {
         status.connected_miners ??
         status.active_miners ??
         0;
-      const submitted = status.shares_submitted ?? 0;
-      const accepted = status.shares_accepted ?? 0;
-      const acceptRate = submitted > 0 ? (accepted / submitted) * 100 : 100;
+      // This node's OWN connected-miner count (not the mesh-wide figure) —
+      // mirrors the `miner_count` health field the "This Node" stat area uses.
+      const nodeMiners = status.miner_count ?? status.local_connected_miners ?? 0;
 
       const push = (arr: SeriesPoint[], v: number): SeriesPoint[] => {
         const next = [...arr, { t, v }];
@@ -111,7 +112,7 @@ export function usePoolSeries(): PoolSeries {
         meshHashrate: push(prev.meshHashrate, meshTh * 1e12),
         nodeHashrate: push(prev.nodeHashrate, nodeTh * 1e12),
         miners: push(prev.miners, miners),
-        acceptRate: push(prev.acceptRate, acceptRate),
+        nodeMiners: push(prev.nodeMiners, nodeMiners),
         sampleCount: prev.sampleCount + 1,
       }));
     };
@@ -133,8 +134,8 @@ export function usePoolSeries(): PoolSeries {
         meshHashrate: samples.map((s) => ({ t: s.t, v: s.mesh_hashrate_th * 1e12 })),
         nodeHashrate: samples.map((s) => ({ t: s.t, v: s.local_hashrate_th * 1e12 })),
         miners: samples.map((s) => ({ t: s.t, v: s.miners })),
-        // No backend accept-rate series — keep the session-derived one.
-        acceptRate: session.acceptRate,
+        // No backend this-node-miners series — keep the session-derived one.
+        nodeMiners: session.nodeMiners,
         sampleCount: session.sampleCount,
         serverBacked: true,
       };


### PR DESCRIPTION
## Summary

Four tweaks to the Node Pool page (`dashboard/src/app/(dashboard)/pool/page.tsx`) plus a supporting change to `usePoolSeries`.

### 1. Info banner moved to the bottom
The chart-source explanatory banner moved from the top of the page to the very bottom (after Recent Payouts). Wording updated: it no longer references the removed share accept-rate chart and now describes the this-node connected-miners chart as the always-session-buffered one.

### 2. Share Accept Rate chart → This Node Connected Miners
The bottom-right chart (previously a live accept-rate session buffer) now plots **this node's own connected-miner count over time**, titled **This Node Connected Miners** (subtitle "Miners connected to this node only"). The value is sourced from this node's own `miner_count` health field (falling back to `local_connected_miners`) — NOT the mesh-wide `mesh_active_miners`. It reuses the existing session rolling buffer in `usePoolSeries` (new `nodeMiners` series, replacing the now-unused `acceptRate` series) and keeps the `live (session)` badge. The Accept Rate stat card at the top is unchanged.

### 3. Connected Miners chart → Pool Connected Miners
The top-right mesh-wide chart renamed to **Pool Connected Miners** (mesh subtitle kept) to disambiguate it from the new this-node chart.

### 4. Best-shares audit (no code change — investigation)
The best-shares section shows four windows (Current Round, Last Hour, Last 24h, All Time). On live vm1, `current_round` and `last_hour` come back empty while `last_24h`/`all_time` have data.

**Finding: this is neither a frontend wiring gap nor a backend omission — it is correct, data-dependent behaviour.**
- The backend `/api/v1/mining/best-hash` handler DOES populate `current_round` (scoped by `round_id`) and `last_hour` (timestamp cutoff) — `crates/ghost-verification/src/routes.rs:5140-5141`.
- The frontend already reads all four windows and honestly renders "No data yet" when a window has no share (difficulty 0). No fake values.
- The underlying queries (`get_best_share_in_round`, `get_best_share_since` in `crates/ghost-storage/src/queries.rs`) filter `instr(miner_id,'.') > 0` so only real `address.worker` local-miner shares count (excluding cross-node gossip-ledger proof twins). On vm1 right now there were 2027 shares in the last hour but **0** real-miner shares — all recent rows are gossip twins with no `.`; the last real local-miner share was ~19h ago. Hence Current Round + Last Hour are legitimately empty; they populate when a real miner is actively submitting to this node.

No backend work is required for the frontend to be honest — it already is. The empty windows are an accurate reflection of "no recent real-miner shares on this node."

## Verification
- `npx tsc --noEmit`: clean
- `eslint` on both changed files: clean
- `npm run build`: `✓ Compiled successfully`, all 54 routes generated (incl. `/pool`)

Note: origin/main currently has a pre-existing, unrelated build breakage — `dashboard/src/app/(dashboard)/filtering/advanced/page.tsx` still imports `FullRbfControl`, which was deleted in commit `ff0565cb`. That is outside this PR's scope and left untouched; the build above was verified with that dead import removed locally to isolate this PR's changes.