### PR TITLE
backup: wire real manual export/verify/import (fixes #284)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3759,6 +3759,7 @@ name = "ghost-verification"
 version = "1.10.21"
 dependencies = [
  "axum 0.7.9",
+ "base64 0.22.1",
  "bitcoin",
  "chrono",
  "ed25519-dalek",

--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -2380,6 +2380,21 @@ async fn main() -> Result<()> {
 
     // Initialize database
     let db_path = data_dir.join("ghost.db");
+
+    // Apply a pending restore staged by the dashboard Backup & Restore import,
+    // if any. This MUST run before the DB is opened so the swap happens while the
+    // file is closed (never corrupting a running DB). It first copies the current
+    // DB to a timestamped `.pre-restore-*.db` safety backup. A failure here is
+    // non-fatal — the existing DB is left intact and we start from it.
+    match ghost_storage::database::apply_pending_restore(&db_path) {
+        Ok(true) => info!("Applied pending database restore from dashboard import"),
+        Ok(false) => {}
+        Err(e) => error!(
+            error = %e,
+            "Pending database restore failed; starting with the existing database"
+        ),
+    }
+
     let db = Arc::new(Database::open(&db_path)?);
     info!("Database opened: {}", db_path.display());
 

--- a/crates/ghost-storage/src/database.rs
+++ b/crates/ghost-storage/src/database.rs
@@ -199,6 +199,142 @@ struct DatabaseInner {
     encryption_key: RwLock<Option<[u8; 32]>>,
 }
 
+/// Tables a valid Ghost pool-database backup MUST contain. Used by
+/// [`Database::verify_backup_file`] to reject a file that opens as SQLite but
+/// isn't actually a Ghost pool database.
+pub const REQUIRED_BACKUP_TABLES: &[&str] = &["miners", "shares", "rounds"];
+
+/// Outcome of [`Database::verify_backup_file`]. Purely informational — reading
+/// it never touches the live database or the artifact.
+#[derive(Debug, Clone)]
+pub struct BackupVerification {
+    /// Overall verdict: integrity check passed AND all required tables present.
+    pub valid: bool,
+    /// `PRAGMA integrity_check` returned `ok`.
+    pub integrity_ok: bool,
+    /// The artifact was opened as a SQLCipher-encrypted file (`true`) using the
+    /// node key, or as plain SQLite (`false`).
+    pub encrypted: bool,
+    /// `PRAGMA user_version` (schema version) read from the artifact.
+    pub schema_version: u32,
+    /// Required Ghost tables that were found.
+    pub tables_present: Vec<String>,
+    /// Required Ghost tables that were missing (empty when `valid`).
+    pub missing_tables: Vec<String>,
+    /// Total number of tables in the artifact.
+    pub table_count: u64,
+    /// Row count of the `miners` table (0 when absent).
+    pub miner_count: u64,
+    /// Size of the artifact on disk, in bytes.
+    pub size_bytes: u64,
+    /// Human-readable reason when not `valid`.
+    pub detail: Option<String>,
+}
+
+impl BackupVerification {
+    /// Construct a failed verification that never opened as a database.
+    fn failed(size_bytes: u64, detail: &str) -> Self {
+        Self {
+            valid: false,
+            integrity_ok: false,
+            encrypted: false,
+            schema_version: 0,
+            tables_present: Vec::new(),
+            missing_tables: REQUIRED_BACKUP_TABLES.iter().map(|t| t.to_string()).collect(),
+            table_count: 0,
+            miner_count: 0,
+            size_bytes,
+            detail: Some(detail.to_string()),
+        }
+    }
+}
+
+/// Path where a validated restore artifact is staged, adjacent to the live DB.
+/// The suffix is appended (not an extension replacement) so the file sits next
+/// to `ghost.db` as `ghost.db.restore-pending` on the same filesystem, making
+/// the final swap in [`apply_pending_restore`] an atomic rename.
+pub fn pending_restore_path(db_path: &Path) -> std::path::PathBuf {
+    let mut os = db_path.as_os_str().to_os_string();
+    os.push(".restore-pending");
+    std::path::PathBuf::from(os)
+}
+
+/// Apply a pending database restore, if one is staged next to `db_path`.
+///
+/// MUST be called at startup, BEFORE the database is opened, so the swap happens
+/// while the DB file is closed (never corrupting a running database). When a
+/// staged artifact exists it:
+///   1. confirms the staged file at least opens (defence-in-depth; the API
+///      fully verified it before staging),
+///   2. copies the CURRENT live DB (if any) to a timestamped
+///      `<db>.pre-restore-<unix>.db` safety backup,
+///   3. removes the live DB's stale `-wal`/`-shm` sidecars,
+///   4. atomically renames the staged file into `db_path`.
+///
+/// Returns `Ok(true)` when a restore was applied, `Ok(false)` when nothing was
+/// staged. The only destructive step (the final rename) is atomic, so a failure
+/// leaves the existing live DB intact.
+pub fn apply_pending_restore(db_path: &Path) -> GhostResult<bool> {
+    let staged = pending_restore_path(db_path);
+    if !staged.exists() {
+        return Ok(false);
+    }
+    info!(staged = %staged.display(), "Pending database restore detected; applying before open");
+
+    // Defence in depth: the staged file must at least open. A SQLCipher artifact
+    // won't read sqlite_master without a key, so only hard-fail on an OPEN error
+    // (accepts both plain and encrypted staged files — the API already verified
+    // the contents against the node key before staging).
+    {
+        Connection::open_with_flags(
+            &staged,
+            OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_FULL_MUTEX,
+        )
+        .map_err(|e| GhostError::Database(format!("staged restore not openable: {}", e)))?;
+    }
+
+    // Safety-copy the current live DB. ghost-pool checkpoints the WAL on shutdown
+    // before exiting for a restart, so a plain file copy here is consistent.
+    if db_path.exists() {
+        let ts = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        let mut os = db_path.as_os_str().to_os_string();
+        os.push(format!(".pre-restore-{}.db", ts));
+        let safety = std::path::PathBuf::from(os);
+        std::fs::copy(db_path, &safety)
+            .map_err(|e| GhostError::Database(format!("safety backup of live DB failed: {}", e)))?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = std::fs::set_permissions(&safety, std::fs::Permissions::from_mode(0o600));
+        }
+        info!(backup = %safety.display(), "Live database copied to safety backup before restore");
+    }
+
+    // Drop stale WAL/SHM sidecars so the restored DB isn't reconciled against the
+    // previous database's journal. For `ghost.db` these are `ghost.db-wal` /
+    // `ghost.db-shm`, which `with_extension` produces exactly.
+    for ext in ["db-wal", "db-shm"] {
+        let side = db_path.with_extension(ext);
+        if side.exists() {
+            let _ = std::fs::remove_file(&side);
+        }
+    }
+
+    // Atomic swap (staged is adjacent to db_path → same filesystem).
+    std::fs::rename(&staged, db_path)
+        .map_err(|e| GhostError::Database(format!("failed to move staged restore into place: {}", e)))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(db_path, std::fs::Permissions::from_mode(0o600));
+    }
+    info!(db = %db_path.display(), "Pending database restore applied");
+    Ok(true)
+}
+
 impl Database {
     /// Open a database at the given path
     ///
@@ -842,6 +978,145 @@ impl Database {
         info!(path = %path_str, size_mb = size / (1024 * 1024), "Database backup complete");
 
         Ok(())
+    }
+
+    /// Verify a backup artifact produced by [`Database::backup`] WITHOUT mutating
+    /// it or the live database.
+    ///
+    /// Opens the file read-only and, in order:
+    ///   1. Confirms it is a readable SQLite database. If a plain open cannot
+    ///      read `sqlite_master` and this database has an encryption key
+    ///      configured, it retries once with the same SQLCipher key so an
+    ///      encrypted artifact verifies with the node's own key.
+    ///   2. Runs `PRAGMA integrity_check`.
+    ///   3. Confirms every table in [`REQUIRED_BACKUP_TABLES`] is present, so a
+    ///      random SQLite file that isn't a Ghost pool database is rejected.
+    ///   4. Reads `PRAGMA user_version` and a `miners` row count for reporting.
+    ///
+    /// A file that opens but fails the checks yields `Ok(v)` with `v.valid ==
+    /// false` (with `detail` explaining why); only an I/O-level failure to open
+    /// the path at all is an `Err`. Never logs key material.
+    pub fn verify_backup_file(&self, path: &Path) -> GhostResult<BackupVerification> {
+        let size_bytes = std::fs::metadata(path).map(|m| m.len()).unwrap_or(0);
+
+        let open_ro = || {
+            Connection::open_with_flags(
+                path,
+                OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_FULL_MUTEX,
+            )
+        };
+
+        // First attempt: plain (unencrypted) SQLite.
+        let conn = open_ro()
+            .map_err(|e| GhostError::Database(format!("cannot open backup file: {}", e)))?;
+        let (conn, encrypted) = if conn
+            .query_row("SELECT count(*) FROM sqlite_master", [], |_| Ok(()))
+            .is_ok()
+        {
+            (conn, false)
+        } else {
+            drop(conn);
+            // Not readable as plain SQLite. If we hold an encryption key, the
+            // artifact may be SQLCipher-encrypted under it — retry once.
+            let key = *self.inner.encryption_key.read();
+            match key {
+                Some(k) => {
+                    let conn = open_ro().map_err(|e| {
+                        GhostError::Database(format!("cannot open backup file: {}", e))
+                    })?;
+                    conn.pragma_update(None, "key", format!("x'{}'", hex::encode(k)))
+                        .map_err(|e| {
+                            GhostError::Database(format!("SQLCipher PRAGMA key: {}", e))
+                        })?;
+                    if conn
+                        .query_row("SELECT count(*) FROM sqlite_master", [], |_| Ok(()))
+                        .is_ok()
+                    {
+                        (conn, true)
+                    } else {
+                        return Ok(BackupVerification::failed(
+                            size_bytes,
+                            "file is not a readable SQLite/SQLCipher database (wrong key or corrupt)",
+                        ));
+                    }
+                }
+                None => {
+                    return Ok(BackupVerification::failed(
+                        size_bytes,
+                        "file is not a readable SQLite database (corrupt or encrypted)",
+                    ));
+                }
+            }
+        };
+
+        // Structural integrity.
+        let integrity: String = conn
+            .query_row("PRAGMA integrity_check", [], |r| r.get(0))
+            .unwrap_or_else(|e| format!("integrity_check error: {}", e));
+        let integrity_ok = integrity == "ok";
+
+        // Required Ghost tables.
+        let mut tables_present = Vec::new();
+        let mut missing_tables = Vec::new();
+        for t in REQUIRED_BACKUP_TABLES {
+            let exists = conn
+                .query_row(
+                    "SELECT count(*) FROM sqlite_master WHERE type='table' AND name=?1",
+                    [t],
+                    |r| r.get::<_, i64>(0),
+                )
+                .unwrap_or(0)
+                > 0;
+            if exists {
+                tables_present.push((*t).to_string());
+            } else {
+                missing_tables.push((*t).to_string());
+            }
+        }
+
+        let table_count = conn
+            .query_row(
+                "SELECT count(*) FROM sqlite_master WHERE type='table'",
+                [],
+                |r| r.get::<_, i64>(0),
+            )
+            .unwrap_or(0) as u64;
+
+        let miner_count = if tables_present.iter().any(|t| t == "miners") {
+            conn.query_row("SELECT count(*) FROM miners", [], |r| r.get::<_, i64>(0))
+                .unwrap_or(0) as u64
+        } else {
+            0
+        };
+
+        let schema_version: u32 = conn
+            .query_row("PRAGMA user_version", [], |r| r.get(0))
+            .unwrap_or(0);
+
+        let valid = integrity_ok && missing_tables.is_empty();
+        let detail = if valid {
+            None
+        } else if !integrity_ok {
+            Some(format!("integrity check failed: {}", integrity))
+        } else {
+            Some(format!(
+                "missing required Ghost tables: {}",
+                missing_tables.join(", ")
+            ))
+        };
+
+        Ok(BackupVerification {
+            valid,
+            integrity_ok,
+            encrypted,
+            schema_version,
+            tables_present,
+            missing_tables,
+            table_count,
+            miner_count,
+            size_bytes,
+            detail,
+        })
     }
 
     /// Prune old, fully-settled rounds from the database.
@@ -1578,5 +1853,91 @@ mod tests {
             .get_node_payout_address(node_id)
             .expect("Failed to get node address");
         assert_eq!(retrieved, Some(address.to_string()));
+    }
+
+    /// Unique scratch path under the system temp dir for a file-based test DB.
+    fn temp_db_path(tag: &str) -> std::path::PathBuf {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        std::env::temp_dir().join(format!(
+            "ghost-verify-test-{}-{}-{}.db",
+            std::process::id(),
+            tag,
+            nanos
+        ))
+    }
+
+    #[test]
+    fn test_backup_and_verify_roundtrip() {
+        let src = temp_db_path("src");
+        let backup = temp_db_path("backup");
+        let _ = std::fs::remove_file(&src);
+        let _ = std::fs::remove_file(&backup);
+
+        let db = Database::open(&src).expect("open source db");
+        // Produce a real backup with VACUUM INTO (same path the API uses).
+        db.backup(&backup).expect("backup");
+
+        // A readable, encrypted-key-free copy that verifies as a Ghost DB.
+        let v = db.verify_backup_file(&backup).expect("verify");
+        assert!(v.valid, "expected valid backup, detail={:?}", v.detail);
+        assert!(v.integrity_ok);
+        assert!(!v.encrypted);
+        assert!(v.missing_tables.is_empty());
+        for required in REQUIRED_BACKUP_TABLES {
+            assert!(
+                v.tables_present.iter().any(|t| t == required),
+                "missing required table {required}"
+            );
+        }
+        assert!(v.size_bytes > 0);
+        assert!(v.table_count >= REQUIRED_BACKUP_TABLES.len() as u64);
+
+        let _ = db.shutdown();
+        drop(db);
+        let _ = std::fs::remove_file(&src);
+        let _ = std::fs::remove_file(&backup);
+        for ext in ["db-wal", "db-shm"] {
+            let _ = std::fs::remove_file(src.with_extension(ext));
+        }
+    }
+
+    #[test]
+    fn test_verify_rejects_corrupt_artifact() {
+        let corrupt = temp_db_path("corrupt");
+        std::fs::write(&corrupt, b"this is definitely not a sqlite database\x00\x01\x02")
+            .expect("write corrupt file");
+
+        // A key-less handle (in-memory) cannot open garbage as SQLite.
+        let db = Database::in_memory().expect("in-memory db");
+        let v = db.verify_backup_file(&corrupt).expect("verify runs");
+        assert!(!v.valid);
+        assert!(!v.integrity_ok);
+        assert!(v.detail.is_some());
+
+        let _ = std::fs::remove_file(&corrupt);
+    }
+
+    #[test]
+    fn test_verify_rejects_non_ghost_sqlite() {
+        let other = temp_db_path("other");
+        let _ = std::fs::remove_file(&other);
+        {
+            // A valid SQLite DB, but NOT a Ghost pool database.
+            let conn = Connection::open(&other).expect("open plain sqlite");
+            conn.execute("CREATE TABLE unrelated (id INTEGER)", [])
+                .expect("create table");
+        }
+
+        let db = Database::in_memory().expect("in-memory db");
+        let v = db.verify_backup_file(&other).expect("verify runs");
+        assert!(!v.valid, "a non-Ghost sqlite file must not verify");
+        // It IS structurally sound — it just lacks the Ghost schema.
+        assert!(v.integrity_ok);
+        assert!(!v.missing_tables.is_empty());
+
+        let _ = std::fs::remove_file(&other);
     }
 }

--- a/crates/ghost-verification/Cargo.toml
+++ b/crates/ghost-verification/Cargo.toml
@@ -46,6 +46,7 @@ tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 hex = { workspace = true }
+base64 = { workspace = true }
 tracing = { workspace = true }
 thiserror = { workspace = true }
 tower = { workspace = true }

--- a/crates/ghost-verification/src/routes.rs
+++ b/crates/ghost-verification/src/routes.rs
@@ -24,9 +24,9 @@
 
 use axum::{
     extract::{ws::WebSocketUpgrade, Path, Query, State},
-    http::{HeaderMap, StatusCode},
+    http::{header, HeaderMap, StatusCode},
     middleware::{self, Next},
-    response::IntoResponse,
+    response::{IntoResponse, Response},
     routing::{delete, get, post, put},
     Json, Router,
 };
@@ -554,13 +554,11 @@ pub fn create_router(state: Arc<VerificationState>) -> Router {
             get(api_backup_export_handler).post(api_backup_export_handler),
         )
         .route(
-            "/api/v1/backup/import",
-            get(api_backup_import_handler).post(api_backup_import_handler),
+            "/api/v1/backup/download/:filename",
+            get(api_backup_download_handler),
         )
-        .route(
-            "/api/v1/backup/verify",
-            get(api_backup_verify_handler).post(api_backup_verify_handler),
-        )
+        .route("/api/v1/backup/import", post(api_backup_import_handler))
+        .route("/api/v1/backup/verify", post(api_backup_verify_handler))
         .route(
             "/api/v1/backup/delete/:filename",
             delete(api_backup_delete_handler),
@@ -7099,36 +7097,454 @@ async fn api_watchdog_clear_cache_handler(
 // ============================================================================
 // Backup Endpoints
 // ============================================================================
+//
+// These endpoints drive the dashboard "Backup & Restore" card against the REAL
+// backup path (`Database::backup` = `VACUUM INTO`, the same routine the daily
+// and scheduled-backup tasks use). The produced artifact is a consistent,
+// compact copy of the live pool database and inherits whatever at-rest
+// protection the live DB has (payout addresses stay field-encrypted under the
+// node's P-4 key; if the DB itself is SQLCipher-encrypted the copy is encrypted
+// under the same key). Nothing here fabricates success — export writes a real
+// file, verify runs a real integrity/structure check, and import stages a
+// verified artifact for an atomic swap on the next restart.
 
-/// API v1 Backup export handler
-async fn api_backup_export_handler(
-    State(_state): State<Arc<VerificationState>>,
-) -> impl IntoResponse {
-    Json(serde_json::json!({
-        "status": "idle",
-        "message": "Backup export not started"
-    }))
+/// Uploaded-artifact request body for verify/import. `file_content` is the
+/// backup file as standard base64 (the dashboard reads the file client-side and
+/// sends it through the HMAC-signing proxy as text-safe base64).
+#[derive(Debug, Deserialize)]
+struct BackupArtifactRequest {
+    #[serde(default)]
+    file_content: String,
 }
 
-/// API v1 Backup import handler
+/// Base directories a backup artifact is allowed to live under (M-15). Mirrors
+/// the allow-list the backup-history endpoint enforces, so export/download/
+/// delete all honour the same traversal guard.
+fn backup_allowed_bases() -> [std::path::PathBuf; 4] {
+    [
+        std::path::PathBuf::from("/home/ghost/.ghost"),
+        std::path::PathBuf::from("/var/lib/ghost"),
+        std::path::PathBuf::from("/tmp/ghost-backups"),
+        std::path::PathBuf::from("/opt/ghost"),
+    ]
+}
+
+/// Whether a canonical directory sits within an allowed base (M-15).
+fn backup_dir_within_allowed(canonical: &std::path::Path) -> bool {
+    backup_allowed_bases().iter().any(|base| match base.canonicalize() {
+        Ok(canonical_base) => canonical.starts_with(&canonical_base),
+        Err(_) => canonical.starts_with(base),
+    })
+}
+
+/// Resolve + validate the configured backup directory. Enforces the same M-15
+/// guards as the history endpoint (absolute, canonicalised, within an allowed
+/// base). When `create`, the directory is created first so an export can write
+/// into a not-yet-existing dir.
+fn resolve_backup_dir(
+    state: &VerificationState,
+    create: bool,
+) -> Result<std::path::PathBuf, String> {
+    let raw = { state.dashboard_config.read().backup_dir.clone() };
+    let p = std::path::Path::new(&raw);
+    if !p.is_absolute() {
+        return Err("Backup directory must be an absolute path".to_string());
+    }
+    if create {
+        std::fs::create_dir_all(p)
+            .map_err(|e| format!("Failed to create backup directory: {}", e))?;
+    }
+    let canonical = p
+        .canonicalize()
+        .map_err(|e| format!("Invalid backup directory path: {}", e))?;
+    if !backup_dir_within_allowed(&canonical) {
+        return Err("Backup directory must be within allowed paths".to_string());
+    }
+    Ok(canonical)
+}
+
+/// Validate an artifact filename (no path components / traversal, `.db`/`.backup`
+/// only) and join it under `dir`.
+fn resolve_backup_file(
+    dir: &std::path::Path,
+    filename: &str,
+) -> Result<std::path::PathBuf, String> {
+    if filename.is_empty()
+        || filename.contains('/')
+        || filename.contains('\\')
+        || filename.contains("..")
+    {
+        return Err("Invalid backup filename".to_string());
+    }
+    let path = dir.join(filename);
+    match path.extension().and_then(|e| e.to_str()) {
+        Some("db") | Some("backup") => Ok(path),
+        _ => Err("Invalid backup file extension".to_string()),
+    }
+}
+
+/// Timestamped filename for a manual backup: `ghost-manual-YYYYMMDD-HHMMSS.db`.
+/// The `ghost-manual-` prefix keeps manual artifacts distinct from the scheduled
+/// `ghost-backup-` ones (so the scheduled retention prune never removes them),
+/// and the `.db` extension makes them show up in the backup-history list.
+fn manual_backup_filename(unix_secs: u64) -> String {
+    use chrono::{TimeZone, Utc};
+    let stamp = Utc
+        .timestamp_opt(unix_secs as i64, 0)
+        .single()
+        .map(|dt| dt.format("%Y%m%d-%H%M%S").to_string())
+        .unwrap_or_else(|| format!("{unix_secs:012}"));
+    format!("ghost-manual-{stamp}.db")
+}
+
+fn now_unix() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// A unique scratch path adjacent to the live DB for an uploaded artifact.
+/// Placing it beside the live DB keeps it on the same filesystem as the restore
+/// staging path, so the import rename is atomic.
+fn artifact_temp_path(db_path: &str, tag: &str) -> std::path::PathBuf {
+    let parent = std::path::Path::new(db_path)
+        .parent()
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| std::path::PathBuf::from("."));
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    parent.join(format!(".ghost-{}-{}-{}.tmp", tag, std::process::id(), nanos))
+}
+
+/// Write uploaded artifact bytes to `path` with restrictive (0600) permissions.
+fn write_artifact_temp(path: &std::path::Path, bytes: &[u8]) -> std::io::Result<()> {
+    std::fs::write(path, bytes)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?;
+    }
+    Ok(())
+}
+
+/// Standard error envelope for backup endpoints.
+fn backup_error(status: StatusCode, msg: &str) -> Response {
+    (
+        status,
+        Json(serde_json::json!({ "success": false, "error": msg })),
+    )
+        .into_response()
+}
+
+/// Decode a base64 uploaded artifact into raw bytes.
+fn decode_artifact(file_content: &str) -> Result<Vec<u8>, String> {
+    use base64::Engine;
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(file_content.trim())
+        .map_err(|e| format!("invalid file encoding: {}", e))?;
+    if bytes.is_empty() {
+        return Err("uploaded backup file is empty".to_string());
+    }
+    Ok(bytes)
+}
+
+/// Render a [`ghost_storage::BackupVerification`] into the dashboard-facing
+/// `VerifyBackupResponse` shape.
+fn verification_to_json(v: &ghost_storage::BackupVerification) -> serde_json::Value {
+    serde_json::json!({
+        "valid": v.valid,
+        "error": if v.valid { serde_json::Value::Null } else {
+            serde_json::Value::String(
+                v.detail.clone().unwrap_or_else(|| "backup failed verification".to_string())
+            )
+        },
+        "info": {
+            "integrity_ok": v.integrity_ok,
+            "encrypted": v.encrypted,
+            "schema_version": v.schema_version,
+            "table_count": v.table_count,
+            "miner_count": v.miner_count,
+            "missing_tables": v.missing_tables,
+            "size_bytes": v.size_bytes,
+            "checksum_valid": v.integrity_ok,
+        }
+    })
+}
+
+/// API v1 Backup export handler.
+///
+/// Runs `Database::backup` (VACUUM INTO) into the configured backup directory
+/// under a timestamped `ghost-manual-*.db` name and returns the filename +
+/// metadata. The dashboard then downloads the bytes via
+/// `GET /api/v1/backup/download/:filename`. The body (if any) is ignored — the
+/// artifact is a full snapshot encrypted with the node's own key, so there is
+/// no per-request password or partial-selection to honour.
+async fn api_backup_export_handler(State(state): State<Arc<VerificationState>>) -> Response {
+    let Some(db) = state.database.clone() else {
+        return backup_error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "database is not available on this node",
+        );
+    };
+    let dir = match resolve_backup_dir(&state, true) {
+        Ok(d) => d,
+        Err(e) => return backup_error(StatusCode::BAD_REQUEST, &e),
+    };
+
+    let created_at = now_unix();
+    let filename = manual_backup_filename(created_at);
+    let path = dir.join(&filename);
+
+    // VACUUM INTO is blocking DB + filesystem work — keep it off the async worker.
+    let path_for_task = path.clone();
+    let result = tokio::task::spawn_blocking(move || db.backup(&path_for_task)).await;
+
+    match result {
+        Ok(Ok(())) => {
+            let size = std::fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
+            info!(filename = %filename, size_bytes = size, "Manual backup export created");
+            (
+                StatusCode::OK,
+                Json(serde_json::json!({
+                    "success": true,
+                    "filename": filename,
+                    "size_bytes": size,
+                    "created_at": created_at,
+                    "download_url": format!("/api/v1/backup/download/{}", filename),
+                    "message": "Encrypted backup created"
+                })),
+            )
+                .into_response()
+        }
+        Ok(Err(e)) => {
+            error!(error = %e, "Manual backup export failed");
+            backup_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &format!("backup failed: {}", e),
+            )
+        }
+        Err(e) => backup_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            &format!("backup task failed: {}", e),
+        ),
+    }
+}
+
+/// API v1 Backup download handler — streams an artifact from the backup dir with
+/// an attachment disposition. Path-guarded like the history endpoint.
+async fn api_backup_download_handler(
+    State(state): State<Arc<VerificationState>>,
+    Path(filename): Path<String>,
+) -> Response {
+    let dir = match resolve_backup_dir(&state, false) {
+        Ok(d) => d,
+        Err(e) => return backup_error(StatusCode::BAD_REQUEST, &e),
+    };
+    let path = match resolve_backup_file(&dir, &filename) {
+        Ok(p) => p,
+        Err(e) => return backup_error(StatusCode::BAD_REQUEST, &e),
+    };
+    // Canonicalize + confirm the resolved file is directly inside the backup dir
+    // (defeats symlink escapes), matching the M-15 history guard.
+    let canonical = match path.canonicalize() {
+        Ok(p) => p,
+        Err(_) => return backup_error(StatusCode::NOT_FOUND, "backup file not found"),
+    };
+    if canonical.parent() != Some(dir.as_path()) {
+        return backup_error(StatusCode::BAD_REQUEST, "invalid backup path");
+    }
+
+    let bytes = match tokio::fs::read(&canonical).await {
+        Ok(b) => b,
+        Err(e) => {
+            return backup_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &format!("failed to read backup: {}", e),
+            )
+        }
+    };
+
+    let safe_name = filename.replace(['"', '\\'], "");
+    let disposition = format!("attachment; filename=\"{}\"", safe_name);
+    (
+        [
+            (header::CONTENT_TYPE, "application/octet-stream".to_string()),
+            (header::CONTENT_DISPOSITION, disposition),
+        ],
+        bytes,
+    )
+        .into_response()
+}
+
+/// API v1 Backup import (restore) handler.
+///
+/// SAFE restore: the uploaded artifact is written to a temp file, VERIFIED with
+/// the same integrity/structure check as `/verify`, and — only if it passes —
+/// staged next to the live DB as `<db>.restore-pending`. The live database is
+/// NOT touched in-process (that would corrupt a running WAL DB). The swap is
+/// applied atomically on the next startup by `apply_pending_restore`, which
+/// first copies the current DB to a timestamped `.pre-restore-*.db` safety
+/// backup. The response therefore reports `restart_required: true`.
 async fn api_backup_import_handler(
-    State(_state): State<Arc<VerificationState>>,
-) -> impl IntoResponse {
-    Json(serde_json::json!({
-        "status": "idle",
-        "message": "No backup import in progress"
-    }))
+    State(state): State<Arc<VerificationState>>,
+    Json(req): Json<BackupArtifactRequest>,
+) -> Response {
+    let Some(db) = state.database.clone() else {
+        return backup_error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "database is not available on this node",
+        );
+    };
+    let db_path = db.path().to_string();
+    if db_path == ":memory:" {
+        return backup_error(
+            StatusCode::BAD_REQUEST,
+            "cannot restore into an in-memory database",
+        );
+    }
+
+    let bytes = match decode_artifact(&req.file_content) {
+        Ok(b) => b,
+        Err(e) => return backup_error(StatusCode::BAD_REQUEST, &e),
+    };
+
+    let tmp = artifact_temp_path(&db_path, "restore-upload");
+    if let Err(e) = write_artifact_temp(&tmp, &bytes) {
+        return backup_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            &format!("failed to stage uploaded backup: {}", e),
+        );
+    }
+
+    // Verify BEFORE touching anything durable.
+    let db_verify = db.clone();
+    let tmp_verify = tmp.clone();
+    let verification =
+        tokio::task::spawn_blocking(move || db_verify.verify_backup_file(&tmp_verify)).await;
+
+    let v = match verification {
+        Ok(Ok(v)) => v,
+        Ok(Err(e)) => {
+            let _ = std::fs::remove_file(&tmp);
+            return backup_error(
+                StatusCode::BAD_REQUEST,
+                &format!("could not verify uploaded backup: {}", e),
+            );
+        }
+        Err(e) => {
+            let _ = std::fs::remove_file(&tmp);
+            return backup_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &format!("verify task failed: {}", e),
+            );
+        }
+    };
+
+    if !v.valid {
+        let _ = std::fs::remove_file(&tmp);
+        let detail = v.detail.unwrap_or_else(|| "failed verification".to_string());
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "success": false,
+                "restart_required": false,
+                "error": format!("refusing to restore: uploaded file failed verification ({})", detail)
+            })),
+        )
+            .into_response();
+    }
+
+    // Stage the validated artifact for the atomic startup swap.
+    let staged = ghost_storage::pending_restore_path(std::path::Path::new(&db_path));
+    if let Err(e) = std::fs::rename(&tmp, &staged) {
+        // Cross-device fallback (temp + staged should be same fs, but be safe).
+        if std::fs::copy(&tmp, &staged).is_err() {
+            let _ = std::fs::remove_file(&tmp);
+            return backup_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &format!("failed to stage restore: {}", e),
+            );
+        }
+        let _ = std::fs::remove_file(&tmp);
+    }
+
+    info!(
+        staged = %staged.display(),
+        schema_version = v.schema_version,
+        miner_count = v.miner_count,
+        "Backup verified and staged for restore on next restart"
+    );
+
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({
+            "success": true,
+            "restart_required": true,
+            "staged_path": staged.to_string_lossy(),
+            "message": "Backup verified and staged. Restart ghost-pool to apply the restore; \
+                        the current database is copied to a timestamped .pre-restore backup \
+                        automatically before the swap."
+        })),
+    )
+        .into_response()
 }
 
