### PR TITLE
dashboard(ghost-pay): revamp into operator L2-status page (status / settlement / earnings, cut explainers)

### DIFF
--- a/dashboard/src/app/(dashboard)/ghost-pay/page.tsx
+++ b/dashboard/src/app/(dashboard)/ghost-pay/page.tsx
@@ -1,89 +1,137 @@
 "use client";
 
-import Link from "next/link";
-import { Card, CardHeader } from "@/components/ui/Card";
+import { Card } from "@/components/ui/Card";
 import { PageHeader } from "@/components/ui/PageHeader";
 import { StatCard } from "@/components/ui/StatCard";
 import { Badge } from "@/components/ui/Badge";
+import { Toggle } from "@/components/ui/Toggle";
 import { SectionErrorBoundary } from "@/components/ui/SectionErrorBoundary";
 import { SkeletonCard } from "@/components/ui/Skeleton";
 import { EmptyState } from "@/components/ui/EmptyState";
 import {
   useGhostPayStatus,
-  useWraithStats,
-  useSettlementStatus,
-  useGhostLocks,
+  useSettlement,
+  useL2TreeState,
+  useL2FeeDistributionContext,
+  useGhostPayPayoutHistory,
+  useShares,
+  useNodeStatus,
+  useFullConfig,
+  useSetGhostPay,
+  useL2PruningStatus,
 } from "@/hooks/queries";
+
+/**
+ * Ghost Pay — operator view of the L2 this node helps run.
+ *
+ * Ghost Pay is Ghost's L2 for fast, private payments. Sending and receiving
+ * live in the wallet; this page is purely the node operator's read on the L2
+ * they help run: is it alive and busy, is it settling to L1, and what is the
+ * node earning for running it. Every value here is a live backend field —
+ * nothing is synthesised. Sections whose data is genuinely empty say so
+ * honestly rather than rendering a misleading zero.
+ */
 
 function formatL2Block(era: number, height: number): string {
   if (era <= 1) return height.toLocaleString();
   return `${era}:${height.toLocaleString()}`;
 }
 
-function FeatureCard({
-  href,
-  icon,
-  name,
-  description,
-  statusLabel,
-  statusVariant,
-  accentColor,
-}: {
-  href?: string;
-  icon: React.ReactNode;
-  name: string;
-  description: string;
-  statusLabel: string;
-  statusVariant: "success" | "warning" | "info" | "default";
-  accentColor: string;
-}) {
-  const content = (
-    <div className={`p-5 rounded-lg border ${accentColor} bg-gray-800/30 hover:bg-gray-800/50 transition-colors h-full flex flex-col`}>
-      <div className="flex items-start justify-between mb-3">
-        <div className="w-9 h-9 rounded-lg bg-gray-800/80 border border-gray-700 flex items-center justify-center flex-shrink-0">
-          {icon}
-        </div>
-        <Badge variant={statusVariant}>{statusLabel}</Badge>
-      </div>
-      <h3 className="text-gray-100 font-semibold text-sm mb-1.5">{name}</h3>
-      <p className="text-gray-400 text-xs leading-relaxed flex-1">{description}</p>
-      {href && (
-        <div className="mt-3 text-purple-400 text-xs font-medium">
-          Learn more &rarr;
-        </div>
-      )}
+function formatSats(sats?: number | null): string {
+  if (sats == null) return "0 sats";
+  return `${sats.toLocaleString()} sats`;
+}
+
+function shortId(id?: string): string {
+  if (!id) return "—";
+  return id.length > 12 ? `${id.slice(0, 8)}…${id.slice(-4)}` : id;
+}
+
+function formatWhen(ts?: number | null): string {
+  if (!ts) return "—";
+  // Backend timestamps are unix seconds.
+  const d = new Date(ts * 1000);
+  if (Number.isNaN(d.getTime())) return "—";
+  return d.toLocaleString();
+}
+
+const labelStyle: React.CSSProperties = {
+  color: "var(--dim)",
+  fontSize: "13px",
+  fontFamily: "var(--font-mono)",
+  textTransform: "uppercase",
+  letterSpacing: "0.06em",
+};
+
+const valueStyle: React.CSSProperties = {
+  color: "var(--fg)",
+  fontSize: "14px",
+  fontFamily: "var(--font-mono)",
+};
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        gap: "16px",
+        padding: "12px 0",
+        borderBottom: "1px solid var(--rule)",
+      }}
+    >
+      <span style={labelStyle}>{label}</span>
+      <span style={valueStyle}>{children}</span>
     </div>
   );
