### PR TITLE
dashboard(settings): theme-aware colours for light mode

### DIFF
--- a/dashboard/src/app/(dashboard)/settings/AppearanceSection.tsx
+++ b/dashboard/src/app/(dashboard)/settings/AppearanceSection.tsx
@@ -13,7 +13,7 @@ export function AppearanceSection() {
     <SettingsSection title="Appearance" subtitle="Customize the dashboard theme">
       <div className="space-y-4">
         <div>
-          <label className="block text-sm text-gray-400 mb-3">Accent Color</label>
+          <label className="block text-sm text-[color:var(--dim)] mb-3">Accent Color</label>
           <div className="grid grid-cols-4 sm:grid-cols-8 gap-3">
             {(Object.entries(ACCENT_COLORS) as [AccentColorKey, typeof ACCENT_COLORS[AccentColorKey]][]).map(
               ([key, color]) => (
@@ -23,7 +23,7 @@ export function AppearanceSection() {
                   className={`
                     relative h-10 w-10 rounded-lg transition-all duration-200
                     ${accentColor === key
-                      ? 'ring-2 ring-white ring-offset-2 ring-offset-gray-900 scale-110'
+                      ? 'ring-2 ring-[var(--fg)] ring-offset-2 ring-offset-[var(--bg)] scale-110'
                       : 'hover:scale-105'
                     }
                   `}
@@ -41,7 +41,7 @@ export function AppearanceSection() {
               )
             )}
           </div>
-          <p className="text-xs text-gray-500 mt-3">
+          <p className="text-xs text-[color:var(--fainter)] mt-3">
             Current: <span style={{ color: ACCENT_COLORS[accentColor].hex }}>{ACCENT_COLORS[accentColor].name}</span>
           </p>
         </div>

--- a/dashboard/src/app/(dashboard)/settings/IdentitySection.tsx
+++ b/dashboard/src/app/(dashboard)/settings/IdentitySection.tsx
@@ -36,7 +36,7 @@ export function IdentitySection() {
     <SettingsSection title="Node Identity" subtitle="Configure your node identification">
       <div className="space-y-4">
         <div>
-          <label className="block text-sm text-gray-400 mb-1">Node Nickname</label>
+          <label className="block text-sm text-[color:var(--dim)] mb-1">Node Nickname</label>
           <div className="flex gap-3">
             <Input
               value={nickname}
@@ -52,29 +52,29 @@ export function IdentitySection() {
               Save
             </Button>
           </div>
-          <p className="text-xs text-gray-500 mt-1">
+          <p className="text-xs text-[color:var(--fainter)] mt-1">
             Useful for identifying nodes in multi-node setups
           </p>
         </div>
 
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div className="p-3 bg-gray-800/50 rounded-lg">
-            <div className="text-sm text-gray-400 mb-1">Node ID</div>
-            <code className="text-gray-100 text-sm break-all">
+          <div className="p-3 bg-[var(--surface)]/50 rounded-lg">
+            <div className="text-sm text-[color:var(--dim)] mb-1">Node ID</div>
+            <code className="text-[color:var(--fg)] text-sm break-all">
               {nodeInfo?.node_id ?? "Loading..."}
             </code>
           </div>
-          <div className="p-3 bg-gray-800/50 rounded-lg">
-            <div className="text-sm text-gray-400 mb-1">Ghost ID (Short)</div>
-            <code className="text-orange-400 text-sm">
+          <div className="p-3 bg-[var(--surface)]/50 rounded-lg">
+            <div className="text-sm text-[color:var(--dim)] mb-1">Ghost ID (Short)</div>
+            <code className="text-[color:var(--accent)] text-sm">
               {nodeInfo?.node_id_short ?? "Loading..."}
             </code>
           </div>
         </div>
 
-        <div className="p-3 bg-gray-800/50 rounded-lg">
+        <div className="p-3 bg-[var(--surface)]/50 rounded-lg">
           <div className="flex justify-between items-center">
-            <div className="text-sm text-gray-400">Version</div>
+            <div className="text-sm text-[color:var(--dim)]">Version</div>
             <Badge variant="info">{nodeInfo?.version ?? "Unknown"}</Badge>
           </div>
         </div>

--- a/dashboard/src/app/(dashboard)/settings/MempoolProfileDialog.tsx
+++ b/dashboard/src/app/(dashboard)/settings/MempoolProfileDialog.tsx
@@ -75,18 +75,18 @@ export function MempoolProfileDialog({
     >
       <div className="space-y-4 max-h-[70vh] overflow-y-auto">
         {/* Advanced User Warning */}
-        <div className="p-4 bg-orange-900/20 border border-orange-700 rounded-lg">
+        <div className="p-4 bg-[var(--accent)]/20 border border-[var(--accent)] rounded-lg">
           <div className="flex items-start gap-3">
-            <span className="text-orange-400 text-xl">&#9888;</span>
+            <span className="text-[color:var(--accent)] text-xl">&#9888;</span>
             <div>
-              <h4 className="text-orange-300 font-medium">Advanced Configuration</h4>
-              <p className="text-orange-300/80 text-sm mt-1">
+              <h4 className="text-[color:var(--accent)] font-medium">Advanced Configuration</h4>
+              <p className="text-[color:var(--accent)]/80 text-sm mt-1">
                 Custom mempool profiles are intended for advanced users. Incorrect settings may
                 cause your node to reject valid transactions or accept unwanted ones.
               </p>
-              <p className="text-orange-300/80 text-sm mt-2">
+              <p className="text-[color:var(--accent)]/80 text-sm mt-2">
                 If you&apos;re unsure, use one of the preset profiles instead. For guidance, refer to
-                the <a href="/docs/mempool-profiles" className="text-orange-200 underline hover:text-orange-100">Mempool Profile Guide</a>.
+                the <a href="/docs/mempool-profiles" className="text-[color:var(--accent)] underline hover:text-[color:var(--accent)]">Mempool Profile Guide</a>.
               </p>
             </div>
           </div>
@@ -94,7 +94,7 @@ export function MempoolProfileDialog({
 
         {/* Profile Name */}
         <div>
-          <label className="block text-sm text-gray-400 mb-1">Profile Name</label>
+          <label className="block text-sm text-[color:var(--dim)] mb-1">Profile Name</label>
           <Input
             value={profile.name}
             onChange={(e) => update({ name: e.target.value })}
@@ -104,7 +104,7 @@ export function MempoolProfileDialog({
 
         {/* Core Mempool Settings */}
         <div>
-          <h4 className="text-sm font-medium text-gray-300 mb-3">Core Mempool Settings</h4>
+          <h4 className="text-sm font-medium text-[color:var(--dim)] mb-3">Core Mempool Settings</h4>
           <div className="space-y-2">
             <NumberInput
               label="Min Relay Fee"
@@ -142,7 +142,7 @@ export function MempoolProfileDialog({
 
         {/* Transaction Acceptance */}
         <div>
-          <h4 className="text-sm font-medium text-gray-300 mb-3">Transaction Acceptance</h4>
+          <h4 className="text-sm font-medium text-[color:var(--dim)] mb-3">Transaction Acceptance</h4>
           <div className="space-y-2">
             <ToggleRow
               label="Permit Bare Multisig"
@@ -177,7 +177,7 @@ export function MempoolProfileDialog({
 
         {/* RBF Settings */}
         <div>
-          <h4 className="text-sm font-medium text-gray-300 mb-3">Replace-By-Fee (RBF)</h4>
+          <h4 className="text-sm font-medium text-[color:var(--dim)] mb-3">Replace-By-Fee (RBF)</h4>
           <div className="space-y-2">
             <ToggleRow
               label="Full RBF"
@@ -198,7 +198,7 @@ export function MempoolProfileDialog({
 
         {/* Ghost Extensions - Spam/Dust Protection */}
         <div>
-          <h4 className="text-sm font-medium text-orange-300 mb-3">Spam & Dust Protection</h4>
+          <h4 className="text-sm font-medium text-[color:var(--accent)] mb-3">Spam & Dust Protection</h4>
           <div className="space-y-2">
             <NumberInput
               label="Dust Limit"
@@ -228,7 +228,7 @@ export function MempoolProfileDialog({
 
         {/* Ghost Extensions - Output Preferences */}
         <div>
-          <h4 className="text-sm font-medium text-orange-300 mb-3">Output Type Preferences</h4>
+          <h4 className="text-sm font-medium text-[color:var(--accent)] mb-3">Output Type Preferences</h4>
           <div className="space-y-2">
             <ToggleRow
               label="Prefer Native SegWit"
@@ -247,7 +247,7 @@ export function MempoolProfileDialog({
 
         {/* Ghost Extensions - Inscription Filtering */}
         <div>
-          <h4 className="text-sm font-medium text-orange-300 mb-3">Inscription Filtering</h4>
+          <h4 className="text-sm font-medium text-[color:var(--accent)] mb-3">Inscription Filtering</h4>
           <div className="space-y-2">
             <ToggleRow
               label="Filter Ordinal Inscriptions"
@@ -272,7 +272,7 @@ export function MempoolProfileDialog({
 
         {/* Ghost Extensions - Lightning & Privacy */}
         <div>
-          <h4 className="text-sm font-medium text-orange-300 mb-3">Lightning & Privacy</h4>
+          <h4 className="text-sm font-medium text-[color:var(--accent)] mb-3">Lightning & Privacy</h4>
           <div className="space-y-2">
             <ToggleRow
               label="Prioritize Lightning Opens"
@@ -307,7 +307,7 @@ export function MempoolProfileDialog({
 
         {/* Ghost Extensions - Chain Limits */}
         <div>
-          <h4 className="text-sm font-medium text-orange-300 mb-3">Chain Limits (CPFP)</h4>
+          <h4 className="text-sm font-medium text-[color:var(--accent)] mb-3">Chain Limits (CPFP)</h4>
           <div className="space-y-2">
             <NumberInput
               label="Max Ancestor Count"
@@ -339,7 +339,7 @@ export function MempoolProfileDialog({
         {/* BUDS Tiers */}
         <div>
           <div className="flex items-center gap-2 mb-3">
-            <h4 className="text-sm font-medium text-gray-300">BUDS Transaction Tiers</h4>
+            <h4 className="text-sm font-medium text-[color:var(--dim)]">BUDS Transaction Tiers</h4>
             {!budsEnabled && (
               <Badge variant="warning">Requires Ghost Pay</Badge>
             )}
@@ -387,7 +387,7 @@ export function MempoolProfileDialog({
         </div>
 
         {/* Actions */}
-        <div className="flex gap-3 pt-4 border-t border-gray-800">
+        <div className="flex gap-3 pt-4 border-t border-[var(--rule)]">
           <Button
             variant="ghost"
             className="flex-1"

--- a/dashboard/src/app/(dashboard)/settings/PayoutSection.tsx
+++ b/dashboard/src/app/(dashboard)/settings/PayoutSection.tsx
@@ -61,7 +61,7 @@ export function PayoutSection() {
       <div className="space-y-4">
         {/* Mining Payout Address */}
         <div>
-          <label className="block text-sm text-gray-400 mb-1">Mining Payout Address</label>
+          <label className="block text-sm text-[color:var(--dim)] mb-1">Mining Payout Address</label>
           <div className="flex gap-3">
             <Input
               value={miningPayoutAddress}
@@ -77,14 +77,14 @@ export function PayoutSection() {
               Save
             </Button>
           </div>
-          <p className="text-xs text-gray-500 mt-1">
+          <p className="text-xs text-[color:var(--fainter)] mt-1">
             Mining block rewards and coinbase fees will be sent to this address
           </p>
         </div>
 
         {/* GhostPay Payout Address */}
         <div>
-          <label className="block text-sm text-gray-400 mb-1">GhostPay Fee Address</label>
+          <label className="block text-sm text-[color:var(--dim)] mb-1">GhostPay Fee Address</label>
           <div className="flex gap-3">
             <Input
               value={ghostPayPayoutAddress}
@@ -100,7 +100,7 @@ export function PayoutSection() {
               Save
             </Button>
           </div>
-          <p className="text-xs text-gray-500 mt-1">
+          <p className="text-xs text-[color:var(--fainter)] mt-1">
             GhostPay L2 transaction fee distributions will be sent to this address.
             Requires Ghost Pay to be enabled.
           </p>

--- a/dashboard/src/app/(dashboard)/settings/TemplateProfileDialog.tsx
+++ b/dashboard/src/app/(dashboard)/settings/TemplateProfileDialog.tsx
@@ -74,18 +74,18 @@ export function TemplateProfileDialog({
     >
       <div className="space-y-4 max-h-[70vh] overflow-y-auto">
         {/* Advanced User Warning */}
-        <div className="p-4 bg-orange-900/20 border border-orange-700 rounded-lg">
+        <div className="p-4 bg-[var(--accent)]/20 border border-[var(--accent)] rounded-lg">
           <div className="flex items-start gap-3">
-            <span className="text-orange-400 text-xl">&#9888;</span>
+            <span className="text-[color:var(--accent)] text-xl">&#9888;</span>
             <div>
-              <h4 className="text-orange-300 font-medium">Advanced Configuration</h4>
-              <p className="text-orange-300/80 text-sm mt-1">
+              <h4 className="text-[color:var(--accent)] font-medium">Advanced Configuration</h4>
+              <p className="text-[color:var(--accent)]/80 text-sm mt-1">
                 Custom block templates are intended for advanced users. Incorrect settings may
                 affect your mining efficiency or block validity.
               </p>
-              <p className="text-orange-300/80 text-sm mt-2">
+              <p className="text-[color:var(--accent)]/80 text-sm mt-2">
                 If you&apos;re unsure, use one of the preset profiles instead. For guidance, refer to
-                the <a href="/docs/template-profiles" className="text-orange-200 underline hover:text-orange-100">Block Template Guide</a>.
+                the <a href="/docs/template-profiles" className="text-[color:var(--accent)] underline hover:text-[color:var(--accent)]">Block Template Guide</a>.
               </p>
             </div>
           </div>
@@ -93,7 +93,7 @@ export function TemplateProfileDialog({
 
         {/* Profile Name */}
         <div>
-          <label className="block text-sm text-gray-400 mb-1">Profile Name</label>
+          <label className="block text-sm text-[color:var(--dim)] mb-1">Profile Name</label>
           <Input
             value={profile.name}
             onChange={(e) => update({ name: e.target.value })}
@@ -103,7 +103,7 @@ export function TemplateProfileDialog({
 
         {/* Core Template Settings */}
         <div>
-          <h4 className="text-sm font-medium text-gray-300 mb-3">Core Template Settings</h4>
+          <h4 className="text-sm font-medium text-[color:var(--dim)] mb-3">Core Template Settings</h4>
           <div className="space-y-2">
             <NumberInput
               label="Block Max Weight"
@@ -127,7 +127,7 @@ export function TemplateProfileDialog({
 
         {/* Priority Settings */}
         <div>
-          <h4 className="text-sm font-medium text-gray-300 mb-3">Priority Settings</h4>
+          <h4 className="text-sm font-medium text-[color:var(--dim)] mb-3">Priority Settings</h4>
           <div className="space-y-2">
             <ToggleRow
               label="Prioritise by Fee"
@@ -146,7 +146,7 @@ export function TemplateProfileDialog({
 
         {/* Ghost Extensions - Block Composition */}
         <div>
-          <h4 className="text-sm font-medium text-orange-300 mb-3">Block Composition</h4>
+          <h4 className="text-sm font-medium text-[color:var(--accent)] mb-3">Block Composition</h4>
           <div className="space-y-2">
             <NumberInput
               label="Reserve Weight for Lightning"
@@ -175,7 +175,7 @@ export function TemplateProfileDialog({
 
         {/* Ghost Extensions - Inscription Filtering */}
         <div>
-          <h4 className="text-sm font-medium text-orange-300 mb-3">Inscription Filtering</h4>
+          <h4 className="text-sm font-medium text-[color:var(--accent)] mb-3">Inscription Filtering</h4>
           <div className="space-y-2">
             <ToggleRow
               label="Filter Ordinal Inscriptions"
@@ -208,7 +208,7 @@ export function TemplateProfileDialog({
 
         {/* Ghost Extensions - Transaction Preferences */}
         <div>
-          <h4 className="text-sm font-medium text-orange-300 mb-3">Transaction Preferences</h4>
+          <h4 className="text-sm font-medium text-[color:var(--accent)] mb-3">Transaction Preferences</h4>
           <div className="space-y-2">
             <ToggleRow
               label="Boost Consolidations"
@@ -227,7 +227,7 @@ export function TemplateProfileDialog({
 
         {/* Ghost Extensions - Package Relay */}
         <div>
-          <h4 className="text-sm font-medium text-orange-300 mb-3">Package Relay (CPFP)</h4>
+          <h4 className="text-sm font-medium text-[color:var(--accent)] mb-3">Package Relay (CPFP)</h4>
           <div className="space-y-2">
             <ToggleRow
               label="Enable Package Relay"
@@ -250,7 +250,7 @@ export function TemplateProfileDialog({
 
         {/* Ghost Extensions - MEV Protection */}
         <div>
-          <h4 className="text-sm font-medium text-orange-300 mb-3">MEV Protection</h4>
+          <h4 className="text-sm font-medium text-[color:var(--accent)] mb-3">MEV Protection</h4>
           <div className="space-y-2">
             <ToggleRow
               label="Randomize Transaction Order"
@@ -273,7 +273,7 @@ export function TemplateProfileDialog({
 
         {/* Ghost Extensions - Economic Preferences */}
         <div>
-          <h4 className="text-sm font-medium text-orange-300 mb-3">Economic Preferences</h4>
+          <h4 className="text-sm font-medium text-[color:var(--accent)] mb-3">Economic Preferences</h4>
           <div className="space-y-2">
             <ToggleRow
               label="Include Free Relay"
@@ -297,7 +297,7 @@ export function TemplateProfileDialog({
         {/* BUDS Tiers */}
         <div>
           <div className="flex items-center gap-2 mb-3">
-            <h4 className="text-sm font-medium text-gray-300">BUDS Transaction Tiers</h4>
+            <h4 className="text-sm font-medium text-[color:var(--dim)]">BUDS Transaction Tiers</h4>
             {!budsEnabled && <Badge variant="warning">Requires Ghost Pay</Badge>}
           </div>
           {!budsEnabled && (
@@ -342,7 +342,7 @@ export function TemplateProfileDialog({
         </div>
 
         {/* Actions */}
-        <div className="flex gap-3 pt-4 border-t border-gray-800">
+        <div className="flex gap-3 pt-4 border-t border-[var(--rule)]">
           <Button
             variant="ghost"
             className="flex-1"

--- a/dashboard/src/app/(dashboard)/settings/alerts/page.tsx
+++ b/dashboard/src/app/(dashboard)/settings/alerts/page.tsx
@@ -119,7 +119,7 @@ export default function AlertsSettingsPage() {
   };
 
   if (isLoading) {
-    return <div className="text-gray-400 text-sm">Loading alert settings…</div>;
+    return <div className="text-[color:var(--dim)] text-sm">Loading alert settings…</div>;
   }
 
   return (
@@ -142,12 +142,12 @@ export default function AlertsSettingsPage() {
         <CardHeader title="Channels" subtitle="Enable one or more delivery channels and enter their details." />
         <div className="space-y-4">
           {/* Email */}
-          <div className="p-4 bg-gray-800/50 rounded-lg space-y-3">
+          <div className="p-4 bg-[var(--surface)]/50 rounded-lg space-y-3">
             <div className="flex items-center justify-between">
               <div>
-                <div className="text-gray-100 font-medium">Email</div>
-                <div className="text-sm text-gray-400">
-                  POSTs <code className="text-orange-400">{"{to, subject, body}"}</code> to your mail-relay webhook.
+                <div className="text-[color:var(--fg)] font-medium">Email</div>
+                <div className="text-sm text-[color:var(--dim)]">
+                  POSTs <code className="text-[color:var(--accent)]">{"{to, subject, body}"}</code> to your mail-relay webhook.
                 </div>
               </div>
               <Toggle
@@ -181,12 +181,12 @@ export default function AlertsSettingsPage() {
           </div>
 
           {/* Push */}
-          <div className="p-4 bg-gray-800/50 rounded-lg space-y-3">
+          <div className="p-4 bg-[var(--surface)]/50 rounded-lg space-y-3">
             <div className="flex items-center justify-between">
               <div>
-                <div className="text-gray-100 font-medium">Push</div>
-                <div className="text-sm text-gray-400">
-                  POSTs <code className="text-orange-400">{"{title, message}"}</code> to an ntfy-style webhook.
+                <div className="text-[color:var(--fg)] font-medium">Push</div>
+                <div className="text-sm text-[color:var(--dim)]">
+                  POSTs <code className="text-[color:var(--accent)]">{"{title, message}"}</code> to an ntfy-style webhook.
                 </div>
               </div>
               <Toggle
@@ -210,11 +210,11 @@ export default function AlertsSettingsPage() {
           </div>
 
           {/* Telegram */}
-          <div className="p-4 bg-gray-800/50 rounded-lg space-y-3">
+          <div className="p-4 bg-[var(--surface)]/50 rounded-lg space-y-3">
             <div className="flex items-center justify-between">
               <div>
-                <div className="text-gray-100 font-medium">Telegram</div>
-                <div className="text-sm text-gray-400">Delivers via the Telegram Bot API.</div>
+                <div className="text-[color:var(--fg)] font-medium">Telegram</div>
+                <div className="text-sm text-[color:var(--dim)]">Delivers via the Telegram Bot API.</div>
               </div>
               <Toggle
                 label="Enable Telegram"
@@ -271,7 +271,7 @@ export default function AlertsSettingsPage() {
         <Button variant="outline" onClick={handleTest} loading={sendTest.isPending}>
           Send test alert
         </Button>
-        <span className="text-xs text-gray-500">
+        <span className="text-xs text-[color:var(--fainter)]">
           Test delivers to every enabled + configured channel. Save first so a newly entered token is applied.
         </span>
       </div>
@@ -282,10 +282,10 @@ export default function AlertsSettingsPage() {
           <CardHeader title="Test result" subtitle={testResult.message} />
           <div className="space-y-2">
             {testResult.results.map((r) => (
-              <div key={r.channel} className="flex items-center justify-between p-3 bg-gray-800/50 rounded-lg">
-                <span className="text-gray-100 capitalize">{r.channel}</span>
+              <div key={r.channel} className="flex items-center justify-between p-3 bg-[var(--surface)]/50 rounded-lg">
+                <span className="text-[color:var(--fg)] capitalize">{r.channel}</span>
                 <div className="flex items-center gap-3">
-                  <span className="text-xs text-gray-400">{r.detail}</span>
+                  <span className="text-xs text-[color:var(--dim)]">{r.detail}</span>
                   <Badge variant={!r.attempted ? "default" : r.success ? "success" : "error"}>
                     {!r.attempted ? "Skipped" : r.success ? "Delivered" : "Failed"}
                   </Badge>

--- a/dashboard/src/app/(dashboard)/settings/daemon/page.tsx
+++ b/dashboard/src/app/(dashboard)/settings/daemon/page.tsx
@@ -120,10 +120,10 @@ function FieldRow({
   inputMode?: "numeric" | "text";
 }) {
   return (
-    <div className="flex items-center justify-between gap-4 p-3 bg-gray-800/50 rounded-lg">
+    <div className="flex items-center justify-between gap-4 p-3 bg-[var(--surface)]/50 rounded-lg">
       <div className="flex-1 min-w-0">
-        <div className="text-gray-100 font-medium">{label}</div>
-        <div className="text-sm text-gray-400">{description}</div>
+        <div className="text-[color:var(--fg)] font-medium">{label}</div>
+        <div className="text-sm text-[color:var(--dim)]">{description}</div>
       </div>
       <div className="flex items-center gap-2 shrink-0">
         <Input
@@ -134,7 +134,7 @@ function FieldRow({
           placeholder={placeholder ?? "default"}
           className="w-28 text-right"
         />
-        {unit && <span className="text-gray-400 text-sm w-10">{unit}</span>}
+        {unit && <span className="text-[color:var(--dim)] text-sm w-10">{unit}</span>}
       </div>
     </div>
   );
@@ -156,13 +156,13 @@ function ToggleFieldRow({
   badge?: React.ReactNode;
 }) {
   return (
-    <div className="flex items-center justify-between gap-4 p-3 bg-gray-800/50 rounded-lg">
+    <div className="flex items-center justify-between gap-4 p-3 bg-[var(--surface)]/50 rounded-lg">
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2">
-          <span className="text-gray-100 font-medium">{label}</span>
+          <span className="text-[color:var(--fg)] font-medium">{label}</span>
           {badge}
         </div>
-        <div className="text-sm text-gray-400">{description}</div>
+        <div className="text-sm text-[color:var(--dim)]">{description}</div>
       </div>
       <Toggle enabled={enabled} onChange={onChange} label={label} disabled={disabled} />
     </div>
@@ -224,7 +224,7 @@ export default function DaemonSettingsPage() {
           title="Daemon / Node"
           subtitle="ghostd launch flags for this node. Every setting here is read only at startup, so applying any change restarts ghostd (and briefly bounces the pool)."
         />
-        <div className="flex items-center gap-2 text-sm text-gray-400">
+        <div className="flex items-center gap-2 text-sm text-[color:var(--dim)]">
           <span>Last apply:</span>
           {applyState ? (
             <Badge
@@ -243,13 +243,13 @@ export default function DaemonSettingsPage() {
           ) : (
             <Badge variant="default">idle</Badge>
           )}
-          {applyMessage && <span className="text-gray-500 truncate">{applyMessage}</span>}
+          {applyMessage && <span className="text-[color:var(--fainter)] truncate">{applyMessage}</span>}
         </div>
       </Card>
 
       {isLoading ? (
         <Card>
-          <p className="text-gray-400 text-sm">Loading daemon settings…</p>
+          <p className="text-[color:var(--dim)] text-sm">Loading daemon settings…</p>
         </Card>
       ) : (
         <SectionErrorBoundary section="Daemon settings">
@@ -344,7 +344,7 @@ export default function DaemonSettingsPage() {
                 disabled={!form.blockFilterIndex}
               />
               {bip157Invalid && (
-                <p className="text-xs text-red-400 px-1">
+                <p className="text-xs text-[color:var(--red)] px-1">
                   Peer block filters need the block filter index enabled too.
                 </p>
               )}
@@ -355,9 +355,9 @@ export default function DaemonSettingsPage() {
           <Card>
             <CardHeader title="Privacy networking" subtitle="Restrict outbound networks and reach I2P peers (-onlynet / -i2psam)." />
             <div className="space-y-3">
-              <div className="p-3 bg-gray-800/50 rounded-lg">
-                <div className="text-gray-100 font-medium">Only connect via networks</div>
-                <div className="text-sm text-gray-400 mb-3">
+              <div className="p-3 bg-[var(--surface)]/50 rounded-lg">
+                <div className="text-[color:var(--fg)] font-medium">Only connect via networks</div>
+                <div className="text-sm text-[color:var(--dim)] mb-3">
                   Restrict automatic outbound connections to the selected networks. None selected = no restriction.
                 </div>
                 <div className="flex flex-wrap gap-2">
@@ -370,8 +370,8 @@ export default function DaemonSettingsPage() {
                         onClick={() => toggleNet(net)}
                         className={`px-3 py-1 rounded-lg text-sm border transition-colors ${
                           on
-                            ? "bg-orange-600 text-white border-orange-500"
-                            : "bg-transparent text-gray-300 border-gray-600 hover:bg-gray-800"
+                            ? "bg-[var(--accent)] text-white border-[var(--accent)]"
+                            : "bg-transparent text-[color:var(--dim)] border-[var(--rule-strong)] hover:bg-[var(--surface)]"
                         }`}
                       >
                         {net}
@@ -395,7 +395,7 @@ export default function DaemonSettingsPage() {
                 disabled={form.i2pSam.trim() === ""}
               />
               {i2pIncomingInvalid && (
-                <p className="text-xs text-red-400 px-1">
+                <p className="text-xs text-[color:var(--red)] px-1">
                   Accepting inbound I2P needs an I2P SAM proxy address.
                 </p>
               )}
@@ -405,7 +405,7 @@ export default function DaemonSettingsPage() {
           {/* Apply */}
           <Card>
             <div className="flex items-center justify-between gap-4">
-              <div className="text-sm text-gray-400">
+              <div className="text-sm text-[color:var(--dim)]">
                 Applying these changes restarts ghostd and briefly bounces ghost-pool.
               </div>
               <Button

--- a/dashboard/src/app/(dashboard)/settings/filtering/page.tsx
+++ b/dashboard/src/app/(dashboard)/settings/filtering/page.tsx
@@ -29,9 +29,9 @@ export default function FilteringSettingsPage() {
             subtitle="How strictly this node filters, by transaction class (BUDS T0–T3). Changing it restarts the node."
           />
           <PolicyProfileSelector />
-          <p className="text-xs text-gray-500 mt-3">
+          <p className="text-xs text-[color:var(--fainter)] mt-3">
             Prefer the guided view? The same choice, with a live mempool-by-class breakdown, is on{" "}
-            <Link href="/filtering/basic" className="text-orange-400 hover:text-orange-300 underline">
+            <Link href="/filtering/basic" className="text-[color:var(--accent)] hover:text-[color:var(--accent)] underline">
               Filtering › Basic
             </Link>
             .

--- a/dashboard/src/app/(dashboard)/settings/layout.tsx
+++ b/dashboard/src/app/(dashboard)/settings/layout.tsx
@@ -41,7 +41,7 @@ const NAV_ITEMS = [
         <path strokeLinecap="round" strokeLinejoin="round" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
       </svg>
     ),
-    accent: "text-red-400",
+    accent: "text-[color:var(--red)]",
   },
   {
     href: "/settings/policy",
@@ -137,12 +137,12 @@ export default function SettingsLayout({ children }: { children: ReactNode }) {
                   className={`
                     flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium whitespace-nowrap transition-colors
                     ${isActive
-                      ? "bg-gray-800 text-gray-100"
-                      : "text-gray-400 hover:text-gray-200 hover:bg-gray-800/50"
+                      ? "bg-[var(--surface)] text-[color:var(--fg)]"
+                      : "text-[color:var(--dim)] hover:text-[color:var(--fg)] hover:bg-[var(--surface)]/50"
                     }
                   `}
                 >
-                  <span className={isActive ? (item.accent ?? "text-gray-100") : "text-gray-500"}>{item.icon}</span>
+                  <span className={isActive ? (item.accent ?? "text-[color:var(--fg)]") : "text-[color:var(--fainter)]"}>{item.icon}</span>
                   {item.label}
                 </Link>
               );

--- a/dashboard/src/app/(dashboard)/settings/onboarding/page.tsx
+++ b/dashboard/src/app/(dashboard)/settings/onboarding/page.tsx
@@ -47,9 +47,9 @@ const STEPS = [
 
 function StatItem({ label, value }: { label: string; value: React.ReactNode }) {
   return (
-    <div className="flex items-center justify-between p-3 bg-gray-800/50 rounded-lg">
-      <span className="text-sm text-gray-400">{label}</span>
-      <span className="text-sm text-gray-100 font-medium">{value}</span>
+    <div className="flex items-center justify-between p-3 bg-[var(--surface)]/50 rounded-lg">
+      <span className="text-sm text-[color:var(--dim)]">{label}</span>
+      <span className="text-sm text-[color:var(--fg)] font-medium">{value}</span>
     </div>
   );
 }
@@ -324,13 +324,13 @@ export default function OnboardingPage() {
               )}
 
               <div
-                className={`p-3 bg-gray-800/50 rounded-lg flex justify-between items-center ${
+                className={`p-3 bg-[var(--surface)]/50 rounded-lg flex justify-between items-center ${
                   reaperEnabled ? "opacity-50" : ""
                 }`}
               >
                 <div>
-                  <div className="text-gray-100">Current Profile</div>
-                  <div className="text-sm text-gray-400">{activeMempoolProfile}</div>
+                  <div className="text-[color:var(--fg)]">Current Profile</div>
+                  <div className="text-sm text-[color:var(--dim)]">{activeMempoolProfile}</div>
                 </div>
                 <Badge variant="info">{activeMempoolProfile}</Badge>
               </div>
@@ -347,12 +347,12 @@ export default function OnboardingPage() {
                     disabled={reaperEnabled || activateMempoolProfile.isPending}
                     className={`p-3 rounded-lg border transition-colors text-left ${
                       activeMempoolProfile === p.name
-                        ? "bg-orange-900/30 border-orange-600 text-orange-300"
-                        : "bg-gray-800/50 border-gray-700 text-gray-300 hover:border-gray-500"
+                        ? "bg-[var(--accent)]/30 border-[var(--accent)] text-[color:var(--accent)]"
+                        : "bg-[var(--surface)]/50 border-[var(--rule-strong)] text-[color:var(--dim)] hover:border-[var(--rule-strong)]"
                     }`}
                   >
                     <div className="font-medium capitalize">{p.name.replace(/_/g, " ")}</div>
-                    <div className="text-xs text-gray-500 mt-1">{p.desc}</div>
+                    <div className="text-xs text-[color:var(--fainter)] mt-1">{p.desc}</div>
                   </button>
                 ))}
               </div>

--- a/dashboard/src/app/(dashboard)/settings/policy/page.tsx
+++ b/dashboard/src/app/(dashboard)/settings/policy/page.tsx
@@ -75,14 +75,14 @@ function ProfileGrid({
           key={profile.name}
           className={`p-3 rounded-lg border transition-colors text-left ${
             activeProfile === profile.name
-              ? "bg-orange-900/30 border-orange-600 text-orange-300"
-              : "bg-gray-800/50 border-gray-700 text-gray-300 hover:border-gray-500"
+              ? "bg-[var(--accent)]/30 border-[var(--accent)] text-[color:var(--accent)]"
+              : "bg-[var(--surface)]/50 border-[var(--rule-strong)] text-[color:var(--dim)] hover:border-[var(--rule-strong)]"
           }`}
           onClick={() => onActivate(profile.name)}
           disabled={disabled || (profile.name === ghostModeRequired && !ghostModeActive)}
         >
           <div className="font-medium capitalize">{profile.name.replace(/_/g, " ")}</div>
-          <div className="text-xs text-gray-500 mt-1">{profile.desc}</div>
+          <div className="text-xs text-[color:var(--fainter)] mt-1">{profile.desc}</div>
         </button>
       ))}
     </div>
@@ -107,15 +107,15 @@ function CustomProfileList<T extends { name: string }>({
   if (profiles.length === 0) return null;
   return (
     <div className={`space-y-2 ${disabled ? "opacity-50 pointer-events-none" : ""}`}>
-      <h4 className="text-sm font-medium text-gray-300">Custom Profiles</h4>
+      <h4 className="text-sm font-medium text-[color:var(--dim)]">Custom Profiles</h4>
       {profiles.map((profile) => (
         <div
           key={profile.name}
-          className="p-3 bg-gray-800/50 rounded-lg flex justify-between items-center"
+          className="p-3 bg-[var(--surface)]/50 rounded-lg flex justify-between items-center"
         >
           <div>
-            <div className="text-gray-100">{profile.name}</div>
-            <div className="text-xs text-gray-500">{renderDetails(profile)}</div>
+            <div className="text-[color:var(--fg)]">{profile.name}</div>
+            <div className="text-xs text-[color:var(--fainter)]">{renderDetails(profile)}</div>
           </div>
           <div className="flex gap-2">
             <Button size="sm" variant="secondary" onClick={() => onEdit(profile)} disabled={disabled}>Edit</Button>
@@ -131,7 +131,7 @@ function CustomProfileList<T extends { name: string }>({
 function AdvancedToggle({ open, onToggle, count }: { open: boolean; onToggle: () => void; count: number }) {
   return (
     <button
-      className="flex items-center gap-2 text-sm text-gray-400 hover:text-gray-200 transition-colors"
+      className="flex items-center gap-2 text-sm text-[color:var(--dim)] hover:text-[color:var(--fg)] transition-colors"
       onClick={onToggle}
     >
       <svg
@@ -142,7 +142,7 @@ function AdvancedToggle({ open, onToggle, count }: { open: boolean; onToggle: ()
       </svg>
       {open ? "Hide Advanced" : "Show Advanced"}
       {count > 0 && !open && (
-        <span className="text-xs text-gray-600">({count} custom)</span>
+        <span className="text-xs text-[color:var(--fainter)]">({count} custom)</span>
       )}
     </button>
   );
@@ -258,10 +258,10 @@ export default function PolicySettingsPage() {
       <Card>
         <CardHeader title="Mempool Policy" subtitle="Configure which transactions to accept in your mempool" />
         <div className="space-y-4">
-          <div className="p-3 bg-gray-800/50 rounded-lg flex justify-between items-center">
+          <div className="p-3 bg-[var(--surface)]/50 rounded-lg flex justify-between items-center">
             <div>
-              <div className="text-gray-100">Current Profile</div>
-              <div className="text-sm text-gray-400">{config?.mempool_profile ?? "standard"}</div>
+              <div className="text-[color:var(--fg)]">Current Profile</div>
+              <div className="text-sm text-[color:var(--dim)]">{config?.mempool_profile ?? "standard"}</div>
             </div>
             <Badge variant="info">{config?.mempool_profile ?? "standard"}</Badge>
           </div>
@@ -305,10 +305,10 @@ export default function PolicySettingsPage() {
       <Card>
         <CardHeader title="Block Template Policy" subtitle="Configure which transactions to include when mining blocks" />
         <div className="space-y-4">
-          <div className="p-3 bg-gray-800/50 rounded-lg flex justify-between items-center">
+          <div className="p-3 bg-[var(--surface)]/50 rounded-lg flex justify-between items-center">
             <div>
-              <div className="text-gray-100">Current Profile</div>
-              <div className="text-sm text-gray-400">{config?.template_profile ?? "standard"}</div>
+              <div className="text-[color:var(--fg)]">Current Profile</div>
+              <div className="text-sm text-[color:var(--dim)]">{config?.template_profile ?? "standard"}</div>
             </div>
             <Badge variant="info">{config?.template_profile ?? "standard"}</Badge>
           </div>

--- a/dashboard/src/app/(dashboard)/settings/privacy/page.tsx
+++ b/dashboard/src/app/(dashboard)/settings/privacy/page.tsx
@@ -59,9 +59,9 @@ export default function PrivacySettingsPage() {
 
   return (
     <>
-      <Card className="border-red-600/30">
+      <Card className="border-[var(--red)]/30">
         <CardHeader
-          title={<span className="text-red-400">Privacy &amp; Anonymity</span>}
+          title={<span className="text-[color:var(--red)]">Privacy &amp; Anonymity</span>}
           subtitle="Control your node's privacy features"
         />
         <div className="space-y-4">
@@ -80,26 +80,26 @@ export default function PrivacySettingsPage() {
             }
           />
 
-          <div className="flex items-center justify-between p-3 bg-gray-800/50 rounded-lg">
+          <div className="flex items-center justify-between p-3 bg-[var(--surface)]/50 rounded-lg">
             <div className="flex-1">
               <div className="flex items-center gap-2">
-                <span className="text-gray-100 font-medium">Tor Mode</span>
+                <span className="text-[color:var(--fg)] font-medium">Tor Mode</span>
                 {status?.tor_mode ? (
                   <Badge variant="success">Active</Badge>
                 ) : (
                   <Badge variant="default">Disabled</Badge>
                 )}
               </div>
-              <div className="text-sm text-gray-400">
+              <div className="text-sm text-[color:var(--dim)]">
                 Routes all P2P connections through the Tor network, hiding your node&apos;s IP address
               </div>
               {status?.tor_mode && status?.onion_address && (
                 <div className="mt-2 flex items-center gap-2">
-                  <code className="text-xs text-orange-400 bg-gray-900/50 px-2 py-1 rounded font-mono">
+                  <code className="text-xs text-[color:var(--accent)] bg-[var(--surface)]/50 px-2 py-1 rounded font-mono">
                     {status.onion_address}
                   </code>
                   <button
-                    className="text-xs text-gray-500 hover:text-gray-300 transition-colors"
+                    className="text-xs text-[color:var(--fainter)] hover:text-[color:var(--dim)] transition-colors"
                     onClick={() => {
                       navigator.clipboard.writeText(status.onion_address!);
                     }}
@@ -109,7 +109,7 @@ export default function PrivacySettingsPage() {
                 </div>
               )}
               {!status?.tor_mode && (
-                <div className="text-xs text-gray-600 mt-1">
+                <div className="text-xs text-[color:var(--fainter)] mt-1">
                   Configure via Ghost Core startup flags (-proxy, -torcontrol). Set at startup, read-only here.
                 </div>
               )}
@@ -117,10 +117,10 @@ export default function PrivacySettingsPage() {
           </div>
 
           {/* Ghost Shroud — configurable via the same wizard as Settings › Wizards */}
-          <div className="flex items-center justify-between p-3 bg-gray-800/50 rounded-lg">
+          <div className="flex items-center justify-between p-3 bg-[var(--surface)]/50 rounded-lg">
             <div className="flex-1">
               <div className="flex items-center gap-2">
-                <span className="text-gray-100 font-medium">Ghost Shroud</span>
+                <span className="text-[color:var(--fg)] font-medium">Ghost Shroud</span>
                 {shroudStatus ? (
                   <Badge variant={shroudStatus.enabled ? "success" : "default"}>
                     {shroudStatus.enabled ? "Active" : "Disabled"}
@@ -129,7 +129,7 @@ export default function PrivacySettingsPage() {
                   <Badge variant="default">Unknown</Badge>
                 )}
               </div>
-              <div className="text-sm text-gray-400">
+              <div className="text-sm text-[color:var(--dim)]">
                 Random delays before relaying transactions — protects against timing analysis
               </div>
             </div>
@@ -139,10 +139,10 @@ export default function PrivacySettingsPage() {
           </div>
 
           {/* Ghost Haze — configurable via the same wizard as Settings › Wizards */}
-          <div className="flex items-center justify-between p-3 bg-gray-800/50 rounded-lg">
+          <div className="flex items-center justify-between p-3 bg-[var(--surface)]/50 rounded-lg">
             <div className="flex-1">
               <div className="flex items-center gap-2">
-                <span className="text-gray-100 font-medium">Ghost Haze</span>
+                <span className="text-[color:var(--fg)] font-medium">Ghost Haze</span>
                 {hazeStatus ? (
                   <Badge variant={hazeMode === "hazed" ? "success" : hazeMode === "full_archive" ? "info" : "default"}>
                     {hazeModeLabel}
@@ -151,7 +151,7 @@ export default function PrivacySettingsPage() {
                   <Badge variant="default">Unknown</Badge>
                 )}
               </div>
-              <div className="text-sm text-gray-400">
+              <div className="text-sm text-[color:var(--dim)]">
                 Strips privacy-sensitive data (signatures, witness data, inscriptions) from stored blocks
               </div>
             </div>
@@ -171,13 +171,13 @@ export default function PrivacySettingsPage() {
               badge={wraithEnabled ? <Badge variant="success">Active</Badge> : <Badge variant="default">Available</Badge>}
             />
           ) : (
-            <div className="flex items-center justify-between p-3 bg-gray-800/50 rounded-lg">
+            <div className="flex items-center justify-between p-3 bg-[var(--surface)]/50 rounded-lg">
               <div className="flex-1">
                 <div className="flex items-center gap-2">
-                  <span className="text-gray-100 font-medium">Wraith Protocol</span>
+                  <span className="text-[color:var(--fg)] font-medium">Wraith Protocol</span>
                   <Badge variant="warning">Not Running</Badge>
                 </div>
-                <div className="text-sm text-gray-400">
+                <div className="text-sm text-[color:var(--dim)]">
                   CoinJoin mixing on the L2 network — breaks transaction linkability. Requires an active
                   ghost-pay-node.
                 </div>

--- a/dashboard/src/app/(dashboard)/settings/shared.tsx
+++ b/dashboard/src/app/(dashboard)/settings/shared.tsx
@@ -37,13 +37,13 @@ export function ToggleRow({
   badge?: React.ReactNode;
 }) {
   return (
-    <div className="flex items-center justify-between p-3 bg-gray-800/50 rounded-lg">
+    <div className="flex items-center justify-between p-3 bg-[var(--surface)]/50 rounded-lg">
       <div className="flex-1">
         <div className="flex items-center gap-2">
-          <span className="text-gray-100 font-medium">{label}</span>
+          <span className="text-[color:var(--fg)] font-medium">{label}</span>
           {badge}
         </div>
-        <div className="text-sm text-gray-400">{description}</div>
+        <div className="text-sm text-[color:var(--dim)]">{description}</div>
       </div>
       <Toggle enabled={enabled} onChange={onChange} label={label} disabled={disabled} />
     </div>
@@ -52,13 +52,13 @@ export function ToggleRow({
 
 export function StatusRow({ label, description, badge }: { label: string; description: string; badge: React.ReactNode }) {
   return (
-    <div className="flex items-center justify-between p-3 bg-gray-800/50 rounded-lg">
+    <div className="flex items-center justify-between p-3 bg-[var(--surface)]/50 rounded-lg">
       <div className="flex-1">
         <div className="flex items-center gap-2">
-          <span className="text-gray-100 font-medium">{label}</span>
+          <span className="text-[color:var(--fg)] font-medium">{label}</span>
           {badge}
         </div>
-        <div className="text-sm text-gray-400">{description}</div>
+        <div className="text-sm text-[color:var(--dim)]">{description}</div>
       </div>
     </div>
   );
@@ -82,8 +82,8 @@ export function NumberInput({
   unit?: string;
 }) {
   return (
-    <div className="flex items-center justify-between p-3 bg-gray-800/50 rounded-lg">
-      <span className="text-gray-100">{label}</span>
+    <div className="flex items-center justify-between p-3 bg-[var(--surface)]/50 rounded-lg">
+      <span className="text-[color:var(--fg)]">{label}</span>
       <div className="flex items-center gap-2">
         <Input
           type="number"
@@ -94,7 +94,7 @@ export function NumberInput({
           step={step}
           className="w-24 text-right"
         />
-        {unit && <span className="text-gray-400 text-sm w-12">{unit}</span>}
+        {unit && <span className="text-[color:var(--dim)] text-sm w-12">{unit}</span>}
       </div>
     </div>
   );

--- a/dashboard/src/app/(dashboard)/settings/storage/page.tsx
+++ b/dashboard/src/app/(dashboard)/settings/storage/page.tsx
@@ -19,13 +19,13 @@ export default function StorageSettingsPage() {
       </SectionErrorBoundary>
 
       <Card>
-        <p className="text-sm text-gray-400">
+        <p className="text-sm text-[color:var(--dim)]">
           Looking for L2 (Ghost Pay) pruning status and the full storage breakdown? See{" "}
-          <Link href="/storage" className="text-orange-400 hover:text-orange-300 underline">
+          <Link href="/storage" className="text-[color:var(--accent)] hover:text-[color:var(--accent)] underline">
             Storage
           </Link>
           . Backups and software updates live under{" "}
-          <Link href="/system" className="text-orange-400 hover:text-orange-300 underline">
+          <Link href="/system" className="text-[color:var(--accent)] hover:text-[color:var(--accent)] underline">
             System
           </Link>
           .

--- a/dashboard/src/app/(dashboard)/settings/system/page.tsx
+++ b/dashboard/src/app/(dashboard)/settings/system/page.tsx
@@ -21,17 +21,17 @@ export default function SystemSettingsPage() {
             title="Software Updates"
             subtitle="Keep this node current automatically, or drive updates by hand from System."
           />
-          <div className="p-4 bg-gray-800/50 rounded-lg">
+          <div className="p-4 bg-[var(--surface)]/50 rounded-lg">
             <AutoUpdateSection />
           </div>
         </Card>
       </SectionErrorBoundary>
 
       <Card>
-        <p className="text-sm text-gray-400">
+        <p className="text-sm text-[color:var(--dim)]">
           Check for and install updates manually, roll back to a previous version, or manage encrypted
           backups on{" "}
-          <Link href="/system" className="text-orange-400 hover:text-orange-300 underline">
+          <Link href="/system" className="text-[color:var(--accent)] hover:text-[color:var(--accent)] underline">
             System
           </Link>
           .

--- a/dashboard/src/app/(dashboard)/settings/wizards/BuildRunWizard.tsx
+++ b/dashboard/src/app/(dashboard)/settings/wizards/BuildRunWizard.tsx
@@ -216,41 +216,41 @@ export default function BuildRunWizard({ isOpen, onClose }: BuildRunWizardProps)
               {checks.map((check) => (
                 <div
                   key={check.label}
-                  className="p-4 rounded-lg bg-gray-800/50 flex items-center justify-between"
+                  className="p-4 rounded-lg bg-[var(--surface)]/50 flex items-center justify-between"
                 >
                   <div className="flex items-center gap-3">
                     {check.status === 'pending' && (
-                      <div className="w-5 h-5 rounded-full border-2 border-gray-600 border-t-orange-500 animate-spin" />
+                      <div className="w-5 h-5 rounded-full border-2 border-[var(--rule-strong)] border-t-orange-500 animate-spin" />
                     )}
                     {check.status === 'ok' && (
-                      <svg className="w-5 h-5 text-green-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <svg className="w-5 h-5 text-[color:var(--green)]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
                       </svg>
                     )}
                     {check.status === 'error' && (
-                      <svg className="w-5 h-5 text-red-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <svg className="w-5 h-5 text-[color:var(--red)]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
                       </svg>
                     )}
-                    <span className="text-gray-100 font-medium">{check.label}</span>
+                    <span className="text-[color:var(--fg)] font-medium">{check.label}</span>
                   </div>
                   {check.message && (
-                    <span className={`text-sm ${check.status === 'ok' ? 'text-green-400' : check.status === 'error' ? 'text-red-400' : 'text-gray-400'}`}>
+                    <span className={`text-sm ${check.status === 'ok' ? 'text-[color:var(--green)]' : check.status === 'error' ? 'text-[color:var(--red)]' : 'text-[color:var(--dim)]'}`}>
                       {check.message}
                     </span>
                   )}
                 </div>
               ))}
               {checksComplete && !allChecksOk && (
-                <div className="p-4 rounded-lg bg-orange-900/20 border border-orange-800">
-                  <p className="text-sm text-orange-300">
+                <div className="p-4 rounded-lg bg-[var(--accent)]/20 border border-[var(--accent)]">
+                  <p className="text-sm text-[color:var(--accent)]">
                     Some pre-flight checks failed. You can still proceed, but the action may not succeed.
                   </p>
                 </div>
               )}
               {checksComplete && allChecksOk && (
-                <div className="p-4 rounded-lg bg-green-900/20 border border-green-800">
-                  <p className="text-sm text-green-300">
+                <div className="p-4 rounded-lg bg-[var(--green)]/20 border border-[var(--green)]">
+                  <p className="text-sm text-[color:var(--green)]">
                     All pre-flight checks passed. Your node is ready.
                   </p>
                 </div>
@@ -269,22 +269,22 @@ export default function BuildRunWizard({ isOpen, onClose }: BuildRunWizardProps)
                   className={`
                     w-full text-left p-4 rounded-lg border transition-colors
                     ${data.action === action.id
-                      ? 'bg-orange-900/30 border-orange-600'
-                      : 'bg-gray-800/50 border-gray-700 hover:border-gray-600'}
+                      ? 'bg-[var(--accent)]/30 border-[var(--accent)]'
+                      : 'bg-[var(--surface)]/50 border-[var(--rule-strong)] hover:border-[var(--rule-strong)]'}
                   `}
                 >
                   <div className="flex items-center gap-3">
-                    <svg className="w-5 h-5 text-gray-300 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <svg className="w-5 h-5 text-[color:var(--dim)] flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d={action.icon} />
                     </svg>
                     <div className="flex-1">
                       <div className="flex items-center justify-between">
-                        <span className="text-gray-100 font-medium">{action.label}</span>
+                        <span className="text-[color:var(--fg)] font-medium">{action.label}</span>
                         {data.action === action.id && (
                           <Badge variant="warning">Selected</Badge>
                         )}
                       </div>
-                      <p className="text-sm text-gray-400 mt-1">{action.description}</p>
+                      <p className="text-sm text-[color:var(--dim)] mt-1">{action.description}</p>
                     </div>
                   </div>
                 </button>
@@ -295,17 +295,17 @@ export default function BuildRunWizard({ isOpen, onClose }: BuildRunWizardProps)
           {/* Step 2: Confirm */}
           {wizard.currentStep === 2 && (
             <div className="space-y-4">
-              <div className="p-4 rounded-lg bg-gray-800/50">
-                <h4 className="text-gray-100 font-medium mb-3">Action Summary</h4>
+              <div className="p-4 rounded-lg bg-[var(--surface)]/50">
+                <h4 className="text-[color:var(--fg)] font-medium mb-3">Action Summary</h4>
                 <div className="space-y-3">
                   <div className="flex items-center justify-between">
-                    <span className="text-gray-400">Action</span>
+                    <span className="text-[color:var(--dim)]">Action</span>
                     <Badge variant={data.action === 'stop' ? 'error' : 'warning'}>
                       {data.action.charAt(0).toUpperCase() + data.action.slice(1)}
                     </Badge>
                   </div>
                   <div className="flex items-center justify-between">
-                    <span className="text-gray-400">Pre-flight Status</span>
+                    <span className="text-[color:var(--dim)]">Pre-flight Status</span>
                     <Badge variant={data.health_ok ? 'success' : 'error'}>
                       {data.health_ok ? 'All Passed' : 'Issues Detected'}
                     </Badge>
@@ -313,24 +313,24 @@ export default function BuildRunWizard({ isOpen, onClose }: BuildRunWizardProps)
                 </div>
               </div>
               {data.action === 'stop' && (
-                <div className="p-4 rounded-lg bg-red-900/20 border border-red-800">
-                  <p className="text-sm text-red-300">
+                <div className="p-4 rounded-lg bg-[var(--red)]/20 border border-[var(--red)]">
+                  <p className="text-sm text-[color:var(--red)]">
                     Stopping the node will disconnect all miners and peers. The node will not participate
                     in consensus or earn rewards while stopped.
                   </p>
                 </div>
               )}
               {data.action === 'restart' && (
-                <div className="p-4 rounded-lg bg-orange-900/20 border border-orange-800">
-                  <p className="text-sm text-orange-300">
+                <div className="p-4 rounded-lg bg-[var(--accent)]/20 border border-[var(--accent)]">
+                  <p className="text-sm text-[color:var(--accent)]">
                     Restarting the node will cause a brief interruption. Miners will automatically
                     reconnect after the restart completes.
                   </p>
                 </div>
               )}
               {data.action === 'start' && (
-                <div className="p-4 rounded-lg bg-green-900/20 border border-green-800">
-                  <p className="text-sm text-green-300">
+                <div className="p-4 rounded-lg bg-[var(--green)]/20 border border-[var(--green)]">
+                  <p className="text-sm text-[color:var(--green)]">
                     The node will start and begin syncing with the network. It may take a moment to
                     fully connect to peers.
                   </p>

--- a/dashboard/src/app/(dashboard)/settings/wizards/ChangeSetupWizard.tsx
+++ b/dashboard/src/app/(dashboard)/settings/wizards/ChangeSetupWizard.tsx
@@ -281,10 +281,10 @@ export default function ChangeSetupWizard({ isOpen, onClose }: ChangeSetupWizard
             <div className="space-y-4">
               {configLoading ? (
                 <div className="space-y-3">
-                  <div className="p-4 rounded-lg bg-gray-800/50">
+                  <div className="p-4 rounded-lg bg-[var(--surface)]/50">
                     <div className="flex items-center gap-3 mb-3">
-                      <div className="w-5 h-5 rounded-full border-2 border-gray-600 border-t-orange-500 animate-spin" />
-                      <span className="text-gray-100 font-medium">Loading current configuration...</span>
+                      <div className="w-5 h-5 rounded-full border-2 border-[var(--rule-strong)] border-t-orange-500 animate-spin" />
+                      <span className="text-[color:var(--fg)] font-medium">Loading current configuration...</span>
                     </div>
                     <div className="space-y-2">
                       <Skeleton className="h-4 w-full" />
@@ -292,48 +292,48 @@ export default function ChangeSetupWizard({ isOpen, onClose }: ChangeSetupWizard
                       <Skeleton className="h-4 w-1/2" />
                     </div>
                   </div>
-                  <div className="p-4 rounded-lg bg-gray-800/50">
+                  <div className="p-4 rounded-lg bg-[var(--surface)]/50">
                     <Skeleton className="h-4 w-2/3 mb-2" />
                     <Skeleton className="h-4 w-full" />
                   </div>
                 </div>
               ) : (
                 <div className="space-y-4">
-                  <div className="p-4 rounded-lg bg-green-900/20 border border-green-800">
+                  <div className="p-4 rounded-lg bg-[var(--green)]/20 border border-[var(--green)]">
                     <div className="flex items-center gap-3">
-                      <svg className="w-5 h-5 text-green-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <svg className="w-5 h-5 text-[color:var(--green)]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
                       </svg>
-                      <span className="text-green-300 font-medium">Configuration loaded</span>
+                      <span className="text-[color:var(--green)] font-medium">Configuration loaded</span>
                     </div>
                   </div>
-                  <div className="p-4 rounded-lg bg-gray-800/50">
-                    <h4 className="text-gray-100 font-medium mb-3">Current Settings</h4>
+                  <div className="p-4 rounded-lg bg-[var(--surface)]/50">
+                    <h4 className="text-[color:var(--fg)] font-medium mb-3">Current Settings</h4>
                     <div className="space-y-2 text-sm">
                       <div className="flex items-center justify-between">
-                        <span className="text-gray-400">Nickname</span>
-                        <span className="text-gray-100">{currentConfig.nickname || '--'}</span>
+                        <span className="text-[color:var(--dim)]">Nickname</span>
+                        <span className="text-[color:var(--fg)]">{currentConfig.nickname || '--'}</span>
                       </div>
                       <div className="flex items-center justify-between">
-                        <span className="text-gray-400">Ghost Mode</span>
+                        <span className="text-[color:var(--dim)]">Ghost Mode</span>
                         <Badge variant={currentConfig.ghost_mode ? 'success' : 'default'}>
                           {currentConfig.ghost_mode ? 'On' : 'Off'}
                         </Badge>
                       </div>
                       <div className="flex items-center justify-between">
-                        <span className="text-gray-400">Public Mining</span>
+                        <span className="text-[color:var(--dim)]">Public Mining</span>
                         <Badge variant={currentConfig.public_mining ? 'success' : 'default'}>
                           {currentConfig.public_mining ? 'On' : 'Off'}
                         </Badge>
                       </div>
                       <div className="flex items-center justify-between">
-                        <span className="text-gray-400">Mempool Profile</span>
+                        <span className="text-[color:var(--dim)]">Mempool Profile</span>
                         <Badge variant="warning">{currentConfig.mempool_profile}</Badge>
                       </div>
                     </div>
                   </div>
-                  <div className="p-4 rounded-lg bg-gray-800/50">
-                    <p className="text-sm text-gray-400">
+                  <div className="p-4 rounded-lg bg-[var(--surface)]/50">
+                    <p className="text-sm text-[color:var(--dim)]">
                       Review your current settings above. Click Next to step through each section
                       and make changes. Only modified values will be submitted.
                     </p>
@@ -346,7 +346,7 @@ export default function ChangeSetupWizard({ isOpen, onClose }: ChangeSetupWizard
           {/* Step 1: Identity */}
           {wizard.currentStep === 1 && (
             <div className="space-y-4">
-              <div className="p-4 rounded-lg bg-gray-800/50">
+              <div className="p-4 rounded-lg bg-[var(--surface)]/50">
                 <Input
                   label="Node Nickname"
                   type="text"
@@ -359,7 +359,7 @@ export default function ChangeSetupWizard({ isOpen, onClose }: ChangeSetupWizard
                 {hasChanged('nickname') && (
                   <div className="mt-2 flex items-center gap-2">
                     <Badge variant="warning">Changed</Badge>
-                    <span className="text-xs text-gray-400">
+                    <span className="text-xs text-[color:var(--dim)]">
                       from &quot;{original?.nickname || '--'}&quot;
                     </span>
                   </div>
@@ -371,11 +371,11 @@ export default function ChangeSetupWizard({ isOpen, onClose }: ChangeSetupWizard
           {/* Step 2: Mining */}
           {wizard.currentStep === 2 && (
             <div className="space-y-4">
-              <div className="p-4 rounded-lg bg-gray-800/50">
+              <div className="p-4 rounded-lg bg-[var(--surface)]/50">
                 <div className="flex items-center justify-between">
                   <div>
-                    <span className="text-gray-100 font-medium">Public Mining</span>
-                    <p className="text-sm text-gray-400 mt-1">
+                    <span className="text-[color:var(--fg)] font-medium">Public Mining</span>
+                    <p className="text-sm text-[color:var(--dim)] mt-1">
                       Open your Stratum port to external miners. Earns +3 shares.
                     </p>
                   </div>
@@ -391,7 +391,7 @@ export default function ChangeSetupWizard({ isOpen, onClose }: ChangeSetupWizard
                   </div>
                 )}
               </div>
-              <div className="p-4 rounded-lg bg-gray-800/50">
+              <div className="p-4 rounded-lg bg-[var(--surface)]/50">
                 <Input
                   label="Mining Payout Address"
                   type="text"
@@ -403,7 +403,7 @@ export default function ChangeSetupWizard({ isOpen, onClose }: ChangeSetupWizard
                 {hasChanged('payout_address') && (
                   <div className="mt-2 flex items-center gap-2">
                     <Badge variant="warning">Changed</Badge>
-                    <span className="text-xs text-gray-400 truncate max-w-[150px]">
+                    <span className="text-xs text-[color:var(--dim)] truncate max-w-[150px]">
                       from &quot;{original?.payout_address || '--'}&quot;
                     </span>
                   </div>
@@ -416,11 +416,11 @@ export default function ChangeSetupWizard({ isOpen, onClose }: ChangeSetupWizard
           {wizard.currentStep === 3 && (
             <div className="space-y-3">
               {NODE_MODES.map((mode) => (
-                <div key={mode.key} className="p-4 rounded-lg bg-gray-800/50">
+                <div key={mode.key} className="p-4 rounded-lg bg-[var(--surface)]/50">
                   <div className="flex items-center justify-between">
                     <div className="flex-1 mr-4">
                       <div className="flex items-center gap-2">
-                        <span className="text-gray-100 font-medium">{mode.label}</span>
+                        <span className="text-[color:var(--fg)] font-medium">{mode.label}</span>
                         {mode.shares && (
                           <Badge variant="info">{mode.shares}</Badge>
                         )}
@@ -428,7 +428,7 @@ export default function ChangeSetupWizard({ isOpen, onClose }: ChangeSetupWizard
                           <Badge variant="warning">Changed</Badge>
                         )}
                       </div>
-                      <p className="text-sm text-gray-400 mt-1">{mode.description}</p>
+                      <p className="text-sm text-[color:var(--dim)] mt-1">{mode.description}</p>
                     </div>
                     <Toggle
                       enabled={data[mode.key]}
@@ -452,13 +452,13 @@ export default function ChangeSetupWizard({ isOpen, onClose }: ChangeSetupWizard
                   className={`
                     w-full text-left p-4 rounded-lg border transition-colors
                     ${data.mempool_profile === profile.id
-                      ? 'bg-orange-900/30 border-orange-600'
-                      : 'bg-gray-800/50 border-gray-700 hover:border-gray-600'}
+                      ? 'bg-[var(--accent)]/30 border-[var(--accent)]'
+                      : 'bg-[var(--surface)]/50 border-[var(--rule-strong)] hover:border-[var(--rule-strong)]'}
                   `}
                 >
                   <div className="flex items-center justify-between">
                     <div className="flex items-center gap-2">
-                      <span className="text-gray-100 font-medium">{profile.label}</span>
+                      <span className="text-[color:var(--fg)] font-medium">{profile.label}</span>
                       {data.mempool_profile === profile.id && hasChanged('mempool_profile') && (
                         <Badge variant="warning">Changed</Badge>
                       )}
@@ -467,7 +467,7 @@ export default function ChangeSetupWizard({ isOpen, onClose }: ChangeSetupWizard
                       <Badge variant="warning">Selected</Badge>
                     )}
                   </div>
-                  <p className="text-sm text-gray-400 mt-1">{profile.description}</p>
+                  <p className="text-sm text-[color:var(--dim)] mt-1">{profile.description}</p>
                 </button>
               ))}
             </div>
@@ -505,8 +505,8 @@ export default function ChangeSetupWizard({ isOpen, onClose }: ChangeSetupWizard
 
                 if (changes.length === 0) {
                   return (
-                    <div className="p-4 rounded-lg bg-gray-800/50">
-                      <p className="text-gray-400 text-sm">
+                    <div className="p-4 rounded-lg bg-[var(--surface)]/50">
+                      <p className="text-[color:var(--dim)] text-sm">
                         No changes detected. All settings match the current configuration.
                       </p>
                     </div>
@@ -515,25 +515,25 @@ export default function ChangeSetupWizard({ isOpen, onClose }: ChangeSetupWizard
 
                 return (
                   <>
-                    <div className="p-4 rounded-lg bg-gray-800/50">
-                      <h4 className="text-gray-100 font-medium mb-3">
+                    <div className="p-4 rounded-lg bg-[var(--surface)]/50">
+                      <h4 className="text-[color:var(--fg)] font-medium mb-3">
                         Changes to Apply ({changes.length})
                       </h4>
                       <div className="space-y-3">
                         {changes.map((change) => (
                           <div key={change.label} className="flex items-center justify-between">
-                            <span className="text-gray-400">{change.label}</span>
+                            <span className="text-[color:var(--dim)]">{change.label}</span>
                             <div className="flex items-center gap-2 text-sm">
-                              <span className="text-gray-500 truncate max-w-[100px]">{change.from}</span>
-                              <span className="text-gray-600">-&gt;</span>
-                              <span className="text-orange-300 font-medium truncate max-w-[100px]">{change.to}</span>
+                              <span className="text-[color:var(--fainter)] truncate max-w-[100px]">{change.from}</span>
+                              <span className="text-[color:var(--fainter)]">-&gt;</span>
+                              <span className="text-[color:var(--accent)] font-medium truncate max-w-[100px]">{change.to}</span>
                             </div>
                           </div>
                         ))}
                       </div>
                     </div>
-                    <div className="p-4 rounded-lg bg-orange-900/20 border border-orange-800">
-                      <p className="text-sm text-orange-300">
+                    <div className="p-4 rounded-lg bg-[var(--accent)]/20 border border-[var(--accent)]">
+                      <p className="text-sm text-[color:var(--accent)]">
                         Click Finish to apply {changes.length} change{changes.length > 1 ? 's' : ''}.
                         Only modified settings will be updated.
                       </p>

--- a/dashboard/src/app/(dashboard)/settings/wizards/GhostIdWizard.tsx
+++ b/dashboard/src/app/(dashboard)/settings/wizards/GhostIdWizard.tsx
@@ -90,36 +90,36 @@ export default function GhostIdWizard({ isOpen, onClose }: GhostIdWizardProps) {
       }
     >
       <div className="space-y-4">
-        <div className="p-4 rounded-lg bg-gray-800/50">
-          <p className="text-sm text-gray-400">
+        <div className="p-4 rounded-lg bg-[var(--surface)]/50">
+          <p className="text-sm text-[color:var(--dim)]">
             This is the single Ghost ID derived from this node&apos;s keypair. Other Ghost users
             can send L2 payments to it. It is read-only here -- L2 actions live in the Ghost
             Wallet app.
           </p>
         </div>
 
-        <div className="p-4 rounded-lg bg-gray-800/50">
+        <div className="p-4 rounded-lg bg-[var(--surface)]/50">
           <div className="flex items-center justify-between mb-2">
-            <h4 className="text-gray-100 font-medium">Receive Address</h4>
+            <h4 className="text-[color:var(--fg)] font-medium">Receive Address</h4>
             <Badge variant="info">Node Keypair</Badge>
           </div>
 
           {isLoading && (
             <div className="flex items-center gap-3 py-2">
-              <div className="w-5 h-5 rounded-full border-2 border-gray-600 border-t-orange-500 animate-spin" />
-              <span className="text-sm text-gray-400">Retrieving Ghost ID...</span>
+              <div className="w-5 h-5 rounded-full border-2 border-[var(--rule-strong)] border-t-orange-500 animate-spin" />
+              <span className="text-sm text-[color:var(--dim)]">Retrieving Ghost ID...</span>
             </div>
           )}
 
           {!isLoading && error && (
-            <div className="p-3 rounded-lg bg-red-900/20 border border-red-800">
-              <p className="text-sm text-red-300">{error}</p>
+            <div className="p-3 rounded-lg bg-[var(--red)]/20 border border-[var(--red)]">
+              <p className="text-sm text-[color:var(--red)]">{error}</p>
             </div>
           )}
 
           {!isLoading && !error && ghostId && (
             <div className="flex items-center gap-2">
-              <code className="flex-1 break-all rounded bg-gray-900/70 px-3 py-2 text-sm text-orange-300">
+              <code className="flex-1 break-all rounded bg-[var(--surface)]/70 px-3 py-2 text-sm text-[color:var(--accent)]">
                 {ghostId}
               </code>
               <Button variant="secondary" size="sm" onClick={handleCopy}>

--- a/dashboard/src/app/(dashboard)/settings/wizards/GhostModeWizard.tsx
+++ b/dashboard/src/app/(dashboard)/settings/wizards/GhostModeWizard.tsx
@@ -66,35 +66,35 @@ export default function GhostModeWizard({ isOpen, onClose }: GhostModeWizardProp
         <div className="space-y-6">
           {wizard.currentStep === 0 && (
             <div className="space-y-4">
-              <div className="p-4 rounded-lg bg-gray-800/50">
+              <div className="p-4 rounded-lg bg-[var(--surface)]/50">
                 <div className="flex items-center justify-between">
-                  <span className="text-gray-100 font-medium">Current Status</span>
+                  <span className="text-[color:var(--fg)] font-medium">Current Status</span>
                   <Badge variant={config?.ghost_mode ? 'success' : 'default'}>
                     {config?.ghost_mode ? 'Active' : 'Inactive'}
                   </Badge>
                 </div>
-                <p className="text-sm text-gray-400 mt-1">
+                <p className="text-sm text-[color:var(--dim)] mt-1">
                   Ghost Mode enables Ghost protocol features including L2 participation,
                   privacy tools, and node reward eligibility.
                 </p>
               </div>
-              <div className="p-4 rounded-lg bg-gray-800/50">
-                <h4 className="text-gray-100 font-medium mb-2">What Ghost Mode does</h4>
-                <ul className="space-y-2 text-sm text-gray-400">
+              <div className="p-4 rounded-lg bg-[var(--surface)]/50">
+                <h4 className="text-[color:var(--fg)] font-medium mb-2">What Ghost Mode does</h4>
+                <ul className="space-y-2 text-sm text-[color:var(--dim)]">
                   <li className="flex items-center gap-2">
-                    <span className="text-orange-300">--</span>
+                    <span className="text-[color:var(--accent)]">--</span>
                     Signals your node as a Ghost protocol participant
                   </li>
                   <li className="flex items-center gap-2">
-                    <span className="text-orange-300">--</span>
+                    <span className="text-[color:var(--accent)]">--</span>
                     Enables node capability verification eligibility
                   </li>
                   <li className="flex items-center gap-2">
-                    <span className="text-orange-300">--</span>
+                    <span className="text-[color:var(--accent)]">--</span>
                     Individual capabilities (Ghost Pay, Archive, etc.) are configured separately
                   </li>
                   <li className="flex items-center gap-2">
-                    <span className="text-orange-300">--</span>
+                    <span className="text-[color:var(--accent)]">--</span>
                     Does not grant shares on its own — shares come from verified capabilities
                   </li>
                 </ul>
@@ -104,11 +104,11 @@ export default function GhostModeWizard({ isOpen, onClose }: GhostModeWizardProp
 
           {wizard.currentStep === 1 && (
             <div className="space-y-4">
-              <div className="p-4 rounded-lg bg-gray-800/50">
+              <div className="p-4 rounded-lg bg-[var(--surface)]/50">
                 <div className="flex items-center justify-between">
                   <div>
-                    <span className="text-gray-100 font-medium">Ghost Mode</span>
-                    <p className="text-sm text-gray-400 mt-1">
+                    <span className="text-[color:var(--fg)] font-medium">Ghost Mode</span>
+                    <p className="text-sm text-[color:var(--dim)] mt-1">
                       Enable Ghost protocol features and L2 participation
                     </p>
                   </div>
@@ -120,15 +120,15 @@ export default function GhostModeWizard({ isOpen, onClose }: GhostModeWizardProp
                 </div>
               </div>
               {data.enabled && (
-                <div className="p-4 rounded-lg bg-green-900/20 border border-green-800">
-                  <p className="text-sm text-green-300">
+                <div className="p-4 rounded-lg bg-[var(--green)]/20 border border-[var(--green)]">
+                  <p className="text-sm text-[color:var(--green)]">
                     Your node will join the Ghost network and become eligible for node rewards.
                   </p>
                 </div>
               )}
               {!data.enabled && (
-                <div className="p-4 rounded-lg bg-orange-900/20 border border-orange-800">
-                  <p className="text-sm text-orange-300">
+                <div className="p-4 rounded-lg bg-[var(--accent)]/20 border border-[var(--accent)]">
+                  <p className="text-sm text-[color:var(--accent)]">
                     Disabling Ghost Mode will disconnect your node from the Ghost network.
                     You will no longer earn node rewards or participate in L2 services.
                   </p>
@@ -139,15 +139,15 @@ export default function GhostModeWizard({ isOpen, onClose }: GhostModeWizardProp
 
           {wizard.currentStep === 2 && (
             <div className="space-y-4">
-              <div className="p-4 rounded-lg bg-gray-800/50">
-                <h4 className="text-gray-100 font-medium mb-3">Change Summary</h4>
+              <div className="p-4 rounded-lg bg-[var(--surface)]/50">
+                <h4 className="text-[color:var(--fg)] font-medium mb-3">Change Summary</h4>
                 <div className="flex items-center justify-between">
-                  <span className="text-gray-400">Ghost Mode</span>
+                  <span className="text-[color:var(--dim)]">Ghost Mode</span>
                   <div className="flex items-center gap-2">
                     <Badge variant={config?.ghost_mode ? 'success' : 'default'}>
                       {config?.ghost_mode ? 'Active' : 'Inactive'}
                     </Badge>
-                    <span className="text-gray-500">-&gt;</span>
+                    <span className="text-[color:var(--fainter)]">-&gt;</span>
                     <Badge variant={data.enabled ? 'success' : 'default'}>
                       {data.enabled ? 'Active' : 'Inactive'}
                     </Badge>
@@ -155,14 +155,14 @@ export default function GhostModeWizard({ isOpen, onClose }: GhostModeWizardProp
                 </div>
               </div>
               {data.enabled !== (config?.ghost_mode ?? false) ? (
-                <div className="p-4 rounded-lg bg-orange-900/20 border border-orange-800">
-                  <p className="text-sm text-orange-300">
+                <div className="p-4 rounded-lg bg-[var(--accent)]/20 border border-[var(--accent)]">
+                  <p className="text-sm text-[color:var(--accent)]">
                     Click Finish to apply this change. Your node configuration will be updated immediately.
                   </p>
                 </div>
               ) : (
-                <div className="p-4 rounded-lg bg-gray-800/50">
-                  <p className="text-sm text-gray-400">
+                <div className="p-4 rounded-lg bg-[var(--surface)]/50">
+                  <p className="text-sm text-[color:var(--dim)]">
                     No changes detected. The setting matches the current configuration.
                   </p>
                 </div>

--- a/dashboard/src/app/(dashboard)/settings/wizards/HazeWizard.tsx
+++ b/dashboard/src/app/(dashboard)/settings/wizards/HazeWizard.tsx
@@ -83,11 +83,11 @@ export default function HazeWizard({ isOpen, onClose }: HazeWizardProps) {
           {/* Step 1: Current Status */}
           {wizard.currentStep === 0 && (
             <div className="space-y-4">
-              <div className="p-4 rounded-lg bg-gray-800/50">
-                <h4 className="text-gray-100 font-medium mb-3">Current Haze Status</h4>
+              <div className="p-4 rounded-lg bg-[var(--surface)]/50">
+                <h4 className="text-[color:var(--fg)] font-medium mb-3">Current Haze Status</h4>
                 <div className="space-y-3">
                   <div className="flex items-center justify-between">
-                    <span className="text-gray-400">Storage Mode</span>
+                    <span className="text-[color:var(--dim)]">Storage Mode</span>
                     <Badge
                       variant={
                         currentMode === 'hazed'
@@ -103,21 +103,21 @@ export default function HazeWizard({ isOpen, onClose }: HazeWizardProps) {
                   {hazeStatus && (
                     <>
                       <div className="flex items-center justify-between">
-                        <span className="text-gray-400">Blocks Stored</span>
-                        <span className="text-gray-100">
+                        <span className="text-[color:var(--dim)]">Blocks Stored</span>
+                        <span className="text-[color:var(--fg)]">
                           {hazeStatus.blocks?.toLocaleString() ?? 'N/A'}
                         </span>
                       </div>
                       <div className="flex items-center justify-between">
-                        <span className="text-gray-400">Size on Disk</span>
-                        <span className="text-gray-100">
+                        <span className="text-[color:var(--dim)]">Size on Disk</span>
+                        <span className="text-[color:var(--fg)]">
                           {hazeStatus.size_on_disk
                             ? `${(hazeStatus.size_on_disk / (1024 * 1024 * 1024)).toFixed(2)} GB`
                             : 'N/A'}
                         </span>
                       </div>
                       <div className="flex items-center justify-between">
-                        <span className="text-gray-400">Archive Mode</span>
+                        <span className="text-[color:var(--dim)]">Archive Mode</span>
                         <Badge variant={hazeStatus.archive_mode ? 'success' : 'default'}>
                           {hazeStatus.archive_mode ? 'Active' : 'Inactive'}
                         </Badge>
@@ -126,8 +126,8 @@ export default function HazeWizard({ isOpen, onClose }: HazeWizardProps) {
                   )}
                 </div>
               </div>
-              <div className="p-4 rounded-lg bg-gray-800/50">
-                <p className="text-sm text-gray-400">
+              <div className="p-4 rounded-lg bg-[var(--surface)]/50">
+                <p className="text-sm text-[color:var(--dim)]">
                   Ghost Haze controls how your node stores block data. Hazed mode strips
                   non-financial witness data from blocks, reducing storage requirements while
                   maintaining full transaction verification capability.
@@ -151,28 +151,28 @@ export default function HazeWizard({ isOpen, onClose }: HazeWizardProps) {
                       w-full text-left p-4 rounded-lg border-2 transition-colors
                       ${
                         isSelected
-                          ? 'border-orange-500 bg-orange-900/20'
-                          : 'border-gray-700 bg-gray-800/50 hover:border-gray-600'
+                          ? 'border-[var(--accent)] bg-[var(--accent)]/20'
+                          : 'border-[var(--rule-strong)] bg-[var(--surface)]/50 hover:border-[var(--rule-strong)]'
                       }
                     `}
                   >
                     <div className="flex items-center justify-between mb-1">
-                      <span className="text-gray-100 font-medium">{modeLabels[mode]}</span>
+                      <span className="text-[color:var(--fg)] font-medium">{modeLabels[mode]}</span>
                       <div className="flex items-center gap-2">
                         {isCurrent && (
                           <Badge variant="info">Current</Badge>
                         )}
                         {isSelected && (
-                          <div className="w-4 h-4 rounded-full bg-orange-500 flex items-center justify-center">
+                          <div className="w-4 h-4 rounded-full bg-[var(--accent)] flex items-center justify-center">
                             <div className="w-2 h-2 rounded-full bg-white" />
                           </div>
                         )}
                         {!isSelected && (
-                          <div className="w-4 h-4 rounded-full border-2 border-gray-600" />
+                          <div className="w-4 h-4 rounded-full border-2 border-[var(--rule-strong)]" />
                         )}
                       </div>
                     </div>
-                    <p className="text-sm text-gray-400">{modeDescriptions[mode]}</p>
+                    <p className="text-sm text-[color:var(--dim)]">{modeDescriptions[mode]}</p>
                   </button>
                 );
               })}
@@ -182,10 +182,10 @@ export default function HazeWizard({ isOpen, onClose }: HazeWizardProps) {
           {/* Step 3: Confirm */}
           {wizard.currentStep === 2 && (
             <div className="space-y-4">
-              <div className="p-4 rounded-lg bg-gray-800/50">
-                <h4 className="text-gray-100 font-medium mb-3">Change Summary</h4>
+              <div className="p-4 rounded-lg bg-[var(--surface)]/50">
+                <h4 className="text-[color:var(--fg)] font-medium mb-3">Change Summary</h4>
                 <div className="flex items-center justify-between">
-                  <span className="text-gray-400">Storage Mode</span>
+                  <span className="text-[color:var(--dim)]">Storage Mode</span>
                   <div className="flex items-center gap-2">
                     <Badge
                       variant={
@@ -198,7 +198,7 @@ export default function HazeWizard({ isOpen, onClose }: HazeWizardProps) {
                     >
                       {modeLabels[currentMode as HazeMode] ?? 'Unknown'}
                     </Badge>
-                    <span className="text-gray-500">-&gt;</span>
+                    <span className="text-[color:var(--fainter)]">-&gt;</span>
                     <Badge
                       variant={
                         data.mode === 'hazed'
@@ -214,22 +214,22 @@ export default function HazeWizard({ isOpen, onClose }: HazeWizardProps) {
                 </div>
               </div>
               {data.mode !== currentMode ? (
-                <div className="p-4 rounded-lg bg-orange-900/20 border border-orange-800">
-                  <p className="text-sm text-orange-300">
+                <div className="p-4 rounded-lg bg-[var(--accent)]/20 border border-[var(--accent)]">
+                  <p className="text-sm text-[color:var(--accent)]">
                     Click Finish to change the storage mode. This may require Ghost Core to
                     reprocess blocks depending on the mode transition.
                   </p>
                 </div>
               ) : (
-                <div className="p-4 rounded-lg bg-gray-800/50">
-                  <p className="text-sm text-gray-400">
+                <div className="p-4 rounded-lg bg-[var(--surface)]/50">
+                  <p className="text-sm text-[color:var(--dim)]">
                     No changes detected. The selected mode matches the current configuration.
                   </p>
                 </div>
               )}
-              <div className="p-4 rounded-lg bg-gray-800/50">
-                <h4 className="text-gray-100 font-medium mb-2">Mode Details</h4>
-                <p className="text-sm text-gray-400">{modeDescriptions[data.mode]}</p>
+              <div className="p-4 rounded-lg bg-[var(--surface)]/50">
+                <h4 className="text-[color:var(--fg)] font-medium mb-2">Mode Details</h4>
+                <p className="text-sm text-[color:var(--dim)]">{modeDescriptions[data.mode]}</p>
               </div>
             </div>
           )}

--- a/dashboard/src/app/(dashboard)/settings/wizards/InitialSetupWizard.tsx
+++ b/dashboard/src/app/(dashboard)/settings/wizards/InitialSetupWizard.tsx
@@ -199,15 +199,15 @@ export default function InitialSetupWizard({ isOpen, onClose }: InitialSetupWiza
           {/* Step 0: Welcome */}
           {wizard.currentStep === 0 && (
             <div className="space-y-4">
-              <div className="p-4 rounded-lg bg-gray-800/50">
-                <h4 className="text-gray-100 font-medium mb-2">Welcome to Ghost Pool</h4>
-                <p className="text-sm text-gray-400">
+              <div className="p-4 rounded-lg bg-[var(--surface)]/50">
+                <h4 className="text-[color:var(--fg)] font-medium mb-2">Welcome to Ghost Pool</h4>
+                <p className="text-sm text-[color:var(--dim)]">
                   This wizard will guide you through the initial configuration of your Ghost node.
                   All capabilities are enabled by default for maximum privacy and shares (15/15).
                   You can disable anything you don&apos;t need.
                 </p>
-                <div className="mt-3 text-sm text-gray-500">
-                  <p className="font-medium text-gray-400 mb-1">Share breakdown:</p>
+                <div className="mt-3 text-sm text-[color:var(--fainter)]">
+                  <p className="font-medium text-[color:var(--dim)] mb-1">Share breakdown:</p>
                   <ul className="space-y-1 ml-2">
                     <li>Archive Mode: +5 shares</li>
                     <li>Ghost Pay: +4 shares</li>
@@ -217,29 +217,29 @@ export default function InitialSetupWizard({ isOpen, onClose }: InitialSetupWiza
                   </ul>
                 </div>
               </div>
-              <div className="p-4 rounded-lg bg-gray-800/50">
-                <h4 className="text-gray-100 font-medium mb-2">What we will set up</h4>
-                <ul className="space-y-2 text-sm text-gray-400">
+              <div className="p-4 rounded-lg bg-[var(--surface)]/50">
+                <h4 className="text-[color:var(--fg)] font-medium mb-2">What we will set up</h4>
+                <ul className="space-y-2 text-sm text-[color:var(--dim)]">
                   <li className="flex items-center gap-2">
-                    <span className="text-orange-300">1.</span>
+                    <span className="text-[color:var(--accent)]">1.</span>
                     Node identity and nickname
                   </li>
                   <li className="flex items-center gap-2">
-                    <span className="text-orange-300">2.</span>
+                    <span className="text-[color:var(--accent)]">2.</span>
                     Mining configuration and payout address
                   </li>
                   <li className="flex items-center gap-2">
-                    <span className="text-orange-300">3.</span>
+                    <span className="text-[color:var(--accent)]">3.</span>
                     Node capabilities (Ghost Mode, Archive, Pure, Pay)
                   </li>
                   <li className="flex items-center gap-2">
-                    <span className="text-orange-300">4.</span>
+                    <span className="text-[color:var(--accent)]">4.</span>
                     Mempool transaction policy
                   </li>
                 </ul>
               </div>
-              <div className="p-4 rounded-lg bg-orange-900/20 border border-orange-800">
-                <p className="text-sm text-orange-300">
+              <div className="p-4 rounded-lg bg-[var(--accent)]/20 border border-[var(--accent)]">
+                <p className="text-sm text-[color:var(--accent)]">
                   All settings can be changed later from the Settings page. Click Next to begin.
                 </p>
               </div>
@@ -249,7 +249,7 @@ export default function InitialSetupWizard({ isOpen, onClose }: InitialSetupWiza
           {/* Step 1: Identity */}
           {wizard.currentStep === 1 && (
             <div className="space-y-4">
-              <div className="p-4 rounded-lg bg-gray-800/50">
+              <div className="p-4 rounded-lg bg-[var(--surface)]/50">
                 <Input
                   label="Node Nickname"
                   type="text"
@@ -260,8 +260,8 @@ export default function InitialSetupWizard({ isOpen, onClose }: InitialSetupWiza
                   maxLength={32}
                 />
               </div>
-              <div className="p-4 rounded-lg bg-gray-800/50">
-                <p className="text-sm text-gray-400">
+              <div className="p-4 rounded-lg bg-[var(--surface)]/50">
+                <p className="text-sm text-[color:var(--dim)]">
                   Your node will also have a cryptographic node ID derived from its keys. The nickname
                   is an optional friendly label shown in the dashboard and to network peers.
                 </p>
@@ -272,11 +272,11 @@ export default function InitialSetupWizard({ isOpen, onClose }: InitialSetupWiza
           {/* Step 2: Mining */}
           {wizard.currentStep === 2 && (
             <div className="space-y-4">
-              <div className="p-4 rounded-lg bg-gray-800/50">
+              <div className="p-4 rounded-lg bg-[var(--surface)]/50">
                 <div className="flex items-center justify-between">
                   <div>
-                    <span className="text-gray-100 font-medium">Public Mining</span>
-                    <p className="text-sm text-gray-400 mt-1">
+                    <span className="text-[color:var(--fg)] font-medium">Public Mining</span>
+                    <p className="text-sm text-[color:var(--dim)] mt-1">
                       Open your Stratum port to external miners. Earns +3 shares in the node reward pool.
                     </p>
                   </div>
@@ -287,7 +287,7 @@ export default function InitialSetupWizard({ isOpen, onClose }: InitialSetupWiza
                   />
                 </div>
               </div>
-              <div className="p-4 rounded-lg bg-gray-800/50">
+              <div className="p-4 rounded-lg bg-[var(--surface)]/50">
                 <Input
                   label="Mining Payout Address"
                   type="text"
@@ -298,8 +298,8 @@ export default function InitialSetupWizard({ isOpen, onClose }: InitialSetupWiza
                 />
               </div>
               {data.public_mining && !data.payout_address && (
-                <div className="p-4 rounded-lg bg-orange-900/20 border border-orange-800">
-                  <p className="text-sm text-orange-300">
+                <div className="p-4 rounded-lg bg-[var(--accent)]/20 border border-[var(--accent)]">
+                  <p className="text-sm text-[color:var(--accent)]">
                     A payout address is required for public mining. Miners connecting to your pool
                     will contribute shares to this address.
                   </p>
@@ -312,16 +312,16 @@ export default function InitialSetupWizard({ isOpen, onClose }: InitialSetupWiza
           {wizard.currentStep === 3 && (
             <div className="space-y-3">
               {NODE_MODES.map((mode) => (
-                <div key={mode.key} className="p-4 rounded-lg bg-gray-800/50">
+                <div key={mode.key} className="p-4 rounded-lg bg-[var(--surface)]/50">
                   <div className="flex items-center justify-between">
                     <div className="flex-1 mr-4">
                       <div className="flex items-center gap-2">
-                        <span className="text-gray-100 font-medium">{mode.label}</span>
+                        <span className="text-[color:var(--fg)] font-medium">{mode.label}</span>
                         {mode.shares && (
                           <Badge variant="info">{mode.shares}</Badge>
                         )}
                       </div>
-                      <p className="text-sm text-gray-400 mt-1">{mode.description}</p>
+                      <p className="text-sm text-[color:var(--dim)] mt-1">{mode.description}</p>
                     </div>
                     <Toggle
                       enabled={data[mode.key]}
@@ -331,8 +331,8 @@ export default function InitialSetupWizard({ isOpen, onClose }: InitialSetupWiza
                   </div>
                 </div>
               ))}
-              <div className="p-4 rounded-lg bg-gray-800/50">
-                <p className="text-sm text-gray-400">
+              <div className="p-4 rounded-lg bg-[var(--surface)]/50">
+                <p className="text-sm text-[color:var(--dim)]">
                   Capabilities are verified by the network through challenge-response checks.
                   Earning share bonuses requires passing verification with 95% accuracy over 7 days.
                 </p>
@@ -351,17 +351,17 @@ export default function InitialSetupWizard({ isOpen, onClose }: InitialSetupWiza
                   className={`
                     w-full text-left p-4 rounded-lg border transition-colors
                     ${data.mempool_profile === profile.id
-                      ? 'bg-orange-900/30 border-orange-600'
-                      : 'bg-gray-800/50 border-gray-700 hover:border-gray-600'}
+                      ? 'bg-[var(--accent)]/30 border-[var(--accent)]'
+                      : 'bg-[var(--surface)]/50 border-[var(--rule-strong)] hover:border-[var(--rule-strong)]'}
                   `}
                 >
                   <div className="flex items-center justify-between">
-                    <span className="text-gray-100 font-medium">{profile.label}</span>
+                    <span className="text-[color:var(--fg)] font-medium">{profile.label}</span>
                     {data.mempool_profile === profile.id && (
                       <Badge variant="warning">Selected</Badge>
                     )}
                   </div>
-                  <p className="text-sm text-gray-400 mt-1">{profile.description}</p>
+                  <p className="text-sm text-[color:var(--dim)] mt-1">{profile.description}</p>
                 </button>
               ))}
             </div>
@@ -370,66 +370,66 @@ export default function InitialSetupWizard({ isOpen, onClose }: InitialSetupWiza
           {/* Step 5: Confirm */}
           {wizard.currentStep === 5 && (
             <div className="space-y-4">
-              <div className="p-4 rounded-lg bg-gray-800/50">
-                <h4 className="text-gray-100 font-medium mb-3">Setup Summary</h4>
+              <div className="p-4 rounded-lg bg-[var(--surface)]/50">
+                <h4 className="text-[color:var(--fg)] font-medium mb-3">Setup Summary</h4>
                 <div className="space-y-3">
                   <div className="flex items-center justify-between">
-                    <span className="text-gray-400">Nickname</span>
-                    <span className="text-gray-100 font-medium">{data.nickname || '--'}</span>
+                    <span className="text-[color:var(--dim)]">Nickname</span>
+                    <span className="text-[color:var(--fg)] font-medium">{data.nickname || '--'}</span>
                   </div>
                   <div className="flex items-center justify-between">
-                    <span className="text-gray-400">Public Mining</span>
+                    <span className="text-[color:var(--dim)]">Public Mining</span>
                     <Badge variant={data.public_mining ? 'success' : 'default'}>
                       {data.public_mining ? 'Enabled' : 'Disabled'}
                     </Badge>
                   </div>
                   {data.payout_address && (
                     <div className="flex items-center justify-between">
-                      <span className="text-gray-400">Payout Address</span>
-                      <span className="text-gray-100 text-sm font-mono truncate max-w-[200px]">
+                      <span className="text-[color:var(--dim)]">Payout Address</span>
+                      <span className="text-[color:var(--fg)] text-sm font-mono truncate max-w-[200px]">
                         {data.payout_address}
                       </span>
                     </div>
                   )}
                 </div>
               </div>
-              <div className="p-4 rounded-lg bg-gray-800/50">
-                <h4 className="text-gray-100 font-medium mb-3">Node Capabilities</h4>
+              <div className="p-4 rounded-lg bg-[var(--surface)]/50">
+                <h4 className="text-[color:var(--fg)] font-medium mb-3">Node Capabilities</h4>
                 <div className="space-y-3">
                   <div className="flex items-center justify-between">
-                    <span className="text-gray-400">Ghost Mode</span>
+                    <span className="text-[color:var(--dim)]">Ghost Mode</span>
                     <Badge variant={data.ghost_mode ? 'success' : 'default'}>
                       {data.ghost_mode ? 'Enabled' : 'Disabled'}
                     </Badge>
                   </div>
                   <div className="flex items-center justify-between">
-                    <span className="text-gray-400">Archive Mode (+5)</span>
+                    <span className="text-[color:var(--dim)]">Archive Mode (+5)</span>
                     <Badge variant={data.archive_mode ? 'success' : 'default'}>
                       {data.archive_mode ? 'Enabled' : 'Disabled'}
                     </Badge>
                   </div>
                   <div className="flex items-center justify-between">
-                    <span className="text-gray-400">Reaper (+2)</span>
+                    <span className="text-[color:var(--dim)]">Reaper (+2)</span>
                     <Badge variant={data.reaper ? 'success' : 'default'}>
                       {data.reaper ? 'Enabled' : 'Disabled'}
                     </Badge>
                   </div>
                   <div className="flex items-center justify-between">
-                    <span className="text-gray-400">Ghost Pay (+4)</span>
+                    <span className="text-[color:var(--dim)]">Ghost Pay (+4)</span>
                     <Badge variant={data.ghost_pay ? 'success' : 'default'}>
                       {data.ghost_pay ? 'Enabled' : 'Disabled'}
                     </Badge>
                   </div>
                 </div>
               </div>
-              <div className="p-4 rounded-lg bg-gray-800/50">
+              <div className="p-4 rounded-lg bg-[var(--surface)]/50">
                 <div className="flex items-center justify-between">
-                  <span className="text-gray-400">Mempool Profile</span>
+                  <span className="text-[color:var(--dim)]">Mempool Profile</span>
                   <Badge variant="warning">{data.mempool_profile}</Badge>
                 </div>
               </div>
-              <div className="p-4 rounded-lg bg-orange-900/20 border border-orange-800">
-                <p className="text-sm text-orange-300">
+              <div className="p-4 rounded-lg bg-[var(--accent)]/20 border border-[var(--accent)]">
+                <p className="text-sm text-[color:var(--accent)]">
                   Click Finish to apply all settings. Your node will be configured and start
                   operating with the selected parameters.
                 </p>

--- a/dashboard/src/app/(dashboard)/settings/wizards/MempoolPolicyWizard.tsx
+++ b/dashboard/src/app/(dashboard)/settings/wizards/MempoolPolicyWizard.tsx
@@ -225,17 +225,17 @@ export default function MempoolPolicyWizard({ isOpen, onClose }: MempoolPolicyWi
                   className={`
                     w-full text-left p-4 rounded-lg border transition-colors
                     ${data.mempool_profile === profile.id
-                      ? 'bg-orange-900/30 border-orange-600'
-                      : 'bg-gray-800/50 border-gray-700 hover:border-gray-600'}
+                      ? 'bg-[var(--accent)]/30 border-[var(--accent)]'
+                      : 'bg-[var(--surface)]/50 border-[var(--rule-strong)] hover:border-[var(--rule-strong)]'}
                   `}
                 >
                   <div className="flex items-center justify-between">
-                    <span className="text-gray-100 font-medium">{profile.label}</span>
+                    <span className="text-[color:var(--fg)] font-medium">{profile.label}</span>
                     {data.mempool_profile === profile.id && (
                       <Badge variant="warning">Selected</Badge>
                     )}
                   </div>
-                  <p className="text-sm text-gray-400 mt-1">{profile.description}</p>
+                  <p className="text-sm text-[color:var(--dim)] mt-1">{profile.description}</p>
                 </button>
               ))}
             </div>
@@ -244,7 +244,7 @@ export default function MempoolPolicyWizard({ isOpen, onClose }: MempoolPolicyWi
           {/* Step 1: Core Settings (custom only) */}
           {wizard.currentStep === 1 && (
             <div className="space-y-4">
-              <div className="p-4 rounded-lg bg-gray-800/50">
+              <div className="p-4 rounded-lg bg-[var(--surface)]/50">
                 <Input
                   label="Profile Name"
                   type="text"
@@ -253,7 +253,7 @@ export default function MempoolPolicyWizard({ isOpen, onClose }: MempoolPolicyWi
                   helperText="A label for this custom profile; it is saved and activated on your node"
                 />
               </div>
-              <div className="p-4 rounded-lg bg-gray-800/50">
+              <div className="p-4 rounded-lg bg-[var(--surface)]/50">
                 <Input
                   label="Minimum Relay TX Fee (sat/vB)"
                   type="number"
@@ -264,7 +264,7 @@ export default function MempoolPolicyWizard({ isOpen, onClose }: MempoolPolicyWi
                   helperText="Transactions below this fee rate will not be relayed or accepted into the mempool"
                 />
               </div>
-              <div className="p-4 rounded-lg bg-gray-800/50">
+              <div className="p-4 rounded-lg bg-[var(--surface)]/50">
                 <Input
                   label="Max Mempool Size (MB)"
                   type="number"
@@ -275,7 +275,7 @@ export default function MempoolPolicyWizard({ isOpen, onClose }: MempoolPolicyWi
                   helperText="Maximum size of the in-memory transaction pool. Lower values evict low-fee transactions sooner."
                 />
               </div>
-              <div className="p-4 rounded-lg bg-gray-800/50">
+              <div className="p-4 rounded-lg bg-[var(--surface)]/50">
                 <Input
                   label="Mempool Expiry (hours)"
                   type="number"
@@ -292,11 +292,11 @@ export default function MempoolPolicyWizard({ isOpen, onClose }: MempoolPolicyWi
           {/* Step 2: Filtering (custom only) */}
           {wizard.currentStep === 2 && (
             <div className="space-y-4">
-              <div className="p-4 rounded-lg bg-gray-800/50">
+              <div className="p-4 rounded-lg bg-[var(--surface)]/50">
                 <div className="flex items-center justify-between">
                   <div>
-                    <span className="text-gray-100 font-medium">Filter Inscriptions</span>
-                    <p className="text-sm text-gray-400 mt-1">
+                    <span className="text-[color:var(--fg)] font-medium">Filter Inscriptions</span>
+                    <p className="text-sm text-[color:var(--dim)] mt-1">
                       Reject Ordinal inscription transactions from the mempool
                     </p>
                   </div>
@@ -307,11 +307,11 @@ export default function MempoolPolicyWizard({ isOpen, onClose }: MempoolPolicyWi
                   />
                 </div>
               </div>
-              <div className="p-4 rounded-lg bg-gray-800/50">
+              <div className="p-4 rounded-lg bg-[var(--surface)]/50">
                 <div className="flex items-center justify-between">
                   <div>
-                    <span className="text-gray-100 font-medium">Filter BRC-20</span>
-                    <p className="text-sm text-gray-400 mt-1">
+                    <span className="text-[color:var(--fg)] font-medium">Filter BRC-20</span>
+                    <p className="text-sm text-[color:var(--dim)] mt-1">
                       Reject BRC-20 token transfer transactions
                     </p>
                   </div>
@@ -322,11 +322,11 @@ export default function MempoolPolicyWizard({ isOpen, onClose }: MempoolPolicyWi
                   />
                 </div>
               </div>
-              <div className="p-4 rounded-lg bg-gray-800/50">
+              <div className="p-4 rounded-lg bg-[var(--surface)]/50">
                 <div className="flex items-center justify-between">
                   <div>
-                    <span className="text-gray-100 font-medium">Filter Runes</span>
-                    <p className="text-sm text-gray-400 mt-1">
+                    <span className="text-[color:var(--fg)] font-medium">Filter Runes</span>
+                    <p className="text-sm text-[color:var(--dim)] mt-1">
                       Reject Rune protocol transactions from the mempool
                     </p>
                   </div>
@@ -337,11 +337,11 @@ export default function MempoolPolicyWizard({ isOpen, onClose }: MempoolPolicyWi
                   />
                 </div>
               </div>
-              <div className="p-4 rounded-lg bg-gray-800/50">
+              <div className="p-4 rounded-lg bg-[var(--surface)]/50">
                 <div className="flex items-center justify-between">
                   <div>
-                    <span className="text-gray-100 font-medium">Allow OP_RETURN (Datacarrier)</span>
-                    <p className="text-sm text-gray-400 mt-1">
+                    <span className="text-[color:var(--fg)] font-medium">Allow OP_RETURN (Datacarrier)</span>
+                    <p className="text-sm text-[color:var(--dim)] mt-1">
                       Accept transactions with OP_RETURN data outputs
                     </p>
                   </div>
@@ -366,17 +366,17 @@ export default function MempoolPolicyWizard({ isOpen, onClose }: MempoolPolicyWi
                   className={`
                     w-full text-left p-4 rounded-lg border transition-colors
                     ${data.template_profile === profile.id
-                      ? 'bg-orange-900/30 border-orange-600'
-                      : 'bg-gray-800/50 border-gray-700 hover:border-gray-600'}
+                      ? 'bg-[var(--accent)]/30 border-[var(--accent)]'
+                      : 'bg-[var(--surface)]/50 border-[var(--rule-strong)] hover:border-[var(--rule-strong)]'}
                   `}
                 >
                   <div className="flex items-center justify-between">
-                    <span className="text-gray-100 font-medium">{profile.label}</span>
+                    <span className="text-[color:var(--fg)] font-medium">{profile.label}</span>
                     {data.template_profile === profile.id && (
                       <Badge variant="warning">Selected</Badge>
                     )}
                   </div>
-                  <p className="text-sm text-gray-400 mt-1">{profile.description}</p>
+                  <p className="text-sm text-[color:var(--dim)] mt-1">{profile.description}</p>
                 </button>
               ))}
             </div>
@@ -385,66 +385,66 @@ export default function MempoolPolicyWizard({ isOpen, onClose }: MempoolPolicyWi
           {/* Step 4: Confirm Summary */}
           {wizard.currentStep === 4 && (
             <div className="space-y-4">
-              <div className="p-4 rounded-lg bg-gray-800/50">
-                <h4 className="text-gray-100 font-medium mb-3">Configuration Summary</h4>
+              <div className="p-4 rounded-lg bg-[var(--surface)]/50">
+                <h4 className="text-[color:var(--fg)] font-medium mb-3">Configuration Summary</h4>
                 <div className="space-y-3">
                   <div className="flex items-center justify-between">
-                    <span className="text-gray-400">Mempool Profile</span>
+                    <span className="text-[color:var(--dim)]">Mempool Profile</span>
                     <Badge variant="warning">{data.mempool_profile}</Badge>
                   </div>
                   <div className="flex items-center justify-between">
-                    <span className="text-gray-400">Template Profile</span>
+                    <span className="text-[color:var(--dim)]">Template Profile</span>
                     <Badge variant="warning">{data.template_profile}</Badge>
                   </div>
                 </div>
               </div>
               {isCustom && (
-                <div className="p-4 rounded-lg bg-gray-800/50">
-                  <h4 className="text-gray-100 font-medium mb-3">Custom Settings</h4>
+                <div className="p-4 rounded-lg bg-[var(--surface)]/50">
+                  <h4 className="text-[color:var(--fg)] font-medium mb-3">Custom Settings</h4>
                   <div className="space-y-3">
                     <div className="flex items-center justify-between">
-                      <span className="text-gray-400">Profile Name</span>
-                      <span className="text-gray-100">{data.profile_name}</span>
+                      <span className="text-[color:var(--dim)]">Profile Name</span>
+                      <span className="text-[color:var(--fg)]">{data.profile_name}</span>
                     </div>
                     <div className="flex items-center justify-between">
-                      <span className="text-gray-400">Min Relay Fee</span>
-                      <span className="text-gray-100">{data.min_relay_tx_fee} sat/vB</span>
+                      <span className="text-[color:var(--dim)]">Min Relay Fee</span>
+                      <span className="text-[color:var(--fg)]">{data.min_relay_tx_fee} sat/vB</span>
                     </div>
                     <div className="flex items-center justify-between">
-                      <span className="text-gray-400">Max Mempool Size</span>
-                      <span className="text-gray-100">{data.max_mempool_size} MB</span>
+                      <span className="text-[color:var(--dim)]">Max Mempool Size</span>
+                      <span className="text-[color:var(--fg)]">{data.max_mempool_size} MB</span>
                     </div>
                     <div className="flex items-center justify-between">
-                      <span className="text-gray-400">Mempool Expiry</span>
-                      <span className="text-gray-100">{data.mempool_expiry} hours</span>
+                      <span className="text-[color:var(--dim)]">Mempool Expiry</span>
+                      <span className="text-[color:var(--fg)]">{data.mempool_expiry} hours</span>
                     </div>
                   </div>
                 </div>
               )}
               {isCustom && (
-                <div className="p-4 rounded-lg bg-gray-800/50">
-                  <h4 className="text-gray-100 font-medium mb-3">Filtering</h4>
+                <div className="p-4 rounded-lg bg-[var(--surface)]/50">
+                  <h4 className="text-[color:var(--fg)] font-medium mb-3">Filtering</h4>
                   <div className="space-y-3">
                     <div className="flex items-center justify-between">
-                      <span className="text-gray-400">Filter Inscriptions</span>
+                      <span className="text-[color:var(--dim)]">Filter Inscriptions</span>
                       <Badge variant={data.filter_inscriptions ? 'error' : 'success'}>
                         {data.filter_inscriptions ? 'Blocked' : 'Allowed'}
                       </Badge>
                     </div>
                     <div className="flex items-center justify-between">
-                      <span className="text-gray-400">Filter BRC-20</span>
+                      <span className="text-[color:var(--dim)]">Filter BRC-20</span>
                       <Badge variant={data.filter_brc20 ? 'error' : 'success'}>
                         {data.filter_brc20 ? 'Blocked' : 'Allowed'}
                       </Badge>
                     </div>
                     <div className="flex items-center justify-between">
-                      <span className="text-gray-400">Filter Runes</span>
+                      <span className="text-[color:var(--dim)]">Filter Runes</span>
                       <Badge variant={data.filter_runes ? 'error' : 'success'}>
                         {data.filter_runes ? 'Blocked' : 'Allowed'}
                       </Badge>
                     </div>
                     <div className="flex items-center justify-between">
-                      <span className="text-gray-400">OP_RETURN Data</span>
+                      <span className="text-[color:var(--dim)]">OP_RETURN Data</span>
                       <Badge variant={data.datacarrier ? 'success' : 'error'}>
                         {data.datacarrier ? 'Allowed' : 'Blocked'}
                       </Badge>
@@ -452,8 +452,8 @@ export default function MempoolPolicyWizard({ isOpen, onClose }: MempoolPolicyWi
                   </div>
                 </div>
               )}
-              <div className="p-4 rounded-lg bg-orange-900/20 border border-orange-800">
-                <p className="text-sm text-orange-300">
+              <div className="p-4 rounded-lg bg-[var(--accent)]/20 border border-[var(--accent)]">
+                <p className="text-sm text-[color:var(--accent)]">
                   Click Finish to apply these changes. Your node mempool and template configuration will be updated immediately.
                 </p>
               </div>

--- a/dashboard/src/app/(dashboard)/settings/wizards/PoolSetupWizard.tsx
+++ b/dashboard/src/app/(dashboard)/settings/wizards/PoolSetupWizard.tsx
@@ -155,21 +155,21 @@ export default function PoolSetupWizard({ isOpen, onClose }: PoolSetupWizardProp
                     })}
                     className={`w-full p-4 rounded-lg border text-left transition-all ${
                       isActive
-                        ? 'bg-orange-900/20 border-orange-600 ring-1 ring-orange-600/50'
-                        : 'bg-gray-800/30 border-gray-700 hover:border-gray-600'
+                        ? 'bg-[var(--accent)]/20 border-[var(--accent)] ring-1 ring-[var(--accent)]/50'
+                        : 'bg-[var(--surface)]/30 border-[var(--rule-strong)] hover:border-[var(--rule-strong)]'
                     }`}
                   >
                     <div className="flex items-center gap-2 mb-1">
                       <div className={`w-3 h-3 rounded-full border-2 flex items-center justify-center ${
-                        isActive ? 'border-orange-500' : 'border-gray-600'
+                        isActive ? 'border-[var(--accent)]' : 'border-[var(--rule-strong)]'
                       }`}>
-                        {isActive && <div className="w-1.5 h-1.5 rounded-full bg-orange-500" />}
+                        {isActive && <div className="w-1.5 h-1.5 rounded-full bg-[var(--accent)]" />}
                       </div>
-                      <span className={`font-medium ${isActive ? 'text-orange-400' : 'text-gray-300'}`}>{label}</span>
+                      <span className={`font-medium ${isActive ? 'text-[color:var(--accent)]' : 'text-[color:var(--dim)]'}`}>{label}</span>
                       {isActive && <Badge variant="success">Selected</Badge>}
                       {key === 'pool' && <Badge variant="info">+3 Shares</Badge>}
                     </div>
-                    <div className="text-xs text-gray-500 ml-5">{desc}</div>
+                    <div className="text-xs text-[color:var(--fainter)] ml-5">{desc}</div>
                   </button>
                 );
               })}
@@ -179,22 +179,22 @@ export default function PoolSetupWizard({ isOpen, onClose }: PoolSetupWizardProp
           {/* Step 2: Payout Address */}
           {wizard.currentStep === 1 && (
             <div className="space-y-4">
-              <div className="p-4 rounded-lg bg-gray-800/50">
+              <div className="p-4 rounded-lg bg-[var(--surface)]/50">
                 <Input
                   label="Mining Payout Address"
                   value={data.payout_address}
                   onChange={(e) => setData({ payout_address: e.target.value })}
                   placeholder="bc1q... / tb1q... / bcrt1q..."
                 />
-                <p className="text-sm text-gray-400 mt-1">
+                <p className="text-sm text-[color:var(--dim)] mt-1">
                   Enter a bech32 Bitcoin address to receive mining payouts. Must start with
                   bc1 (mainnet), tb1 (testnet/signet), or bcrt1 (regtest).
                 </p>
               </div>
               {data.payout_address.trim() && (
-                <div className="p-4 rounded-lg bg-gray-800/50">
+                <div className="p-4 rounded-lg bg-[var(--surface)]/50">
                   <div className="flex items-center justify-between">
-                    <span className="text-gray-400">Address Valid</span>
+                    <span className="text-[color:var(--dim)]">Address Valid</span>
                     {isValidBech32Address(data.payout_address) ? (
                       <Badge variant="success">Valid</Badge>
                     ) : (
@@ -203,8 +203,8 @@ export default function PoolSetupWizard({ isOpen, onClose }: PoolSetupWizardProp
                   </div>
                   {isValidBech32Address(data.payout_address) && (
                     <div className="mt-2">
-                      <span className="text-gray-400 text-sm">Network: </span>
-                      <span className="text-orange-300 text-sm">
+                      <span className="text-[color:var(--dim)] text-sm">Network: </span>
+                      <span className="text-[color:var(--accent)] text-sm">
                         {data.payout_address.trim().toLowerCase().startsWith('bc1')
                           ? 'Mainnet'
                           : data.payout_address.trim().toLowerCase().startsWith('bcrt1')
@@ -216,8 +216,8 @@ export default function PoolSetupWizard({ isOpen, onClose }: PoolSetupWizardProp
                 </div>
               )}
               {data.mining_mode !== 'private_solo' && !data.payout_address.trim() && (
-                <div className="p-4 rounded-lg bg-orange-900/20 border border-orange-800">
-                  <p className="text-sm text-orange-300">
+                <div className="p-4 rounded-lg bg-[var(--accent)]/20 border border-[var(--accent)]">
+                  <p className="text-sm text-[color:var(--accent)]">
                     A payout address is required for pool modes (the node receives its own share of pool rewards here).
                   </p>
                 </div>
@@ -228,7 +228,7 @@ export default function PoolSetupWizard({ isOpen, onClose }: PoolSetupWizardProp
           {/* Step 3: Pool Info */}
           {wizard.currentStep === 2 && (
             <div className="space-y-4">
-              <div className="p-4 rounded-lg bg-gray-800/50">
+              <div className="p-4 rounded-lg bg-[var(--surface)]/50">
                 <Input
                   label="Pool Name (optional)"
                   value={data.pool_name}
@@ -240,50 +240,50 @@ export default function PoolSetupWizard({ isOpen, onClose }: PoolSetupWizardProp
                   }}
                   placeholder="e.g. SatoshiPool"
                 />
-                <p className="text-sm text-gray-400 mt-1">
+                <p className="text-sm text-[color:var(--dim)] mt-1">
                   Custom name shown in block coinbase. ASCII only, max 30 characters.
                 </p>
                 {data.pool_name.trim() && (
-                  <div className="mt-2 p-2 rounded bg-gray-900 font-mono text-sm text-orange-300">
+                  <div className="mt-2 p-2 rounded bg-[var(--surface)] font-mono text-sm text-[color:var(--accent)]">
                     - G H O S T - {data.pool_name.trim()}
                   </div>
                 )}
               </div>
-              <div className="p-4 rounded-lg bg-gray-800/50">
-                <h4 className="text-gray-100 font-medium mb-3">Pool Configuration</h4>
+              <div className="p-4 rounded-lg bg-[var(--surface)]/50">
+                <h4 className="text-[color:var(--fg)] font-medium mb-3">Pool Configuration</h4>
                 <div className="space-y-3">
                   <div className="flex items-center justify-between">
-                    <span className="text-gray-400">Stratum Port</span>
-                    <span className="text-gray-100 font-mono">3333</span>
+                    <span className="text-[color:var(--dim)]">Stratum Port</span>
+                    <span className="text-[color:var(--fg)] font-mono">3333</span>
                   </div>
                   <div className="flex items-center justify-between">
-                    <span className="text-gray-400">Protocol</span>
-                    <span className="text-gray-100">Stratum V1</span>
+                    <span className="text-[color:var(--dim)]">Protocol</span>
+                    <span className="text-[color:var(--fg)]">Stratum V1</span>
                   </div>
                   <div className="flex items-center justify-between">
-                    <span className="text-gray-400">Variable Difficulty</span>
+                    <span className="text-[color:var(--dim)]">Variable Difficulty</span>
                     <Badge variant="success">Active</Badge>
                   </div>
                   <div className="flex items-center justify-between">
-                    <span className="text-gray-400">Target Rate</span>
-                    <span className="text-gray-100">4 shares/minute</span>
+                    <span className="text-[color:var(--dim)]">Target Rate</span>
+                    <span className="text-[color:var(--fg)]">4 shares/minute</span>
                   </div>
                   <div className="flex items-center justify-between">
-                    <span className="text-gray-400">Share Cap</span>
-                    <span className="text-gray-100">10% per miner</span>
+                    <span className="text-[color:var(--dim)]">Share Cap</span>
+                    <span className="text-[color:var(--fg)]">10% per miner</span>
                   </div>
                 </div>
               </div>
-              <div className="p-4 rounded-lg bg-gray-800/50">
-                <h4 className="text-gray-100 font-medium mb-2">Miner Connection Format</h4>
-                <p className="text-sm text-gray-400 mb-2">
+              <div className="p-4 rounded-lg bg-[var(--surface)]/50">
+                <h4 className="text-[color:var(--fg)] font-medium mb-2">Miner Connection Format</h4>
+                <p className="text-sm text-[color:var(--dim)] mb-2">
                   Miners connect with the following worker name format:
                 </p>
-                <div className="p-3 rounded bg-gray-900 font-mono text-sm text-orange-300">
+                <div className="p-3 rounded bg-[var(--surface)] font-mono text-sm text-[color:var(--accent)]">
                   stratum+tcp://your-node-ip:3333
                 </div>
-                <p className="text-sm text-gray-400 mt-2">
-                  Worker name: <span className="text-orange-300 font-mono">bitcoin_address.worker_id</span>
+                <p className="text-sm text-[color:var(--dim)] mt-2">
+                  Worker name: <span className="text-[color:var(--accent)] font-mono">bitcoin_address.worker_id</span>
                 </p>
               </div>
             </div>
@@ -292,16 +292,16 @@ export default function PoolSetupWizard({ isOpen, onClose }: PoolSetupWizardProp
           {/* Step 4: Confirm */}
           {wizard.currentStep === 3 && (
             <div className="space-y-4">
-              <div className="p-4 rounded-lg bg-gray-800/50">
-                <h4 className="text-gray-100 font-medium mb-3">Configuration Summary</h4>
+              <div className="p-4 rounded-lg bg-[var(--surface)]/50">
+                <h4 className="text-[color:var(--fg)] font-medium mb-3">Configuration Summary</h4>
                 <div className="space-y-3">
                   <div className="flex items-center justify-between">
-                    <span className="text-gray-400">Mining Mode</span>
+                    <span className="text-[color:var(--dim)]">Mining Mode</span>
                     <div className="flex items-center gap-2">
                       <Badge variant="default">
                         {MODES.find(m => m.key === currentMode)?.label ?? currentMode}
                       </Badge>
-                      <span className="text-gray-500">-&gt;</span>
+                      <span className="text-[color:var(--fainter)]">-&gt;</span>
                       <Badge variant="success">
                         {MODES.find(m => m.key === data.mining_mode)?.label ?? data.mining_mode}
                       </Badge>
@@ -309,8 +309,8 @@ export default function PoolSetupWizard({ isOpen, onClose }: PoolSetupWizardProp
                   </div>
                   {data.payout_address.trim() && (
                     <div className="flex items-center justify-between">
-                      <span className="text-gray-400">Payout Address</span>
-                      <span className="text-gray-100 font-mono text-sm">
+                      <span className="text-[color:var(--dim)]">Payout Address</span>
+                      <span className="text-[color:var(--fg)] font-mono text-sm">
                         {data.payout_address.trim().slice(0, 12)}...
                         {data.payout_address.trim().slice(-8)}
                       </span>
@@ -318,16 +318,16 @@ export default function PoolSetupWizard({ isOpen, onClose }: PoolSetupWizardProp
                   )}
                   {data.pool_name.trim() && (
                     <div className="flex items-center justify-between">
-                      <span className="text-gray-400">Pool Name</span>
-                      <span className="text-orange-300 font-mono text-sm">
+                      <span className="text-[color:var(--dim)]">Pool Name</span>
+                      <span className="text-[color:var(--accent)] font-mono text-sm">
                         - G H O S T - {data.pool_name.trim()}
                       </span>
                     </div>
                   )}
                 </div>
               </div>
-              <div className="p-4 rounded-lg bg-orange-900/20 border border-orange-800">
-                <p className="text-sm text-orange-300">
+              <div className="p-4 rounded-lg bg-[var(--accent)]/20 border border-[var(--accent)]">
+                <p className="text-sm text-[color:var(--accent)]">
                   Click Finish to apply mining settings. Changes will take effect immediately.
                   {data.mining_mode !== 'private_solo'
                     ? ' Miners will be able to connect to your node on port 3333.'

--- a/dashboard/src/app/(dashboard)/settings/wizards/ReaperWizard.tsx
+++ b/dashboard/src/app/(dashboard)/settings/wizards/ReaperWizard.tsx
@@ -81,16 +81,16 @@ export default function ReaperWizard({ isOpen, onClose }: ReaperWizardProps) {
     data: ReaperSettings,
     setData: (patch: Partial<ReaperSettings>) => void
   ) => (
-    <div className="p-4 rounded-lg bg-gray-800/50 space-y-4">
+    <div className="p-4 rounded-lg bg-[var(--surface)]/50 space-y-4">
       <div>
-        <h4 className="text-gray-100 font-medium">{title}</h4>
-        <p className="text-xs text-gray-500 mt-0.5">{note}</p>
+        <h4 className="text-[color:var(--fg)] font-medium">{title}</h4>
+        <p className="text-xs text-[color:var(--fainter)] mt-0.5">{note}</p>
       </div>
       {vectors.map((v) => (
         <div key={v.key} className="flex items-center justify-between">
           <div className="pr-4">
-            <span className="text-gray-100">{v.label}</span>
-            <p className="text-sm text-gray-400 mt-1">{v.desc}</p>
+            <span className="text-[color:var(--fg)]">{v.label}</span>
+            <p className="text-sm text-[color:var(--dim)] mt-1">{v.desc}</p>
           </div>
           <Toggle
             enabled={Boolean(data[v.key])}
@@ -110,11 +110,11 @@ export default function ReaperWizard({ isOpen, onClose }: ReaperWizardProps) {
           {/* Step 1: Enable */}
           {wizard.currentStep === 0 && (
             <div className="space-y-4">
-              <div className="p-4 rounded-lg bg-gray-800/50">
+              <div className="p-4 rounded-lg bg-[var(--surface)]/50">
                 <div className="flex items-center justify-between">
                   <div className="pr-4">
-                    <span className="text-gray-100 font-medium">Reaper Mode</span>
-                    <p className="text-sm text-gray-400 mt-1">
+                    <span className="text-[color:var(--fg)] font-medium">Reaper Mode</span>
+                    <p className="text-sm text-[color:var(--dim)] mt-1">
                       Master switch. When off, every detector is disabled on both the pool template
                       reaper and the node mempool reaper. When on, the per-detector choices below apply.
                     </p>
@@ -123,10 +123,10 @@ export default function ReaperWizard({ isOpen, onClose }: ReaperWizardProps) {
                 </div>
               </div>
               {data.enabled && (
-                <div className="p-4 rounded-lg bg-green-900/20 border border-green-800">
+                <div className="p-4 rounded-lg bg-[var(--green)]/20 border border-[var(--green)]">
                   <div className="flex items-center gap-2">
                     <Badge variant="success">+2 Shares</Badge>
-                    <span className="text-sm text-green-300">Enables Reaper capability verification for node rewards</span>
+                    <span className="text-sm text-[color:var(--green)]">Enables Reaper capability verification for node rewards</span>
                   </div>
                 </div>
               )}
@@ -137,8 +137,8 @@ export default function ReaperWizard({ isOpen, onClose }: ReaperWizardProps) {
           {wizard.currentStep === 1 && (
             <div className="space-y-4">
               {!data.enabled && (
-                <div className="p-4 rounded-lg bg-orange-900/20 border border-orange-800">
-                  <p className="text-sm text-orange-300">Reaper is disabled — these choices take effect once you enable it.</p>
+                <div className="p-4 rounded-lg bg-[var(--accent)]/20 border border-[var(--accent)]">
+                  <p className="text-sm text-[color:var(--accent)]">Reaper is disabled — these choices take effect once you enable it.</p>
                 </div>
               )}
               {renderGroup('Shared detectors', 'Apply to both the pool (block templates) and the node (mempool relay).', SHARED, data, setData)}
@@ -149,8 +149,8 @@ export default function ReaperWizard({ isOpen, onClose }: ReaperWizardProps) {
 
           {/* Step 3: Thresholds */}
           {wizard.currentStep === 2 && (
-            <div className="p-4 rounded-lg bg-gray-800/50 space-y-4">
-              <h4 className="text-gray-100 font-medium">Thresholds</h4>
+            <div className="p-4 rounded-lg bg-[var(--surface)]/50 space-y-4">
+              <h4 className="text-[color:var(--fg)] font-medium">Thresholds</h4>
               <Input label="Max OP_RETURN bytes (shared)" type="number" value={data.max_op_return_bytes}
                 onChange={(e) => setData({ max_op_return_bytes: Number(e.target.value) })} disabled={!data.enabled} />
               <Input label="Min drop-stuffing push size (shared)" type="number" value={data.min_drop_size}
@@ -167,15 +167,15 @@ export default function ReaperWizard({ isOpen, onClose }: ReaperWizardProps) {
           {/* Step 4: Confirm */}
           {wizard.currentStep === 3 && (
             <div className="space-y-4">
-              <div className="p-4 rounded-lg bg-gray-800/50">
+              <div className="p-4 rounded-lg bg-[var(--surface)]/50">
                 <div className="flex items-center justify-between">
-                  <span className="text-gray-400">Reaper Mode</span>
+                  <span className="text-[color:var(--dim)]">Reaper Mode</span>
                   <Badge variant={data.enabled ? 'success' : 'default'}>{data.enabled ? 'Enabled' : 'Disabled'}</Badge>
                 </div>
-                <div className="border-t border-gray-700 mt-3 pt-3 grid grid-cols-2 gap-2 text-sm">
+                <div className="border-t border-[var(--rule-strong)] mt-3 pt-3 grid grid-cols-2 gap-2 text-sm">
                   {[...SHARED, ...NODE_ONLY, ...POOL_ONLY].map((v) => (
                     <div key={v.key} className="flex items-center justify-between">
-                      <span className="text-gray-400">{v.label}</span>
+                      <span className="text-[color:var(--dim)]">{v.label}</span>
                       <Badge variant={data.enabled && Boolean(data[v.key]) ? 'error' : 'default'}>
                         {data.enabled && Boolean(data[v.key]) ? 'Reject' : 'Allow'}
                       </Badge>
@@ -183,8 +183,8 @@ export default function ReaperWizard({ isOpen, onClose }: ReaperWizardProps) {
                   ))}
                 </div>
               </div>
-              <div className="p-4 rounded-lg bg-orange-900/20 border border-orange-800">
-                <p className="text-sm text-orange-300">
+              <div className="p-4 rounded-lg bg-[var(--accent)]/20 border border-[var(--accent)]">
+                <p className="text-sm text-[color:var(--accent)]">
                   Click Finish to save. Both reapers apply automatically: the pool reaper on the next
                   ghost-pool restart, and the ghostd mempool reaper is regenerated for you (ghostd briefly
                   restarts). No manual <code>ghost-setup apply-reaper</code> step is needed.

--- a/dashboard/src/app/(dashboard)/settings/wizards/ShroudWizard.tsx
+++ b/dashboard/src/app/(dashboard)/settings/wizards/ShroudWizard.tsx
@@ -72,25 +72,25 @@ export default function ShroudWizard({ isOpen, onClose }: ShroudWizardProps) {
           {/* Step 1: Current Status */}
           {wizard.currentStep === 0 && (
             <div className="space-y-4">
-              <div className="p-4 rounded-lg bg-gray-800/50">
-                <h4 className="text-gray-100 font-medium mb-3">Current Shroud Status</h4>
+              <div className="p-4 rounded-lg bg-[var(--surface)]/50">
+                <h4 className="text-[color:var(--fg)] font-medium mb-3">Current Shroud Status</h4>
                 <div className="space-y-3">
                   <div className="flex items-center justify-between">
-                    <span className="text-gray-400">Shroud Enabled</span>
+                    <span className="text-[color:var(--dim)]">Shroud Enabled</span>
                     <Badge variant={shroudStatus?.enabled ? 'success' : 'default'}>
                       {shroudStatus?.enabled ? 'Active' : 'Inactive'}
                     </Badge>
                   </div>
                   <div className="flex items-center justify-between">
-                    <span className="text-gray-400">Ghost Core Connected</span>
+                    <span className="text-[color:var(--dim)]">Ghost Core Connected</span>
                     <Badge variant={shroudStatus?.ghost_core_connected ? 'success' : 'warning'}>
                       {shroudStatus?.ghost_core_connected ? 'Connected' : 'Not Connected'}
                     </Badge>
                   </div>
                 </div>
               </div>
-              <div className="p-4 rounded-lg bg-gray-800/50">
-                <p className="text-sm text-gray-400">
+              <div className="p-4 rounded-lg bg-[var(--surface)]/50">
+                <p className="text-sm text-[color:var(--dim)]">
                   Ghost Shroud adds a random 0-5 second delay before relaying transactions
                   to peers, making it harder for network observers to determine the origin
                   of a transaction. This setting requires a ghost-core restart to take effect.
@@ -102,11 +102,11 @@ export default function ShroudWizard({ isOpen, onClose }: ShroudWizardProps) {
           {/* Step 2: Configure */}
           {wizard.currentStep === 1 && (
             <div className="space-y-4">
-              <div className="p-4 rounded-lg bg-gray-800/50 space-y-4">
+              <div className="p-4 rounded-lg bg-[var(--surface)]/50 space-y-4">
                 <div className="flex items-center justify-between">
                   <div>
-                    <span className="text-gray-100 font-medium">Enable Shroud</span>
-                    <p className="text-sm text-gray-400 mt-1">
+                    <span className="text-[color:var(--fg)] font-medium">Enable Shroud</span>
+                    <p className="text-sm text-[color:var(--dim)] mt-1">
                       Add random 0-5 second delays to transaction relay for privacy
                     </p>
                   </div>
@@ -129,16 +129,16 @@ export default function ShroudWizard({ isOpen, onClose }: ShroudWizardProps) {
           {/* Step 3: Confirm */}
           {wizard.currentStep === 2 && (
             <div className="space-y-4">
-              <div className="p-4 rounded-lg bg-gray-800/50">
-                <h4 className="text-gray-100 font-medium mb-3">Change Summary</h4>
+              <div className="p-4 rounded-lg bg-[var(--surface)]/50">
+                <h4 className="text-[color:var(--fg)] font-medium mb-3">Change Summary</h4>
                 <div className="space-y-3">
                   <div className="flex items-center justify-between">
-                    <span className="text-gray-400">Shroud</span>
+                    <span className="text-[color:var(--dim)]">Shroud</span>
                     <div className="flex items-center gap-2">
                       <Badge variant={shroudStatus?.enabled ? 'success' : 'default'}>
                         {shroudStatus?.enabled ? 'Active' : 'Inactive'}
                       </Badge>
-                      <span className="text-gray-500">-&gt;</span>
+                      <span className="text-[color:var(--fainter)]">-&gt;</span>
                       <Badge variant={data.enabled ? 'success' : 'default'}>
                         {data.enabled ? 'Active' : 'Inactive'}
                       </Badge>
@@ -147,15 +147,15 @@ export default function ShroudWizard({ isOpen, onClose }: ShroudWizardProps) {
                 </div>
               </div>
               {data.enabled ? (
-                <div className="p-4 rounded-lg bg-green-900/20 border border-green-800">
-                  <p className="text-sm text-green-300">
+                <div className="p-4 rounded-lg bg-[var(--green)]/20 border border-[var(--green)]">
+                  <p className="text-sm text-[color:var(--green)]">
                     Shroud will add random 0-5 second delays before relaying transactions.
                     A ghost-core restart is required to activate this change.
                   </p>
                 </div>
               ) : (
-                <div className="p-4 rounded-lg bg-orange-900/20 border border-orange-800">
-                  <p className="text-sm text-orange-300">
+                <div className="p-4 rounded-lg bg-[var(--accent)]/20 border border-[var(--accent)]">
+                  <p className="text-sm text-[color:var(--accent)]">
                     Shroud will be disabled. Transactions will be relayed immediately to
                     peers without privacy delays. A ghost-core restart is required.
                   </p>


### PR DESCRIPTION
## Summary

The dashboard SETTINGS pages and setup WIZARDS used hardcoded dark Tailwind colour classes (`text-gray-100`, `bg-gray-800`, `border-orange-800`, etc.) that do not respond to the theme. In light mode this produced invisible near-white text and panels that stayed dark. This PR swaps those hardcoded classes for the theme CSS variables already defined in `globals.css`, so every surface flips correctly between light and dark.

## Scope

Only `dashboard/src/app/(dashboard)/settings/**` — all sub-pages, `PayoutSection.tsx`, the settings layout, the shared components, and every wizard (Initial, MempoolPolicy, PoolSetup, ChangeSetup, Reaper, GhostId, GhostMode, Haze, Shroud, BuildRun). No changes to `src/components/**`, non-settings pages, or `globals.css`.

## Conversion mapping

- `text-white`/`gray-50/100/200` → `var(--fg)`; `gray-300/400` → `var(--dim)`; `gray-500/600` → `var(--fainter)`
- `bg-gray-800/900` → `var(--surface)` (alpha preserved, e.g. `/50`)
- `border-gray-800` → `var(--rule)`; `border-gray-500/600/700` → `var(--rule-strong)`
- `text/bg/border-orange-*` → `var(--accent)`; `green-*` → `var(--green)`; `red-*` → `var(--red)`

## Judgment calls

- **`text-white`/`bg-white` left as-is** where they sit on a coloured fill (the accent-swatch checkmark, the selected radio dot on an orange circle, white label on the orange `daemon` selected button) — correct in both themes.
- **`ring-white` on the accent-colour picker** converted to `ring-[var(--fg)]` with `ring-offset-[var(--bg)]` so the selection ring is visible in light mode (was invisible white-on-light).
- **Blue and yellow callouts left untouched** — they are outside the supplied palette (no `--blue`/`--yellow` var) and carry distinct semantics (blue info note in Shroud, yellow "Locked by Reaper" warnings). Mapping them to accent/red would change meaning; theming them properly needs new vars in `globals.css`, which is out of scope for this PR.

## Verification

- 449 colour-token conversions across 25 files; colours only, no layout/logic changes.
- `tsc --noEmit`: clean.
- `eslint` on settings: 0 errors (2 pre-existing `PayoutSection` react-hooks warnings unrelated to this change).
- `npm run build`: succeeds.