### PR TITLE
dashboard(filtering): sticky unsaved-changes save bar (reaper + custom policy)

### DIFF
--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -124,6 +124,12 @@ a:not(.bare):not([class*="text-"]):not(button):hover {
 }
 .animate-slide-in { animation: slide-in 0.3s ease-out; }
 
+@keyframes slide-up {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+.animate-slide-up { animation: slide-up 0.2s ease-out; }
+
 @keyframes pulse-ring {
   0%   { transform: scale(0.8); opacity: 1; }
   100% { transform: scale(2);   opacity: 0; }

--- a/dashboard/src/components/filtering/AdvancedPolicyPanel.tsx
+++ b/dashboard/src/components/filtering/AdvancedPolicyPanel.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, type ReactNode } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { Button } from "@/components/ui/Button";
+import { StickySaveBar } from "@/components/ui/StickySaveBar";
 import { useFullConfig } from "@/hooks/queries/useConfigQueries";
 import {
   setPolicyCustom,
@@ -42,17 +43,19 @@ export function AdvancedPolicyPanel() {
   const queryClient = useQueryClient();
 
   const [form, setForm] = useState<PolicyCustomConfig>(POLICY_CUSTOM_DEFAULTS);
+  // `baseline` is the last-saved (or loaded) state used to compute dirtiness.
+  const [baseline, setBaseline] = useState<PolicyCustomConfig>(POLICY_CUSTOM_DEFAULTS);
   const [confirming, setConfirming] = useState(false);
   const [saving, setSaving] = useState(false);
 
   const isCustomActive = fullConfig?.policy?.profile === "custom";
   const stored = fullConfig?.policy?.custom;
 
-  // Seed the form from the node's persisted custom values once they arrive, so
-  // the panel edits the real config rather than blank defaults.
+  // Seed the form + baseline from the node's persisted custom values once they
+  // arrive, so the panel edits the real config rather than blank defaults.
   useEffect(() => {
     if (stored) {
-      setForm({
+      const seeded: PolicyCustomConfig = {
         allow_t0: stored.allow_t0,
         allow_t1: stored.allow_t1,
         allow_t2: stored.allow_t2,
@@ -65,9 +68,13 @@ export function AdvancedPolicyPanel() {
         max_tx_outputs: stored.max_tx_outputs,
         max_tx_size: stored.max_tx_size,
         min_fee_rate: stored.min_fee_rate,
-      });
+      };
+      setForm(seeded);
+      setBaseline(seeded);
     }
   }, [stored]);
+
+  const dirty = JSON.stringify(form) !== JSON.stringify(baseline);
 
   const setBool = (key: keyof PolicyCustomConfig, value: boolean) =>
     setForm((f) => ({ ...f, [key]: value }));
@@ -81,6 +88,7 @@ export function AdvancedPolicyPanel() {
     try {
       await setPolicyCustom(form);
       success("Custom policy saved", "The node is restarting to apply your custom tier policy.");
+      setBaseline(form);
       setConfirming(false);
       queryClient.invalidateQueries({ queryKey: ["config"] });
     } catch (e) {
@@ -149,18 +157,21 @@ export function AdvancedPolicyPanel() {
         ))}
       </PanelSection>
 
-      {!confirming ? (
-        <Button variant="secondary" size="sm" onClick={() => setConfirming(true)}>
-          Save custom policy…
-        </Button>
-      ) : (
+      {confirming ? (
+        // Sticky confirm bar — keeps the restart confirmation reachable no
+        // matter how far the operator has scrolled. Cancel/back-out is safe.
         <div
+          className="animate-slide-up"
           style={{
-            marginTop: "4px",
+            position: "sticky",
+            bottom: 0,
+            zIndex: 20,
+            marginTop: "8px",
             padding: "12px 14px",
             border: "1px solid var(--accent)",
             borderRadius: "6px",
             background: "var(--accent-weak)",
+            boxShadow: "0 -6px 20px -8px rgba(0, 0, 0, 0.35)",
           }}
         >
           <div style={{ color: "var(--fg)", fontSize: "13px", marginBottom: "10px" }}>
@@ -176,6 +187,22 @@ export function AdvancedPolicyPanel() {
             </Button>
           </div>
         </div>
+      ) : dirty ? (
+        // Pending edits: the sticky Save bar takes over as the save affordance.
+        // Save opens the restart-confirm flow above; Reset reverts to baseline.
+        <StickySaveBar
+          dirty={dirty}
+          saving={saving}
+          onSave={() => setConfirming(true)}
+          onReset={() => setForm(baseline)}
+          saveLabel="Save custom policy…"
+        />
+      ) : (
+        // No pending edits: the plain trigger still lets an operator (re)apply
+        // the custom profile — e.g. to switch a preset node over to custom.
+        <Button variant="secondary" size="sm" onClick={() => setConfirming(true)}>
+          Save custom policy…
+        </Button>
       )}
     </div>
   );

--- a/dashboard/src/components/filtering/ReaperControls.tsx
+++ b/dashboard/src/components/filtering/ReaperControls.tsx
@@ -6,6 +6,7 @@ import { Toggle } from "@/components/ui/Toggle";
 import { Input } from "@/components/ui/Input";
 import { Button } from "@/components/ui/Button";
 import { useToast } from "@/components/ui/Toast";
+import { StickySaveBar } from "@/components/ui/StickySaveBar";
 import { useReaperConfig, useSetReaper } from "@/hooks/queries/useConfigQueries";
 import { type ReaperSettings } from "@/lib/api/config";
 
@@ -318,6 +319,10 @@ export function ReaperControls() {
             <code>ghost-setup apply-reaper</code> step is needed.
           </p>
         </div>
+
+        {/* Sticky bottom bar — keeps Save/Reset reachable while editing the
+            thresholds at the bottom, where the top header bar is off-screen. */}
+        <StickySaveBar dirty={dirty} saving={pending} onSave={onSave} onReset={onReset} />
       </div>
     </Card>
   );

--- a/dashboard/src/components/ui/StickySaveBar.tsx
+++ b/dashboard/src/components/ui/StickySaveBar.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { Button } from "@/components/ui/Button";
+
+// ---------------------------------------------------------------------------
+// StickySaveBar — a bottom-anchored "unsaved changes" bar that keeps a Save /
+// Reset affordance reachable no matter how far the operator has scrolled.
+//
+// It uses `position: sticky; bottom: 0` so it floats at the bottom of the
+// dashboard scroll container (the <main overflow-auto>) while any part of its
+// host panel is on screen, then comes to rest flush with the panel's bottom
+// edge. Negative horizontal/bottom margins cancel the host Card's `p-6`
+// padding so the bar spans the card width like a real footer.
+//
+// It renders nothing when there are no pending edits, so the panel returns to
+// a clean/hidden state after a successful save.
+// ---------------------------------------------------------------------------
+
+export function StickySaveBar({
+  dirty,
+  saving,
+  onSave,
+  onReset,
+  saveLabel = "Save changes",
+}: {
+  dirty: boolean;
+  saving: boolean;
+  onSave: () => void;
+  onReset: () => void;
+  saveLabel?: string;
+}) {
+  if (!dirty) return null;
+
+  return (
+    <div
+      className="animate-slide-up"
+      style={{
+        position: "sticky",
+        bottom: 0,
+        zIndex: 20,
+        // Cancel the host Card's 24px padding so the bar sits flush with its edges.
+        margin: "16px -24px -24px",
+        padding: "12px 24px",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        gap: "16px",
+        flexWrap: "wrap",
+        background: "var(--surface)",
+        borderTop: "1px solid var(--accent)",
+        borderBottomLeftRadius: "4px",
+        borderBottomRightRadius: "4px",
+        boxShadow: "0 -6px 20px -8px rgba(0, 0, 0, 0.35)",
+      }}
+    >
+      <div className="flex items-center gap-2">
+        <span
+          aria-hidden
+          style={{
+            width: "8px",
+            height: "8px",
+            borderRadius: "50%",
+            background: "var(--accent)",
+            flex: "0 0 auto",
+          }}
+        />
+        <span style={{ color: "var(--fg)", fontSize: "13px", fontWeight: 600 }}>
+          Unsaved changes
+        </span>
+      </div>
+      <div className="flex items-center gap-2" style={{ flex: "0 0 auto" }}>
+        <Button variant="ghost" size="sm" onClick={onReset} disabled={saving}>
+          Reset
+        </Button>
+        <Button variant="primary" size="sm" onClick={onSave} loading={saving} disabled={saving}>
+          {saveLabel}
+        </Button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Problem
On the dashboard filtering settings, the Save control isn't discoverable while editing:
- **Reaper panel** — its Save/Reset lives in the card header, which scrolls off-screen once the operator is down editing the Thresholds at the bottom.
- **Custom-policy panel** — had no dirty indicator at all near the inputs.

## Change
Add a shared `StickySaveBar` (`components/ui/StickySaveBar.tsx`) — a bottom-anchored bar that floats within the dashboard scroll container (`<main overflow-auto>`) whenever a panel has pending edits, so a Save button is always reachable. It renders nothing when clean, shows an **Unsaved changes** hint plus accent **Save** and **Reset** when `dirty`, and returns to the hidden/clean state on save success. Props: `{ dirty, saving, onSave, onReset, saveLabel }`.

It uses `position: sticky; bottom: 0` with negative margins that cancel the host `Card`'s padding, so it reads as a real footer flush with the card edges and never overlaps the sidebar (it lives inside the content column). Theme-aware via CSS custom properties.

### ReaperControls
- Wired the sticky bar at the bottom of the panel. The existing header Save/Reset is retained; the sticky bar simply keeps the same action reachable while scrolled down.

### AdvancedPolicyPanel
- Added dirty tracking against a loaded `baseline` (seeded from the node's persisted custom policy).
- Sticky bar's **Save** opens the existing confirm-before-apply → restart flow (safety preserved); **Reset** reverts to baseline.
- The restart-confirm box is now also sticky so the confirmation stays reachable after pressing Save.
- The plain "Save custom policy…" trigger is kept for the not-dirty case (lets an operator (re)activate the custom profile without edits), so there is only ever one save affordance at a time.

## Verify
- `tsc --noEmit` clean
- `eslint` clean
- `npm run build` succeeds (54/54 pages)
- Changing any reaper toggle/threshold or any custom-policy field surfaces the sticky Save bar; saving clears it; Reset reverts.