### PR TITLE
fix: /home (and WS reconnect) bounces authenticated operator to login

### DIFF
--- a/dashboard/src/hooks/useWebSocket.ts
+++ b/dashboard/src/hooks/useWebSocket.ts
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState, useCallback } from "react";
 import type { NodeEvent } from "@/types/api";
-import { getWsUrl, isSessionExpired, redirectToLogin } from "@/lib/api/ws";
+import { getWsUrl, confirmSessionExpired, redirectToLogin } from "@/lib/api/ws";
 
 type ConnectionState = "connecting" | "connected" | "disconnected" | "error";
 
@@ -104,8 +104,10 @@ export function useWebSocket(options: UseWebSocketOptions = {}) {
         if (!wasOpen) {
           // Handshake never completed. Could be a dead session (relay 401) or a
           // transient backend outage — ask the auth layer which it is before
-          // deciding to reconnect, so an expired session doesn't hot-loop.
-          isSessionExpired().then((expired) => {
+          // deciding to reconnect, so an expired session doesn't hot-loop. Only
+          // a CONFIRMED-stable 401 ejects to /login; a single transient blip on
+          // this always-on socket must not bounce a logged-in operator.
+          confirmSessionExpired().then((expired) => {
             if (!mountedRef.current) return;
             if (expired) {
               authDeadRef.current = true;

--- a/dashboard/src/lib/api/ws.ts
+++ b/dashboard/src/lib/api/ws.ts
@@ -43,6 +43,23 @@ export async function isSessionExpired(): Promise<boolean> {
   }
 }
 
+/**
+ * Confirm the session is REALLY dead before ejecting the operator to /login.
+ *
+ * A single probe is not sufficient grounds to bounce. The Home screen mounts an
+ * always-on socket that reconnects continuously, so a lone close-before-open —
+ * a reconnect racing a cookie rotation, a momentary relay/backend blip — must
+ * NOT log a working operator out. We only treat the session as expired when the
+ * probe returns a definite 401 AND a second probe, a short beat later, still
+ * does. A genuinely expired or cleared cookie returns 401 persistently, so real
+ * logouts still redirect (about a second later); a transient reconnect does not.
+ */
+export async function confirmSessionExpired(): Promise<boolean> {
+  if (!(await isSessionExpired())) return false;
+  await new Promise((resolve) => setTimeout(resolve, 1200));
+  return isSessionExpired();
+}
+
 /** Redirect to the login page once, preserving the current path for return. */
 export function redirectToLogin(): void {
   if (redirecting || typeof window === "undefined") return;

--- a/dashboard/src/middleware.ts
+++ b/dashboard/src/middleware.ts
@@ -25,6 +25,26 @@ import { resolveJwtSecret, verifySession } from "@/lib/jwt";
 // supporting auth API (login/logout/refresh), and Next.js static assets.
 const PUBLIC_PREFIXES = ["/login", "/api/auth/"];
 
+// Paths owned ENTIRELY by the custom Node server (`server.js`), never by Next —
+// this middleware must not touch them.
+//
+// `/api/ws` is the authenticated WebSocket relay. A real handshake is an HTTP
+// `upgrade` event that `server.js` intercepts and authorises itself (same JWT),
+// so it never reaches this middleware. But a NON-upgrade request to the very
+// same path — an intermediary/SSH-tunnel/proxy that strips the `Upgrade`
+// header, or a browser reconnect quirk — DOES fall through to Next and lands
+// here. Because `/api/ws` is not a Next route, the middleware would treat it as
+// a protected page/API and, when the cookie is absent-or-lapsed, run
+// `denyAccess`, whose 401 response carries a `Set-Cookie` that DELETES
+// `ghost-session`. That turns a transient blip into a hard logout — and on the
+// always-on Home screen, whose socket reconnects continuously, it fires
+// repeatedly, ejecting a working operator to /login.
+//
+// The relay owns its own auth, so leave `/api/ws` strictly alone here. This is
+// NOT an auth hole: a genuine handshake is still gated by `server.js`, and a
+// non-upgrade GET to `/api/ws` matches no route and 404s (it proxies nothing).
+const RELAY_OWNED_PREFIXES = ["/api/ws"];
+
 const SECURITY_HEADERS = {
   "X-Frame-Options": "DENY",
   "X-Content-Type-Options": "nosniff",
@@ -53,6 +73,17 @@ export async function middleware(request: NextRequest) {
 
   // Public, unauthenticated paths: login flow + Next.js internals/static.
   if (PUBLIC_PREFIXES.some((p) => pathname.startsWith(p)) || isStaticAsset(pathname)) {
+    return NextResponse.next();
+  }
+
+  // Relay-owned paths (the WebSocket relay): pass through untouched so the
+  // middleware can never clear `ghost-session` on a stray `/api/ws` request.
+  // `server.js` authenticates the actual upgrade; see RELAY_OWNED_PREFIXES.
+  if (
+    RELAY_OWNED_PREFIXES.some(
+      (p) => pathname === p || pathname.startsWith(`${p}/`),
+    )
+  ) {
     return NextResponse.next();
   }
 


### PR DESCRIPTION
## Symptom

Navigating to `/home` bounced a logged-in operator to `/login`, while other pages worked and the session was valid.

## Root cause

`/home` (the former `/overlays`, now promoted to the Home dashboard) mounts a permanently-`active` `NodeVitalsOverlay`. The dashboard's single shared WebSocket (the `/api/ws` relay) reconnects continuously. Two fragilities let that churn eject a working operator:

1. **The middleware managed the session cookie for `/api/ws` — a path it does not own.** `/api/ws` is the WebSocket relay, authenticated by the custom server (`server.js`) on the HTTP `upgrade` event. A real handshake is intercepted by `server.js` and never reaches the middleware (verified: upgrade with a valid cookie returns `101`, not a middleware `404`). But a **non-upgrade** request to the same path — an intermediary/SSH-tunnel/proxy that strips the `Upgrade` header, or a browser reconnect quirk — falls through to Next and hits the middleware. Because `/api/ws` is not a Next route and was not excluded (`PUBLIC_PREFIXES` is only `/login` + `/api/auth/`), the middleware treated it as protected and, on an absent-or-lapsed cookie, ran `denyAccess`, whose `401` response carries a `Set-Cookie` that **deletes `ghost-session`**. On the continuously-reconnecting Home socket this fires repeatedly, converting a transient auth gap into a hard logout.

2. **`useWebSocket` redirected on a single expired-session probe.** A lone close-before-open (a reconnect racing a cookie rotation, a momentary relay blip) called `isSessionExpired()` once and, on a single `401`, hard-redirected to `/login`.

## Fix

- **`middleware.ts`** — add `RELAY_OWNED_PREFIXES = ["/api/ws"]` and pass those paths through untouched, so the middleware can never emit the cookie-clearing `Set-Cookie` on `/api/ws`. **Not an auth hole:** `server.js` still authenticates every real upgrade with the same JWT, and a non-upgrade `GET /api/ws` matches no route and `404`s (it proxies nothing to the backend).
- **`ws.ts` / `useWebSocket.ts`** — introduce `confirmSessionExpired()`, which only reports the session dead when a definite `401` is confirmed by a second probe a short beat later. A genuinely expired/cleared session returns `401` persistently and still redirects (about a second later); a single transient reconnect does not.

## Security stays intact

- Every protected route/API still fails closed. Verified on the production build:
  - `/api/ws` (no/invalid cookie) → `404`, **no `Set-Cookie`** (was `401` + cookie-clear).
  - protected page (no cookie) → `307` → `/login` + cookie cleared (unchanged).
  - protected `/api/*` (no cookie) → `401` + cookie cleared (unchanged).
- WS relay auth unchanged — `tests/ws-auth.test.js` passes: upgrade without a session → `401`, with a session → `101`.
- A truly expired session still redirects (persistent `401` on the confirmed probe, and the middleware `307` on the next navigation).

## Verification

- `tsc --noEmit`: clean.
- `eslint` on the changed files: no new findings (the one `react-hooks` error on `useWebSocket.ts:91` is pre-existing on `main` — confirmed by linting the unmodified `origin/main` file at the same path).
- `npm run build`: compiled successfully (exit `0`).
- `node --test tests/ws-auth.test.js`: 6/6 pass.
- Runtime check against the production build confirmed the `/api/ws` and control behaviours above.
