### PR TITLE
chain: persist + display reorgs and tip-lag (Chain Health on Sync page)

### DIFF
--- a/bins/ghost-pool/src/alert_monitors.rs
+++ b/bins/ghost-pool/src/alert_monitors.rs
@@ -30,6 +30,7 @@ use std::time::{Duration, Instant};
 
 use ghost_common::rpc::BitcoinRpc;
 use ghost_verification::alerts::{AlertDispatcher, AlertEvent};
+use ghost_verification::chain_health::{derive_tip_status, ChainHealth};
 use tokio::sync::broadcast;
 use tracing::{debug, info};
 
@@ -158,8 +159,14 @@ async fn read_versions(installed_fallback: &str) -> Option<(String, String)> {
 /// Spawn the behind-tip monitor. `local_height` reads this node's current L1
 /// height; `best_peer_height` reads the highest L1 height reported by a
 /// connected mesh peer (0 when none is known). Runs until `shutdown` fires.
+///
+/// On each tick it also records a derived tip-status snapshot into the shared
+/// [`ChainHealth`] holder (same inputs it evaluates for the alert), so the Sync
+/// page's Chain Health view can display the live tip-lag status — not just be
+/// paged when the node falls behind.
 pub fn spawn_behind_tip_monitor<L, P>(
     alerts: Arc<AlertDispatcher>,
+    chain_health: Arc<ChainHealth>,
     local_height: L,
     best_peer_height: P,
     mut shutdown: broadcast::Receiver<()>,
@@ -184,6 +191,16 @@ pub fn spawn_behind_tip_monitor<L, P>(
                     }
                     let best_peer = best_peer_height();
                     let tip_age = last_change.elapsed().as_secs();
+                    // Record the derived tip status for the Chain Health view,
+                    // using the same thresholds the alert below evaluates so the
+                    // displayed status and the fired alert always agree.
+                    chain_health.set_tip(derive_tip_status(
+                        local,
+                        best_peer,
+                        tip_age,
+                        BEHIND_TIP_LAG_BLOCKS,
+                        BEHIND_TIP_MAX_AGE_SECS,
+                    ));
                     let detail = evaluate_behind_tip(
                         local,
                         best_peer,

--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -6962,6 +6962,7 @@ async fn main() -> Result<()> {
         let alerts_for_tip = Arc::clone(&alert_dispatcher);
         ghost_pool::alert_monitors::spawn_behind_tip_monitor(
             alerts_for_tip,
+            Arc::clone(&verification_state.chain_health),
             move || rm_for_tip.current_height(),
             move || {
                 // Highest L1 height reported by a fresh, connected mesh peer
@@ -8090,9 +8091,14 @@ async fn main() -> Result<()> {
         // operator-alert dispatcher so the existing reorg-detection point also
         // fires a `ReorgDetected` alert (gated on the operator's event flag).
         let block_events = zmq_subscriber.subscribe_block_events();
+        let rm_for_reorg = Arc::clone(&round_manager);
         let reorg_handler = ReorgHandler::new(Arc::clone(&db), ReorgConfig::default())
             .with_vote_handler(Arc::clone(&vote_handler))
-            .with_alert_dispatcher(Arc::clone(&alert_dispatcher));
+            .with_alert_dispatcher(Arc::clone(&alert_dispatcher))
+            // Record each detected reorg into the shared chain-health ring so the
+            // Sync page's Chain Health view can display it (not just alert).
+            .with_chain_health(Arc::clone(&verification_state.chain_health))
+            .with_height_getter(move || rm_for_reorg.current_height());
         reorg_handler.start(block_events);
 
         info!("ZMQ block watcher connected to {}", zmq_endpoint);

--- a/bins/ghost-pool/src/reorg.rs
+++ b/bins/ghost-pool/src/reorg.rs
@@ -47,7 +47,12 @@ use ghost_consensus::vote_handler::VoteHandler;
 use ghost_storage::models::PayoutStatus;
 use ghost_storage::Database;
 use ghost_verification::alerts::{AlertDispatcher, AlertEvent};
+use ghost_verification::chain_health::ChainHealth;
 use std::time::Duration;
+
+/// Callback returning the node's current local L1 height, used to record the
+/// post-disconnect tip height alongside a reorg event.
+type HeightGetter = Box<dyn Fn() -> u64 + Send + Sync>;
 
 /// Debounce window for reorg alerts. A single reorg emits one `Disconnected`
 /// event per orphaned block, so without this a depth-N reorg would fire N
@@ -120,6 +125,13 @@ pub struct ReorgHandler {
     /// per debounce window, and only if the operator has the event enabled) at
     /// the existing reorg-detection point.
     alerts: Option<Arc<AlertDispatcher>>,
+    /// Shared chain-health state. When set, every detected reorg is recorded
+    /// into its bounded ring (in addition to firing the alert) so the Sync
+    /// page's Chain Health view can display it. Read-through the API.
+    chain_health: Option<Arc<ChainHealth>>,
+    /// Optional local-height source, so a recorded reorg carries the node's
+    /// height right after the disconnect (the ZMQ event itself has no new tip).
+    get_height: Option<HeightGetter>,
     config: ReorgConfig,
     /// Counter for consecutive reorgs (deep reorg detection)
     consecutive_reorgs: AtomicU32,
@@ -145,6 +157,8 @@ impl ReorgHandler {
             db,
             vote_handler: None,
             alerts: None,
+            chain_health: None,
+            get_height: None,
             consecutive_reorgs: AtomicU32::new(0),
             stats: ReorgStatsInner {
                 total_reorgs: AtomicU64::new(0),
@@ -167,6 +181,23 @@ impl ReorgHandler {
     /// Wire the operator-alert dispatcher so reorgs page the operator.
     pub fn with_alert_dispatcher(mut self, alerts: Arc<AlertDispatcher>) -> Self {
         self.alerts = Some(alerts);
+        self
+    }
+
+    /// Wire the shared chain-health state so each detected reorg is recorded
+    /// into its bounded ring for the Sync page's Chain Health view.
+    pub fn with_chain_health(mut self, chain_health: Arc<ChainHealth>) -> Self {
+        self.chain_health = Some(chain_health);
+        self
+    }
+
+    /// Wire a local-height source so a recorded reorg carries the node's height
+    /// right after the disconnect.
+    pub fn with_height_getter<F>(mut self, get_height: F) -> Self
+    where
+        F: Fn() -> u64 + Send + Sync + 'static,
+    {
+        self.get_height = Some(Box::new(get_height));
         self
     }
 
@@ -318,6 +349,22 @@ impl ReorgHandler {
                     &detail,
                 )
                 .await;
+        }
+
+        // Persist the reorg into the shared chain-health ring so the Sync page
+        // can display it (the alert above only pages the operator). Records
+        // what the ZMQ sequence event carries — the disconnected (old-tip) hash
+        // and the consecutive-disconnect depth — plus the node's local height
+        // right after the disconnect when a height source is wired. The new tip
+        // hash is not on the event, so it is not fabricated.
+        if let Some(chain_health) = &self.chain_health {
+            let new_tip_height = self.get_height.as_ref().map(|f| f());
+            chain_health.record_reorg(
+                chrono::Utc::now().timestamp(),
+                reorg_depth,
+                block_hash,
+                new_tip_height,
+            );
         }
 
         // 1. Mark affected rounds as orphaned

--- a/crates/ghost-verification/src/chain_health.rs
+++ b/crates/ghost-verification/src/chain_health.rs
@@ -1,0 +1,276 @@
+//! In-memory chain-health state: recent reorgs + the current tip-lag signal.
+//!
+//! The node already *detects* reorgs (the ZMQ-driven reorg handler in
+//! `bins/ghost-pool`) and *evaluates* tip-lag (the behind-tip monitor), but
+//! historically both only fired an operator alert — nothing was persisted, so
+//! an operator could never look back and SEE a reorg or the current tip status.
+//!
+//! This module keeps a bounded, process-local record of recent reorg events
+//! plus the latest tip-status snapshot, shared (behind `Arc`) between the
+//! writer tasks (reorg handler, behind-tip monitor) and the
+//! `GET /api/v1/chain/health` route handler. It mirrors the bounded-`VecDeque`
+//! shape of [`crate::pool_series`], but also carries a single latest-value cell
+//! for the tip status.
+//!
+//! In-memory only — resets on restart, like the other operator-facing rings.
+
+use parking_lot::RwLock;
+use serde::Serialize;
+use std::collections::VecDeque;
+
+/// Default number of recent reorg events retained. Reorgs are rare; a few dozen
+/// is plenty of scrollback for an operator, and each entry is tiny.
+pub const DEFAULT_REORG_CAPACITY: usize = 50;
+
+/// One detected reorg (block disconnected from the main chain).
+///
+/// The ZMQ sequence event that drives detection carries only the disconnected
+/// block hash and the consecutive-disconnect depth, so those are always
+/// present; `new_tip_height` is filled from the node's own height source when
+/// one is wired (the ZMQ event itself does not carry a new tip), and the new
+/// tip hash is not available from the event so it is not recorded.
+#[derive(Debug, Clone, Serialize)]
+pub struct ReorgEvent {
+    /// Unix timestamp (seconds) the reorg was recorded.
+    pub unix_time: i64,
+    /// Consecutive-disconnect depth at the time this block was orphaned.
+    pub depth: u32,
+    /// Hash of the disconnected (orphaned) block — the old tip.
+    pub old_tip_hash: String,
+    /// The node's local chain height right after the disconnect, when a height
+    /// source is wired; `None` when unavailable.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub new_tip_height: Option<u64>,
+}
+
+/// Tip-lag status label. `at_tip` is the normal, healthy state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TipStatusKind {
+    /// Caught up with the network (or ahead) — healthy.
+    AtTip,
+    /// Behind the best known peer by more than the lag threshold.
+    Behind,
+    /// No new block for longer than the stale threshold while a peer is ahead.
+    Stale,
+}
+
+/// Snapshot of the current tip-lag signal, derived from the same inputs the
+/// behind-tip monitor uses (local height, best-peer height, tip age).
+#[derive(Debug, Clone, Serialize)]
+pub struct TipStatus {
+    /// This node's current local L1 height.
+    pub local_height: u64,
+    /// Highest L1 height reported by a fresh connected mesh peer (0 = unknown).
+    pub best_peer_height: u64,
+    /// How many blocks behind the best peer (0 when caught up or peer unknown).
+    pub behind_by: u64,
+    /// Seconds since the local height last advanced (tip age).
+    pub tip_age_secs: u64,
+    /// Derived status label.
+    pub status: TipStatusKind,
+}
+
+/// Derive a [`TipStatus`] from the raw signals. Pure — no I/O or clock access —
+/// so the classification is unit-testable independently of the monitor.
+///
+/// Mirrors the behind-tip alert thresholds so the displayed status and the
+/// fired alert agree:
+/// * `best_peer_height == 0` (unknown / isolated) → `AtTip` (never false-alarm).
+/// * lagging: `best_peer - local > lag_blocks_k` → `Behind`.
+/// * stalled: `tip_age > max_tip_age` AND a peer is strictly ahead → `Stale`.
+/// * otherwise → `AtTip`.
+///
+/// `behind_by` is the raw `best_peer - local` gap (saturating, 0 when peer
+/// unknown), reported regardless of whether it crosses the alert threshold.
+pub fn derive_tip_status(
+    local_height: u64,
+    best_peer_height: u64,
+    tip_age_secs: u64,
+    lag_blocks_k: u64,
+    max_tip_age_secs: u64,
+) -> TipStatus {
+    let behind_by = if best_peer_height == 0 {
+        0
+    } else {
+        best_peer_height.saturating_sub(local_height)
+    };
+    let status = if best_peer_height == 0 {
+        TipStatusKind::AtTip
+    } else if behind_by > lag_blocks_k {
+        TipStatusKind::Behind
+    } else if tip_age_secs > max_tip_age_secs && best_peer_height > local_height {
+        TipStatusKind::Stale
+    } else {
+        TipStatusKind::AtTip
+    };
+    TipStatus {
+        local_height,
+        best_peer_height,
+        behind_by,
+        tip_age_secs,
+        status,
+    }
+}
+
+/// Shared chain-health state: a bounded ring of recent reorgs plus the latest
+/// tip-status snapshot. Cheap reads/writes behind independent `RwLock`s.
+pub struct ChainHealth {
+    reorgs: RwLock<VecDeque<ReorgEvent>>,
+    reorg_capacity: usize,
+    tip: RwLock<Option<TipStatus>>,
+}
+
+impl ChainHealth {
+    /// Create a holder retaining at most `reorg_capacity` reorg events.
+    pub fn new(reorg_capacity: usize) -> Self {
+        let reorg_capacity = reorg_capacity.max(1);
+        Self {
+            reorgs: RwLock::new(VecDeque::with_capacity(reorg_capacity.min(64))),
+            reorg_capacity,
+            tip: RwLock::new(None),
+        }
+    }
+
+    /// Record a detected reorg, evicting the oldest when at capacity (FIFO).
+    /// `unix_time` is the current wall-clock second.
+    pub fn record_reorg(
+        &self,
+        unix_time: i64,
+        depth: u32,
+        old_tip_hash: impl Into<String>,
+        new_tip_height: Option<u64>,
+    ) {
+        let mut buf = self.reorgs.write();
+        while buf.len() >= self.reorg_capacity {
+            buf.pop_front();
+        }
+        buf.push_back(ReorgEvent {
+            unix_time,
+            depth,
+            old_tip_hash: old_tip_hash.into(),
+            new_tip_height,
+        });
+    }
+
+    /// All retained reorg events, newest first.
+    pub fn recent_reorgs(&self) -> Vec<ReorgEvent> {
+        self.reorgs.read().iter().rev().cloned().collect()
+    }
+
+    /// Count of reorg events recorded at or after `cutoff` (unix seconds).
+    pub fn reorg_count_since(&self, cutoff: i64) -> usize {
+        self.reorgs
+            .read()
+            .iter()
+            .filter(|e| e.unix_time >= cutoff)
+            .count()
+    }
+
+    /// Number of reorg events currently retained.
+    pub fn reorg_len(&self) -> usize {
+        self.reorgs.read().len()
+    }
+
+    /// Replace the current tip-status snapshot.
+    pub fn set_tip(&self, tip: TipStatus) {
+        *self.tip.write() = Some(tip);
+    }
+
+    /// The latest tip-status snapshot, if the monitor has run at least once.
+    pub fn tip(&self) -> Option<TipStatus> {
+        self.tip.read().clone()
+    }
+}
+
+impl Default for ChainHealth {
+    fn default() -> Self {
+        Self::new(DEFAULT_REORG_CAPACITY)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reorg_ring_evicts_oldest_at_capacity() {
+        let ch = ChainHealth::new(3);
+        for i in 0..5 {
+            ch.record_reorg(i, i as u32 + 1, format!("hash{i}"), Some(1000 + i as u64));
+        }
+        assert_eq!(ch.reorg_len(), 3);
+        // Newest first; oldest two (t=0,1) evicted, so t=4,3,2 remain.
+        let recent = ch.recent_reorgs();
+        assert_eq!(
+            recent.iter().map(|e| e.unix_time).collect::<Vec<_>>(),
+            vec![4, 3, 2]
+        );
+        assert_eq!(recent[0].old_tip_hash, "hash4");
+        assert_eq!(recent[0].new_tip_height, Some(1004));
+    }
+
+    #[test]
+    fn reorg_count_since_filters_by_cutoff() {
+        let ch = ChainHealth::new(50);
+        for t in 0..10 {
+            ch.record_reorg(t, 1, "h", None);
+        }
+        assert_eq!(ch.reorg_count_since(7), 3); // t = 7,8,9
+        assert_eq!(ch.reorg_count_since(i64::MIN), 10);
+        assert_eq!(ch.reorg_count_since(100), 0);
+    }
+
+    #[test]
+    fn capacity_is_at_least_one() {
+        let ch = ChainHealth::new(0);
+        ch.record_reorg(1, 1, "h", None);
+        assert_eq!(ch.reorg_len(), 1);
+    }
+
+    #[test]
+    fn tip_is_none_until_set() {
+        let ch = ChainHealth::new(4);
+        assert!(ch.tip().is_none());
+        ch.set_tip(derive_tip_status(100, 100, 5, 3, 1800));
+        assert_eq!(ch.tip().unwrap().status, TipStatusKind::AtTip);
+    }
+
+    #[test]
+    fn derive_at_tip_when_peer_unknown() {
+        // best_peer == 0 → unknown, never Behind/Stale even if local is 0.
+        let t = derive_tip_status(0, 0, 999_999, 3, 1800);
+        assert_eq!(t.status, TipStatusKind::AtTip);
+        assert_eq!(t.behind_by, 0);
+    }
+
+    #[test]
+    fn derive_at_tip_when_caught_up_or_ahead() {
+        assert_eq!(derive_tip_status(100, 100, 5, 3, 1800).status, TipStatusKind::AtTip);
+        assert_eq!(derive_tip_status(105, 100, 5, 3, 1800).status, TipStatusKind::AtTip);
+        // lag exactly K is not "more than K".
+        assert_eq!(derive_tip_status(100, 103, 5, 3, 1800).status, TipStatusKind::AtTip);
+    }
+
+    #[test]
+    fn derive_behind_when_lag_exceeds_k() {
+        let t = derive_tip_status(100, 105, 5, 3, 1800);
+        assert_eq!(t.status, TipStatusKind::Behind);
+        assert_eq!(t.behind_by, 5);
+    }
+
+    #[test]
+    fn derive_stale_when_tip_old_and_peer_ahead() {
+        // Only 1 behind (within K) but tip older than max age and peer ahead.
+        let t = derive_tip_status(100, 101, 1801, 3, 1800);
+        assert_eq!(t.status, TipStatusKind::Stale);
+        assert_eq!(t.behind_by, 1);
+    }
+
+    #[test]
+    fn derive_not_stale_when_old_but_caught_up() {
+        // Tip old but we are at/above best peer → healthy.
+        let t = derive_tip_status(101, 101, 5000, 3, 1800);
+        assert_eq!(t.status, TipStatusKind::AtTip);
+    }
+}

--- a/crates/ghost-verification/src/lib.rs
+++ b/crates/ghost-verification/src/lib.rs
@@ -39,6 +39,7 @@
 
 pub mod alerts;
 pub mod auth;
+pub mod chain_health;
 pub mod challenge;
 pub mod client;
 pub mod config;

--- a/crates/ghost-verification/src/routes.rs
+++ b/crates/ghost-verification/src/routes.rs
@@ -236,6 +236,11 @@ pub fn create_router(state: Arc<VerificationState>) -> Router {
         // sampled every 30s (24h retention). `?window=1h|24h`. Lets the pool
         // page chart real history instead of a client-side session buffer.
         .route("/api/v1/pool/series", get(api_pool_series_handler))
+        // Chain-health view: current tip-lag status + recently recorded reorgs
+        // (persisted in a bounded in-memory ring). Backs the Sync page's
+        // "Chain Health" section so reorgs and tip-lag are visible, not just
+        // paged as alerts.
+        .route("/api/v1/chain/health", get(api_chain_health_handler))
         // Mesh-wide leaderboard: node-ranked (self + peers by hashrate) plus the
         // mesh-wide best-share records per window, aggregated from existing mesh
         // data with no new gossip. Replaces the pool page's this-node-only list.
@@ -2963,6 +2968,32 @@ async fn api_pool_series_handler(
         "sample_interval_secs": 30,
         "count": samples.len(),
         "samples": samples,
+    }))
+}
+
+/// Chain-health view: the current tip-lag status plus the recently recorded
+/// reorg events. Backs the Sync page's "Chain Health" section so operators can
+/// SEE reorgs and tip-lag — signals that historically only fired an alert and
+/// were never persisted.
+///
+/// * `tip` — the latest snapshot from the behind-tip monitor: local height,
+///   best connected-peer height, how far behind, tip age, and a derived
+///   `status` (`at_tip` / `behind` / `stale`). `null` until the monitor has run
+///   at least once after startup.
+/// * `reorgs` — the retained recent reorg events, newest first (bounded ring).
+/// * `reorg_count_24h` — how many reorgs were recorded in the last 24 hours;
+///   `0` is the normal, healthy state.
+///
+/// Read-only, same public surface as the other `/api/v1/...` read endpoints.
+async fn api_chain_health_handler(
+    State(state): State<Arc<VerificationState>>,
+) -> impl IntoResponse {
+    let ch = &state.chain_health;
+    let cutoff_24h = chrono::Utc::now().timestamp() - 24 * 3600;
+    Json(serde_json::json!({
+        "tip": ch.tip(),
+        "reorgs": ch.recent_reorgs(),
+        "reorg_count_24h": ch.reorg_count_since(cutoff_24h),
     }))
 }
 

--- a/crates/ghost-verification/src/server.rs
+++ b/crates/ghost-verification/src/server.rs
@@ -1392,6 +1392,12 @@ pub struct VerificationState {
     /// `GET /api/v1/pool/series`. Bounded ring; empty until the first sample
     /// (the dashboard keeps its client-side session buffer as a fallback).
     pub pool_series: crate::pool_series::PoolSeries,
+    /// Chain-health state: a bounded ring of recent reorg events plus the
+    /// latest tip-lag snapshot. Written by the reorg handler + behind-tip
+    /// monitor in `bins/ghost-pool` (both hold a clone of this `Arc`) and read
+    /// by the `GET /api/v1/chain/health` route, so operators can SEE reorgs and
+    /// tip-lag instead of only being paged. In-memory; resets on restart.
+    pub chain_health: Arc<crate::chain_health::ChainHealth>,
     /// Operator-alert dispatcher, late-bound after startup. Populated by
     /// `bins/ghost-pool` once the dispatcher is built (its live-config closure
     /// needs this `Arc<VerificationState>`), so the internal failed-login
@@ -1556,6 +1562,7 @@ impl VerificationState {
             stratum_verify_cache: parking_lot::Mutex::new(std::collections::HashMap::new()),
             // 24h of history at the sampler's 30s cadence (2880 samples).
             pool_series: crate::pool_series::PoolSeries::new(2880),
+            chain_health: Arc::new(crate::chain_health::ChainHealth::default()),
             alert_dispatcher: std::sync::OnceLock::new(),
         }
     }

--- a/dashboard/src/app/(dashboard)/sync/page.tsx
+++ b/dashboard/src/app/(dashboard)/sync/page.tsx
@@ -10,6 +10,9 @@ import {
   Clock,
   CheckCircle2,
   Loader2,
+  GitBranch,
+  ShieldCheck,
+  AlertTriangle,
 } from "lucide-react";
 import { PageHeader } from "@/components/ui/PageHeader";
 import { Card, CardHeader } from "@/components/ui/Card";
@@ -18,8 +21,13 @@ import { StatCard } from "@/components/ui/StatCard";
 import { ProgressBar } from "@/components/ui/ProgressBar";
 import { SkeletonCard } from "@/components/ui/Skeleton";
 import { SectionErrorBoundary } from "@/components/ui/SectionErrorBoundary";
-import { useBlockchainStatus } from "@/hooks/queries";
-import type { BlockchainStatus } from "@/types/api";
+import { useBlockchainStatus, useChainHealth } from "@/hooks/queries";
+import type {
+  BlockchainStatus,
+  ChainHealthResponse,
+  ChainTipStatus,
+  ChainReorgEvent,
+} from "@/types/api";
 
 // ─── formatting helpers ──────────────────────────────────────────────────────
 
@@ -113,6 +121,7 @@ function deriveView(data: BlockchainStatus | undefined): SyncView {
 
 export default function SyncPage() {
   const { data, isLoading, isError, error } = useBlockchainStatus({ refetchInterval: 10_000 });
+  const chainHealth = useChainHealth({ refetchInterval: 30_000 });
 
   // Single ticking clock so relative times stay live between polls.
   const [now, setNow] = useState<number>(() => Date.now());
@@ -288,7 +297,193 @@ export default function SyncPage() {
           )}
         </Card>
       </SectionErrorBoundary>
+
+      {/* Chain health: reorgs + tip-lag */}
+      <SectionErrorBoundary section="Chain health">
+        <ChainHealthSection
+          data={chainHealth.data}
+          isLoading={chainHealth.isLoading}
+          isError={chainHealth.isError}
+          now={now}
+        />
+      </SectionErrorBoundary>
     </div>
+  );
+}
+
+// ─── chain health ────────────────────────────────────────────────────────────
+
+// Human-readable tip status, keyed off the derived `status` label from the API.
+function tipStatusLabel(tip: ChainTipStatus): string {
+  switch (tip.status) {
+    case "at_tip":
+      return "At tip";
+    case "behind":
+      return `Behind by ${formatCount(tip.behind_by)} block${tip.behind_by === 1 ? "" : "s"}`;
+    case "stale": {
+      const mins = Math.floor(tip.tip_age_secs / 60);
+      return `Stale — no block in ${formatCount(mins)} min`;
+    }
+    default:
+      return DASH;
+  }
+}
+
+function TipStatusBadge({ tip }: { tip: ChainTipStatus | null }) {
+  if (!tip) return <Badge variant="default">Awaiting first check</Badge>;
+  if (tip.status === "at_tip") {
+    return (
+      <Badge variant="success">
+        <ShieldCheck size={13} strokeWidth={2} className="mr-1" />
+        {tipStatusLabel(tip)}
+      </Badge>
+    );
+  }
+  if (tip.status === "behind") {
+    return (
+      <Badge variant="warning">
+        <AlertTriangle size={13} strokeWidth={2} className="mr-1" />
+        {tipStatusLabel(tip)}
+      </Badge>
+    );
+  }
+  return (
+    <Badge variant="error">
+      <AlertTriangle size={13} strokeWidth={2} className="mr-1" />
+      {tipStatusLabel(tip)}
+    </Badge>
+  );
+}
+
+// One-line summary of the most recent reorg: time · depth · old→new tip.
+function reorgSummary(ev: ChainReorgEvent, now: number): string {
+  const when = formatRelative(ev.unix_time, now);
+  const oldTip = truncateHash(ev.old_tip_hash);
+  const newTip = isNum(ev.new_tip_height) ? `height ${formatCount(ev.new_tip_height)}` : "new tip";
+  return `${when} · depth ${formatCount(ev.depth)} · ${oldTip} → ${newTip}`;
+}
+
+function ChainHealthSection({
+  data,
+  isLoading,
+  isError,
+  now,
+}: {
+  data: ChainHealthResponse | undefined;
+  isLoading: boolean;
+  isError: boolean;
+  now: number;
+}) {
+  const tip = data?.tip ?? null;
+  const reorgs = data?.reorgs ?? [];
+  const count24h = data?.reorg_count_24h ?? 0;
+  const lastReorg = reorgs[0];
+  const stable = count24h === 0;
+
+  return (
+    <Card>
+      <CardHeader
+        title="Chain health"
+        subtitle="Tip-lag against the network and any recent chain reorganisations this node has seen."
+        action={<TipStatusBadge tip={tip} />}
+      />
+
+      {isError ? (
+        <p style={{ color: "var(--dim)", fontSize: "14px" }}>
+          Chain-health data is unavailable right now.
+        </p>
+      ) : isLoading ? (
+        <div className="space-y-3">
+          <div className="h-4 w-2/3 rounded" style={{ background: "var(--rule)" }} />
+          <div className="h-4 w-1/2 rounded" style={{ background: "var(--rule)" }} />
+        </div>
+      ) : (
+        <div className="space-y-5">
+          {/* Tip detail */}
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <Field
+              label="Tip status"
+              value={tip ? tipStatusLabel(tip) : "Awaiting first check"}
+            />
+            <Field
+              label="Local height"
+              value={tip && isNum(tip.local_height) ? formatCount(tip.local_height) : DASH}
+              sub={
+                tip && tip.best_peer_height > 0
+                  ? `best peer ${formatCount(tip.best_peer_height)}`
+                  : "no peer height reported"
+              }
+            />
+            <Field
+              label="Tip age"
+              value={
+                tip && isNum(tip.tip_age_secs)
+                  ? `${formatCount(Math.floor(tip.tip_age_secs / 60))}m ${tip.tip_age_secs % 60}s`
+                  : DASH
+              }
+              sub="since local height last advanced"
+            />
+          </div>
+
+          {/* Reorg summary */}
+          <div
+            className="rounded-lg p-4"
+            style={{
+              background: stable ? "var(--card-2, var(--rule))" : undefined,
+              border: "1px solid var(--rule)",
+            }}
+          >
+            <div className="flex items-center gap-2" style={{ marginBottom: "6px" }}>
+              <GitBranch size={15} strokeWidth={1.75} style={{ color: "var(--dim)" }} />
+              <span style={{ color: "var(--fg)", fontSize: "14px", fontWeight: 500 }}>
+                Reorgs (last 24h)
+              </span>
+              <Badge variant={stable ? "success" : "warning"}>{formatCount(count24h)}</Badge>
+            </div>
+            {stable ? (
+              <p style={{ color: "var(--dim)", fontSize: "13px" }}>
+                None in the last 24 hours — a stable, single chain is the normal, healthy state.
+              </p>
+            ) : (
+              <p style={{ color: "var(--dim)", fontSize: "13px" }}>
+                {formatCount(count24h)} chain reorganisation{count24h === 1 ? "" : "s"} recorded in
+                the last 24 hours.
+              </p>
+            )}
+          </div>
+
+          {/* Last reorg */}
+          <Field
+            label="Last reorg"
+            value={lastReorg ? reorgSummary(lastReorg, now) : "None recently"}
+            sub={lastReorg ? formatAbsolute(lastReorg.unix_time) : undefined}
+          />
+
+          {/* Recent reorgs list */}
+          {reorgs.length > 0 && (
+            <div>
+              <div
+                style={{ color: "var(--dim)", fontSize: "12px", marginBottom: "6px" }}
+              >
+                Recent reorgs
+              </div>
+              <ul className="space-y-1.5">
+                {reorgs.map((ev, i) => (
+                  <li
+                    key={`${ev.unix_time}-${ev.old_tip_hash}-${i}`}
+                    className="flex items-center gap-2 font-mono"
+                    style={{ color: "var(--fg)", fontSize: "13px" }}
+                  >
+                    <GitBranch size={13} strokeWidth={1.75} style={{ color: "var(--fainter)" }} />
+                    <span>{reorgSummary(ev, now)}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      )}
+    </Card>
   );
 }
 

--- a/dashboard/src/hooks/queries/useNodeQueries.ts
+++ b/dashboard/src/hooks/queries/useNodeQueries.ts
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { getNodeInfo, getNodeStatus, getBlockchainStatus, getShares, getHealth, getNickname, setNickname } from '@/lib/api/node';
+import { getNodeInfo, getNodeStatus, getBlockchainStatus, getChainHealth, getShares, getHealth, getNickname, setNickname } from '@/lib/api/node';
 import { useNodeStore } from '@/stores';
 
 // Query keys for consistency
@@ -8,6 +8,7 @@ export const nodeKeys = {
   info: () => [...nodeKeys.all, 'info'] as const,
   status: () => [...nodeKeys.all, 'status'] as const,
   blockchain: () => [...nodeKeys.all, 'blockchain'] as const,
+  chainHealth: () => [...nodeKeys.all, 'chain-health'] as const,
   shares: () => [...nodeKeys.all, 'shares'] as const,
   health: () => [...nodeKeys.all, 'health'] as const,
   nickname: () => [...nodeKeys.all, 'nickname'] as const,
@@ -46,6 +47,14 @@ export function useBlockchainStatus(options?: { refetchInterval?: number }) {
     queryKey: nodeKeys.blockchain(),
     queryFn: getBlockchainStatus,
     refetchInterval: options?.refetchInterval ?? 10_000, // Poll every 10 seconds
+  });
+}
+
+export function useChainHealth(options?: { refetchInterval?: number }) {
+  return useQuery({
+    queryKey: nodeKeys.chainHealth(),
+    queryFn: getChainHealth,
+    refetchInterval: options?.refetchInterval ?? 30_000, // Poll every 30 seconds
   });
 }
 

--- a/dashboard/src/lib/api/node.ts
+++ b/dashboard/src/lib/api/node.ts
@@ -1,9 +1,16 @@
 // Node API endpoints
 import { fetchApi } from './client';
-import type { NodeInfo, NodeStatus, SharesInfo, HealthStatus, BlockchainStatus } from '@/types/api';
+import type { NodeInfo, NodeStatus, SharesInfo, HealthStatus, BlockchainStatus, ChainHealthResponse } from '@/types/api';
 
 export async function getNodeInfo(): Promise<NodeInfo> {
   return fetchApi<NodeInfo>('/api/v1/node/info');
+}
+
+// Chain health: current tip-lag status + recently recorded reorg events.
+// Persisted server-side (bounded ring), so the Sync page can SEE reorgs and
+// tip-lag rather than these only firing operator alerts.
+export async function getChainHealth(): Promise<ChainHealthResponse> {
+  return fetchApi<ChainHealthResponse>('/api/v1/chain/health');
 }
 
 export async function getNodeStatus(): Promise<NodeStatus> {

--- a/dashboard/src/types/api.ts
+++ b/dashboard/src/types/api.ts
@@ -331,6 +331,46 @@ export interface PoolSeriesResponse {
   samples: PoolSeriesSample[];
 }
 
+// Chain health (GET /api/v1/chain/health) — the current tip-lag status plus
+// recently recorded reorg events. Persisted server-side in a bounded ring, so
+// operators can SEE reorgs and tip-lag (both historically only fired alerts).
+
+/** Derived tip-lag status label. `at_tip` is the normal, healthy state. */
+export type TipStatusKind = "at_tip" | "behind" | "stale";
+
+export interface ChainTipStatus {
+  /** This node's current local L1 height. */
+  local_height: number;
+  /** Highest L1 height reported by a fresh connected mesh peer (0 = unknown). */
+  best_peer_height: number;
+  /** How many blocks behind the best peer (0 when caught up or peer unknown). */
+  behind_by: number;
+  /** Seconds since the local height last advanced (tip age). */
+  tip_age_secs: number;
+  /** Derived status label. */
+  status: TipStatusKind;
+}
+
+export interface ChainReorgEvent {
+  /** Unix timestamp (seconds) the reorg was recorded. */
+  unix_time: number;
+  /** Consecutive-disconnect depth when this block was orphaned. */
+  depth: number;
+  /** Hash of the disconnected (orphaned) block — the old tip. */
+  old_tip_hash: string;
+  /** Local height right after the disconnect, when a height source is wired. */
+  new_tip_height?: number;
+}
+
+export interface ChainHealthResponse {
+  /** Latest tip-status snapshot; null until the monitor has run once. */
+  tip: ChainTipStatus | null;
+  /** Recently recorded reorg events, newest first. */
+  reorgs: ChainReorgEvent[];
+  /** Reorgs recorded in the last 24h; 0 is the normal, healthy state. */
+  reorg_count_24h: number;
+}
+
 // Mesh-wide leaderboard (GET /api/v1/pool/mesh-leaderboard) — node-ranked
 // leaderboard + mesh-wide best-share records per window, aggregated with no new
 // gossip.


### PR DESCRIPTION
## Chain Health — persist + display reorgs and tip-lag

Reorgs (`bins/ghost-pool/src/reorg.rs`) and behind-tip (`bins/ghost-pool/src/alert_monitors.rs`) previously only *fired an operator alert* — nothing was persisted, so an operator could never look back and SEE a reorg or the live tip-lag status. This makes both visible.

### Backend
- New `crates/ghost-verification/src/chain_health.rs`: a bounded in-memory `ChainHealth` holder (recent-reorg ring, cap 50, newest-first) plus the latest tip-status snapshot, hung off `VerificationState` behind an `Arc` (mirrors the `pool_series` pattern). Includes a pure `derive_tip_status(...)` classifier (`at_tip` / `behind` / `stale`) that reuses the exact behind-tip thresholds, so the displayed status and the fired alert always agree.
- `ReorgHandler::handle_reorg` now records each detected reorg into the ring (in addition to firing the alert). It records what the ZMQ sequence event carries — the disconnected (old-tip) hash and the consecutive-disconnect depth — plus the node's local height right after the disconnect (via a wired height getter). The new tip hash is not on the event, so it is not fabricated.
- The behind-tip monitor writes a derived tip-status snapshot into the holder every tick.
- New read-only endpoint `GET /api/v1/chain/health` returning `{ tip: {local_height, best_peer_height, behind_by, tip_age_secs, status}, reorgs: [...], reorg_count_24h }`. Same public surface as the other `/api/v1/...` read endpoints.

### Frontend
- New "Chain Health" section on the Sync page (`dashboard/src/app/(dashboard)/sync/page.tsx`): plain-language tip status (At tip / Behind by N blocks / Stale — no block in X min), a 24h reorg count with **0 framed as the normal, healthy state**, the last reorg (time · depth · old→new tip, or "None recently"), and a recent-reorgs list with an empty state. Adds the `getChainHealth` API client, `useChainHealth` hook, and the response types. Matches the existing `PageHeader`/`Card` styling and is theme-aware.

### Verify
- `cargo check -p ghost-verification -p ghost-pool -j2 --features zk-production` clean.
- Unit tests for the reorg-ring record/cap + the tip-status derivation (pure logic) — 9 tests pass.
- `tsc --noEmit` + `eslint` clean; `npm run build` succeeds.

### Deploy note
This is a backend change (new endpoint + persistence on `ghost-pool`), so it needs a full ghost-pool deploy — the dashboard alone will not surface the data until the node ships this binary.
