### PR TITLE
fix(build): drop dead FullRbfControl import on Advanced filtering page

### DIFF
--- a/dashboard/src/app/(dashboard)/filtering/advanced/page.tsx
+++ b/dashboard/src/app/(dashboard)/filtering/advanced/page.tsx
@@ -6,7 +6,6 @@ import { Toggle } from "@/components/ui/Toggle";
 import { SectionErrorBoundary } from "@/components/ui/SectionErrorBoundary";
 import { ReaperControls } from "@/components/filtering/ReaperControls";
 import { AdvancedPolicyPanel } from "@/components/filtering/AdvancedPolicyPanel";
-import { FullRbfControl } from "@/components/filtering/FullRbfControl";
 import { useAdvancedFilteringGate } from "@/hooks/useAdvancedFilteringGate";
 
 export default function AdvancedFilteringPage() {
@@ -49,10 +48,6 @@ export default function AdvancedFilteringPage() {
               />
               <AdvancedPolicyPanel />
             </Card>
-          </SectionErrorBoundary>
-
-          <SectionErrorBoundary section="Replace-by-fee">
-            <FullRbfControl />
           </SectionErrorBoundary>
         </>
       )}


### PR DESCRIPTION
main build is broken — #292 deleted FullRbfControl.tsx but the import/usage on the Advanced page wasn't committed. Removes them. tsc clean.