+}
 
-  if (href) {
-    return <Link href={href} className="block">{content}</Link>;
-  }
-  return content;
+function SectionTitle({ title, subtitle, action }: { title: string; subtitle?: string; action?: React.ReactNode }) {
+  return (
+    <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: "16px", marginBottom: "16px" }}>
+      <div>
+        <h2 style={{ color: "var(--fg)", fontSize: "16px", fontWeight: 500 }}>{title}</h2>
+        {subtitle && <p style={{ color: "var(--dim)", fontSize: "13px", marginTop: "4px", lineHeight: 1.5 }}>{subtitle}</p>}
+      </div>
+      {action}
+    </div>
+  );
 }
 
 export default function GhostPayPage() {
   const { data: status, isLoading: statusLoading, error: statusError } = useGhostPayStatus();
-  const { data: wraithStats } = useWraithStats();
-  const { data: reconciliation } = useSettlementStatus();
-  const { data: locksData } = useGhostLocks();
+  const { data: tree } = useL2TreeState();
+  const { data: settlement } = useSettlement();
+  const { data: feeContext } = useL2FeeDistributionContext();
+  const { data: payoutHistory } = useGhostPayPayoutHistory("all");
+  const { data: shares } = useShares();
+  const { data: nodeStatus } = useNodeStatus();
+  const { data: fullConfig } = useFullConfig();
+  const { data: pruning } = useL2PruningStatus();
+  const setGhostPay = useSetGhostPay();
 
-  // If Ghost Pay is not enabled / not reachable
+  // Not reachable at all — ghost-pay service down / dashboard can't sign.
   if (!statusLoading && statusError) {
     return (
       <div className="space-y-6">
-        <PageHeader title="Ghost Pay" subtitle="L2 instant payments and privacy toolkit" />
-        <Card className="border-purple-600/30">
+        <PageHeader
+          eyebrow="ghost pay"
+          title="Your node's view of the L2."
+          subtitle="Ghost Pay is Ghost's L2 for fast private payments. Sending lives in the wallet — this is your node's view of the L2 it helps run."
+        />
+        <Card>
           <EmptyState
             icon={
               <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
                 <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 18.75a60.07 60.07 0 0115.797 2.101c.727.198 1.453-.342 1.453-1.096V18.75M3.75 4.5v.75A.75.75 0 013 6h-.75m0 0v-.375c0-.621.504-1.125 1.125-1.125H20.25M2.25 6v9m18-10.5v.75c0 .414.336.75.75.75h.75m-1.5-1.5h.375c.621 0 1.125.504 1.125 1.125v9.75c0 .621-.504 1.125-1.125 1.125h-.375m1.5-1.5H21a.75.75 0 00-.75.75v.75m0 0H3.75m0 0h-.375a1.125 1.125 0 01-1.125-1.125V15m1.5 1.5v-.75A.75.75 0 003 15h-.75M15 10.5a3 3 0 11-6 0 3 3 0 016 0zm3 0h.008v.008H18V10.5zm-12 0h.008v.008H6V10.5z" />
               </svg>
             }
-            title="Ghost Pay is not connected"
-            description="Enable Ghost Pay in Settings to access L2 payments, Wraith mixing, and Ghost Locks."
+            title="Ghost Pay is not reachable"
+            description="The ghost-pay service on this node isn't responding. Enable Ghost Pay in Settings, or check the ghost-pay daemon on port 8800."
             action={
-              <a href="/settings" className="text-sm text-purple-400 hover:text-purple-300">
-                Go to Settings
+              <a href="/settings" className="bare" style={{ color: "var(--accent)", fontSize: "14px" }}>
+                Go to Settings →
               </a>
             }
           />
@@ -92,203 +140,185 @@ export default function GhostPayPage() {
     );
   }
 
-  const l2Era = status?.l2_era || 1;
-  const l2Height = status?.l2_height || status?.block_height || 0;
-  const activeLocks = locksData?.summary?.total_locks ?? locksData?.active_locks ?? 0;
-  const activeSessions = wraithStats?.active_sessions ?? 0;
-  const pendingSettlement = reconciliation?.pending_count ?? 0;
+  const l2Era = status?.l2_era ?? 1;
+  const l2Height = status?.l2_height ?? status?.virtual_block ?? 0;
+  const epoch = status?.epoch ?? 0;
+  const syncState = status?.sync_state;
+  const enabled = status?.enabled ?? false;
+  const peerCount = status?.peer_count ?? 0;
+
+  // Settlement (flat backend shape from /api/v1/settlement/status).
+  const last = settlement?.last_settlement as
+    | { batch_id?: string; total_amount_sats?: number; l1_txid?: string | null; finalized_at?: number | null }
+    | null
+    | undefined;
+  const pendingSettlements = settlement?.pending_count ?? settlement?.pending_settlements ?? 0;
+  const totalSettled = settlement?.total_settled_sats ?? 0;
+  const settlementStatus = settlement?.status ?? "idle";
+
+  // Earnings.
+  const capabilityClaimed = !!nodeStatus?.ghost_pay || !!fullConfig?.ghost_pay;
+  const capabilityQualified = !!shares?.ghost_pay;
+  const treasuryBalance = feeContext?.treasury_balance_sats ?? 0;
+  const ghostPayNodeCount = feeContext?.ghost_pay_nodes?.length ?? 0;
+  const thresholdReachedAt = feeContext?.threshold_reached_at ?? null;
+  const payoutCount = payoutHistory?.total ?? payoutHistory?.payouts?.length ?? 0;
+
+  // Config.
+  const ghostPayOn = !!fullConfig?.ghost_pay;
+  const pruneEnabled = !!pruning?.enabled;
+  const pruneProfile = String(pruning?.profile ?? fullConfig?.prune_profile ?? "none");
+  const pruneThreshold = Number(pruning?.threshold_sats ?? 0);
 
   return (
     <div className="space-y-6">
-      {/* 1. PageHeader */}
+      {/* 1. Header + one-line explainer (replaces the old privacy-layer cards). */}
       <PageHeader
         eyebrow="ghost pay"
-        title="L2 instant payments."
-        subtitle="L2 instant payments and privacy toolkit"
+        title="Your node's view of the L2."
+        subtitle="Ghost Pay is Ghost's L2 for fast private payments. Sending lives in the wallet — this is your node's view of the L2 it helps run: is it alive, settling to L1, and earning."
       />
 
-      {/* 2. StatCards Row */}
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-        <StatCard
-          label="L2 Block"
-          value={status ? formatL2Block(l2Era, l2Height) : "--"}
-          loading={statusLoading}
-        />
-        <StatCard
-          label="Active Locks"
-          value={activeLocks || 0}
-          loading={statusLoading}
-        />
-        <StatCard
-          label="Wraith Sessions"
-          value={activeSessions || 0}
-          loading={statusLoading}
-        />
-        <StatCard
-          label="Peers"
-          value={status?.peer_count ?? 0}
-          loading={statusLoading}
-        />
-      </div>
-
-      {/* 3. How It Works — collapsible, defaultCollapsed */}
-      <Card collapsible defaultCollapsed>
-        <CardHeader
-          title="How It Works"
-          subtitle="How privacy layers stack together"
-        />
-        <div className="space-y-3">
-          <p className="text-gray-300 text-sm leading-relaxed">
-            Ghost Pay combines multiple privacy layers. <span className="text-purple-400">Ghost Keys</span> hide
-            your identity with unique addresses per payment. <span className="text-red-400">Ghost Wraith</span> breaks
-            transaction links through CoinJoin mixing. <span className="text-blue-400">Ghost Shroud</span> hides
-            relay timing to prevent network-level correlation. <span className="text-green-400">Ghost Locks</span> secure
-            your funds with timelocked P2TR recovery paths and automatic key rotation via Jump Locks.
-          </p>
+      {/* 2. Status strip — is the L2 alive and busy. */}
+      <SectionErrorBoundary section="L2 status">
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          <StatCard
+            label="Ghost Pay"
+            value={enabled ? (syncState === "synced" ? "Synced" : syncState ?? "Running") : "Disabled"}
+            sublabel={status?.network ?? undefined}
+            loading={statusLoading}
+          />
+          <StatCard
+            label="L2 Height"
+            value={status ? formatL2Block(l2Era, l2Height) : "—"}
+            sublabel={`epoch ${epoch}`}
+            loading={statusLoading}
+          />
+          <StatCard
+            label="L2 Notes"
+            value={tree ? (tree.note_count ?? 0).toLocaleString() : "—"}
+            sublabel={`tree epoch ${tree?.epoch ?? 0}`}
+            tooltip="Commitment-tree note count from /api/v1/l2/tree-state — the live size of the L2 note set this node tracks."
+            loading={statusLoading}
+          />
+          <StatCard
+            label="Mesh Peers"
+            value={peerCount}
+            sublabel={status?.uptime_secs != null ? `${Math.floor(status.uptime_secs / 3600)}h uptime` : undefined}
+            loading={statusLoading}
+          />
         </div>
-      </Card>
+      </SectionErrorBoundary>
 
-      {/* 4. Primary Content — Status Banner + Feature Cards */}
-      <SectionErrorBoundary section="Status Banner">
-        {statusLoading ? <SkeletonCard /> : (
-          <div className="flex items-center gap-6 px-4 py-3 rounded-lg border border-purple-600/20 bg-purple-900/10">
-            <div className="flex items-center gap-2">
-              <span className="w-2 h-2 rounded-full bg-purple-400 animate-pulse" />
-              <span className="text-sm text-gray-300">
-                L2 Block <span className="font-mono text-purple-400">{formatL2Block(l2Era, l2Height)}</span>
-              </span>
-            </div>
-            <div className="text-sm text-gray-400">
-              Epoch <span className="font-mono text-gray-300">{status?.epoch ?? 0}</span>
-            </div>
-            <div className="text-sm text-gray-400">
-              {status?.peer_count ?? 0} peers
-            </div>
-            <div className="text-sm text-gray-400">
-              {status?.sync_state === "synced" ? (
-                <Badge variant="success">Synced</Badge>
-              ) : status?.sync_state ? (
-                <Badge variant="warning">{status.sync_state}</Badge>
-              ) : (
-                <Badge variant="default">Unknown</Badge>
-              )}
+      {/* 3. Settlement to L1 — the genuinely operator-relevant reconciliation view. */}
+      <SectionErrorBoundary section="Settlement to L1">
+        <Card>
+          <SectionTitle
+            title="Settlement to L1"
+            subtitle="Batched L2 → L1 reconciliation. When L2 activity accumulates, the node bundles it into a batch and settles on-chain."
+            action={
+              pendingSettlements > 0
+                ? <Badge variant="warning">{pendingSettlements} pending</Badge>
+                : settlementStatus === "processing"
+                  ? <Badge variant="info">processing</Badge>
+                  : <Badge variant="default">idle</Badge>
+            }
+          />
+          <div>
+            <Field label="Pending batches">{pendingSettlements}</Field>
+            <Field label="Total settled">{formatSats(totalSettled)}</Field>
+            <Field label="Last batch id">{last?.batch_id ? shortId(last.batch_id) : "—"}</Field>
+            <Field label="Last batch amount">{last ? formatSats(last.total_amount_sats) : "—"}</Field>
+            <Field label="Last L1 txid">{last?.l1_txid ? shortId(last.l1_txid) : "—"}</Field>
+            <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: "16px", padding: "12px 0" }}>
+              <span style={labelStyle}>Last settled at</span>
+              <span style={valueStyle}>{formatWhen(last?.finalized_at)}</span>
             </div>
           </div>
-        )}
+          {pendingSettlements === 0 && !last && (
+            <p style={{ color: "var(--fainter)", fontSize: "13px", marginTop: "4px", lineHeight: 1.5 }}>
+              No settlement batches yet. Batches appear here once L2 activity is reconciled to L1.
+            </p>
+          )}
+        </Card>
       </SectionErrorBoundary>
 
-      <SectionErrorBoundary section="Privacy Features">
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-          <FeatureCard
-            href="/locks"
-            icon={
-              <svg className="w-4.5 h-4.5 text-green-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 10-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 002.25-2.25v-6.75a2.25 2.25 0 00-2.25-2.25H6.75a2.25 2.25 0 00-2.25 2.25v6.75a2.25 2.25 0 002.25 2.25z" />
-              </svg>
+      {/* 4. Your L2 earnings — fees the node earns + capability qualification. */}
+      <SectionErrorBoundary section="L2 earnings">
+        <Card>
+          <SectionTitle
+            title="Your L2 earnings"
+            subtitle="Running Ghost Pay earns your node a +4 capability share and a cut of L2 fees, paid from the treasury pool once it reaches threshold."
+            action={
+              capabilityQualified
+                ? <Badge variant="success">Ghost Pay qualified · +4</Badge>
+                : capabilityClaimed
+                  ? <Badge variant="warning">Claimed · not qualified</Badge>
+                  : <Badge variant="default">Not claimed</Badge>
             }
-            name="Ghost Locks"
-            description="P2TR UTXOs with timelocked recovery paths for secure fund custody."
-            statusLabel={`${activeLocks} lock${activeLocks !== 1 ? "s" : ""}`}
-            statusVariant={activeLocks > 0 ? "success" : "default"}
-            accentColor="border-green-600/20"
           />
-          <FeatureCard
-            href="/locks"
-            icon={
-              <svg className="w-4.5 h-4.5 text-green-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182" />
-              </svg>
-            }
-            name="Jump Locks"
-            description="Risk-tiered automatic key rotation for proactive security."
-            statusLabel="Built-in"
-            statusVariant="info"
-            accentColor="border-green-600/20"
-          />
-          <FeatureCard
-            href="/wraith"
-            icon={
-              <svg className="w-4.5 h-4.5 text-red-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M7.5 21L3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5" />
-              </svg>
-            }
-            name="Ghost Wraith"
-            description="Two-phase CoinJoin mixing that breaks UTXO history links."
-            statusLabel={activeSessions > 0 ? `${activeSessions} active` : "Idle"}
-            statusVariant={activeSessions > 0 ? "success" : "default"}
-            accentColor="border-red-600/20"
-          />
-          <FeatureCard
-            icon={
-              <svg className="w-4.5 h-4.5 text-purple-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 5.25a3 3 0 013 3m3 0a6 6 0 01-7.029 5.912c-.563-.097-1.159.026-1.563.43L10.5 17.25H8.25v2.25H6v2.25H2.25v-2.818c0-.597.237-1.17.659-1.591l6.499-6.499c.404-.404.527-1 .43-1.563A6 6 0 1121.75 8.25z" />
-              </svg>
-            }
-            name="Ghost Keys"
-            description="Silent Payment-style addresses — single ID, unlimited unique addresses."
-            statusLabel="Built-in"
-            statusVariant="info"
-            accentColor="border-purple-600/20"
-          />
-          <FeatureCard
-            href="/locks"
-            icon={
-              <svg className="w-4.5 h-4.5 text-green-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M3 4.5h14.25M3 9h9.75M3 13.5h9.75m4.5-4.5v12m0 0l-3.75-3.75M17.25 21l3.75-3.75" />
-              </svg>
-            }
-            name="Reconciliation"
-            description="Batch L1 settlement — Express, Standard, and Economy classes."
-            statusLabel={pendingSettlement > 0 ? `${pendingSettlement} pending` : "Idle"}
-            statusVariant={pendingSettlement > 0 ? "warning" : "default"}
-            accentColor="border-green-600/20"
-          />
-          <FeatureCard
-            href="/shroud"
-            icon={
-              <svg className="w-4.5 h-4.5 text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M3.98 8.223A10.477 10.477 0 001.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.45 10.45 0 0112 4.5c4.756 0 8.773 3.162 10.065 7.498a10.523 10.523 0 01-4.293 5.774M6.228 6.228L3 3m3.228 3.228l3.65 3.65m7.894 7.894L21 21m-3.228-3.228l-3.65-3.65m0 0a3 3 0 10-4.243-4.243m4.242 4.242L9.88 9.88" />
-              </svg>
-            }
-            name="Ghost Shroud"
-            description="Transaction relay privacy via random delays — complements Wraith."
-            statusLabel="Relay privacy"
-            statusVariant="default"
-            accentColor="border-blue-600/20"
-          />
-        </div>
+          <div>
+            <Field label="Capability">
+              {capabilityQualified ? "Qualified (+4 shares)" : capabilityClaimed ? "Claimed, awaiting challenges" : "Off"}
+            </Field>
+            <Field label="Treasury pool">{formatSats(treasuryBalance)}</Field>
+            <Field label="Threshold reached">{thresholdReachedAt ? formatWhen(thresholdReachedAt) : "not yet"}</Field>
+            <Field label="Nodes sharing L2 fees">{ghostPayNodeCount}</Field>
+            <Field label="Your payout records">{payoutCount}</Field>
+          </div>
+          <p style={{ color: "var(--fainter)", fontSize: "13px", marginTop: "12px", lineHeight: 1.5 }}>
+            {capabilityQualified
+              ? "Your node is verified as Ghost Pay-capable and shares in L2 fee distribution. "
+              : "The +4 share counts at payout only once peer challenges qualify the capability. "}
+            L2 fee reference: transfers 10 sats + 0.1%, Wraith mix 1%. Fees accrue to the treasury pool and distribute to qualified nodes.{" "}
+            <a href="/capabilities" className="bare" style={{ color: "var(--accent)", textDecoration: "underline", textDecorationColor: "var(--rule-strong)" }}>
+              Capability detail →
+            </a>
+          </p>
+        </Card>
       </SectionErrorBoundary>
 
-      {/* 5. Technical Details — collapsible, defaultCollapsed */}
-      <Card collapsible defaultCollapsed>
-        <CardHeader
-          title="Fee Structure"
-          subtitle="Ghost Pay transaction and mixing fees"
-        />
-        <div className="overflow-x-auto">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="border-b border-gray-800">
-                <th className="text-left py-2 px-3 text-gray-400 font-medium">Service</th>
-                <th className="text-right py-2 px-3 text-gray-400 font-medium">Fee</th>
-                <th className="text-left py-2 px-3 text-gray-400 font-medium">Description</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr className="border-b border-gray-800/50">
-                <td className="py-2.5 px-3 text-gray-100 font-medium">L2 Transfer</td>
-                <td className="py-2.5 px-3 text-right font-mono text-purple-400">10 sats + 0.1%</td>
-                <td className="py-2.5 px-3 text-gray-500">Instant Ghost Pay transfers between wallets</td>
-              </tr>
-              <tr>
-                <td className="py-2.5 px-3 text-gray-100 font-medium">Wraith Mix</td>
-                <td className="py-2.5 px-3 text-right font-mono text-red-400">1%</td>
-                <td className="py-2.5 px-3 text-gray-500">CoinJoin mixing via Ghost Wraith</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-      </Card>
+      {/* 5. Config — Ghost Pay on/off + L2 pruning. */}
+      <SectionErrorBoundary section="Configuration">
+        <Card>
+          <SectionTitle title="Configuration" subtitle="Whether this node runs the Ghost Pay L2, and how it prunes L2 state." />
+          {statusLoading ? (
+            <SkeletonCard />
+          ) : (
+            <div>
+              <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: "16px", padding: "12px 0", borderBottom: "1px solid var(--rule)" }}>
+                <div>
+                  <div style={{ color: "var(--fg)", fontSize: "14px", fontWeight: 500 }}>Ghost Pay L2</div>
+                  <div style={{ color: "var(--dim)", fontSize: "13px", marginTop: "2px" }}>
+                    Run the L2 payments layer and earn the +4 capability share.
+                  </div>
+                </div>
+                <Toggle
+                  label="Ghost Pay L2"
+                  enabled={ghostPayOn}
+                  disabled={setGhostPay.isPending}
+                  onChange={(v) => setGhostPay.mutate(v)}
+                />
+              </div>
+              <Field label="L2 pruning">{pruneEnabled ? `${pruneProfile} · below ${formatSats(pruneThreshold)}` : "disabled"}</Field>
+              <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: "16px", padding: "12px 0" }}>
+                <span style={labelStyle}>Prune profile</span>
+                <span style={valueStyle}>
+                  {pruneProfile}{" "}
+                  <a href="/storage" className="bare" style={{ color: "var(--accent)", textDecoration: "underline", textDecorationColor: "var(--rule-strong)", fontFamily: "var(--font-sans)" }}>
+                    edit →
+                  </a>
+                </span>
+              </div>
+              {setGhostPay.isError && (
+                <p style={{ color: "var(--red)", fontSize: "13px", marginTop: "8px" }}>
+                  Failed to update Ghost Pay setting. Try again.
+                </p>
+              )}
+            </div>
+          )}
+        </Card>
+      </SectionErrorBoundary>
     </div>
   );
 }

