### PR TITLE
fix(overlays): Earnings Ticker fails to load

### DIFF
--- a/dashboard/src/components/overlays/EarningsTickerOverlay.tsx
+++ b/dashboard/src/components/overlays/EarningsTickerOverlay.tsx
@@ -392,14 +392,16 @@ export function EarningsTickerOverlay({ active }: OverlayProps) {
   const pendingTarget = rewards?.pending_rewards_sats ?? 0;
   const earnedTarget = rewards?.total_earned_sats ?? 0;
 
-  const payouts = useMemo(
-    () =>
-      (payoutData ?? [])
-        .slice()
-        .sort((a, b) => payoutTime(b) - payoutTime(a))
-        .slice(0, 14),
-    [payoutData],
-  );
+  const payouts = useMemo(() => {
+    // Defensive: only ever operate on an array. The node-history endpoint has
+    // been seen to hand back a `{ history, total }` wrapper rather than a bare
+    // array; guarding here keeps a shape surprise from blanking the overlay.
+    const list = Array.isArray(payoutData) ? payoutData : [];
+    return list
+      .slice()
+      .sort((a, b) => payoutTime(b) - payoutTime(a))
+      .slice(0, 14);
+  }, [payoutData]);
 
   const pending = useCountUp(pendingTarget, active);
   const earned = useCountUp(earnedTarget, active);

--- a/dashboard/src/lib/api/rewards.ts
+++ b/dashboard/src/lib/api/rewards.ts
@@ -32,7 +32,14 @@ export async function getNodePayoutHistory(
 ): Promise<NodePayoutEntry[]> {
   const params = new URLSearchParams({ time_filter: timeFilter });
   if (payoutType) params.set('payout_type', payoutType);
-  return fetchApi<NodePayoutEntry[]>(`/api/v1/rewards/node-history?${params.toString()}`);
+  // The /api/v1/rewards/node-history endpoint wraps the entries in
+  // `{ history, total }` (same payload as getNodeBalances) — it does NOT return
+  // a bare array. Unwrap here so every caller receives the array it is typed to
+  // get. Stay tolerant of a bare-array response in case the endpoint changes.
+  const res = await fetchApi<NodePayoutEntry[] | { history?: NodePayoutEntry[] }>(
+    `/api/v1/rewards/node-history?${params.toString()}`,
+  );
+  return Array.isArray(res) ? res : res?.history ?? [];
 }
 
 // Node Balance Accounts — all nodes with their reward balances


### PR DESCRIPTION
## Problem

The **Earnings Ticker** overlay on `/overlays` blanked whenever it became the active overlay — the other five overlays render fine. There is no per-overlay error boundary in the carousel, so a render-time throw takes the whole screen blank.

## Root cause

`getNodePayoutHistory` (`dashboard/src/lib/api/rewards.ts`) is typed `Promise<NodePayoutEntry[]>`, but the `/api/v1/rewards/node-history` endpoint returns a `{ history, total }` **wrapper object** (the same payload as `getNodeBalances`) and ignores the `time_filter` param — it never returns a bare array.

The overlay then ran:

```ts
const payouts = useMemo(() => (payoutData ?? []).slice()...)
```

`payoutData` is a truthy object, so `?? []` never fires and `.slice()` is invoked on a non-array → `payoutData.slice is not a function` throws inside `useMemo` during render → overlay blanks.

The pool page (`pool/page.tsx`) consumes the same helper and is affected too, but its `SectionErrorBoundary` around the Recent Payouts table masked the fault. Both consumers already use balance-entry-aware accessors (`updated_at`, `balance_sats`), confirming they were always meant to receive the unwrapped `history` array.

## Fix

- **Root cause** — `getNodePayoutHistory` now unwraps `.history`, staying tolerant of a bare-array response in case the endpoint changes. This restores the array shape every caller is typed to receive (also un-masks the pool page's Recent Payouts).
- **Robustness** — the overlay now coerces `payoutData` to an array before use, so no future shape surprise can blank the rest-screen. Loading, empty (fresh node: 0 shares / 0 rewards / no payouts), and populated states all render calmly.

## Verification

- `tsc --noEmit` — clean
- `eslint` on both changed files — clean (the repo's 3 pre-existing lint errors / 4 warnings are in unrelated files and present on `main`)
- `npm run build` — succeeds