### PR TITLE
pool: emit estimated_time_to_block_secs + current_round_duration_secs (fixes #310)

### DIFF
--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -5865,6 +5865,7 @@ async fn main() -> Result<()> {
     let rm_for_height = Arc::clone(&round_manager);
     let rm_for_round = Arc::clone(&round_manager);
     let rm_for_miners = Arc::clone(&round_manager);
+    let rm_for_elapsed = Arc::clone(&round_manager);
     let mesh_for_verification = Arc::clone(&mesh);
 
     let mut verification_state = VerificationState::new(
@@ -6025,6 +6026,12 @@ async fn main() -> Result<()> {
             .local_hashrate_th(MESH_HASHRATE_WINDOW_SECS, &self_rx_for_route)
             .unwrap_or(0.0)
     });
+
+    // Seconds elapsed working the current template, surfaced as
+    // `current_round_duration_secs` on the pool-status endpoint so the
+    // dashboard's round-progress readout reflects real round timing.
+    verification_state = verification_state
+        .with_round_elapsed_secs(move || rm_for_elapsed.current_round_elapsed_secs());
 
     // Mesh-wide best records per window — every connected peer's gossiped best,
     // reduced to one winner per window. The records endpoint merges this with

--- a/bins/ghost-pool/src/round.rs
+++ b/bins/ghost-pool/src/round.rs
@@ -270,6 +270,12 @@ pub struct RoundManager {
     current_round: RwLock<RoundId>,
     /// Current block height
     current_height: RwLock<u64>,
+    /// Wall-clock start of the current round (reset on every `start_round`,
+    /// i.e. each new-work / template event). Monotonic `Instant` so the
+    /// reported elapsed time is immune to system clock adjustments. Read by
+    /// `current_round_elapsed_secs` to surface `current_round_duration_secs`
+    /// on the pool-status endpoint.
+    current_round_start: RwLock<std::time::Instant>,
     /// Active rounds (current and recent)
     rounds: RwLock<HashMap<RoundId, RoundShares>>,
     /// Difficulty calculator
@@ -318,6 +324,14 @@ pub struct RoundManager {
     metrics: Option<Arc<ghost_common::metrics::Metrics>>,
 }
 
+/// Seconds elapsed between two monotonic instants, saturating to 0 if `now`
+/// precedes `start` (guards against any ordering surprise; `Instant` is
+/// monotonic so this normally cannot happen). Pure helper so the round-duration
+/// derivation is unit-testable without wall-clock sleeps.
+fn elapsed_secs_between(start: std::time::Instant, now: std::time::Instant) -> u64 {
+    now.saturating_duration_since(start).as_secs()
+}
+
 impl RoundManager {
     /// Create a new round manager
     pub fn new(our_node_id: NodeId, config: RoundConfig) -> Self {
@@ -330,6 +344,7 @@ impl RoundManager {
             config,
             current_round: RwLock::new(0),
             current_height: RwLock::new(0),
+            current_round_start: RwLock::new(std::time::Instant::now()),
             rounds: RwLock::new(HashMap::new()),
             difficulty: RwLock::new(difficulty),
             nodes: RwLock::new(HashMap::new()),
@@ -366,6 +381,9 @@ impl RoundManager {
         };
 
         *self.current_height.write() = block_height;
+        // Reset the round timer so `current_round_duration_secs` measures time
+        // spent working THIS template, not the pool's total uptime.
+        *self.current_round_start.write() = std::time::Instant::now();
 
         // Create new round shares tracker
         let mut rounds = self.rounds.write();
@@ -928,6 +946,14 @@ impl RoundManager {
         *self.current_height.read()
     }
 
+    /// Seconds elapsed in the current round — i.e. how long the pool has been
+    /// working the current template, measured from the most recent
+    /// `start_round`. Surfaced as `current_round_duration_secs` on the
+    /// pool-status endpoint.
+    pub fn current_round_elapsed_secs(&self) -> u64 {
+        elapsed_secs_between(*self.current_round_start.read(), std::time::Instant::now())
+    }
+
     /// Get round statistics
     pub fn round_stats(&self, round_id: RoundId) -> Option<RoundStats> {
         let rounds = self.rounds.read();
@@ -1339,6 +1365,33 @@ mod tests {
         let result = result.unwrap();
         assert_eq!(result.round_id, 1);
         assert!(!result.is_block);
+    }
+
+    #[test]
+    fn test_round_duration_derivation() {
+        use std::time::{Duration, Instant};
+        let start = Instant::now();
+        // 125 seconds later → 125s elapsed.
+        let now = start + Duration::from_secs(125);
+        assert_eq!(elapsed_secs_between(start, now), 125);
+        // Sub-second remainder truncates down to whole seconds.
+        let now = start + Duration::from_millis(4_900);
+        assert_eq!(elapsed_secs_between(start, now), 4);
+        // `now` before `start` (should never happen with a monotonic clock, but
+        // must never underflow/panic) → saturates to 0.
+        assert_eq!(elapsed_secs_between(start + Duration::from_secs(10), start), 0);
+    }
+
+    #[test]
+    fn test_current_round_elapsed_resets_on_start_round() {
+        let node_id = [1u8; 32];
+        let manager = RoundManager::new(node_id, RoundConfig::default());
+        manager.start_round(100);
+        // Immediately after start_round the round has just begun.
+        assert!(
+            manager.current_round_elapsed_secs() < 2,
+            "elapsed should be ~0 right after start_round"
+        );
     }
 
     #[test]

--- a/crates/ghost-verification/src/routes.rs
+++ b/crates/ghost-verification/src/routes.rs
@@ -3353,6 +3353,35 @@ pub fn redact_miner_id(id: &str) -> String {
 }
 
 /// API v1 pool status handler
+/// Expected seconds for a pool to find a block, given the current network
+/// `difficulty` and the pool's aggregate hashrate `pool_hashrate_hps` (in
+/// hashes/second). Standard estimator: on average `difficulty * 2^32` hashes
+/// are needed to find a block, so the expected time is that divided by the
+/// pool's hash rate.
+///
+/// Returns `None` (rather than dividing by zero or emitting a nonsense value)
+/// when the hashrate is non-positive or either input is not a finite positive
+/// number. For a small pool the result is honestly very large — that is the
+/// real expectation, so it is emitted as-is. Computed in `f64` throughout to
+/// avoid the overflow that `difficulty * 2^32` would hit in integer math.
+fn estimated_time_to_block_secs(difficulty: f64, pool_hashrate_hps: f64) -> Option<f64> {
+    // 2^32 — the average number of hashes per unit of difficulty.
+    const HASHES_PER_DIFFICULTY: f64 = 4_294_967_296.0;
+    if !difficulty.is_finite()
+        || difficulty <= 0.0
+        || !pool_hashrate_hps.is_finite()
+        || pool_hashrate_hps <= 0.0
+    {
+        return None;
+    }
+    let secs = difficulty * HASHES_PER_DIFFICULTY / pool_hashrate_hps;
+    if secs.is_finite() {
+        Some(secs)
+    } else {
+        None
+    }
+}
+
 async fn api_pool_status_handler(State(state): State<Arc<VerificationState>>) -> impl IntoResponse {
     let health = state.get_health().await;
     let active_miners = state
@@ -3361,6 +3390,33 @@ async fn api_pool_status_handler(State(state): State<Arc<VerificationState>>) ->
         .and_then(|db| db.count_active_miners(300).ok())
         .unwrap_or(0);
     let mesh_active_miners = state.mesh_active_miners().unwrap_or(active_miners);
+
+    // Seconds elapsed working the current template (round manager provides it;
+    // None on older deploys without the callback wired).
+    let current_round_duration_secs = state.round_elapsed_secs();
+
+    // Expected time for THIS pool to find a block at its current aggregate
+    // hashrate. Pool hashrate is the deduplicated mesh-wide figure (TH/s),
+    // falling back to this node's own realized rate; converted to hashes/sec
+    // for the estimator. Network difficulty comes straight from Ghost Core
+    // (getmininginfo) — the round manager's copy is a static default, so we
+    // read the live value here, mirroring the network-hashrate field on the
+    // mining-status endpoint. `null` when either input is unavailable.
+    let pool_hashrate_th = state.mesh_total_hashrate().or_else(|| state.local_hashrate());
+    let network_difficulty = if let Some(ref rpc) = state.rpc {
+        tokio::time::timeout(std::time::Duration::from_secs(5), rpc.get_mining_info())
+            .await
+            .ok()
+            .and_then(|r| r.ok())
+            .map(|info| info.difficulty)
+    } else {
+        None
+    };
+    let estimated_time_to_block_secs = match (network_difficulty, pool_hashrate_th) {
+        (Some(diff), Some(th)) => estimated_time_to_block_secs(diff, th * 1e12),
+        _ => None,
+    };
+
     Json(serde_json::json!({
         "pool_name": "Ghost Pool",
         "version": health.version,
@@ -3373,6 +3429,8 @@ async fn api_pool_status_handler(State(state): State<Arc<VerificationState>>) ->
         "round_id": health.round_id,
         "uptime_secs": health.uptime_secs,
         "total_shares": health.capabilities.total_shares,
+        "current_round_duration_secs": current_round_duration_secs,
+        "estimated_time_to_block_secs": estimated_time_to_block_secs,
         "stratum_sv2_port": 4444,
         "stratum_sv1_port": 3333,
         "http_port": 8080
@@ -9180,6 +9238,43 @@ async fn api_system_mempool_handler(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_estimated_time_to_block_secs_known_values() {
+        // A pool running at exactly difficulty * 2^32 hashes/sec finds a block
+        // in one second on average.
+        let difficulty = 1_000_000.0;
+        let hps = difficulty * 4_294_967_296.0;
+        let est = estimated_time_to_block_secs(difficulty, hps).unwrap();
+        assert!((est - 1.0).abs() < 1e-9, "expected 1s, got {est}");
+
+        // Concrete worked example: difficulty 1000, pool at 1 TH/s (1e12 h/s).
+        //   1000 * 2^32 / 1e12 = 4_294_967_296_000 / 1e12 = 4.294967296 s
+        let est = estimated_time_to_block_secs(1_000.0, 1e12).unwrap();
+        assert!((est - 4.294_967_296).abs() < 1e-9, "got {est}");
+
+        // Halving the hashrate doubles the expected time.
+        let slow = estimated_time_to_block_secs(1_000.0, 0.5e12).unwrap();
+        assert!((slow - 2.0 * est).abs() < 1e-6, "got {slow}");
+
+        // A small pool honestly yields a very large — but finite — estimate.
+        // difficulty 50e12 at 1 TH/s: 50e12 * 2^32 / 1e12 = 50 * 2^32 ≈ 2.147e11 s.
+        let big = estimated_time_to_block_secs(50_000_000_000_000.0, 1e12).unwrap();
+        assert!(big.is_finite() && big > 1e11, "got {big}");
+    }
+
+    #[test]
+    fn test_estimated_time_to_block_secs_guards() {
+        // Zero / negative / non-finite hashrate → None (no divide-by-zero).
+        assert!(estimated_time_to_block_secs(1_000_000.0, 0.0).is_none());
+        assert!(estimated_time_to_block_secs(1_000_000.0, -5.0).is_none());
+        assert!(estimated_time_to_block_secs(1_000_000.0, f64::NAN).is_none());
+        assert!(estimated_time_to_block_secs(1_000_000.0, f64::INFINITY).is_none());
+        // Non-positive / non-finite difficulty → None.
+        assert!(estimated_time_to_block_secs(0.0, 1e12).is_none());
+        assert!(estimated_time_to_block_secs(-1.0, 1e12).is_none());
+        assert!(estimated_time_to_block_secs(f64::NAN, 1e12).is_none());
+    }
 
     #[test]
     fn test_resolve_mpc_note_spend_path_serves_candidate_then_current() {

--- a/crates/ghost-verification/src/server.rs
+++ b/crates/ghost-verification/src/server.rs
@@ -1319,6 +1319,12 @@ pub struct VerificationState {
     /// exact term it contributes to `get_mesh_total_hashrate`. Surfaced as
     /// `local_hashrate_th` so the per-node and mesh figures reconcile.
     get_local_hashrate: Option<Box<dyn Fn() -> f64 + Send + Sync>>,
+    /// Seconds elapsed in the current mining round (time working the current
+    /// template), from the round manager's `current_round_elapsed_secs`.
+    /// Surfaced as `current_round_duration_secs` on the pool-status endpoint so
+    /// the dashboard's round-progress readout can show how long the pool has
+    /// been on the current template. None on deploys without the provider wired.
+    get_round_elapsed_secs: Option<Box<dyn Fn() -> u64 + Send + Sync>>,
     /// Mesh-wide best (rarest) records per window: the connected peers'
     /// gossiped `best_records`, already reduced to one winner per window.
     /// The records endpoint merges this with the local DB best so it returns
@@ -1541,6 +1547,7 @@ impl VerificationState {
             get_self_deduped_miners: None,
             get_mesh_total_hashrate: None,
             get_local_hashrate: None,
+            get_round_elapsed_secs: None,
             get_mesh_best_records: None,
             get_mesh_nodes: None,
             // VF-C2: Default to requiring internal auth for security
@@ -2149,6 +2156,18 @@ impl VerificationState {
     /// the mesh total — or None if no callback has been wired up.
     pub fn local_hashrate(&self) -> Option<f64> {
         self.get_local_hashrate.as_ref().map(|f| f())
+    }
+
+    /// Set the current-round-elapsed-seconds callback (from the round manager).
+    pub fn with_round_elapsed_secs(mut self, f: impl Fn() -> u64 + Send + Sync + 'static) -> Self {
+        self.get_round_elapsed_secs = Some(Box::new(f));
+        self
+    }
+
+    /// Returns seconds elapsed in the current mining round, or None if no
+    /// callback has been wired up (older deploys without the provider).
+    pub fn round_elapsed_secs(&self) -> Option<u64> {
+        self.get_round_elapsed_secs.as_ref().map(|f| f())
     }
 
     /// Set the mesh-wide best-records-per-window callback.


### PR DESCRIPTION
## Summary

The dashboard's Node Pool page (round-progress) and the Block Clock overlay both consume `current_round_duration_secs` and `estimated_time_to_block_secs` from `GET /api/v1/network/pool`, but the node **never emitted them** — they existed only in the TypeScript types (`dashboard/src/types/api.ts`). The round-progress readout therefore always fell back to a shares-this-round view. This wires the backend to emit both fields for real.

## What a "round" is here

A round is a share-tracking interval keyed by `round_id`, (re)started by `RoundManager::start_round` on every `TemplateEvent::NewWork` — i.e. each new block template / job. It is the **short share-round tied to the current template**, not the block-finding interval; `round_id` advances roughly once a minute as templates refresh. So `current_round_duration_secs` honestly reports how long the pool has been working the *current template*.

## Changes

- **`current_round_duration_secs`** — the round manager now stamps a monotonic `Instant` on every `start_round` and exposes `current_round_elapsed_secs()` (= `now - round_start`). A new `with_round_elapsed_secs` callback on `VerificationState` carries it to the handler. Monotonic clock so it is immune to wall-clock adjustments.
- **`estimated_time_to_block_secs`** — expected time for *this pool* to find a block:

  ```
  estimate_secs = difficulty * 2^32 / pool_hashrate_hps
  ```

  Computed entirely in `f64` to avoid the overflow `difficulty * 2^32` would hit in integer math. Pool hashrate is the deduplicated mesh-wide figure (TH/s, converted to h/s), falling back to this node's own realized rate. Network difficulty is read **live** from Ghost Core (`getmininginfo`) with a 5s timeout — mirroring how the sibling mining-status handler sources `network_hashrate` — because the round manager's own `network_difficulty` is a static default that is never updated. Emits `null` (rather than dividing by zero) when pool hashrate is 0 or either input is unavailable, which the dashboard already treats as "no ETA".

The two fields match the existing TS field names exactly, so the dashboard lights up with no frontend change.

## Sanity check (live vm1)

With live mainnet difficulty `1.3387e14` and mesh pool hashrate `12.14 TH/s`:

```
1.3387e14 * 2^32 / (12.14e12)  =  ~4.74e10 s  (~1,500 years)
```

Honestly enormous — a ~12 TH/s pool against mainnet difficulty — which is exactly the point: the real number is emitted, not a fabricated one.

## Tests

- `estimated_time_to_block_secs` formula: known difficulty+hashrate → expected seconds, halving-hashrate doubles, small-pool stays finite, and divide-by-zero / non-finite guards return `None`.
- Round-duration derivation: `elapsed_secs_between` with known instants (incl. saturating guard) + `current_round_elapsed_secs` is ~0 right after `start_round`.
- `cargo check -p ghost-verification -p ghost-pool` clean; `tsc --noEmit` clean.

## Deploy note

Requires a full **ghost-pool** deploy (canary VM4 → VM1) for the new fields to appear on the endpoint — no schema or config change.