--- a/dashboard/src/hooks/queries/useGhostPayQueries.ts
+++ b/dashboard/src/hooks/queries/useGhostPayQueries.ts
@@ -7,6 +7,8 @@ import {
   getPayments,
   getSettlement,
   getSettlementStatus,
+  getL2FeeDistributionContext,
+  getL2TreeState,
   getGhostPayPayoutHistory,
   joinWraithSession,
   requestLockSettlement,
@@ -24,6 +26,8 @@ export const ghostPayKeys = {
     [...ghostPayKeys.all, 'payments', params] as const,
   settlement: () => [...ghostPayKeys.all, 'settlement'] as const,
   settlementStatus: () => [...ghostPayKeys.all, 'settlement-status'] as const,
+  feeContext: () => [...ghostPayKeys.all, 'fee-context'] as const,
+  treeState: () => [...ghostPayKeys.all, 'tree-state'] as const,
   payoutHistory: (timeFilter: PayoutHistoryTimeFilter) =>
     [...ghostPayKeys.all, 'payout-history', timeFilter] as const,
 };
@@ -122,6 +126,22 @@ export function useSettlementStatus(options?: { refetchInterval?: number }) {
     queryKey: ghostPayKeys.settlementStatus(),
     queryFn: getSettlementStatus,
     refetchInterval: options?.refetchInterval ?? 10_000,
+  });
+}
+
+export function useL2FeeDistributionContext(options?: { refetchInterval?: number }) {
+  return useQuery({
+    queryKey: ghostPayKeys.feeContext(),
+    queryFn: getL2FeeDistributionContext,
+    refetchInterval: options?.refetchInterval ?? 30_000,
+  });
+}
+
+export function useL2TreeState(options?: { refetchInterval?: number }) {
+  return useQuery({
+    queryKey: ghostPayKeys.treeState(),
+    queryFn: getL2TreeState,
+    refetchInterval: options?.refetchInterval ?? 15_000,
   });
 }
 

