### PR TITLE
dashboard(overlays): Mempool River — legible flowing current

### DIFF
--- a/dashboard/src/components/overlays/MempoolRiverOverlay.tsx
+++ b/dashboard/src/components/overlays/MempoolRiverOverlay.tsx
@@ -1,23 +1,28 @@
 /**
  * Overlay: Mempool River
  *
- * CONCEPT — live transaction particles flowing left→right like a river,
- * coloured by their BUDS class (T0 green → T3 red, via `@/lib/budsTiers`). The
- * spawn mix tracks the live tier composition (more green when the mempool is
- * mostly payments) and overall density tracks mempool load. Mid-stream a reaper
- * "blade" visibly cuts the T3 (junk) particles out of the current — scattering
- * and dissolving them — but ONLY while the node's reaper is actually reaping
- * that junk. When the reaper is idle, the red junk flows straight through.
+ * CONCEPT — the live mempool rendered as a calm, legible RIVER of transactions.
+ * Tokens flow left→right along a handful of gently-undulating streamlines
+ * (lanes), each token a crisp comet — a bright jewel core with a short trail
+ * pointing downstream — coloured by its BUDS class (T0 green → T3 red, via
+ * `@/lib/budsTiers`). The spawn mix tracks the live tier composition and the
+ * river's density tracks mempool load, but tokens are spaced along their lane so
+ * the current always reads as a flowing line rather than a blurry swarm. Faint
+ * channel guides trace each streamline so the river reads even when sparse.
+ *
+ * Two-thirds downstream sits the reaper's blade. While the node's reaper is
+ * actually reaping junk, T3 tokens that reach the blade are dramatically cut —
+ * they flash, dissolve and scatter into sparks, and the blade pulses. When the
+ * reaper is idle the junk simply flows straight through.
  *
  * Data:
  *  - `/api/v1/buds/mempool` — sampled tier histogram (by_tier T0..T3 + sample_size).
  *  - `useReaperStatus()`     — cumulative reaper counters (drives the blade).
  *
- * Honours the overlay `active` contract: the rAF loop runs only while active,
- * and is cancelled on inactive / unmount. Poll intervals are gated with
- * `enabled: active`. CSP-safe (canvas 2D, no external assets, no new deps).
- * Theme-aware: background/foreground read live from CSS vars, class colours from
- * the shared BUDS palette.
+ * Honours the overlay `active` contract: the rAF loop runs only while active and
+ * is cancelled on inactive / unmount; polling is gated with `enabled: active`.
+ * CSP-safe (canvas 2D, no external assets, no new deps). Theme-aware: the
+ * background reads live from CSS vars, class colours from the shared BUDS palette.
  */
 'use client';
 
@@ -37,15 +42,25 @@ interface BudsMempoolSample {
   message?: string;
 }
 
