### PR TITLE
dashboard(overlays): rest-screen carousel shell + 6-overlay contract

### DIFF
--- a/dashboard/src/app/(dashboard)/overlays/page.tsx
+++ b/dashboard/src/app/(dashboard)/overlays/page.tsx
@@ -1,0 +1,192 @@
+'use client';
+
+/**
+ * /overlays — full-bleed "rest screen" carousel.
+ *
+ * Shows ONE overlay at a time, full viewport, minimal chrome. Only the visible
+ * overlay is mounted, so only it animates; switching unmounts the old one
+ * (its rAF/cleanup runs) and mounts the next with `active`. The overlay set and
+ * order come from `@/components/overlays/registry`.
+ *
+ * Switching:
+ *   - bottom-centre ‹ › arrows (wrapping)
+ *   - dot indicators (jump straight to one)
+ *   - keyboard Left / Right
+ *   - idle auto-advance every ~30s, paused while the user is interacting/hovering
+ *     (any mouse move / pointer / key resets a 30s idle timer; auto-advance only
+ *     resumes once the screen has been idle again).
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { OVERLAYS } from '@/components/overlays/registry';
+
+const IDLE_MS = 30_000;
+
+export default function OverlaysPage() {
+  const count = OVERLAYS.length;
+  const [index, setIndex] = useState(0);
+  const [paused, setPaused] = useState(false);
+  const resumeRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const go = useCallback(
+    (dir: number) => setIndex((i) => (i + dir + count) % count),
+    [count],
+  );
+  const goto = useCallback(
+    (i: number) => setIndex(((i % count) + count) % count),
+    [count],
+  );
+
+  // Mark the screen "active" (user interacting) and schedule a return to idle.
+  const bump = useCallback(() => {
+    setPaused(true);
+    if (resumeRef.current) clearTimeout(resumeRef.current);
+    resumeRef.current = setTimeout(() => setPaused(false), IDLE_MS);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (resumeRef.current) clearTimeout(resumeRef.current);
+    };
+  }, []);
+
+  // Keyboard prev/next.
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      const t = e.target as HTMLElement | null;
+      if (t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable)) return;
+      if (e.key === 'ArrowLeft') {
+        e.preventDefault();
+        go(-1);
+        bump();
+      } else if (e.key === 'ArrowRight') {
+        e.preventDefault();
+        go(1);
+        bump();
+      }
+    }
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [go, bump]);
+
+  // Idle auto-advance: only while not paused. Resets whenever the index changes
+  // (so a manual switch restarts the clock) or when we return from paused.
+  useEffect(() => {
+    if (paused) return;
+    const t = setTimeout(() => go(1), IDLE_MS);
+    return () => clearTimeout(t);
+  }, [index, paused, go]);
+
+  const current = OVERLAYS[index];
+  const Current = current.Component;
+
+  const navButton: React.CSSProperties = {
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: 34,
+    height: 34,
+    borderRadius: 8,
+    border: '1px solid var(--rule)',
+    background: 'var(--bg)',
+    color: 'var(--dim)',
+    cursor: 'pointer',
+    pointerEvents: 'auto',
+  };
+
+  return (
+    <div
+      className="relative overflow-hidden -mt-14 -mx-4 -mb-4 md:-m-6 h-[100dvh]"
+      style={{ background: 'var(--bg)' }}
+      onMouseMove={bump}
+      onPointerDown={bump}
+    >
+      {/* Only the current overlay is mounted → only it animates. */}
+      <div className="absolute inset-0">
+        <Current active />
+      </div>
+
+      {/* Bottom-centre chrome: dots + arrows + label. */}
+      <div
+        className="absolute bottom-0 left-0 right-0 flex flex-col items-center gap-3"
+        style={{ padding: '20px 16px', pointerEvents: 'none' }}
+      >
+        {/* dot indicators */}
+        <div className="flex items-center gap-2" style={{ pointerEvents: 'auto' }}>
+          {OVERLAYS.map((o, i) => {
+            const isActive = i === index;
+            return (
+              <button
+                key={o.id}
+                onClick={() => {
+                  goto(i);
+                  bump();
+                }}
+                aria-label={`Show ${o.title}`}
+                aria-current={isActive ? 'true' : undefined}
+                style={{
+                  width: isActive ? 20 : 7,
+                  height: 7,
+                  borderRadius: 9999,
+                  border: 'none',
+                  padding: 0,
+                  cursor: 'pointer',
+                  background: isActive ? 'var(--accent)' : 'var(--rule-strong)',
+                  transition: 'width 0.2s ease, background 0.2s ease',
+                }}
+              />
+            );
+          })}
+        </div>
+
+        {/* arrows + current title */}
+        <div className="flex items-center gap-4" style={{ pointerEvents: 'none' }}>
+          <button
+            onClick={() => {
+              go(-1);
+              bump();
+            }}
+            aria-label="Previous overlay"
+            style={navButton}
+            onMouseEnter={(e) => (e.currentTarget.style.color = 'var(--fg)')}
+            onMouseLeave={(e) => (e.currentTarget.style.color = 'var(--dim)')}
+          >
+            <ChevronLeft size={18} strokeWidth={1.75} />
+          </button>
+
+          <span
+            style={{
+              minWidth: 180,
+              textAlign: 'center',
+              fontFamily: 'var(--font-mono)',
+              fontSize: '12px',
+              textTransform: 'uppercase',
+              letterSpacing: '0.16em',
+              color: 'var(--dim)',
+            }}
+          >
+            {current.title}
+            <span style={{ color: 'var(--fainter)' }}>
+              {'  ·  '}
+              {index + 1}/{count}
+            </span>
+          </span>
+
+          <button
+            onClick={() => {
+              go(1);
+              bump();
+            }}
+            aria-label="Next overlay"
+            style={navButton}
+            onMouseEnter={(e) => (e.currentTarget.style.color = 'var(--fg)')}
+            onMouseLeave={(e) => (e.currentTarget.style.color = 'var(--dim)')}
+          >
+            <ChevronRight size={18} strokeWidth={1.75} />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/components/layout/Sidebar.tsx
+++ b/dashboard/src/components/layout/Sidebar.tsx
@@ -2,6 +2,7 @@
 
 import {
   LayoutDashboard,
+  Monitor,
   Pickaxe,
   Activity,
   RefreshCw,
@@ -64,6 +65,7 @@ const GROUPS: NavGroup[] = [
     label: "overview",
     items: [
       { href: "/", label: "Overview", icon: <LayoutDashboard {...ICON} /> },
+      { href: "/overlays", label: "Overlays", icon: <Monitor {...ICON} /> },
       { href: "/sync", label: "Sync", icon: <RefreshCw {...ICON} /> },
       { href: "/geo", label: "Geo", icon: <MapPin {...ICON} /> },
     ],

--- a/dashboard/src/components/overlays/BlockClockOverlay.tsx
+++ b/dashboard/src/components/overlays/BlockClockOverlay.tsx
@@ -1,0 +1,22 @@
+/**
+ * Overlay: Block Clock
+ *
+ * CONCEPT — a giant, ambient next-block countdown: estimated time to the next
+ * block, round progress, current difficulty, and network hashrate. The
+ * centrepiece is the clock itself; everything else is quiet supporting detail.
+ *
+ * IMPLEMENTER NOTES:
+ *  - Keep the `export function BlockClockOverlay({ active }: OverlayProps)`
+ *    signature exactly. Replace only the body of this file.
+ *  - Honour `active`: run your rAF / animation loop and any polling ONLY while
+ *    `active === true`; cancel the rAF and stop polling when it flips to false.
+ *  - CSP-safe only: draw with <canvas> or inline SVG. No external assets.
+ */
+'use client';
+
+import type { OverlayProps } from './types';
+import { OverlayPlaceholder } from './OverlayPlaceholder';
+
+export function BlockClockOverlay({ active }: OverlayProps) {
+  return <OverlayPlaceholder title="Block Clock" active={active} />;
+}

--- a/dashboard/src/components/overlays/ChainHealthPulseOverlay.tsx
+++ b/dashboard/src/components/overlays/ChainHealthPulseOverlay.tsx
@@ -1,0 +1,24 @@
+/**
+ * Overlay: Chain Health Pulse
+ *
+ * CONCEPT — tip stability and reorg history rendered as a calm EKG / pulse
+ * line: a steady heartbeat while the tip is stable, with reorgs showing as
+ * blips in the trace. Data: `/api/v1/chain/health` (this endpoint ships
+ * separately — if it is not live yet, the implementer degrades gracefully;
+ * this placeholder is fine to keep until then).
+ *
+ * IMPLEMENTER NOTES:
+ *  - Keep the `export function ChainHealthPulseOverlay({ active }: OverlayProps)`
+ *    signature exactly. Replace only the body of this file.
+ *  - Honour `active`: run your rAF / animation loop and any polling ONLY while
+ *    `active === true`; cancel the rAF and stop polling when it flips to false.
+ *  - CSP-safe only: draw with <canvas> or inline SVG. No external assets.
+ */
+'use client';
+
+import type { OverlayProps } from './types';
+import { OverlayPlaceholder } from './OverlayPlaceholder';
+
+export function ChainHealthPulseOverlay({ active }: OverlayProps) {
+  return <OverlayPlaceholder title="Chain Health Pulse" active={active} />;
+}

--- a/dashboard/src/components/overlays/EarningsTickerOverlay.tsx
+++ b/dashboard/src/components/overlays/EarningsTickerOverlay.tsx
@@ -1,0 +1,22 @@
+/**
+ * Overlay: Earnings Ticker
+ *
+ * CONCEPT — shares and payouts accumulating over time: an ambient ticker of the
+ * capability shares building up and recent payouts streaming past. Money and
+ * work, visualised as a calm, ever-rising flow.
+ *
+ * IMPLEMENTER NOTES:
+ *  - Keep the `export function EarningsTickerOverlay({ active }: OverlayProps)`
+ *    signature exactly. Replace only the body of this file.
+ *  - Honour `active`: run your rAF / animation loop and any polling ONLY while
+ *    `active === true`; cancel the rAF and stop polling when it flips to false.
+ *  - CSP-safe only: draw with <canvas> or inline SVG. No external assets.
+ */
+'use client';
+
+import type { OverlayProps } from './types';
+import { OverlayPlaceholder } from './OverlayPlaceholder';
+
+export function EarningsTickerOverlay({ active }: OverlayProps) {
+  return <OverlayPlaceholder title="Earnings Ticker" active={active} />;
+}

--- a/dashboard/src/components/overlays/MempoolRiverOverlay.tsx
+++ b/dashboard/src/components/overlays/MempoolRiverOverlay.tsx
@@ -1,0 +1,23 @@
+/**
+ * Overlay: Mempool River
+ *
+ * CONCEPT — live transaction particles flowing downstream like a river,
+ * coloured by their BUDS class (T0 green → T3 red, via `@/lib/budsTiers`), with
+ * the reaper visibly cutting T3 junk out of the current. Particle density
+ * tracks mempool load. Data: `/api/v1/buds/mempool` plus reaper status.
+ *
+ * IMPLEMENTER NOTES:
+ *  - Keep the `export function MempoolRiverOverlay({ active }: OverlayProps)`
+ *    signature exactly. Replace only the body of this file.
+ *  - Honour `active`: run your rAF / animation loop and any polling ONLY while
+ *    `active === true`; cancel the rAF and stop polling when it flips to false.
+ *  - CSP-safe only: draw with <canvas> or inline SVG. No external assets.
+ */
+'use client';
+
+import type { OverlayProps } from './types';
+import { OverlayPlaceholder } from './OverlayPlaceholder';
+
+export function MempoolRiverOverlay({ active }: OverlayProps) {
+  return <OverlayPlaceholder title="Mempool River" active={active} />;
+}

--- a/dashboard/src/components/overlays/MeshConstellationOverlay.tsx
+++ b/dashboard/src/components/overlays/MeshConstellationOverlay.tsx
@@ -1,0 +1,24 @@
+/**
+ * Overlay: Mesh Constellation
+ *
+ * CONCEPT — the 8-node swarm rendered as a living star map: glowing orbs
+ * (elders brighter, sized by hashrate, placed by geo or on a ring), connection
+ * lines that pulse as gossip flows between nodes, and slow-drifting particles
+ * along the edges. Data: `/api/v1/pool/mesh-nodes` (+ the geo lib under
+ * `@/lib/geo` for placement).
+ *
+ * IMPLEMENTER NOTES:
+ *  - Keep the `export function MeshConstellationOverlay({ active }: OverlayProps)`
+ *    signature exactly. Replace only the body of this file.
+ *  - Honour `active`: run your rAF / animation loop and any polling ONLY while
+ *    `active === true`; cancel the rAF and stop polling when it flips to false.
+ *  - CSP-safe only: draw with <canvas> or inline SVG. No external assets.
+ */
+'use client';
+
+import type { OverlayProps } from './types';
+import { OverlayPlaceholder } from './OverlayPlaceholder';
+
+export function MeshConstellationOverlay({ active }: OverlayProps) {
+  return <OverlayPlaceholder title="Mesh Constellation" active={active} />;
+}

--- a/dashboard/src/components/overlays/NodeVitalsOverlay.tsx
+++ b/dashboard/src/components/overlays/NodeVitalsOverlay.tsx
@@ -1,0 +1,23 @@
+/**
+ * Overlay: Node Vitals
+ *
+ * CONCEPT — a calm mission-control board for this node: block height ticking
+ * up, a heartbeat pulse on each new block, current hashrate, the 5-4-3-2-1
+ * capability ring, peer count, uptime, and a sync progress bar. Big, legible,
+ * ambient — designed to be glanced at from across a room.
+ *
+ * IMPLEMENTER NOTES:
+ *  - Keep the `export function NodeVitalsOverlay({ active }: OverlayProps)`
+ *    signature exactly. Replace only the body of this file.
+ *  - Honour `active`: run your rAF / animation loop and any polling ONLY while
+ *    `active === true`; cancel the rAF and stop polling when it flips to false.
+ *  - CSP-safe only: draw with <canvas> or inline SVG. No external assets.
+ */
+'use client';
+
+import type { OverlayProps } from './types';
+import { OverlayPlaceholder } from './OverlayPlaceholder';
+
+export function NodeVitalsOverlay({ active }: OverlayProps) {
+  return <OverlayPlaceholder title="Node Vitals" active={active} />;
+}

--- a/dashboard/src/components/overlays/OverlayPlaceholder.tsx
+++ b/dashboard/src/components/overlays/OverlayPlaceholder.tsx
@@ -1,0 +1,60 @@
+/**
+ * Shared placeholder body for not-yet-implemented overlays.
+ *
+ * Each of the six overlay files renders this until a follow-up agent replaces
+ * that file's body with the real visualisation. When you implement an overlay,
+ * simply stop importing this and render your own <canvas>/SVG instead — this
+ * component and the six placeholders are the only things that reference it.
+ *
+ * Theme-aware (CSS vars) and CSP-safe (no external assets).
+ */
+'use client';
+
+import type { OverlayProps } from './types';
+
+interface OverlayPlaceholderProps extends OverlayProps {
+  title: string;
+}
+
+export function OverlayPlaceholder({ title, active }: OverlayPlaceholderProps) {
+  return (
+    <div
+      className="flex h-full w-full flex-col items-center justify-center gap-5 select-none"
+      style={{ background: 'var(--bg)', color: 'var(--fg)' }}
+    >
+      <span
+        // The dot only pulses while this overlay is the active one — a small,
+        // literal demonstration of the `active` contract every overlay honours.
+        className={active ? 'animate-pulse' : ''}
+        style={{
+          width: 12,
+          height: 12,
+          borderRadius: '9999px',
+          background: 'var(--accent)',
+          boxShadow: '0 0 24px 4px var(--accent-weak)',
+        }}
+      />
+      <div
+        style={{
+          fontFamily: 'var(--font-sans)',
+          fontSize: 'clamp(28px, 5vw, 56px)',
+          fontWeight: 300,
+          letterSpacing: '0.01em',
+        }}
+      >
+        {title}
+      </div>
+      <div
+        style={{
+          fontFamily: 'var(--font-mono)',
+          fontSize: '12px',
+          textTransform: 'uppercase',
+          letterSpacing: '0.22em',
+          color: 'var(--fainter)',
+        }}
+      >
+        coming soon
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/components/overlays/registry.ts
+++ b/dashboard/src/components/overlays/registry.ts
@@ -1,0 +1,24 @@
+import type { OverlayDef } from './types';
+import { MeshConstellationOverlay } from './MeshConstellationOverlay';
+import { NodeVitalsOverlay } from './NodeVitalsOverlay';
+import { MempoolRiverOverlay } from './MempoolRiverOverlay';
+import { BlockClockOverlay } from './BlockClockOverlay';
+import { EarningsTickerOverlay } from './EarningsTickerOverlay';
+import { ChainHealthPulseOverlay } from './ChainHealthPulseOverlay';
+
+/**
+ * The ordered set of rest-screen overlays shown by /overlays.
+ *
+ * Order here is the carousel order (and the dot order). To add an overlay,
+ * append a new `OverlayDef` and create its component file — nothing else in the
+ * shell needs to change. Each follow-up agent owns exactly one component file
+ * and replaces its body in place; this registry stays as-is.
+ */
+export const OVERLAYS: OverlayDef[] = [
+  { id: 'mesh-constellation', title: 'Mesh Constellation', Component: MeshConstellationOverlay },
+  { id: 'node-vitals', title: 'Node Vitals', Component: NodeVitalsOverlay },
+  { id: 'mempool-river', title: 'Mempool River', Component: MempoolRiverOverlay },
+  { id: 'block-clock', title: 'Block Clock', Component: BlockClockOverlay },
+  { id: 'earnings-ticker', title: 'Earnings Ticker', Component: EarningsTickerOverlay },
+  { id: 'chain-health-pulse', title: 'Chain Health Pulse', Component: ChainHealthPulseOverlay },
+];

--- a/dashboard/src/components/overlays/types.ts
+++ b/dashboard/src/components/overlays/types.ts
@@ -1,0 +1,33 @@
+import type React from 'react';
+
+/**
+ * Shared contract for the /overlays rest-screen carousel.
+ *
+ * The carousel shows ONE overlay at a time, full-bleed. Every overlay receives
+ * `active`, which is `true` ONLY when this overlay is the one currently on
+ * screen. Overlays MUST honour it:
+ *
+ *   - When `active === true`  → run animation loop / rAF, fetch/poll data.
+ *   - When `active === false` → PAUSE the animation loop / cancel rAF, stop
+ *     any polling. The component may stay mounted, but it must not burn CPU or
+ *     hold a running requestAnimationFrame while it is off-screen.
+ *
+ * Overlays MUST be CSP-safe: render with canvas / inline SVG only. No external
+ * assets (no remote images, fonts, script CDNs, stylesheets). Data comes from
+ * the node's own same-origin `/api/...` endpoints.
+ */
+export interface OverlayProps {
+  /**
+   * true only when this overlay is the one currently shown — overlays MUST
+   * pause their animation loop / rAF when active===false.
+   */
+  active: boolean;
+}
+
+export interface OverlayDef {
+  /** stable kebab id */
+  id: string;
+  /** shown in the carousel label */
+  title: string;
+  Component: React.ComponentType<OverlayProps>;
+}


### PR DESCRIPTION
## Overlays rest-screen: carousel shell + 6-overlay contract

Foundation PR. Adds a full-bleed `/overlays` "rest screen" under the **Overview** nav group — a carousel of ambient data-viz screens, one at a time, minimal chrome, designed to be left running on a dark display. Six follow-up PRs each fill in one overlay by replacing a single file's body.

### The contract (what the six follow-ups depend on)
`dashboard/src/components/overlays/types.ts`
```ts
export interface OverlayProps {
  active: boolean; // true only when this overlay is the one shown — overlays MUST
                   // pause their animation loop / rAF when active===false
}
export interface OverlayDef {
  id: string;      // stable kebab id
  title: string;   // shown in the carousel label
  Component: React.ComponentType<OverlayProps>;
}
```
`registry.ts` exports `OVERLAYS: OverlayDef[]` listing all six in order: `mesh-constellation`, `node-vitals`, `mempool-river`, `block-clock`, `earnings-ticker`, `chain-health-pulse`.

### Placeholders (compiling, rendering)
Six components under `dashboard/src/components/overlays/`: `MeshConstellationOverlay`, `NodeVitalsOverlay`, `MempoolRiverOverlay`, `BlockClockOverlay`, `EarningsTickerOverlay`, `ChainHealthPulseOverlay`. Each renders a shared theme-aware centred placeholder (title + pulsing dot + "coming soon") and carries a header comment describing its concept plus reminders to honour `active` (pause rAF when false) and stay CSP-safe (canvas/SVG only, no external assets). A follow-up agent replaces exactly one file's body, keeping the `export function <Name>Overlay({ active }: OverlayProps)` signature.

### The carousel
`dashboard/src/app/(dashboard)/overlays/page.tsx` — client component, full-bleed (escapes the dashboard content padding). Only the visible overlay is mounted (so only it animates); switching unmounts the old one. Switch via bottom-centre `‹ ›` arrows (wrapping), dot indicators, keyboard Left/Right, and a ~30s idle auto-advance that pauses while the user interacts/hovers (any mouse move / pointer / key resets the idle timer). Nav item added to the Overview group in `Sidebar.tsx` (lucide `Monitor` icon).

### Verify
- `tsc --noEmit`: clean
- `eslint`: clean
- `npm run build`: succeeds, `/overlays` emitted as a static route

No deploy, no merge.