--- a/dashboard/src/lib/api/ghostpay.ts
+++ b/dashboard/src/lib/api/ghostpay.ts
@@ -12,6 +12,8 @@ import type {
   SettlementStatus,
   GhostPayPayoutHistoryResponse,
   PayoutHistoryTimeFilter,
+  L2FeeDistributionContext,
+  L2TreeState,
 } from '@/types/api';
 
 // The Ghost ID (and other key material) is served by the ghost-pay backend,
@@ -172,6 +174,16 @@ export async function getSettlementStatus(): Promise<SettlementStatus> {
       avg_batch_size: 0,
     };
   }
+}
+
+// L2 fee-distribution context — treasury pool + Ghost Pay nodes sharing L2 fees.
+export async function getL2FeeDistributionContext(): Promise<L2FeeDistributionContext> {
+  return fetchApi<L2FeeDistributionContext>('/api/v1/l2/fee-distribution-context');
+}
+
+// L2 commitment-tree state (root, checkpoint, finalization counts).
+export async function getL2TreeState(): Promise<L2TreeState> {
+  return fetchApi<L2TreeState>('/api/v1/l2/tree-state');
 }
 
 // GhostPay Payout History (for Ghost-Pay page)

--- a/dashboard/src/types/api.ts
+++ b/dashboard/src/types/api.ts
@@ -145,8 +145,14 @@ export interface FullNodeConfig {
   [key: string]: unknown;
 }
 