+// A streamline the tokens ride. All tokens in a lane share its speed so their
+// spacing is preserved downstream — that coherence is what reads as "current".
+interface Lane {
+  baseY: number; // rest height of the lane
+  amp: number; // vertical amplitude of the undulation
+  k: number; // spatial frequency of the undulation
+  drift: number; // how fast the wave crest travels
+  phase: number; // per-lane phase so lanes desync
+  speed: number; // px/sec — shared by every token in the lane
+  thickness: number; // half-height of the lane band (token jitter)
+  gap: number; // px covered since the last spawn (spacing gate)
+}
+
 interface Particle {
-  x: number;
-  y0: number; // baseline y (drift oscillates around it)
-  vx: number; // px/sec
-  r: number;
+  x: number; // head position along the flow
+  lane: number; // index into `lanes`
+  offset: number; // fixed vertical offset within the lane band
+  r: number; // core radius
   tier: BudsTierKey;
-  phase: number;
-  driftFreq: number;
-  driftAmp: number;
   alpha: number;
   cut: boolean; // has entered the reaper blade
   cutT: number; // 0..1 dissolve progress
@@ -61,7 +76,8 @@ interface Spark {
   tier: BudsTierKey;
 }
 
-const MAX_PARTICLES = 260;
+const MAX_PARTICLES = 130;
+const BLADE_FRAC = 0.66; // where the reaper blade crosses the river
 
 // Weighted tier pick from live fractions. Falls back to a payment-heavy mix when
 // there's no sample so the river never looks empty or wrong.
@@ -149,14 +165,15 @@ export function MempoolRiverOverlay({ active }: OverlayProps) {
     if (!active) return;
     const canvas = canvasRef.current;
     if (!canvas) return;
-    const ctx = canvas.getContext('2d');
-    if (!ctx) return;
+    const c = canvas.getContext('2d');
+    if (!c) return;
 
     let raf = 0;
     let running = true;
     const particles: Particle[] = [];
     const sparks: Spark[] = [];
-    let spawnAcc = 0;
+    const lanes: Lane[] = [];
+    let bladeFlash = 0; // spikes on each cut, decays — drives the blade pulse
     let last = performance.now();
 
     // Logical (CSS-pixel) canvas size.
@@ -173,6 +190,37 @@ export function MempoolRiverOverlay({ active }: OverlayProps) {
       theme.fainter = root.getPropertyValue('--fainter').trim() || '#55544f';
     }
 
+    // Build the streamlines for the current canvas size. The river occupies a
+    // central band; lane count scales gently with height so it never crowds.
+    function buildLanes() {
+      lanes.length = 0;
+      const bandTop = cssH * 0.17;
+      const bandBot = cssH * 0.83;
+      const n = Math.max(4, Math.min(8, Math.round(cssH / 82)));
+      const speedBase = Math.max(90, cssW / 9); // cross in ~9s
+      const laneH = (bandBot - bandTop) / n;
+      for (let i = 0; i < n; i++) {
+        const baseY = bandTop + laneH * (i + 0.5);
+        lanes.push({
+          baseY,
+          amp: laneH * (0.28 + Math.random() * 0.22),
+          k: (Math.PI * 2) / (cssW * (0.75 + Math.random() * 0.6)),
+          drift: 0.18 + Math.random() * 0.22,
+          phase: Math.random() * Math.PI * 2,
+          // Slight per-lane speed spread gives the river subtle depth/parallax.
+          speed: speedBase * (0.82 + (i % 3) * 0.08 + Math.random() * 0.1),
+          thickness: laneH * 0.3,
+          gap: Infinity, // ready to spawn immediately
+        });
+      }
+      // Existing particles may reference a now-missing lane after a shrink.
+      for (const p of particles) if (p.lane >= lanes.length) p.lane = lanes.length - 1;
+    }
+
+    function laneY(lane: Lane, x: number, t: number): number {
+      return lane.baseY + Math.sin(x * lane.k + t * lane.drift + lane.phase) * lane.amp;
+    }
+
     function resize() {
       const rect = canvas!.getBoundingClientRect();
       cssW = Math.max(1, rect.width);
@@ -180,7 +228,8 @@ export function MempoolRiverOverlay({ active }: OverlayProps) {
       const dpr = Math.min(2, window.devicePixelRatio || 1);
       canvas!.width = Math.round(cssW * dpr);
       canvas!.height = Math.round(cssH * dpr);
-      ctx!.setTransform(dpr, 0, 0, dpr, 0, 0);
+      c!.setTransform(dpr, 0, 0, dpr, 0, 0);
+      buildLanes();
     }
 
     readTheme();
@@ -191,22 +240,16 @@ export function MempoolRiverOverlay({ active }: OverlayProps) {
     const mo = new MutationObserver(readTheme);
     mo.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
 
-    function spawn() {
-      if (particles.length >= MAX_PARTICLES) return;
+    function spawnInLane(lane: Lane, li: number) {
       const { fractions, total } = dataRef.current;
       const tier = pickTier(fractions, total);
-      const centerY = cssH * 0.5;
-      const bandHalf = cssH * 0.34;
       particles.push({
-        x: -20,
-        y0: centerY + (Math.random() * 2 - 1) * bandHalf,
-        vx: cssW / (6 + Math.random() * 6), // cross in ~6–12s
-        r: 2.4 + Math.random() * 3.6,
+        x: -18,
+        lane: li,
+        offset: (Math.random() * 2 - 1) * lane.thickness,
+        r: 2.1 + Math.random() * 1.3,
         tier,
-        phase: Math.random() * Math.PI * 2,
-        driftFreq: 0.3 + Math.random() * 0.5,
-        driftAmp: cssH * (0.015 + Math.random() * 0.03),
-        alpha: 0.75 + Math.random() * 0.25,
+        alpha: 0.82 + Math.random() * 0.18,
         cut: false,
         cutT: 0,
       });
@@ -218,78 +261,107 @@ export function MempoolRiverOverlay({ active }: OverlayProps) {
       last = now;
       const t = now / 1000;
       const { load, empty, reaperCutting } = dataRef.current;
-      const bladeX = cssW * 0.6;
+      const bladeX = cssW * BLADE_FRAC;
+      bladeFlash = Math.max(0, bladeFlash - dt * 3);
 
-      // Spawn — density tracks mempool load (a gentle baseline keeps it alive).
-      const spawnRate = 3 + load * 34; // particles/sec
-      spawnAcc += dt * spawnRate;
-      while (spawnAcc >= 1) {
-        spawn();
-        spawnAcc -= 1;
+      // Spacing gate: at low load tokens sit far apart; at high load they pack
+      // tighter — but never touch, so the current stays legible. Per-lane, a
+      // token is emitted only once the lane has advanced a full gap downstream.
+      const minGap = 132 - load * 78; // px between tokens in a lane
+      for (let li = 0; li < lanes.length; li++) {
+        const lane = lanes[li];
+        lane.gap += lane.speed * dt;
+        if (!empty && lane.gap >= minGap && particles.length < MAX_PARTICLES) {
+          spawnInLane(lane, li);
+          lane.gap = -Math.random() * minGap * 0.28; // jitter so it isn't a metronome
+        }
       }
 
-      // Motion-blur trail: paint the background at low alpha so particles leave
-      // flowing streaks instead of hard dots.
-      ctx!.globalCompositeOperation = 'source-over';
-      ctx!.fillStyle = `rgba(${theme.bgRgb},0.20)`;
-      ctx!.fillRect(0, 0, cssW, cssH);
+      // Opaque clear each frame — crisp tokens, no smeary motion-blur build-up.
+      c!.globalCompositeOperation = 'source-over';
+      c!.fillStyle = `rgb(${theme.bgRgb})`;
+      c!.fillRect(0, 0, cssW, cssH);
 
-      // Dormant blade marker — a faint vertical rule so the cut point reads even
-      // when the reaper is idle.
-      ctx!.strokeStyle = `rgba(${hexToRgb(theme.fainter)},0.5)`;
-      ctx!.lineWidth = 1;
-      ctx!.beginPath();
-      ctx!.moveTo(bladeX, cssH * 0.12);
-      ctx!.lineTo(bladeX, cssH * 0.88);
-      ctx!.stroke();
+      // Channel guides — faint undulating streamlines so the river reads as a
+      // flowing bed even between tokens.
+      c!.lineWidth = 1;
+      c!.strokeStyle = `rgba(${hexToRgb(theme.fainter)},0.16)`;
+      for (const lane of lanes) {
+        c!.beginPath();
+        for (let x = 0; x <= cssW; x += 18) {
+          const y = laneY(lane, x, t);
+          if (x === 0) c!.moveTo(x, y);
+          else c!.lineTo(x, y);
+        }
+        c!.stroke();
+      }
 
-      // Active reaper blade — a shimmering red band that pulses while cutting.
+      // Blade marker. Idle: a faint dashed rule. Active: a glowing red blade
+      // with a travelling highlight, brightened by recent cuts.
+      const junkRgb = hexToRgb(BUDS_TIER_COLORS.T3);
+      const bTop = cssH * 0.14;
+      const bBot = cssH * 0.86;
       if (reaperCutting) {
-        const junkRgb = hexToRgb(BUDS_TIER_COLORS.T3);
         const shimmer = 0.5 + 0.5 * Math.sin(t * 3);
-        const grad = ctx!.createLinearGradient(bladeX - 10, 0, bladeX + 10, 0);
+        const glow = 0.16 + shimmer * 0.16 + bladeFlash * 0.4;
+        const grad = c!.createLinearGradient(bladeX - 14, 0, bladeX + 14, 0);
         grad.addColorStop(0, `rgba(${junkRgb},0)`);
-        grad.addColorStop(0.5, `rgba(${junkRgb},${0.18 + shimmer * 0.18})`);
+        grad.addColorStop(0.5, `rgba(${junkRgb},${glow})`);
         grad.addColorStop(1, `rgba(${junkRgb},0)`);
-        ctx!.fillStyle = grad;
-        ctx!.fillRect(bladeX - 10, cssH * 0.1, 20, cssH * 0.8);
-        // A brighter travelling highlight along the blade.
-        const hy = cssH * (0.1 + ((t * 0.25) % 1) * 0.8);
-        ctx!.fillStyle = `rgba(${junkRgb},0.7)`;
-        ctx!.fillRect(bladeX - 1.5, hy - 14, 3, 28);
+        c!.fillStyle = grad;
+        c!.fillRect(bladeX - 14, bTop, 28, bBot - bTop);
+        // Bright core line + a travelling highlight sliding down the blade.
+        c!.strokeStyle = `rgba(${junkRgb},${0.5 + bladeFlash * 0.5})`;
+        c!.lineWidth = 1.5;
+        c!.beginPath();
+        c!.moveTo(bladeX, bTop);
+        c!.lineTo(bladeX, bBot);
+        c!.stroke();
+        const hy = bTop + ((t * 0.3) % 1) * (bBot - bTop);
+        c!.fillStyle = 'rgba(255,255,255,0.7)';
+        c!.fillRect(bladeX - 1.5, hy - 12, 3, 24);
+      } else {
+        c!.strokeStyle = `rgba(${hexToRgb(theme.fainter)},0.4)`;
+        c!.lineWidth = 1;
+        c!.setLineDash([4, 6]);
+        c!.beginPath();
+        c!.moveTo(bladeX, bTop);
+        c!.lineTo(bladeX, bBot);
+        c!.stroke();
+        c!.setLineDash([]);
       }
 
-      // Particles.
-      ctx!.globalCompositeOperation = 'lighter';
+      // Tokens — comets riding their lane, drawn head-first with a downstream
+      // trail. source-over (no additive 'lighter') keeps overlaps crisp.
       for (let i = particles.length - 1; i >= 0; i--) {
         const p = particles[i];
-        p.x += p.vx * dt;
-        const y = p.y0 + Math.sin(t * p.driftFreq + p.phase) * p.driftAmp;
+        const lane = lanes[p.lane];
+        p.x += lane.speed * dt;
+        const yh = laneY(lane, p.x, t) + p.offset;
 
-        // Reaper cut: a T3 particle reaching the blade dissolves + scatters.
+        // Reaper cut: a T3 token reaching the blade flashes, dissolves + scatters.
         if (!p.cut && reaperCutting && p.tier === 'T3' && p.x >= bladeX) {
           p.cut = true;
-          for (let s = 0; s < 6; s++) {
+          bladeFlash = 1;
+          for (let s = 0; s < 8; s++) {
             sparks.push({
               x: bladeX,
-              y,
-              vx: (Math.random() - 0.3) * 90,
-              vy: (Math.random() - 0.5) * 160,
-              life: 0.5 + Math.random() * 0.4,
+              y: yh,
+              vx: (Math.random() - 0.2) * 110,
+              vy: (Math.random() - 0.5) * 190,
+              life: 0.45 + Math.random() * 0.45,
               maxLife: 0.9,
               tier: 'T3',
             });
           }
         }
 
-        let drawAlpha = p.alpha;
+        let a = p.alpha;
         let drawR = p.r;
-        let drawY = y;
         if (p.cut) {
-          p.cutT += dt * 2.6;
-          drawAlpha = p.alpha * Math.max(0, 1 - p.cutT);
-          drawR = p.r * (1 + p.cutT * 0.6);
-          drawY = y + p.cutT * (p.phase - Math.PI) * 6; // slight scatter
+          p.cutT += dt * 3.2;
+          a = p.alpha * Math.max(0, 1 - p.cutT);
+          drawR = p.r * (1 + p.cutT * 0.5);
           if (p.cutT >= 1) {
             particles.splice(i, 1);
             continue;
@@ -302,16 +374,36 @@ export function MempoolRiverOverlay({ active }: OverlayProps) {
         }
 
         const rgb = hexToRgb(BUDS_TIER_COLORS[p.tier]);
-        // Soft glow.
-        ctx!.fillStyle = `rgba(${rgb},${drawAlpha * 0.22})`;
-        ctx!.beginPath();
-        ctx!.arc(p.x, drawY, drawR * 2.6, 0, Math.PI * 2);
-        ctx!.fill();
-        // Core.
-        ctx!.fillStyle = `rgba(${rgb},${drawAlpha})`;
-        ctx!.beginPath();
-        ctx!.arc(p.x, drawY, drawR, 0, Math.PI * 2);
-        ctx!.fill();
+        const trailLen = lane.speed * 0.11;
+        const xt = p.x - trailLen;
+        const yt = laneY(lane, xt, t) + p.offset;
+
+        // Downstream trail (tapered, transparent → colour toward the head).
+        const g = c!.createLinearGradient(xt, yt, p.x, yh);
+        g.addColorStop(0, `rgba(${rgb},0)`);
+        g.addColorStop(1, `rgba(${rgb},${a * 0.5})`);
+        c!.strokeStyle = g;
+        c!.lineWidth = drawR * 1.4;
+        c!.lineCap = 'round';
+        c!.beginPath();
+        c!.moveTo(xt, yt);
+        c!.lineTo(p.x, yh);
+        c!.stroke();
+
+        // Tight glow — enough to make the token pop without a fuzzy halo.
+        c!.fillStyle = `rgba(${rgb},${a * 0.14})`;
+        c!.beginPath();
+        c!.arc(p.x, yh, drawR * 2.3, 0, Math.PI * 2);
+        c!.fill();
+        // Jewel core + a bright highlight so it reads as a distinct tx.
+        c!.fillStyle = `rgba(${rgb},${a})`;
+        c!.beginPath();
+        c!.arc(p.x, yh, drawR, 0, Math.PI * 2);
+        c!.fill();
+        c!.fillStyle = `rgba(255,255,255,${a * 0.55})`;
+        c!.beginPath();
+        c!.arc(p.x - drawR * 0.25, yh - drawR * 0.25, drawR * 0.42, 0, Math.PI * 2);
+        c!.fill();
       }
 
       // Sparks from cut junk.
@@ -324,19 +416,19 @@ export function MempoolRiverOverlay({ active }: OverlayProps) {
         }
         s.x += s.vx * dt;
         s.y += s.vy * dt;
-        s.vy += 40 * dt; // gentle settle
-        const a = (s.life / s.maxLife) * 0.8;
+        s.vy += 42 * dt; // gentle settle
+        const a = (s.life / s.maxLife) * 0.85;
         const rgb = hexToRgb(BUDS_TIER_COLORS[s.tier]);
-        ctx!.fillStyle = `rgba(${rgb},${a})`;
-        ctx!.beginPath();
-        ctx!.arc(s.x, s.y, 1.6, 0, Math.PI * 2);
-        ctx!.fill();
+        c!.fillStyle = `rgba(${rgb},${a})`;
+        c!.beginPath();
+        c!.arc(s.x, s.y, 1.5, 0, Math.PI * 2);
+        c!.fill();
       }
 
-      // Legend + status chrome (crisp; drawn over the trail each frame).
-      ctx!.globalCompositeOperation = 'source-over';
-      ctx!.font = '11px var(--font-mono), monospace';
-      ctx!.textBaseline = 'middle';
+      // Legend + status chrome (crisp; drawn over the scene each frame).
+      c!.globalCompositeOperation = 'source-over';
+      c!.font = '11px var(--font-mono), monospace';
+      c!.textBaseline = 'middle';
       const labels: Record<BudsTierKey, string> = {
         T0: 'Payments',
         T1: 'Extended',
@@ -346,28 +438,25 @@ export function MempoolRiverOverlay({ active }: OverlayProps) {
       let lx = 28;
       const ly = cssH - 40;
       for (const k of BUDS_TIER_KEYS) {
-        ctx!.fillStyle = BUDS_TIER_COLORS[k];
-        ctx!.beginPath();
-        ctx!.arc(lx, ly, 4, 0, Math.PI * 2);
-        ctx!.fill();
-        ctx!.fillStyle = theme.dim;
-        ctx!.fillText(labels[k], lx + 10, ly + 1);
-        lx += 20 + ctx!.measureText(labels[k]).width + 18;
+        c!.fillStyle = BUDS_TIER_COLORS[k];
+        c!.beginPath();
+        c!.arc(lx, ly, 4, 0, Math.PI * 2);
+        c!.fill();
+        c!.fillStyle = theme.dim;
+        c!.fillText(labels[k], lx + 10, ly + 1);
+        lx += 20 + c!.measureText(labels[k]).width + 18;
       }
-      ctx!.fillStyle = reaperCutting ? BUDS_TIER_COLORS.T3 : theme.fainter;
-      ctx!.fillText(
-        reaperCutting ? 'reaper cutting junk' : 'reaper idle',
-        28,
-        cssH - 22,
-      );
+      c!.fillStyle = reaperCutting ? BUDS_TIER_COLORS.T3 : theme.fainter;
+      c!.fillText(reaperCutting ? 'reaper cutting junk' : 'reaper idle', 28, cssH - 22);
 
-      // Empty / degraded state — a faint centred note; the river still drifts.
+      // Empty / degraded state — the channel guides keep drifting beneath a
+      // faint centred note.
       if (empty) {
-        ctx!.fillStyle = theme.fainter;
-        ctx!.font = '13px var(--font-mono), monospace';
-        ctx!.textAlign = 'center';
-        ctx!.fillText('waiting for a mempool sample…', cssW / 2, cssH / 2);
-        ctx!.textAlign = 'left';
+        c!.fillStyle = theme.fainter;
+        c!.font = '13px var(--font-mono), monospace';
+        c!.textAlign = 'center';
+        c!.fillText('waiting for a mempool sample…', cssW / 2, cssH / 2);
+        c!.textAlign = 'left';
       }
 
       raf = requestAnimationFrame(frame);


### PR DESCRIPTION
## What

Rebuilds the body of `dashboard/src/components/overlays/MempoolRiverOverlay.tsx` so the rest-screen overlay reads as an elegant, legible *river* of transactions rather than a chaotic field of blurry green smears. Public signature (`export function MempoolRiverOverlay({ active }: OverlayProps)`), data sources and the overlay `active` contract are unchanged.

## Why

The previous version scattered big fuzzy additive glow-blobs across the whole canvas with a low-alpha motion-blur fill, so overlapping particles smeared into a blurred mass with no sense of direction. Individual transactions were not legible and, when the reaper was idle, nothing composed the scene.

## Changes

- **Directional current via lanes.** Tokens now ride a handful of gently-undulating horizontal streamlines (lane count scales with height). Every token in a lane shares the lane's speed, so spacing is preserved downstream — the eye reads coherent *flow* left→right, not scatter. Faint channel guides trace each streamline so the river bed reads even when sparse.
- **Crisper tokens.** Each transaction is a comet — a jewel core with a bright highlight and a short tapered trail pointing downstream — instead of a fuzzy blob. Dropped the additive `lighter` compositing and the smeary motion-blur fill in favour of an opaque per-frame clear, so overlaps stay crisp and overdraw is reduced.
- **Sensible density & spacing.** A per-lane spacing gate emits a token only once its lane has advanced a full gap; the gap tightens with mempool load but tokens never touch. Particle count is capped, so a busy mempool packs the current without flooding the screen.
- **The reaper moment matters.** While the node's reaper is actually reaping, T3 (junk) tokens reaching the blade flash, dissolve and scatter into sparks, and the blade pulses on each cut. Idle: a faint dashed rule and junk flows straight through.
- BUDS colours + legend + reaper-status line kept. Theme-aware (background/foreground from CSS vars, class colours from the shared BUDS palette). CSP-safe canvas 2D, no new deps. Graceful empty state ("waiting for a mempool sample…") with the channel guides still drifting beneath.

## Verify

- `tsc --noEmit` clean
- `eslint` clean
- `npm run build` succeeds