-/// API v1 Backup verify handler
+/// API v1 Backup verify handler — decodes the uploaded artifact, runs the real
+/// integrity + Ghost-schema check, and returns a genuine pass/fail with detail.
 async fn api_backup_verify_handler(
-    State(_state): State<Arc<VerificationState>>,
-) -> impl IntoResponse {
-    Json(serde_json::json!({
-        "status": "ok",
-        "valid": true,
-        "message": "Backup verification status"
-    }))
+    State(state): State<Arc<VerificationState>>,
+    Json(req): Json<BackupArtifactRequest>,
+) -> Response {
+    let Some(db) = state.database.clone() else {
+        return backup_error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "database is not available on this node",
+        );
+    };
+
+    let bytes = match decode_artifact(&req.file_content) {
+        Ok(b) => b,
+        // A decode failure is a genuine "invalid backup" verdict, not an HTTP error.
+        Err(e) => {
+            return Json(serde_json::json!({
+                "valid": false,
+                "error": e,
+                "info": serde_json::Value::Null
+            }))
+            .into_response()
+        }
+    };
+
+    let db_path = db.path().to_string();
+    let tmp = artifact_temp_path(&db_path, "verify-upload");
+    if let Err(e) = write_artifact_temp(&tmp, &bytes) {
+        return backup_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            &format!("failed to stage uploaded backup: {}", e),
+        );
+    }
+
+    let tmp_verify = tmp.clone();
+    let verification =
+        tokio::task::spawn_blocking(move || db.verify_backup_file(&tmp_verify)).await;
+    let _ = std::fs::remove_file(&tmp);
+
+    match verification {
+        Ok(Ok(v)) => Json(verification_to_json(&v)).into_response(),
+        Ok(Err(e)) => Json(serde_json::json!({
+            "valid": false,
+            "error": format!("verification error: {}", e),
+            "info": serde_json::Value::Null
+        }))
+        .into_response(),
+        Err(e) => backup_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            &format!("verify task failed: {}", e),
+        ),
+    }
 }
 
 /// Auth token handler (returns null token for dashboard compatibility)