-// L2 Pruning config (from ghost-pay-node)
+// L2 Pruning config (from /api/v1/ghost-pay/pruning). The backend returns the
+// profile-derived enable flag + sat threshold; the *_pruned counters are only
+// populated once a prune has run.
 export interface L2PruningConfig {
+  enabled?: boolean;
+  profile?: string;
+  threshold_sats?: number;
+  last_prune?: number | null;
   retention_days?: number;
   auto_prune?: boolean;
   prune_interval_hours?: number;
@@ -155,6 +161,35 @@ export interface L2PruningConfig {
   attestations_pruned?: number;
   locks_pruned?: number;
   [key: string]: unknown;
+}
+
+// L2 fee-distribution context (from /api/v1/l2/fee-distribution-context) — the
+// treasury pool plus the set of Ghost Pay-capable nodes that share L2 fees.
+export interface L2FeeDistributionNode {
+  node_id: string;
+  address: string;
+  shares: number;
+}
+
+export interface L2FeeDistributionContext {
+  treasury_balance_sats?: number;
+  threshold_reached_at?: number | null;
+  ghost_pay_nodes?: L2FeeDistributionNode[];
+  error?: string;
+}
+
+// L2 commitment-tree state (from /api/v1/l2/tree-state).
+export interface L2TreeState {
+  epoch?: number;
+  tree_root?: string;
+  checkpoint_height?: number;
+  checkpoint_root?: string;
+  checkpoint_tx_count?: number;
+  note_count?: number;
+  recent_finalizations?: number;
+  active_finalizations?: number;
+  roots_match?: boolean;
+  error?: string;
 }
 
 export interface SharesInfo {


### PR DESCRIPTION
## What

Rebuilds the **Ghost Pay Network** dashboard page from a half-wallet / half-tutorial into a focused **operator view of the L2 the node helps run**. Ghost Pay is Ghost's L2 for fast private payments — sending/receiving lives in the wallet; this page is the operator's "is my L2 healthy, busy, settling, and earning?" dashboard.

## Cut

- The big **"How It Works"** privacy-layers card (Ghost Keys / Wraith / Shroud / Locks marketing copy).
- The big **"Fee Structure"** table card.
- The 6 marketing **FeatureCard** tiles linking to Locks / Jump Locks / Wraith / Keys / Reconciliation / Shroud.

Replaced with a single one-line explainer in the page header and a compact inline fee reference.

## New structure (every value is a live backend field — nothing synthesised)

1. **Header + one-liner** — "Ghost Pay is Ghost's L2 for fast private payments. Sending lives in the wallet — this is your node's view of the L2 it helps run." Keeps the not-reachable empty state.
2. **Status strip** (4 `StatCard`s) — Ghost Pay running/synced, L2 height (+ epoch), L2 commitment-tree note count (+ tree epoch), mesh peers (+ uptime).
3. **Settlement to L1** — pending batches, total settled, last batch id / amount / L1 txid / finalized-at, honest empty state when there are no batches yet. Reads the real flat shape of `/api/v1/settlement/status`.
4. **Your L2 earnings** — Ghost Pay capability qualification (+4 shares, claimed vs qualified), treasury pool balance, threshold-reached, count of nodes sharing L2 fees, payout-record count, inline L2 fee reference.
5. **Configuration** — the existing Ghost Pay on/off `Toggle` (`useFullConfig` + `useSetGhostPay`) plus L2 pruning profile / threshold.

## Data plumbing

Added two API clients + hooks + types reusing existing patterns (no new backend routes):

- `getL2FeeDistributionContext` / `useL2FeeDistributionContext` → `GET /api/v1/l2/fee-distribution-context`
- `getL2TreeState` / `useL2TreeState` → `GET /api/v1/l2/tree-state`
- Typed `L2FeeDistributionContext`, `L2TreeState`, and corrected `L2PruningConfig` to match the endpoint's real `{enabled, profile, threshold_sats, last_prune}` shape.

Settlement now reads `useSettlement()` (the raw flat `SettlementResponse`) rather than the pre-existing `getSettlementStatus` mapper, which reads a nested `stats.*` shape the backend never returns (it fell through to all-zeros).

## Verified live against vm1 (`127.0.0.1:8080`)

| Section | Endpoint | Live vm1 value |
|---|---|---|
| Status: Ghost Pay / L2 height / epoch / peers | `/ghostpay/status` | `enabled:true, sync_state:"synced", l2_era:44, l2_height:96293, epoch:44, peer_count:7, network:"mainnet", uptime_secs:5217` |
| Status: L2 notes / tree epoch | `/l2/tree-state` | `note_count:0, epoch:7, checkpoint_height:783681, roots_match:true, recent_finalizations:100` |
| Settlement | `/settlement/status` | `status:"idle", pending_count:0, last_settlement:null, total_settled_sats:0` (real, currently empty) |
| Earnings: treasury / nodes / threshold | `/l2/fee-distribution-context` | `treasury_balance_sats:0, threshold_reached_at:null, ghost_pay_nodes:[3 nodes]` |
| Earnings: capability qualified | `/node/shares` | `ghost_pay:true` (qualified, +4), `total:10, uptime_qualified:true` |
| Earnings: payout records | `/ghostpay/payout-history` | `payouts:[], total:0` (real, empty) |
| Config: toggle / pruning | `/config/full`, `/ghost-pay/pruning` | `ghost_pay:true, prune_profile:"none"`; `enabled:false, profile:"none", threshold_sats:0` |

## Dropped because the data isn't real

- **Throughput / `epoch_tx_count`** — the task spec named this, but `/ghostpay/status` does **not** return it (nor payments/epoch). The strip uses the L2 commitment-tree **note count** from `/l2/tree-state` as the honest "busy" signal instead of a fabricated throughput number.
- `batches_24h` from `/settlement/status` is hardcoded `0` in the backend, so it's not surfaced as a metric.

## Checks

- `tsc --noEmit`: clean
- `eslint` on changed files: clean (the 3 pre-existing repo-wide lint errors are in untouched files: `useWebSocket.ts`, `swarm/page.tsx`, `PayoutSection.tsx`, `ThemeToggle.tsx`, `useOnboarding.ts`)
- `npm run build`: succeeds, `/ghost-pay` route compiles