@@ -8999,16 +9415,45 @@ async fn api_config_operator_window_post_handler(
     }
 }
 
-/// Backup delete handler
+/// Backup delete handler — removes an artifact from the backup directory after
+/// the same path-safety checks as download. Reports a real success/failure.
 async fn api_backup_delete_handler(
-    State(_state): State<Arc<VerificationState>>,
+    State(state): State<Arc<VerificationState>>,
     Path(filename): Path<String>,
-) -> impl IntoResponse {
+) -> Response {
     debug!(filename = %filename, "Delete backup requested");
-    Json(serde_json::json!({
-        "success": true,
-        "message": format!("Backup {} deleted", filename)
-    }))
+    let dir = match resolve_backup_dir(&state, false) {
+        Ok(d) => d,
+        Err(e) => return backup_error(StatusCode::BAD_REQUEST, &e),
+    };
+    let path = match resolve_backup_file(&dir, &filename) {
+        Ok(p) => p,
+        Err(e) => return backup_error(StatusCode::BAD_REQUEST, &e),
+    };
+    let canonical = match path.canonicalize() {
+        Ok(p) => p,
+        Err(_) => return backup_error(StatusCode::NOT_FOUND, "backup file not found"),
+    };
+    if canonical.parent() != Some(dir.as_path()) {
+        return backup_error(StatusCode::BAD_REQUEST, "invalid backup path");
+    }
+    match std::fs::remove_file(&canonical) {
+        Ok(()) => {
+            info!(filename = %filename, "Backup deleted");
+            (
+                StatusCode::OK,
+                Json(serde_json::json!({
+                    "success": true,
+                    "message": format!("Backup {} deleted", filename)
+                })),
+            )
+                .into_response()
+        }
+        Err(e) => backup_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            &format!("failed to delete backup: {}", e),
+        ),
+    }
 }
 
 /// Build the detailed connected-miner list (miners with a share in the last

--- a/dashboard/src/app/(dashboard)/system/page.tsx
+++ b/dashboard/src/app/(dashboard)/system/page.tsx
@@ -5,8 +5,6 @@ import { Card, CardHeader } from "@/components/ui/Card";
 import { Badge } from "@/components/ui/Badge";
 import { Button } from "@/components/ui/Button";
 import { Dialog } from "@/components/ui/Dialog";
-import { Input } from "@/components/ui/Input";
-import { Toggle } from "@/components/ui/Toggle";
 import { ProgressBar } from "@/components/ui/ProgressBar";
 import { PageHeader } from "@/components/ui/PageHeader";
 import { SectionErrorBoundary } from "@/components/ui/SectionErrorBoundary";
@@ -188,21 +186,12 @@ export default function SystemPage() {
   const deleteBackupMutation = useDeleteBackup();
 
   const [exportDialogOpen, setExportDialogOpen] = useState(false);
-  const [exportPassword, setExportPassword] = useState("");
-  const [exportConfirmPassword, setExportConfirmPassword] = useState("");
-  const [exportOptions, setExportOptions] = useState({
-    include_identity: true,
-    include_wallet_keys: true,
-    include_config: true,
-    include_ghost_pay_db: true,
-    include_block_history: true,
-    include_logs: false,
-  });
 
   const [importDialogOpen, setImportDialogOpen] = useState(false);
-  const [importPassword, setImportPassword] = useState("");
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [verifyResult, setVerifyResult] = useState<VerifyBackupResponse | null>(null);
+  // Set after a successful import: the artifact is staged and a restart applies it.
+  const [restartRequired, setRestartRequired] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const backupHistory = historyData?.backups ?? [];
@@ -335,20 +324,10 @@ export default function SystemPage() {
   };
 
   const handleExport = async () => {
-    if (exportPassword !== exportConfirmPassword) {
-      toastError("Password Mismatch", "Passwords do not match");
-      return;
-    }
-    if (exportPassword.length < 8) {
-      toastError("Weak Password", "Password must be at least 8 characters");
-      return;
-    }
-
     try {
-      const result = await createBackup.mutateAsync({
-        options: exportOptions,
-        password: exportPassword,
-      });
+      // The node produces a full encrypted snapshot server-side, then we stream
+      // the bytes down through the proxy.
+      const result = await createBackup.mutateAsync();
 
       const link = document.createElement("a");
       link.href = getBackupDownloadUrl(result.filename);
@@ -359,8 +338,6 @@ export default function SystemPage() {
 
       success("Backup Created", `Backup saved as ${result.filename}`);
       setExportDialogOpen(false);
-      setExportPassword("");
-      setExportConfirmPassword("");
     } catch (err) {
       toastError("Export Failed", err instanceof Error ? err.message : "Unknown error");
     }
@@ -374,19 +351,16 @@ export default function SystemPage() {
   };
 
   const handleVerify = async () => {
-    if (!selectedFile || !importPassword) return;
+    if (!selectedFile) return;
 
     try {
-      const result = await verifyBackup.mutateAsync({
-        file: selectedFile,
-        password: importPassword,
-      });
+      const result = await verifyBackup.mutateAsync({ file: selectedFile });
       setVerifyResult(result);
 
       if (result.valid) {
-        success("Backup Verified", "Backup file is valid and can be imported");
+        success("Backup Verified", "Backup file passed the integrity and schema checks");
       } else {
-        warning("Verification Failed", result.error ?? "Backup file is invalid or password is incorrect");
+        warning("Verification Failed", result.error ?? "Backup file is invalid or corrupt");
       }
     } catch (err) {
       toastError("Verification Failed", err instanceof Error ? err.message : "Unknown error");
@@ -394,19 +368,16 @@ export default function SystemPage() {
   };
 
   const handleImport = async () => {
-    if (!selectedFile || !importPassword || !verifyResult?.valid) return;
+    if (!selectedFile || !verifyResult?.valid) return;
 
     try {
-      await importBackup.mutateAsync({
-        file: selectedFile,
-        password: importPassword,
-      });
-
-      success("Import Complete", "Backup restored successfully. The node will restart.");
-      setImportDialogOpen(false);
-      setSelectedFile(null);
-      setImportPassword("");
-      setVerifyResult(null);
+      const result = await importBackup.mutateAsync({ file: selectedFile });
+      setRestartRequired(Boolean(result.restart_required));
+      success(
+        "Restore Staged",
+        result.message ??
+          "Backup verified and staged. Restart ghost-pool to apply the restore.",
+      );
     } catch (err) {
       toastError("Import Failed", err instanceof Error ? err.message : "Unknown error");
     }
@@ -901,7 +872,9 @@ export default function SystemPage() {
               <div className="p-4 bg-gray-800/50 rounded-lg">
                 <div className="text-gray-100 font-medium mb-1">Export Backup</div>
                 <p className="text-gray-400 text-sm mb-3">
-                  Create an encrypted backup of your node configuration, locks, wallet data, and history.
+                  Create a full snapshot of this node&apos;s pool database (miners, shares,
+                  rounds, payouts) and download it. The artifact is encrypted with this
+                  node&apos;s own key.
                 </p>
                 <Button variant="primary" onClick={() => setExportDialogOpen(true)}>
                   Create Backup
@@ -911,7 +884,9 @@ export default function SystemPage() {
               <div className="p-4 bg-gray-800/50 rounded-lg">
                 <div className="text-gray-100 font-medium mb-1">Import Backup</div>
                 <p className="text-gray-400 text-sm mb-3">
-                  Restore from an encrypted backup file. This will replace current data with the backup contents.
+                  Restore from a backup file. The artifact is verified, then staged and applied
+                  atomically on the next ghost-pool restart (your current database is copied to a
+                  safety backup first).
                 </p>
                 <Button variant="secondary" onClick={() => setImportDialogOpen(true)}>
                   Restore Backup
@@ -954,9 +929,7 @@ export default function SystemPage() {
                           </div>
                         </div>
                         <div className="flex items-center gap-2">
-                          <Badge variant={backup.type === "full" ? "success" : "info"}>
-                            {backup.type === "full" ? "Full" : "Partial"}
-                          </Badge>
+                          <Badge variant="success">Full</Badge>
                           <Button
                             variant="ghost"
                             size="sm"
@@ -986,7 +959,7 @@ export default function SystemPage() {
               <ul className="text-sm text-orange-300/80 space-y-1 list-disc list-inside">
                 <li>Create regular backups before making configuration changes</li>
                 <li>Store backup files in a secure location separate from your node</li>
-                <li>Use a strong, unique password and store it safely</li>
+                <li>The artifact is encrypted with this node&apos;s key — restore it on this node</li>
                 <li>Test your backups periodically by verifying them</li>
                 <li>Keep multiple backup copies in different locations</li>
               </ul>
@@ -1086,101 +1059,23 @@ export default function SystemPage() {
         title="Create Backup"
       >
         <div className="space-y-4">
-          <div>
-            <h4 className="text-sm font-medium text-gray-300 mb-3">Include in Backup</h4>
-            <div className="space-y-3">
-              <div className="flex items-center justify-between">
-                <div>
-                  <div className="text-gray-100">Node Identity</div>
-                  <div className="text-xs text-gray-400">Node ID and keys</div>
-                </div>
-                <Toggle
-                  enabled={exportOptions.include_identity}
-                  onChange={(v) => setExportOptions({ ...exportOptions, include_identity: v })}
-                  label="Include identity"
-                />
-              </div>
-              <div className="flex items-center justify-between">
-                <div>
-                  <div className="text-gray-100">Wallet Keys</div>
-                  <div className="text-xs text-gray-400">Private keys and wallet data</div>
-                </div>
-                <Toggle
-                  enabled={exportOptions.include_wallet_keys}
-                  onChange={(v) => setExportOptions({ ...exportOptions, include_wallet_keys: v })}
-                  label="Include wallet"
-                />
-              </div>
-              <div className="flex items-center justify-between">
-                <div>
-                  <div className="text-gray-100">Configuration</div>
-                  <div className="text-xs text-gray-400">Node settings and preferences</div>
-                </div>
-                <Toggle
-                  enabled={exportOptions.include_config}
-                  onChange={(v) => setExportOptions({ ...exportOptions, include_config: v })}
-                  label="Include config"
-                />
-              </div>
-              <div className="flex items-center justify-between">
-                <div>
-                  <div className="text-gray-100">Ghost Pay Database</div>
-                  <div className="text-xs text-gray-400">L2 locks and payment data</div>
-                </div>
-                <Toggle
-                  enabled={exportOptions.include_ghost_pay_db}
-                  onChange={(v) => setExportOptions({ ...exportOptions, include_ghost_pay_db: v })}
-                  label="Include ghost pay"
-                />
-              </div>
-              <div className="flex items-center justify-between">
-                <div>
-                  <div className="text-gray-100">Block History</div>
-                  <div className="text-xs text-gray-400">Historical block data</div>
-                </div>
-                <Toggle
-                  enabled={exportOptions.include_block_history}
-                  onChange={(v) => setExportOptions({ ...exportOptions, include_block_history: v })}
-                  label="Include history"
-                />
-              </div>
-              <div className="flex items-center justify-between">
-                <div>
-                  <div className="text-gray-100">Logs</div>
-                  <div className="text-xs text-gray-400">Node log files</div>
-                </div>
-                <Toggle
-                  enabled={exportOptions.include_logs}
-                  onChange={(v) => setExportOptions({ ...exportOptions, include_logs: v })}
-                  label="Include logs"
-                />
-              </div>
-            </div>
-          </div>
+          <p className="text-sm text-gray-300">
+            This creates a consistent, compact snapshot of this node&apos;s pool database
+            (<span className="font-mono text-gray-200">VACUUM INTO</span>) — miners, shares,
+            rounds and payout records — and downloads it as a timestamped
+            <span className="font-mono text-gray-200"> .db</span> file.
+          </p>
 
-          <div>
-            <label className="block text-sm text-gray-400 mb-1">Encryption Password</label>
-            <Input
-              type="password"
-              value={exportPassword}
-              onChange={(e) => setExportPassword(e.target.value)}
-              placeholder="Enter a strong password"
-            />
-          </div>
-
-          <div>
-            <label className="block text-sm text-gray-400 mb-1">Confirm Password</label>
-            <Input
-              type="password"
-              value={exportConfirmPassword}
-              onChange={(e) => setExportConfirmPassword(e.target.value)}
-              placeholder="Confirm password"
-            />
+          <div className="p-3 bg-gray-800/50 border border-gray-700 rounded space-y-1">
+            <p className="text-sm text-gray-300">
+              The artifact is encrypted with this node&apos;s own key: payout addresses stay
+              field-encrypted, so no separate backup password is needed.
+            </p>
           </div>
 
           <div className="p-3 bg-yellow-900/20 border border-yellow-800 rounded">
             <p className="text-yellow-400 text-sm">
-              Store your password securely. You will need it to restore from this backup.
+              Because it is bound to this node&apos;s key, restore this backup on this same node.
             </p>
           </div>
 
@@ -1193,11 +1088,6 @@ export default function SystemPage() {
               className="flex-1"
               onClick={handleExport}
               loading={createBackup.isPending}
-              disabled={
-                !exportPassword ||
-                exportPassword !== exportConfirmPassword ||
-                exportPassword.length < 8
-              }
             >
               Create Backup
             </Button>
@@ -1211,8 +1101,8 @@ export default function SystemPage() {
         onClose={() => {
           setImportDialogOpen(false);
           setSelectedFile(null);
-          setImportPassword("");
           setVerifyResult(null);
+          setRestartRequired(false);
         }}
         title="Restore Backup"
       >
@@ -1222,7 +1112,7 @@ export default function SystemPage() {
             <input
               ref={fileInputRef}
               type="file"
-              accept=".ghost,.backup"
+              accept=".db,.backup"
               onChange={handleFileSelect}
               className="hidden"
             />
@@ -1235,24 +1125,20 @@ export default function SystemPage() {
                 {selectedFile ? selectedFile.name : "Select File"}
               </Button>
               {selectedFile && (
-                <Button variant="ghost" onClick={() => setSelectedFile(null)}>
+                <Button
+                  variant="ghost"
+                  onClick={() => {
+                    setSelectedFile(null);
+                    setVerifyResult(null);
+                  }}
+                >
                   Clear
                 </Button>
               )}
             </div>
           </div>
 
-          <div>
-            <label className="block text-sm text-gray-400 mb-1">Backup Password</label>
-            <Input
-              type="password"
-              value={importPassword}
-              onChange={(e) => setImportPassword(e.target.value)}
-              placeholder="Enter backup password"
-            />
-          </div>
-
-          {!verifyResult && selectedFile && importPassword && (
+          {!restartRequired && !verifyResult && selectedFile && (
             <Button
               variant="secondary"
               onClick={handleVerify}
@@ -1263,7 +1149,7 @@ export default function SystemPage() {
             </Button>
           )}
 
-          {verifyResult && (
+          {!restartRequired && verifyResult && (
             <div
               className={`p-4 rounded-lg border ${
                 verifyResult.valid
@@ -1276,29 +1162,45 @@ export default function SystemPage() {
                   {verifyResult.valid ? "Valid" : "Invalid"}
                 </Badge>
                 <span className={verifyResult.valid ? "text-green-400" : "text-red-400"}>
-                  {verifyResult.valid ? "Backup verified" : verifyResult.error}
+                  {verifyResult.valid ? "Passed integrity + schema checks" : verifyResult.error}
                 </span>
               </div>
               {verifyResult.valid && verifyResult.info && (
                 <div className="text-sm text-gray-400 space-y-1">
-                  <p>Created: {formatTimestampDate(verifyResult.info.created_at ?? 0)}</p>
-                  <p>Node ID: {(verifyResult.info.node_id ?? "").slice(0, 12)}...</p>
-                  <p>Locks: {verifyResult.info.locks_count ?? 0}</p>
+                  <p>Integrity: {verifyResult.info.integrity_ok ? "ok" : "failed"}</p>
+                  <p>Schema version: {verifyResult.info.schema_version ?? "?"}</p>
+                  <p>Tables: {verifyResult.info.table_count ?? 0}</p>
+                  <p>Miners: {verifyResult.info.miner_count ?? 0}</p>
+                  <p>Size: {formatBytes(verifyResult.info.size_bytes ?? 0)}</p>
                   <div className="flex gap-2 mt-2">
-                    {verifyResult.info.config_included && <Badge variant="info">Config</Badge>}
-                    {(verifyResult.info.locks_count ?? 0) > 0 && <Badge variant="info">Locks</Badge>}
-                    {verifyResult.info.ghost_pay_blocks && <Badge variant="info">Ghost Pay</Badge>}
+                    {verifyResult.info.encrypted && <Badge variant="info">Encrypted</Badge>}
                   </div>
                 </div>
               )}
             </div>
           )}
 
-          {verifyResult?.valid && (
+          {!restartRequired && verifyResult?.valid && (
             <div className="p-3 bg-yellow-900/20 border border-yellow-800 rounded">
               <p className="text-yellow-400 text-sm">
-                Warning: Importing a backup will replace your current node data. This action cannot
-                be undone.
+                Restoring stages this artifact and applies it on the next ghost-pool restart.
+                Your current database is copied to a timestamped safety backup first, then
+                replaced. Restart the node to complete the restore.
+              </p>
+            </div>
+          )}
+
+          {restartRequired && (
+            <div className="p-4 rounded-lg border bg-blue-900/20 border-blue-800 space-y-2">
+              <div className="flex items-center gap-2">
+                <Badge variant="info">Restart required</Badge>
+                <span className="text-blue-300">Restore staged</span>
+              </div>
+              <p className="text-sm text-gray-400">
+                The backup was verified and staged. Restart ghost-pool (System &gt; Restart, or
+                the node&apos;s service manager) to apply it. The current database is copied to a
+                <span className="font-mono"> .pre-restore-*.db </span> safety backup automatically
+                before the swap.
               </p>
             </div>
           )}
@@ -1310,21 +1212,23 @@ export default function SystemPage() {
               onClick={() => {
                 setImportDialogOpen(false);
                 setSelectedFile(null);
-                setImportPassword("");
                 setVerifyResult(null);
+                setRestartRequired(false);
               }}
             >
-              Cancel
+              {restartRequired ? "Close" : "Cancel"}
             </Button>
-            <Button
-              variant="danger"
-              className="flex-1"
-              onClick={handleImport}
-              loading={importBackup.isPending}
-              disabled={!verifyResult?.valid}
-            >
-              Restore Backup
-            </Button>
+            {!restartRequired && (
+              <Button
+                variant="danger"
+                className="flex-1"
+                onClick={handleImport}
+                loading={importBackup.isPending}
+                disabled={!verifyResult?.valid}
+              >
+                Restore Backup
+              </Button>
+            )}
           </div>
         </div>
       </Dialog>

--- a/dashboard/src/app/api/proxy/[...path]/route.ts
+++ b/dashboard/src/app/api/proxy/[...path]/route.ts
@@ -42,12 +42,31 @@ async function proxyRequest(request: NextRequest, params: Promise<{ path: string
       body,
     });
 
+    const contentType = response.headers.get("Content-Type") || "application/json";
+
+    // Binary payloads (e.g. a backup download) must NOT be round-tripped through
+    // `.text()` — that would decode the bytes as UTF-8 and corrupt the file.
+    // Pass them through as an ArrayBuffer, preserving the attachment headers.
+    const isBinary = !contentType.includes("json") && !contentType.startsWith("text/");
+    if (isBinary) {
+      const buffer = await response.arrayBuffer();
+      const outHeaders: Record<string, string> = { "Content-Type": contentType };
+      const disposition = response.headers.get("Content-Disposition");
+      if (disposition) outHeaders["Content-Disposition"] = disposition;
+      const length = response.headers.get("Content-Length");
+      if (length) outHeaders["Content-Length"] = length;
+      return new NextResponse(buffer, {
+        status: response.status,
+        headers: outHeaders,
+      });
+    }
+
     const responseData = await response.text();
 
     return new NextResponse(responseData, {
       status: response.status,
       headers: {
-        "Content-Type": response.headers.get("Content-Type") || "application/json",
+        "Content-Type": contentType,
       },
     });
   } catch (error) {

--- a/dashboard/src/hooks/queries/useBackupQueries.ts
+++ b/dashboard/src/hooks/queries/useBackupQueries.ts
@@ -6,7 +6,6 @@ import {
   getBackupHistory,
   deleteBackup,
 } from '@/lib/api/backup';
-import type { BackupOptions } from '@/types/api';
 
 export const backupKeys = {
   all: ['backup'] as const,
@@ -25,8 +24,7 @@ export function useCreateBackup() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({ options, password }: { options: BackupOptions; password: string }) =>
-      createBackup(options, password),
+    mutationFn: () => createBackup(),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: backupKeys.history() });
     },
@@ -35,8 +33,7 @@ export function useCreateBackup() {
 
 export function useVerifyBackup() {
   return useMutation({
-    mutationFn: ({ file, password }: { file: File; password: string }) =>
-      verifyBackup(file, password),
+    mutationFn: ({ file }: { file: File }) => verifyBackup(file),
   });
 }
 
@@ -44,8 +41,7 @@ export function useImportBackup() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({ file, password }: { file: File; password: string }) =>
-      importBackup(file, password),
+    mutationFn: ({ file }: { file: File }) => importBackup(file),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: backupKeys.all });
     },

--- a/dashboard/src/lib/api/backup.ts
+++ b/dashboard/src/lib/api/backup.ts
@@ -1,25 +1,29 @@
 // Backup/Migration API endpoints
 import { fetchApi, fetchWithTimeout, getApiBase } from './client';
-import type { BackupOptions, BackupResponse, BackupHistoryResponse, VerifyBackupResponse } from '@/types/api';
+import type { BackupResponse, BackupHistoryResponse, VerifyBackupResponse, ImportBackupResponse } from '@/types/api';
 
-export async function createBackup(options: BackupOptions, password: string): Promise<BackupResponse> {
+// The artifact is a full snapshot of the pool database, produced server-side by
+// VACUUM INTO and encrypted with the NODE's own key (payout addresses stay
+// field-encrypted; a SQLCipher DB copies under the same key). There is no
+// per-request password to supply — the node key is used automatically.
+export async function createBackup(): Promise<BackupResponse> {
   return fetchApi<BackupResponse>('/api/v1/backup/export', {
     method: 'POST',
-    body: JSON.stringify({ options, password }),
+    body: JSON.stringify({}),
   });
 }
 
-export async function verifyBackup(file: File, password: string): Promise<VerifyBackupResponse> {
-  // Read file and convert to base64
+export async function verifyBackup(file: File): Promise<VerifyBackupResponse> {
+  // Read file and convert to base64 (text-safe transport through the proxy).
   const fileContent = await fileToBase64(file);
 
   return fetchApi<VerifyBackupResponse>('/api/v1/backup/verify', {
     method: 'POST',
-    body: JSON.stringify({ file_content: fileContent, password }),
+    body: JSON.stringify({ file_content: fileContent }),
   });
 }
 
-export async function importBackup(file: File, password: string): Promise<void> {
+export async function importBackup(file: File): Promise<ImportBackupResponse> {
   // Read file and convert to base64
   const fileContent = await fileToBase64(file);
 
@@ -27,18 +31,19 @@ export async function importBackup(file: File, password: string): Promise<void> 
     `${getApiBase()}/api/proxy/api/v1/backup/import`,
     {
       method: 'POST',
-      body: JSON.stringify({ file_content: fileContent, password }),
+      body: JSON.stringify({ file_content: fileContent }),
       headers: {
         'Content-Type': 'application/json',
       },
     },
-    60000 // 60 second timeout for import
+    120000 // 2 minute timeout: import verifies the artifact server-side
   );
 
-  if (!response.ok) {
-    const error = await response.json().catch(() => ({ error: 'Unknown error' }));
-    throw new Error(error.error || `API error: ${response.status}`);
+  const data = (await response.json().catch(() => ({}))) as ImportBackupResponse;
+  if (!response.ok || data.success === false) {
+    throw new Error(data.error || `API error: ${response.status}`);
   }
+  return data;
 }
 
 // Helper to convert File to base64
@@ -67,5 +72,7 @@ export async function deleteBackup(filename: string): Promise<{ success: boolean
 }
 
 export function getBackupDownloadUrl(filename: string): string {
-  return `${getApiBase()}/api/v1/backup/download/${encodeURIComponent(filename)}`;
+  // Route through the HMAC-signing proxy; the proxy streams binary payloads
+  // (see api/proxy/[...path]) so the download arrives byte-for-byte.
+  return `${getApiBase()}/api/proxy/api/v1/backup/download/${encodeURIComponent(filename)}`;
 }

--- a/dashboard/src/types/api.ts
+++ b/dashboard/src/types/api.ts
@@ -944,24 +944,17 @@ export interface SwarmResponse {
 }
 
 // Backup/Migration types
-export interface BackupOptions {
-  include_identity?: boolean;
-  include_wallet_keys?: boolean;
-  include_config?: boolean;
-  include_ghost_pay_db?: boolean;
-  include_block_history?: boolean;
-  include_logs?: boolean;
-}
 
+// Real verification detail returned by the node's /api/v1/backup/verify. These
+// come straight from opening the artifact read-only and running an integrity +
+// Ghost-schema check — no fabricated fields.
 export interface BackupInfo {
-  node_id?: string;
-  elder_status?: boolean;
-  elder_slot?: number | null;
-  config_included?: boolean;
-  ghost_pay_blocks?: number | null;
-  locks_count?: number;
-  locks_balance_btc?: number;
-  created_at?: number;
+  integrity_ok?: boolean;
+  encrypted?: boolean;
+  schema_version?: number;
+  table_count?: number;
+  miner_count?: number;
+  missing_tables?: string[];
   size_bytes?: number;
   checksum_valid?: boolean;
 }
@@ -978,13 +971,23 @@ export interface BackupResponse {
   success: boolean;
   filename: string;
   size_bytes?: number;
+  created_at?: number;
   download_url?: string;
+  message?: string;
 }
 
 export interface VerifyBackupResponse {
   valid?: boolean;
   info?: BackupInfo | null;
   error?: string | null;
+}
+
+export interface ImportBackupResponse {
+  success: boolean;
+  restart_required?: boolean;
+  staged_path?: string;
+  message?: string;
+  error?: string;
 }
 
 export interface BackupHistoryResponse {


### PR DESCRIPTION
Fixes #284.

The dashboard Backup & Restore card was faking success: the node's manual
`/api/v1/backup/{export,verify,import}` handlers were stubs (and `delete`
too). They are now wired to the REAL backup path — `Database::backup`
(`VACUUM INTO`), the same routine the daily/scheduled-backup tasks use.

## What each handler now does

- **export** (`POST /api/v1/backup/export`): runs `Database::backup` into the
  configured `backup_dir` under a timestamped `ghost-manual-YYYYMMDD-HHMMSS.db`
  name and returns `{ filename, size_bytes, created_at, download_url }`. The
  artifact is a consistent, compact snapshot that inherits the live DB's at-rest
  protection (payout addresses stay field-encrypted under the node's P-4 key; a
  SQLCipher DB copies under the same key). No per-request password — the node
  key is used automatically.
- **download** (`GET /api/v1/backup/download/:filename`, new): streams an
  artifact with an attachment disposition, guarded by the same M-15
  canonicalise-and-allow-list path checks as backup history. Also fixes the
  history "Download" button, which pointed at a non-existent route.
- **verify** (`POST /api/v1/backup/verify`): decodes the uploaded artifact,
  opens it read-only and runs a REAL check — `PRAGMA integrity_check` plus
  confirmation that the required Ghost tables (`miners`, `shares`, `rounds`)
  exist — returning a genuine pass/fail with integrity/schema/table/miner
  detail. Never claims valid without checking. Key-aware: if a plain open fails
  and the node holds an encryption key, it retries once with that SQLCipher key.
- **import (restore)** (`POST /api/v1/backup/import`): DELICATE, done safely.
  The upload is written to a temp file, verified with the same check, and — only
  if valid — staged next to the live DB as `<db>.restore-pending`. The running
  database is never touched in-process. Returns `restart_required: true`.
- **delete**: now actually removes the artifact after path validation (was a
  fake-success stub).

## How import stays safe (atomic / restart)

The swap happens at startup, while the DB file is closed, in
`apply_pending_restore` (called before `Database::open`):

1. confirm the staged file opens,
2. copy the current live DB to a timestamped `<db>.pre-restore-<unix>.db` safety
   backup,
3. drop stale `-wal`/`-shm` sidecars,
4. **atomically rename** the staged file into place (same filesystem).

The only destructive step is the atomic rename, so any failure leaves the
existing DB intact. No half-written DB is ever possible, and a running DB is
never corrupted. Cross-node note: the artifact is bound to the node's key, so
restore it on the same node.

## Frontend

The Backup & Restore card drives these for real: export creates a backup then
downloads it, verify shows the real result, import surfaces the
restart-required state. The API proxy now streams binary payloads (it was
round-tripping them through `.text()`, which corrupts bytes). Removed the fake
encryption-password fields and the granular `include_*` toggles that never
mapped to the real full-DB snapshot.

## Auth

All endpoints stay behind the existing HMAC-authenticated router (same auth as
the other config-mutation endpoints). No secrets are logged.

## Verification

- `cargo check -p ghost-verification -p ghost-storage -p ghost-pool -j2` — clean.
- New `ghost-storage` unit tests pass: backup+verify roundtrip (readable copy),
  corrupt-artifact rejection, non-Ghost-SQLite rejection.
- `tsc --noEmit`, `eslint`, and `npm run build` — all clean.

## Deploy

Needs a full ghost-pool fleet deploy (canary VM4 -> VM1) plus the rebuilt
dashboard; the startup `apply_pending_restore` hook only runs once the new
binary is in place.
