### PR TITLE
dashboard(pages): theme-aware colours for light mode

### DIFF
--- a/dashboard/src/app/(dashboard)/elders/page.tsx
+++ b/dashboard/src/app/(dashboard)/elders/page.tsx
@@ -85,7 +85,7 @@ const contributorColumns: ColumnDef<MpcContributor>[] = [
     accessorKey: "position",
     header: "#",
     cell: ({ row }) => (
-      <span className="font-mono text-orange-400 font-medium">
+      <span className="font-mono text-[color:var(--accent)] font-medium">
         {row.original.position}
       </span>
     ),
@@ -110,7 +110,7 @@ const contributorColumns: ColumnDef<MpcContributor>[] = [
     accessorKey: "created_at",
     header: "Contributed",
     cell: ({ row }) => (
-      <span className="text-gray-400 text-sm">{formatContributed(row.original.created_at)}</span>
+      <span className="text-[color:var(--dim)] text-sm">{formatContributed(row.original.created_at)}</span>
     ),
   },
 ];
@@ -259,20 +259,20 @@ export default function EldersPage() {
 
               {/* Details grid */}
               <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-                <div className="p-3 bg-gray-800/50 rounded-lg">
-                  <div className="text-xs text-gray-400 mb-1">Phase</div>
+                <div className="p-3 bg-[var(--surface)] rounded-lg">
+                  <div className="text-xs text-[color:var(--dim)] mb-1">Phase</div>
                   <Badge variant={ceremonyPhase.variant}>{ceremonyPhase.label}</Badge>
                 </div>
-                <div className="p-3 bg-gray-800/50 rounded-lg">
-                  <div className="text-xs text-gray-400 mb-1">Your Status</div>
+                <div className="p-3 bg-[var(--surface)] rounded-lg">
+                  <div className="text-xs text-[color:var(--dim)] mb-1">Your Status</div>
                   <Badge variant={yourStatus.variant}>{yourStatus.label}</Badge>
                 </div>
-                <div className="p-3 bg-gray-800/50 rounded-lg">
-                  <div className="text-xs text-gray-400 mb-1">Circuit Type</div>
-                  <span className="font-mono text-sm text-gray-100">Groth16</span>
+                <div className="p-3 bg-[var(--surface)] rounded-lg">
+                  <div className="text-xs text-[color:var(--dim)] mb-1">Circuit Type</div>
+                  <span className="font-mono text-sm text-[color:var(--fg)]">Groth16</span>
                 </div>
-                <div className="p-3 bg-gray-800/50 rounded-lg">
-                  <div className="text-xs text-gray-400 mb-1">Parameters</div>
+                <div className="p-3 bg-[var(--surface)] rounded-lg">
+                  <div className="text-xs text-[color:var(--dim)] mb-1">Parameters</div>
                   <StatusDot
                     status={mpc?.has_params ? "online" : "offline"}
                     label={mpc?.has_params ? "Generated" : "Pending"}
@@ -283,11 +283,11 @@ export default function EldersPage() {
 
               {/* Downtime warning */}
               {elder?.downtime_warning && (
-                <div className="p-3 bg-yellow-900/20 border border-yellow-800 rounded-lg">
-                  <p className="text-yellow-400 text-sm font-medium">
+                <div className="p-3 bg-[var(--surface)] border border-[color:var(--accent)] rounded-lg">
+                  <p className="text-[color:var(--accent)] text-sm font-medium">
                     Downtime Warning
                   </p>
-                  <p className="text-yellow-400/70 text-sm mt-1">
+                  <p className="text-[color:var(--accent)] text-sm mt-1">
                     {elder.consecutive_downtime_days} consecutive days of downtime detected.
                     Elder status requires 95% uptime over a trailing 7-day window.
                   </p>
@@ -306,7 +306,7 @@ export default function EldersPage() {
             subtitle={`${contributorsData?.count ?? contributors.length} MPC contributors`}
             action={
               mpc?.node_id ? (
-                <span className="text-xs text-gray-500 font-mono">
+                <span className="text-xs text-[color:var(--fainter)] font-mono">
                   You: {truncateId(mpc.node_id, 6)}
                 </span>
               ) : undefined
@@ -332,9 +332,9 @@ export default function EldersPage() {
             title="Zero-Knowledge Proof Info"
             subtitle="How the MPC ceremony secures the network"
           />
-          <div className="space-y-4 text-sm text-gray-400 leading-relaxed">
+          <div className="space-y-4 text-sm text-[color:var(--dim)] leading-relaxed">
             <div>
-              <h4 className="text-gray-200 font-medium mb-1">What is the MPC Ceremony?</h4>
+              <h4 className="text-[color:var(--fg)] font-medium mb-1">What is the MPC Ceremony?</h4>
               <p>
                 The Multi-Party Computation (MPC) ceremony generates trusted setup parameters
                 for Groth16 zero-knowledge proofs. Each of the 101 contributors adds a layer of
@@ -343,7 +343,7 @@ export default function EldersPage() {
               </p>
             </div>
             <div>
-              <h4 className="text-gray-200 font-medium mb-1">Why Groth16?</h4>
+              <h4 className="text-[color:var(--fg)] font-medium mb-1">Why Groth16?</h4>
               <p>
                 Groth16 produces the smallest proofs (just 3 group elements, ~128 bytes) with the
                 fastest verification time of any general-purpose ZK proof system. The tradeoff is
@@ -351,7 +351,7 @@ export default function EldersPage() {
               </p>
             </div>
             <div>
-              <h4 className="text-gray-200 font-medium mb-1">Elder Status</h4>
+              <h4 className="text-[color:var(--fg)] font-medium mb-1">Elder Status</h4>
               <p>
                 Nodes that contribute to the MPC ceremony earn permanent Elder status, granting +1
                 share in the 5-4-3-2-1 capability system. The first 101 nodes to contribute claim
@@ -360,30 +360,30 @@ export default function EldersPage() {
               </p>
             </div>
             <div>
-              <h4 className="text-gray-200 font-medium mb-1">Ossification</h4>
+              <h4 className="text-[color:var(--fg)] font-medium mb-1">Ossification</h4>
               <p>
                 Once all 101 slots are filled, the ceremony is ossified. No new contributions
                 can be accepted and the parameters are finalized. The ceremony cannot be restarted
                 or modified after ossification.
               </p>
             </div>
-            <div className="pt-2 border-t border-gray-800">
+            <div className="pt-2 border-t border-[var(--rule)]">
               <div className="grid grid-cols-2 gap-4">
                 <div>
-                  <span className="text-gray-500">Circuit</span>
-                  <p className="text-gray-200 font-mono">Groth16 (BN254)</p>
+                  <span className="text-[color:var(--fainter)]">Circuit</span>
+                  <p className="text-[color:var(--fg)] font-mono">Groth16 (BN254)</p>
                 </div>
                 <div>
-                  <span className="text-gray-500">Max Contributors</span>
-                  <p className="text-gray-200 font-mono">101</p>
+                  <span className="text-[color:var(--fainter)]">Max Contributors</span>
+                  <p className="text-[color:var(--fg)] font-mono">101</p>
                 </div>
                 <div>
-                  <span className="text-gray-500">Proof Size</span>
-                  <p className="text-gray-200 font-mono">~128 bytes</p>
+                  <span className="text-[color:var(--fainter)]">Proof Size</span>
+                  <p className="text-[color:var(--fg)] font-mono">~128 bytes</p>
                 </div>
                 <div>
-                  <span className="text-gray-500">Share Bonus</span>
-                  <p className="text-gray-200 font-mono">+1 (Elder)</p>
+                  <span className="text-[color:var(--fainter)]">Share Bonus</span>
+                  <p className="text-[color:var(--fg)] font-mono">+1 (Elder)</p>
                 </div>
               </div>
             </div>

--- a/dashboard/src/app/(dashboard)/haze/page.tsx
+++ b/dashboard/src/app/(dashboard)/haze/page.tsx
@@ -128,7 +128,7 @@ export default function HazePage() {
         />
         <div className="space-y-5">
           {/* Explanation */}
-          <p className="text-gray-300 text-sm leading-relaxed">
+          <p className="text-[color:var(--dim)] text-sm leading-relaxed">
             Ghost Haze is a storage privacy layer that classifies and strips non-financial data from blocks
             before writing them to disk. Hazed nodes retain full transaction validity and UTXO integrity
             while ensuring no arbitrary embedded content is persisted locally. This lets node operators
@@ -137,44 +137,44 @@ export default function HazePage() {
 
           {/* 4-step exorcism pipeline */}
           <div>
-            <h4 className="text-gray-200 font-medium text-sm mb-3">The Exorcism Pipeline</h4>
+            <h4 className="text-[color:var(--fg)] font-medium text-sm mb-3">The Exorcism Pipeline</h4>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-              <div className="p-3 bg-gray-800/50 rounded-lg border border-gray-700">
+              <div className="p-3 bg-[var(--surface)] rounded-lg border border-[var(--rule-strong)]">
                 <div className="flex items-center gap-2 mb-1.5">
-                  <span className="text-amber-400 font-mono text-xs font-bold">1</span>
-                  <span className="text-gray-100 text-sm font-medium">Field Classification</span>
+                  <span className="text-[color:var(--accent)] font-mono text-xs font-bold">1</span>
+                  <span className="text-[color:var(--fg)] text-sm font-medium">Field Classification</span>
                 </div>
-                <p className="text-gray-400 text-xs leading-relaxed">
+                <p className="text-[color:var(--dim)] text-xs leading-relaxed">
                   The BUDS system classifies each field in a transaction — witness data, OP_RETURN payloads,
                   script patterns — into financial and non-financial categories.
                 </p>
               </div>
-              <div className="p-3 bg-gray-800/50 rounded-lg border border-gray-700">
+              <div className="p-3 bg-[var(--surface)] rounded-lg border border-[var(--rule-strong)]">
                 <div className="flex items-center gap-2 mb-1.5">
-                  <span className="text-amber-400 font-mono text-xs font-bold">2</span>
-                  <span className="text-gray-100 text-sm font-medium">Block Stripping</span>
+                  <span className="text-[color:var(--accent)] font-mono text-xs font-bold">2</span>
+                  <span className="text-[color:var(--fg)] text-sm font-medium">Block Stripping</span>
                 </div>
-                <p className="text-gray-400 text-xs leading-relaxed">
+                <p className="text-[color:var(--dim)] text-xs leading-relaxed">
                   Non-financial data is stripped from the block at the validation layer, before the block
                   is written to disk. Financial data and consensus-critical fields remain untouched.
                 </p>
               </div>
-              <div className="p-3 bg-gray-800/50 rounded-lg border border-gray-700">
+              <div className="p-3 bg-[var(--surface)] rounded-lg border border-[var(--rule-strong)]">
                 <div className="flex items-center gap-2 mb-1.5">
-                  <span className="text-amber-400 font-mono text-xs font-bold">3</span>
-                  <span className="text-gray-100 text-sm font-medium">GSB Storage</span>
+                  <span className="text-[color:var(--accent)] font-mono text-xs font-bold">3</span>
+                  <span className="text-[color:var(--fg)] text-sm font-medium">GSB Storage</span>
                 </div>
-                <p className="text-gray-400 text-xs leading-relaxed">
-                  Stripped blocks are stored in Ghost Stripped Block (<code className="text-amber-400">.gsb</code>) format —
+                <p className="text-[color:var(--dim)] text-xs leading-relaxed">
+                  Stripped blocks are stored in Ghost Stripped Block (<code className="text-[color:var(--accent)]">.gsb</code>) format —
                   a compact representation that preserves all data needed for chain validation.
                 </p>
               </div>
-              <div className="p-3 bg-gray-800/50 rounded-lg border border-gray-700">
+              <div className="p-3 bg-[var(--surface)] rounded-lg border border-[var(--rule-strong)]">
                 <div className="flex items-center gap-2 mb-1.5">
-                  <span className="text-amber-400 font-mono text-xs font-bold">4</span>
-                  <span className="text-gray-100 text-sm font-medium">UTXO Preservation</span>
+                  <span className="text-[color:var(--accent)] font-mono text-xs font-bold">4</span>
+                  <span className="text-[color:var(--fg)] text-sm font-medium">UTXO Preservation</span>
                 </div>
-                <p className="text-gray-400 text-xs leading-relaxed">
+                <p className="text-[color:var(--dim)] text-xs leading-relaxed">
                   All financial data and the UTXO set integrity are preserved. Your node can fully validate
                   the chain, spend coins, and participate in consensus without any embedded content on disk.
                 </p>
@@ -183,16 +183,16 @@ export default function HazePage() {
           </div>
 
           {/* Exorcist Mode A */}
-          <div className="p-3 bg-gray-800/50 rounded-lg border border-gray-700">
-            <h4 className="text-gray-200 font-medium text-sm mb-1">The Exorcist</h4>
-            <p className="text-gray-400 text-xs leading-relaxed">
+          <div className="p-3 bg-[var(--surface)] rounded-lg border border-[var(--rule-strong)]">
+            <h4 className="text-[color:var(--fg)] font-medium text-sm mb-1">The Exorcist</h4>
+            <p className="text-[color:var(--dim)] text-xs leading-relaxed">
               The Exorcist is the core component that performs the actual stripping. It runs inside
-              Ghost Core (<code className="text-amber-400">ghostd</code>) at the block acceptance layer,
+              Ghost Core (<code className="text-[color:var(--accent)]">ghostd</code>) at the block acceptance layer,
               intercepting blocks before they are serialized to disk.
             </p>
-            <div className="mt-2 p-2 bg-gray-900/50 rounded border border-gray-700">
-              <div className="text-xs text-gray-400 leading-relaxed">
-                <span className="text-amber-400 font-medium">Mode A (Active Stripping):</span> The Exorcist
+            <div className="mt-2 p-2 bg-[var(--surface)] rounded border border-[var(--rule-strong)]">
+              <div className="text-xs text-[color:var(--dim)] leading-relaxed">
+                <span className="text-[color:var(--accent)] font-medium">Mode A (Active Stripping):</span> The Exorcist
                 strips classified content before the block is written to disk. This is the default mode for
                 hazed nodes — blocks arrive from the network, get stripped in memory, and only the clean
                 version is persisted.
@@ -207,8 +207,8 @@ export default function HazePage() {
         {isLoading ? <SkeletonCard /> : error ? (
           <Card>
             <CardHeader title="Node Status" />
-            <div className="p-4 bg-red-900/20 border border-red-800 rounded-lg">
-              <p className="text-red-400 text-sm">
+            <div className="p-4 bg-[var(--surface)] border border-[color:var(--red)] rounded-lg">
+              <p className="text-[color:var(--red)] text-sm">
                 Unable to fetch Ghost Haze status. Ensure Ghost Core is running and the Haze module is enabled.
               </p>
             </div>
@@ -225,19 +225,19 @@ export default function HazePage() {
                 />
               }
             />
-            <div className="divide-y divide-gray-800">
+            <div className="divide-y divide-[var(--rule)]">
               <StatusRow label="Storage Mode">
                 <Badge variant={getModeBadgeVariant(mode)}>
                   {getModeLabel(mode)}
                 </Badge>
               </StatusRow>
               <StatusRow label="Blocks Processed">
-                <span className="font-mono text-sm text-gray-100">
+                <span className="font-mono text-sm text-[color:var(--fg)]">
                   {haze?.blocks.toLocaleString() ?? 0}
                 </span>
               </StatusRow>
               <StatusRow label="Storage on Disk">
-                <span className="font-mono text-sm text-gray-100">
+                <span className="font-mono text-sm text-[color:var(--fg)]">
                   {haze ? formatStorageGB(haze.size_on_disk) : "--"}
                 </span>
               </StatusRow>
@@ -252,14 +252,14 @@ export default function HazePage() {
                 </Badge>
               </StatusRow>
               <StatusRow label="Chain">
-                <span className="font-mono text-sm text-gray-100">
+                <span className="font-mono text-sm text-[color:var(--fg)]">
                   {haze?.chain ?? "--"}
                 </span>
               </StatusRow>
             </div>
             {haze?.error && (
-              <div className="mt-4 p-3 bg-red-900/20 border border-red-800 rounded-lg">
-                <p className="text-red-400 text-sm">{haze.error}</p>
+              <div className="mt-4 p-3 bg-[var(--surface)] border border-[color:var(--red)] rounded-lg">
+                <p className="text-[color:var(--red)] text-sm">{haze.error}</p>
               </div>
             )}
           </Card>
@@ -273,9 +273,9 @@ export default function HazePage() {
           subtitle="Legal compliance and data classification"
         />
         <div className="space-y-4">
-          <div className="p-4 bg-gray-800/50 rounded-lg">
-            <h4 className="text-amber-400 font-medium mb-2">No Illegal Content Storage</h4>
-            <p className="text-gray-300 text-sm leading-relaxed">
+          <div className="p-4 bg-[var(--surface)] rounded-lg">
+            <h4 className="text-[color:var(--accent)] font-medium mb-2">No Illegal Content Storage</h4>
+            <p className="text-[color:var(--dim)] text-sm leading-relaxed">
               Hazed nodes use the BUDS classification system to identify and strip non-financial data
               (OP_RETURN payloads, witness bloat, inscriptions, and other arbitrary content) before
               blocks are written to disk. This means your node never persists content that could
@@ -283,32 +283,32 @@ export default function HazePage() {
             </p>
           </div>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div className="p-4 bg-gray-800/50 rounded-lg">
+            <div className="p-4 bg-[var(--surface)] rounded-lg">
               <div className="flex items-start gap-3">
-                <div className="w-8 h-8 rounded-full bg-green-900/30 border border-green-700 flex items-center justify-center flex-shrink-0 mt-0.5">
-                  <svg className="w-4 h-4 text-green-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <div className="w-8 h-8 rounded-full bg-[var(--surface)] border border-[color:var(--green)] flex items-center justify-center flex-shrink-0 mt-0.5">
+                  <svg className="w-4 h-4 text-[color:var(--green)]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                     <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" />
                   </svg>
                 </div>
                 <div>
-                  <h5 className="text-gray-100 font-medium text-sm">What is Preserved</h5>
-                  <p className="text-gray-400 text-xs mt-1">
+                  <h5 className="text-[color:var(--fg)] font-medium text-sm">What is Preserved</h5>
+                  <p className="text-[color:var(--dim)] text-xs mt-1">
                     All financial transaction data, UTXO set integrity, block headers, and consensus-critical
                     information remain intact. Your node can fully validate the chain.
                   </p>
                 </div>
               </div>
             </div>
-            <div className="p-4 bg-gray-800/50 rounded-lg">
+            <div className="p-4 bg-[var(--surface)] rounded-lg">
               <div className="flex items-start gap-3">
-                <div className="w-8 h-8 rounded-full bg-amber-900/30 border border-amber-700 flex items-center justify-center flex-shrink-0 mt-0.5">
-                  <svg className="w-4 h-4 text-amber-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <div className="w-8 h-8 rounded-full bg-[var(--surface)] border border-[color:var(--accent)] flex items-center justify-center flex-shrink-0 mt-0.5">
+                  <svg className="w-4 h-4 text-[color:var(--accent)]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                     <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m0-10.036A11.959 11.959 0 013.598 6 11.99 11.99 0 003 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285z" />
                   </svg>
                 </div>
                 <div>
-                  <h5 className="text-gray-100 font-medium text-sm">What is Stripped</h5>
-                  <p className="text-gray-400 text-xs mt-1">
+                  <h5 className="text-[color:var(--fg)] font-medium text-sm">What is Stripped</h5>
+                  <p className="text-[color:var(--dim)] text-xs mt-1">
                     Arbitrary data embedded in OP_RETURN outputs, oversized witness data, inscriptions, and
                     other non-financial payloads are removed before storage.
                   </p>
@@ -316,8 +316,8 @@ export default function HazePage() {
               </div>
             </div>
           </div>
-          <div className="pt-2 border-t border-gray-700">
-            <p className="text-gray-400 text-xs mb-3">
+          <div className="pt-2 border-t border-[var(--rule-strong)]">
+            <p className="text-[color:var(--dim)] text-xs mb-3">
               BUDS classification specification and legal framework for operating a hazed node.
             </p>
             <a

--- a/dashboard/src/app/(dashboard)/mining/page.tsx
+++ b/dashboard/src/app/(dashboard)/mining/page.tsx
@@ -90,10 +90,10 @@ function bestHashLooksBlockLevel(data: BestHashResponse | undefined): boolean {
 // rows (ghost-web/miners.html) so operators see the same set in both places.
 function EndpointField({ label, value }: { label: string; value: string }) {
   return (
-    <div className="flex items-center justify-between gap-2 p-2 bg-gray-900/50 rounded">
+    <div className="flex items-center justify-between gap-2 p-2 bg-[var(--surface)] rounded">
       <div className="min-w-0">
-        <div className="text-xs text-gray-500">{label}</div>
-        <code className="text-orange-400 text-sm block truncate">{value}</code>
+        <div className="text-xs text-[color:var(--fainter)]">{label}</div>
+        <code className="text-[color:var(--accent)] text-sm block truncate">{value}</code>
       </div>
       <CopyButton text={value} />
     </div>
@@ -104,28 +104,28 @@ function BestHashCard({ title, entry }: { title: string; entry: BestHashEntry | 
   const diff = entry?.difficulty ?? 0;
   const hasData = entry && diff > 0;
   return (
-    <div className="p-3 bg-gray-800/50 rounded-lg">
-      <div className="text-xs text-gray-400 mb-1">{title}</div>
+    <div className="p-3 bg-[var(--surface)] rounded-lg">
+      <div className="text-xs text-[color:var(--dim)] mb-1">{title}</div>
       {hasData ? (
         <>
-          <div className="text-lg font-semibold text-orange-400">{formatDifficulty(diff)}</div>
-          <div className="font-mono text-xs text-gray-400 truncate">{entry.hash}</div>
-          <div className="text-xs text-gray-500 mt-0.5">{calculateLeadingZeros(diff)} leading zeros</div>
+          <div className="text-lg font-semibold text-[color:var(--accent)]">{formatDifficulty(diff)}</div>
+          <div className="font-mono text-xs text-[color:var(--dim)] truncate">{entry.hash}</div>
+          <div className="text-xs text-[color:var(--fainter)] mt-0.5">{calculateLeadingZeros(diff)} leading zeros</div>
           <div className="flex justify-between items-center mt-1">
             {/* Block height of the round this share was solving for. Only shown
                 when the backend populated it (joined from `rounds`); some rounds
                 lack it, in which case we drop the line rather than render "?" —
                 the timestamp alone conveys recency. */}
             {typeof entry.block_height === "number" && entry.block_height > 0 ? (
-              <span className="text-xs text-gray-500">Block #{entry.block_height.toLocaleString()}</span>
+              <span className="text-xs text-[color:var(--fainter)]">Block #{entry.block_height.toLocaleString()}</span>
             ) : (
               <span />
             )}
-            <span className="text-xs text-gray-500">{formatTimeAgo(entry.timestamp ?? 0)}</span>
+            <span className="text-xs text-[color:var(--fainter)]">{formatTimeAgo(entry.timestamp ?? 0)}</span>
           </div>
         </>
       ) : (
-        <div className="text-gray-500 text-sm">No data yet</div>
+        <div className="text-[color:var(--fainter)] text-sm">No data yet</div>
       )}
     </div>
   );
@@ -248,17 +248,17 @@ export default function MiningPage() {
       {showSelfCheckBanner && (
         <div
           role="alert"
-          className="rounded-lg border border-amber-600/60 bg-amber-900/20 p-4"
+          className="rounded-lg border border-[color:var(--accent)] bg-[var(--surface)] p-4"
         >
           <div className="flex items-start gap-3">
-            <span aria-hidden className="text-amber-400 text-lg leading-none mt-0.5">⚠</span>
+            <span aria-hidden className="text-[color:var(--accent)] text-lg leading-none mt-0.5">⚠</span>
             <div className="flex-1 min-w-0 space-y-2">
-              <div className="text-sm font-semibold text-amber-300">
+              <div className="text-sm font-semibold text-[color:var(--accent)]">
                 Capability prerequisite missing
               </div>
               <ul className="space-y-2">
                 {selfCheckFailureList.map((f) => (
-                  <li key={f.capability} className="text-sm text-amber-100/90 leading-relaxed">
+                  <li key={f.capability} className="text-sm text-[color:var(--accent)] leading-relaxed">
                     {f.capability === "public_mining" ? (
                       <>
                         You&apos;ve enabled <span className="font-medium">Public Mining</span>, but no stratum
@@ -277,7 +277,7 @@ export default function MiningPage() {
                     {/* Exact reason straight from the node probe (true port,
                         remediation hint) so the friendly copy above stays
                         correct even when the configured port differs. */}
-                    <div className="text-xs text-amber-200/60 mt-1">{f.reason}</div>
+                    <div className="text-xs text-[color:var(--accent)] mt-1">{f.reason}</div>
                   </li>
                 ))}
               </ul>
@@ -285,7 +285,7 @@ export default function MiningPage() {
             <button
               type="button"
               onClick={() => setSelfCheckDismissed(true)}
-              className="text-amber-300/70 hover:text-amber-200 text-sm shrink-0"
+              className="text-[color:var(--accent)] hover:text-[color:var(--accent)] text-sm shrink-0"
               aria-label="Dismiss warning"
             >
               Dismiss
@@ -365,20 +365,20 @@ export default function MiningPage() {
                   disabled={isPending}
                   className={`p-4 rounded-lg border text-left transition-all ${
                     isActive
-                      ? "bg-orange-900/20 border-orange-600 ring-1 ring-orange-600/50"
-                      : "bg-gray-800/30 border-gray-700 hover:border-gray-600"
+                      ? "bg-[var(--surface)] border-[color:var(--accent)] ring-1 ring-[color:var(--accent)]"
+                      : "bg-[var(--surface)] border-[var(--rule-strong)] hover:border-[var(--rule-strong)]"
                   } ${isPending ? "opacity-50 cursor-not-allowed" : "cursor-pointer"}`}
                 >
                   <div className="flex items-center gap-2 mb-1">
                     <div className={`w-3 h-3 rounded-full border-2 flex items-center justify-center ${
-                      isActive ? "border-orange-500" : "border-gray-600"
+                      isActive ? "border-[color:var(--accent)]" : "border-[var(--rule-strong)]"
                     }`}>
                       {isActive && <div className="w-1.5 h-1.5 rounded-full bg-orange-500" />}
                     </div>
-                    <span className={`font-medium ${isActive ? "text-orange-400" : "text-gray-300"}`}>{label}</span>
+                    <span className={`font-medium ${isActive ? "text-[color:var(--accent)]" : "text-[color:var(--dim)]"}`}>{label}</span>
                     {isActive && <Badge variant="success">Active</Badge>}
                   </div>
-                  <div className="text-xs text-gray-500 ml-5">{desc}</div>
+                  <div className="text-xs text-[color:var(--fainter)] ml-5">{desc}</div>
                 </button>
               );
             })}
@@ -397,20 +397,20 @@ export default function MiningPage() {
             />
             <div className="space-y-4">
               {showPrivateEndpoints && (
-                <div className="p-4 bg-gray-800/30 rounded-lg border border-gray-700">
-                  <div className="text-sm text-gray-300 font-medium mb-3">Your Stratum Endpoints</div>
+                <div className="p-4 bg-[var(--surface)] rounded-lg border border-[var(--rule-strong)]">
+                  <div className="text-sm text-[color:var(--dim)] font-medium mb-3">Your Stratum Endpoints</div>
                   <div className="space-y-2">
-                    <div className="flex items-center justify-between p-2 bg-gray-900/50 rounded">
+                    <div className="flex items-center justify-between p-2 bg-[var(--surface)] rounded">
                       <div>
-                        <div className="text-xs text-gray-500">Stratum V1</div>
-                        <code className="text-orange-400 text-sm">stratum+tcp://{nodeHost}:{status?.stratum_v1_port || 3333}</code>
+                        <div className="text-xs text-[color:var(--fainter)]">Stratum V1</div>
+                        <code className="text-[color:var(--accent)] text-sm">stratum+tcp://{nodeHost}:{status?.stratum_v1_port || 3333}</code>
                       </div>
                       <CopyButton text={`stratum+tcp://${nodeHost}:${status?.stratum_v1_port || 3333}`} />
                     </div>
-                    <div className="flex items-center justify-between p-2 bg-gray-900/50 rounded">
+                    <div className="flex items-center justify-between p-2 bg-[var(--surface)] rounded">
                       <div>
-                        <div className="text-xs text-gray-500">Stratum V2</div>
-                        <code className="text-orange-400 text-sm">stratum+tcp://{nodeHost}:{status?.stratum_v2_port || 34255}</code>
+                        <div className="text-xs text-[color:var(--fainter)]">Stratum V2</div>
+                        <code className="text-[color:var(--accent)] text-sm">stratum+tcp://{nodeHost}:{status?.stratum_v2_port || 34255}</code>
                       </div>
                       <CopyButton text={`stratum+tcp://${nodeHost}:${status?.stratum_v2_port || 34255}`} />
                     </div>
@@ -419,30 +419,30 @@ export default function MiningPage() {
               )}
 
               {showPublicEndpoints && (
-                <div className="p-4 bg-gray-800/30 rounded-lg border border-gray-700">
-                  <div className="text-sm text-gray-300 font-medium mb-3">Public Pool Endpoints</div>
+                <div className="p-4 bg-[var(--surface)] rounded-lg border border-[var(--rule-strong)]">
+                  <div className="text-sm text-[color:var(--dim)] font-medium mb-3">Public Pool Endpoints</div>
 
                   {/* Two side-by-side stratum columns: SV1 left, SV2 right.
                       Stacks on narrow screens. Every field is individually
                       copyable. */}
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                     {/* SV1 */}
-                    <div className="p-3 bg-gray-900/40 rounded-lg border border-gray-700/60">
-                      <div className="text-sm text-gray-300 font-medium mb-2">Stratum V1</div>
+                    <div className="p-3 bg-[var(--surface)] rounded-lg border border-[var(--rule-strong)]">
+                      <div className="text-sm text-[color:var(--dim)] font-medium mb-2">Stratum V1</div>
                       <div className="space-y-1.5">
                         <EndpointField label="Host" value={PUBLIC_POOL_HOST} />
                         <EndpointField label="Port" value={String(status?.stratum_v1_port || 3333)} />
                         <EndpointField label="Username" value="<your-address>.worker1" />
                         <EndpointField label="Protocol" value="Stratum V1" />
                       </div>
-                      <p className="text-xs text-gray-500 mt-2 leading-relaxed">
+                      <p className="text-xs text-[color:var(--fainter)] mt-2 leading-relaxed">
                         For SV1 miners and firmware — connects through the pool translator.
                       </p>
                     </div>
 
                     {/* SV2 */}
-                    <div className="p-3 bg-gray-900/40 rounded-lg border border-gray-700/60">
-                      <div className="text-sm text-gray-300 font-medium mb-2">Stratum V2 (native)</div>
+                    <div className="p-3 bg-[var(--surface)] rounded-lg border border-[var(--rule-strong)]">
+                      <div className="text-sm text-[color:var(--dim)] font-medium mb-2">Stratum V2 (native)</div>
                       <div className="space-y-1.5">
                         <EndpointField label="Host" value={PUBLIC_POOL_HOST} />
                         <EndpointField label="Port" value={String(status?.stratum_v2_port || 34255)} />
@@ -451,7 +451,7 @@ export default function MiningPage() {
                         <EndpointField label="Channel type" value="Extended" />
                         <EndpointField label="Authority public key" value={authorityPublicKey} />
                       </div>
-                      <p className="text-xs text-gray-500 mt-2 leading-relaxed">
+                      <p className="text-xs text-[color:var(--fainter)] mt-2 leading-relaxed">
                         For native SV2 firmware (e.g. a Bitaxe on AxeOS). The authority key is the
                         same on every public Ghost node — no separate TLS or cert required.
                       </p>
@@ -459,21 +459,21 @@ export default function MiningPage() {
                   </div>
 
                   {/* Shared row — the authorize rule applies to BOTH stratums. */}
-                  <div className="mt-4 p-3 bg-orange-900/10 border border-orange-800/40 rounded">
-                    <div className="text-sm text-orange-300 font-medium mb-1">Username rule — SV1 and SV2</div>
-                    <p className="text-xs text-gray-400 leading-relaxed">
+                  <div className="mt-4 p-3 bg-[var(--surface)] border border-[color:var(--accent)] rounded">
+                    <div className="text-sm text-[color:var(--accent)] font-medium mb-1">Username rule — SV1 and SV2</div>
+                    <p className="text-xs text-[color:var(--dim)] leading-relaxed">
                       Set your miner&apos;s username to your{" "}
-                      <span className="text-gray-300 font-medium">bech32 payout address</span> followed by a
+                      <span className="text-[color:var(--dim)] font-medium">bech32 payout address</span> followed by a
                       worker suffix:
                     </p>
-                    <code className="text-orange-400 text-xs block my-1.5">
+                    <code className="text-[color:var(--accent)] text-xs block my-1.5">
                       &lt;your-payout-address&gt;.&lt;worker&gt;
-                      <span className="text-gray-500"> — e.g. bc1q….worker1</span>
+                      <span className="text-[color:var(--fainter)]"> — e.g. bc1q….worker1</span>
                     </code>
-                    <p className="text-xs text-gray-400 leading-relaxed">
+                    <p className="text-xs text-[color:var(--dim)] leading-relaxed">
                       This is how block rewards are routed to you. Bare worker names (no{" "}
-                      <code className="text-gray-300">.</code> separator, no address) are{" "}
-                      <span className="text-gray-300">rejected</span> — the miner would mine for nobody. The
+                      <code className="text-[color:var(--dim)]">.</code> separator, no address) are{" "}
+                      <span className="text-[color:var(--dim)]">rejected</span> — the miner would mine for nobody. The
                       password field is ignored.
                     </p>
                   </div>
@@ -504,7 +504,7 @@ export default function MiningPage() {
             </div>
           )}
           {!bestHashLoading && bestHashLooksBlockLevel(bestHashData) && (
-            <div className="mt-3 text-xs text-gray-500 border-t border-gray-800 pt-3">
+            <div className="mt-3 text-xs text-[color:var(--fainter)] border-t border-[var(--rule)] pt-3">
               All four windows are currently reporting the same value — the network&apos;s latest block
               hash rather than the best share submitted per window. Per-window miner best-shares are not
               yet tracked by the node API, so these cards will read identically until that lands.

--- a/dashboard/src/app/(dashboard)/page.tsx
+++ b/dashboard/src/app/(dashboard)/page.tsx
@@ -44,7 +44,7 @@ const SHARE_TIERS = [
 
 function InfoIcon() {
   return (
-    <svg className="w-3 h-3 text-gray-600 inline-block mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+    <svg className="w-3 h-3 text-[color:var(--fainter)] inline-block mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
       <circle cx="12" cy="12" r="10" />
       <path d="M12 16v-4M12 8h.01" />
     </svg>
@@ -63,9 +63,9 @@ function L1Card() {
   const isSyncing = syncStatus === false && syncHeight > 0 && blockHeight > 0;
 
   return (
-    <Card className="border-orange-600/30">
+    <Card className="border-[color:var(--accent)]">
       <CardHeader
-        title={<span className="text-orange-400">L1 &middot; Bitcoin</span>}
+        title={<span className="text-[color:var(--accent)]">L1 &middot; Bitcoin</span>}
         action={
           syncStatus != null && (
             <StatusDot
@@ -78,56 +78,56 @@ function L1Card() {
       />
       <div className="grid grid-cols-2 gap-3">
         <Tooltip content={TOOLTIPS.block_height}>
-          <div className="p-3 bg-orange-900/10 rounded-lg">
-            <div className="text-xs text-gray-500 mb-1"><InfoIcon /> Block Height</div>
-            <div className="text-lg font-mono font-semibold text-gray-100">
+          <div className="p-3 bg-[var(--surface)] rounded-lg">
+            <div className="text-xs text-[color:var(--fainter)] mb-1"><InfoIcon /> Block Height</div>
+            <div className="text-lg font-mono font-semibold text-[color:var(--fg)]">
               {isLoading ? "..." : isSyncing
-                ? <span>{syncHeight.toLocaleString()} <span className="text-xs text-orange-400">/ {blockHeight.toLocaleString()}</span></span>
+                ? <span>{syncHeight.toLocaleString()} <span className="text-xs text-[color:var(--accent)]">/ {blockHeight.toLocaleString()}</span></span>
                 : syncHeight.toLocaleString()
               }
             </div>
             {isSyncing && (
-              <div className="text-xs text-orange-400 mt-0.5">
+              <div className="text-xs text-[color:var(--accent)] mt-0.5">
                 IBD &middot; {blockHeight > 0 ? ((syncHeight / blockHeight) * 100).toFixed(1) : 0}%
               </div>
             )}
           </div>
         </Tooltip>
         <Tooltip content={TOOLTIPS.l1_peers}>
-          <div className="p-3 bg-orange-900/10 rounded-lg">
-            <div className="text-xs text-gray-500 mb-1"><InfoIcon /> Mesh Peers</div>
-            <div className="text-lg font-mono font-semibold text-gray-100">
+          <div className="p-3 bg-[var(--surface)] rounded-lg">
+            <div className="text-xs text-[color:var(--fainter)] mb-1"><InfoIcon /> Mesh Peers</div>
+            <div className="text-lg font-mono font-semibold text-[color:var(--fg)]">
               {isLoading ? "..." : `${status?.peer_count ?? 0} connected`}
             </div>
           </div>
         </Tooltip>
         <Tooltip content={TOOLTIPS.network_hashrate}>
-          <div className="p-3 bg-orange-900/10 rounded-lg">
-            <div className="text-xs text-gray-500 mb-1"><InfoIcon /> Network Hashrate</div>
-            <div className="text-lg font-mono font-semibold text-gray-100">
+          <div className="p-3 bg-[var(--surface)] rounded-lg">
+            <div className="text-xs text-[color:var(--fainter)] mb-1"><InfoIcon /> Network Hashrate</div>
+            <div className="text-lg font-mono font-semibold text-[color:var(--fg)]">
               {bestHashLoading ? "..." : bestHash?.network_hashrate ? formatHashrate(bestHash.network_hashrate) : "--"}
             </div>
           </div>
         </Tooltip>
         <Tooltip content={TOOLTIPS.pool_hashrate}>
-          <div className="p-3 bg-orange-900/10 rounded-lg">
-            <div className="text-xs text-gray-500 mb-1"><InfoIcon /> Ghost Pool Hashrate</div>
-            <div className="text-lg font-mono font-semibold text-gray-100">
+          <div className="p-3 bg-[var(--surface)] rounded-lg">
+            <div className="text-xs text-[color:var(--fainter)] mb-1"><InfoIcon /> Ghost Pool Hashrate</div>
+            <div className="text-lg font-mono font-semibold text-[color:var(--fg)]">
               {isLoading ? "..." : mining ? formatHashrate((mining.hashrate_th ?? 0) * 1e12) : "0 H/s"}
             </div>
           </div>
         </Tooltip>
         <Tooltip content={TOOLTIPS.l1_hashrate}>
-          <div className="p-3 bg-orange-900/10 rounded-lg">
-            <div className="text-xs text-gray-500 mb-1"><InfoIcon /> Your Hashrate</div>
-            <div className="text-lg font-mono font-semibold text-gray-100">
+          <div className="p-3 bg-[var(--surface)] rounded-lg">
+            <div className="text-xs text-[color:var(--fainter)] mb-1"><InfoIcon /> Your Hashrate</div>
+            <div className="text-lg font-mono font-semibold text-[color:var(--fg)]">
               {isLoading ? "..." : mining ? formatHashrate((mining.local_hashrate_th ?? 0) * 1e12) : "0 H/s"}
             </div>
           </div>
         </Tooltip>
-        <div className="p-3 bg-orange-900/10 rounded-lg">
-          <div className="text-xs text-gray-500 mb-1">Miners</div>
-          <div className="text-lg font-mono font-semibold text-gray-100">
+        <div className="p-3 bg-[var(--surface)] rounded-lg">
+          <div className="text-xs text-[color:var(--fainter)] mb-1">Miners</div>
+          <div className="text-lg font-mono font-semibold text-[color:var(--fg)]">
             {isLoading ? "..." : `${mining?.connected_miners ?? 0} connected`}
           </div>
         </div>
@@ -171,8 +171,8 @@ function L2Card() {
       <div className="grid grid-cols-2 gap-3">
         <Tooltip content={TOOLTIPS.l2_height}>
           <div className="p-3 bg-purple-900/10 rounded-lg">
-            <div className="text-xs text-gray-500 mb-1"><InfoIcon /> L2 Height</div>
-            <div className="text-lg font-mono font-semibold text-gray-100">
+            <div className="text-xs text-[color:var(--fainter)] mb-1"><InfoIcon /> L2 Height</div>
+            <div className="text-lg font-mono font-semibold text-[color:var(--fg)]">
               {isLoading ? "..." : isSyncing ? <span className="text-purple-400">Syncing...</span> : height}
             </div>
             {isSyncing && (
@@ -184,34 +184,34 @@ function L2Card() {
         </Tooltip>
         <Tooltip content={TOOLTIPS.l2_peers}>
           <div className="p-3 bg-purple-900/10 rounded-lg">
-            <div className="text-xs text-gray-500 mb-1"><InfoIcon /> L2 Peers</div>
-            <div className="text-lg font-mono font-semibold text-gray-100">
+            <div className="text-xs text-[color:var(--fainter)] mb-1"><InfoIcon /> L2 Peers</div>
+            <div className="text-lg font-mono font-semibold text-[color:var(--fg)]">
               {isLoading ? "..." : `${gp?.peer_count ?? 0} connected`}
             </div>
           </div>
         </Tooltip>
         <Tooltip content={TOOLTIPS.l2_wraith}>
           <div className="p-3 bg-purple-900/10 rounded-lg">
-            <div className="text-xs text-gray-500 mb-1"><InfoIcon /> Wraith</div>
+            <div className="text-xs text-[color:var(--fainter)] mb-1"><InfoIcon /> Wraith</div>
             <div className="flex items-center gap-2">
               <StatusDot
                 status={wraithActive ? "online" : "offline"}
                 size="sm"
               />
-              <span className="text-sm font-mono text-gray-100">
+              <span className="text-sm font-mono text-[color:var(--fg)]">
                 {wraithLabel}
               </span>
             </div>
             {!isLoading && (
-              <div className={`text-xs mt-0.5 ${wraithActive ? "text-purple-400" : "text-gray-500"}`}>
+              <div className={`text-xs mt-0.5 ${wraithActive ? "text-purple-400" : "text-[color:var(--fainter)]"}`}>
                 {wraithReason}
               </div>
             )}
           </div>
         </Tooltip>
         <div className="p-3 bg-purple-900/10 rounded-lg">
-          <div className="text-xs text-gray-500 mb-1">Status</div>
-          <div className="text-lg font-mono font-semibold text-gray-100">
+          <div className="text-xs text-[color:var(--fainter)] mb-1">Status</div>
+          <div className="text-lg font-mono font-semibold text-[color:var(--fg)]">
             {isLoading ? "..." : isRunning ? "Active" : "Not enabled"}
           </div>
         </div>
@@ -235,8 +235,8 @@ function SharesSection() {
         subtitle="5-4-3-2-1 Reward System"
         action={
           <Tooltip content={TOOLTIPS.shares}>
-            <span className="text-2xl font-bold text-gray-100">
-              {shares.total}<span className="text-gray-500 text-lg"> / {shares.max_shares}</span>
+            <span className="text-2xl font-bold text-[color:var(--fg)]">
+              {shares.total}<span className="text-[color:var(--fainter)] text-lg"> / {shares.max_shares}</span>
               <InfoIcon />
             </span>
           </Tooltip>
@@ -252,13 +252,13 @@ function SharesSection() {
 
       {/* Uptime gatekeeper */}
       {!shares.uptime_qualified && (
-        <div className="mb-4 p-3 rounded-lg bg-red-900/20 border border-red-800">
+        <div className="mb-4 p-3 rounded-lg bg-[var(--surface)] border border-[color:var(--red)]">
           <div className="flex items-center gap-2">
-            <span className="text-red-400">&#10007;</span>
-            <span className="text-sm text-gray-300">Uptime below 95%</span>
+            <span className="text-[color:var(--red)]">&#10007;</span>
+            <span className="text-sm text-[color:var(--dim)]">Uptime below 95%</span>
             <Badge variant="error">{(shares.uptime_percent ?? 0).toFixed(1)}%</Badge>
           </div>
-          <p className="text-xs text-red-400 mt-1">All shares disabled until uptime recovers</p>
+          <p className="text-xs text-[color:var(--red)] mt-1">All shares disabled until uptime recovers</p>
         </div>
       )}
 
@@ -267,12 +267,12 @@ function SharesSection() {
           const isActive = shares[tier.key as keyof typeof shares] as boolean;
           const disabled = !shares.uptime_qualified;
           return (
-            <div key={tier.key} className="flex items-center justify-between py-1.5 px-2 rounded hover:bg-gray-800/30">
+            <div key={tier.key} className="flex items-center justify-between py-1.5 px-2 rounded hover:bg-[var(--surface)]">
               <div className="flex items-center gap-2">
-                <span className={isActive && !disabled ? "text-green-400" : "text-gray-600"}>
+                <span className={isActive && !disabled ? "text-[color:var(--green)]" : "text-[color:var(--fainter)]"}>
                   {isActive ? "\u2713" : "\u2717"}
                 </span>
-                <span className={isActive && !disabled ? "text-gray-100 text-sm" : "text-gray-500 text-sm"}>
+                <span className={isActive && !disabled ? "text-[color:var(--fg)] text-sm" : "text-[color:var(--fainter)] text-sm"}>
                   {tier.name}
                 </span>
               </div>
@@ -295,7 +295,7 @@ function HealthSection() {
   const statusColor = overallStatus === "healthy" ? "online" : overallStatus === "degraded" ? "warning" : "offline";
 
   return (
-    <Card className="border-green-600/30">
+    <Card className="border-[color:var(--green)]">
       <CardHeader
         title="Health"
         action={
@@ -317,7 +317,7 @@ function HealthSection() {
         ))}
       </div>
       {/* Color legend */}
-      <div className="flex gap-4 text-[10px] text-gray-500 border-t border-gray-800 pt-2">
+      <div className="flex gap-4 text-[10px] text-[color:var(--fainter)] border-t border-[var(--rule)] pt-2">
         <div className="flex items-center gap-1">
           <span className="w-2 h-2 rounded-full bg-green-500" />
           Running
@@ -356,66 +356,66 @@ function PrivacySection() {
   const wraithActive = gpRunning && gp?.wraith_enabled;
 
   return (
-    <Card className="border-red-600/30">
-      <CardHeader title={<span className="text-red-400">Privacy Status</span>} />
+    <Card className="border-[color:var(--red)]">
+      <CardHeader title={<span className="text-[color:var(--red)]">Privacy Status</span>} />
       <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3">
         <Tooltip content={TOOLTIPS.ghost_mode}>
-          <div className="p-3 bg-red-900/10 rounded-lg">
-            <div className="text-xs text-gray-500 mb-1"><InfoIcon /> Ghost Mode</div>
+          <div className="p-3 bg-[var(--surface)] rounded-lg">
+            <div className="text-xs text-[color:var(--fainter)] mb-1"><InfoIcon /> Ghost Mode</div>
             <div className="flex items-center gap-2">
               <StatusDot
                 status={ghostModeActive ? "online" : "offline"}
                 size="sm"
               />
-              <span className="text-sm text-gray-100">{ghostModeActive ? "Active" : "Off"}</span>
+              <span className="text-sm text-[color:var(--fg)]">{ghostModeActive ? "Active" : "Off"}</span>
             </div>
           </div>
         </Tooltip>
         <Tooltip content={TOOLTIPS.privacy_tor}>
-          <div className="p-3 bg-red-900/10 rounded-lg">
-            <div className="text-xs text-gray-500 mb-1"><InfoIcon /> Tor Mode</div>
+          <div className="p-3 bg-[var(--surface)] rounded-lg">
+            <div className="text-xs text-[color:var(--fainter)] mb-1"><InfoIcon /> Tor Mode</div>
             <div className="flex items-center gap-2">
               <StatusDot
                 status={torActive ? "online" : "offline"}
                 size="sm"
               />
-              <span className="text-sm text-gray-100">{torActive ? "Active" : "Off"}</span>
+              <span className="text-sm text-[color:var(--fg)]">{torActive ? "Active" : "Off"}</span>
             </div>
           </div>
         </Tooltip>
         <Tooltip content={TOOLTIPS.privacy_haze}>
-          <div className="p-3 bg-red-900/10 rounded-lg">
-            <div className="text-xs text-gray-500 mb-1"><InfoIcon /> Ghost Haze</div>
+          <div className="p-3 bg-[var(--surface)] rounded-lg">
+            <div className="text-xs text-[color:var(--fainter)] mb-1"><InfoIcon /> Ghost Haze</div>
             <div className="flex items-center gap-2">
               <StatusDot
                 status={hazeActive ? "online" : "offline"}
                 size="sm"
               />
-              <span className="text-sm text-gray-100">{hazeLabel}</span>
+              <span className="text-sm text-[color:var(--fg)]">{hazeLabel}</span>
             </div>
           </div>
         </Tooltip>
         <Tooltip content={TOOLTIPS.privacy_shroud}>
-          <div className="p-3 bg-red-900/10 rounded-lg">
-            <div className="text-xs text-gray-500 mb-1"><InfoIcon /> Ghost Shroud</div>
+          <div className="p-3 bg-[var(--surface)] rounded-lg">
+            <div className="text-xs text-[color:var(--fainter)] mb-1"><InfoIcon /> Ghost Shroud</div>
             <div className="flex items-center gap-2">
               <StatusDot
                 status={shroudActive ? "online" : "offline"}
                 size="sm"
               />
-              <span className="text-sm text-gray-100">{shroudLabel}</span>
+              <span className="text-sm text-[color:var(--fg)]">{shroudLabel}</span>
             </div>
           </div>
         </Tooltip>
         <Tooltip content={TOOLTIPS.privacy_wraith}>
-          <div className="p-3 bg-red-900/10 rounded-lg">
-            <div className="text-xs text-gray-500 mb-1"><InfoIcon /> Wraith</div>
+          <div className="p-3 bg-[var(--surface)] rounded-lg">
+            <div className="text-xs text-[color:var(--fainter)] mb-1"><InfoIcon /> Wraith</div>
             <div className="flex items-center gap-2">
               <StatusDot
                 status={wraithActive ? "online" : "offline"}
                 size="sm"
               />
-              <span className="text-sm text-gray-100">{wraithActive ? "Active" : "Off"}</span>
+              <span className="text-sm text-[color:var(--fg)]">{wraithActive ? "Active" : "Off"}</span>
             </div>
           </div>
         </Tooltip>

--- a/dashboard/src/app/(dashboard)/payouts/page.tsx
+++ b/dashboard/src/app/(dashboard)/payouts/page.tsx
@@ -61,7 +61,7 @@ const nodeBalanceColumns: ColumnDef<NodeBalanceEntry>[] = [
     id: "rank",
     header: "#",
     cell: ({ row }) => (
-      <span className="text-gray-500 text-sm">{row.index + 1}</span>
+      <span className="text-[color:var(--fainter)] text-sm">{row.index + 1}</span>
     ),
   },
   {
@@ -69,7 +69,7 @@ const nodeBalanceColumns: ColumnDef<NodeBalanceEntry>[] = [
     header: "Node",
     cell: ({ row }) => (
       <div className="flex items-center gap-2">
-        <span className="font-mono text-sm text-gray-300">
+        <span className="font-mono text-sm text-[color:var(--dim)]">
           {row.original.node_id.slice(0, 12)}...
         </span>
         {row.original.is_self && (
@@ -82,7 +82,7 @@ const nodeBalanceColumns: ColumnDef<NodeBalanceEntry>[] = [
     accessorKey: "balance_sats",
     header: "Balance",
     cell: ({ row }) => (
-      <span className="font-mono text-green-400">
+      <span className="font-mono text-[color:var(--green)]">
         {formatSats(row.original.balance_sats)}
       </span>
     ),
@@ -91,7 +91,7 @@ const nodeBalanceColumns: ColumnDef<NodeBalanceEntry>[] = [
     accessorKey: "total_credits_sats",
     header: "Lifetime Earned",
     cell: ({ row }) => (
-      <span className="font-mono text-gray-300">
+      <span className="font-mono text-[color:var(--dim)]">
         {formatSats(row.original.total_credits_sats)}
       </span>
     ),
@@ -100,7 +100,7 @@ const nodeBalanceColumns: ColumnDef<NodeBalanceEntry>[] = [
     accessorKey: "total_withdrawals_sats",
     header: "Withdrawn",
     cell: ({ row }) => (
-      <span className="font-mono text-gray-400">
+      <span className="font-mono text-[color:var(--dim)]">
         {formatSats(row.original.total_withdrawals_sats)}
       </span>
     ),
@@ -109,7 +109,7 @@ const nodeBalanceColumns: ColumnDef<NodeBalanceEntry>[] = [
     accessorKey: "last_credited_round",
     header: "Last Credit",
     cell: ({ row }) => (
-      <span className="text-gray-400 text-sm">
+      <span className="text-[color:var(--dim)] text-sm">
         Round #{row.original.last_credited_round}
       </span>
     ),
@@ -118,7 +118,7 @@ const nodeBalanceColumns: ColumnDef<NodeBalanceEntry>[] = [
     accessorKey: "updated_at",
     header: "Updated",
     cell: ({ row }) => (
-      <span className="text-gray-500 text-sm">
+      <span className="text-[color:var(--fainter)] text-sm">
         {formatTimestamp(row.original.updated_at)}
       </span>
     ),
@@ -236,11 +236,11 @@ export default function PayoutsPage() {
           <CardHeader title="Where Rewards Come From" subtitle="Nodes earn from multiple revenue streams" />
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
             {REWARD_SOURCES.map((source) => (
-              <div key={source.name} className="flex items-start gap-3 p-3 bg-gray-800/30 rounded-lg">
+              <div key={source.name} className="flex items-start gap-3 p-3 bg-[var(--surface)] rounded-lg">
                 <div className={`w-2 h-2 rounded-full mt-1.5 flex-shrink-0 ${source.color}`} />
                 <div>
-                  <div className="text-sm font-medium text-gray-200">{source.name}</div>
-                  <div className="text-xs text-gray-500 mt-0.5">{source.desc}</div>
+                  <div className="text-sm font-medium text-[color:var(--fg)]">{source.name}</div>
+                  <div className="text-xs text-[color:var(--fainter)] mt-0.5">{source.desc}</div>
                 </div>
               </div>
             ))}

--- a/dashboard/src/app/(dashboard)/peers/page.tsx
+++ b/dashboard/src/app/(dashboard)/peers/page.tsx
@@ -32,7 +32,7 @@ const peerColumns: ColumnDef<PeerInfo>[] = [
     accessorKey: "version",
     header: "Version",
     cell: ({ row }) => (
-      <span className="font-mono text-gray-400">{row.original.version || "N/A"}</span>
+      <span className="font-mono text-[color:var(--dim)]">{row.original.version || "N/A"}</span>
     ),
   },
   {
@@ -40,7 +40,7 @@ const peerColumns: ColumnDef<PeerInfo>[] = [
     header: "Latency",
     cell: ({ row }) => {
       const latency = row.original.latency_ms;
-      if (latency == null) return <span className="text-gray-500">--</span>;
+      if (latency == null) return <span className="text-[color:var(--fainter)]">--</span>;
       return (
         <Badge variant={latency < 100 ? "success" : latency < 500 ? "warning" : "error"}>
           {latency}ms
@@ -64,10 +64,10 @@ const peerColumns: ColumnDef<PeerInfo>[] = [
     header: "Connected",
     cell: ({ row }) => {
       const connectedAt = row.original.connected_at ?? 0;
-      if (!connectedAt) return <span className="text-gray-500">N/A</span>;
+      if (!connectedAt) return <span className="text-[color:var(--fainter)]">N/A</span>;
       const connectedAgo = Math.floor(Date.now() / 1000 - connectedAt);
-      if (connectedAgo < 0 || connectedAgo > 86400 * 365) return <span className="text-gray-500">N/A</span>;
-      return <span className="text-gray-400">{formatDuration(connectedAgo)}</span>;
+      if (connectedAgo < 0 || connectedAgo > 86400 * 365) return <span className="text-[color:var(--fainter)]">N/A</span>;
+      return <span className="text-[color:var(--dim)]">{formatDuration(connectedAgo)}</span>;
     },
   },
 ];

--- a/dashboard/src/app/(dashboard)/shroud/page.tsx
+++ b/dashboard/src/app/(dashboard)/shroud/page.tsx
@@ -75,7 +75,7 @@ export default function ShroudPage() {
           title="How It Works"
           subtitle="Transaction relay flow with Shroud enabled"
         />
-        <p className="text-gray-300 text-sm leading-relaxed mb-4">
+        <p className="text-[color:var(--dim)] text-sm leading-relaxed mb-4">
           Ghost Shroud adds random delays before relaying transactions to peers, breaking
           timing-based origin detection. Your transactions enter your mempool instantly for
           mining and validation — only the outbound relay to other nodes is delayed, making it
@@ -91,8 +91,8 @@ export default function ShroudPage() {
             { label: "Relay to peers", sublabel: "Delayed broadcast" },
           ]}
         />
-        <div className="mt-4 p-3 bg-gray-800/50 rounded-lg border border-gray-700">
-          <p className="text-xs text-gray-400 leading-relaxed">
+        <div className="mt-4 p-3 bg-[var(--surface)] rounded-lg border border-[var(--rule-strong)]">
+          <p className="text-xs text-[color:var(--dim)] leading-relaxed">
             <span className="text-blue-400 font-medium">Note:</span> The mempool addition is
             instant — your node can mine and validate the transaction immediately. Shroud only
             affects the <span className="text-blue-400">outbound relay</span> timing, ensuring
@@ -111,7 +111,7 @@ export default function ShroudPage() {
               title="Status"
               subtitle="Current Shroud relay configuration"
             />
-            <div className="divide-y divide-gray-800">
+            <div className="divide-y divide-[var(--rule)]">
               <StatusRow label="Shroud Enabled" tooltip={TOOLTIPS.enabled}>
                 <StatusDot
                   status={status.enabled ? "online" : "offline"}
@@ -127,7 +127,7 @@ export default function ShroudPage() {
                 />
               </StatusRow>
               <StatusRow label="Max Delay" tooltip={TOOLTIPS.max_delay}>
-                <span className="text-gray-100 font-mono text-sm">
+                <span className="text-[color:var(--fg)] font-mono text-sm">
                   {status.max_delay_ms.toLocaleString()} ms
                 </span>
               </StatusRow>
@@ -158,27 +158,27 @@ export default function ShroudPage() {
             </h4>
             <ul className="space-y-3">
               <li className="flex items-start gap-2">
-                <span className="text-green-400 mt-0.5 flex-shrink-0">
+                <span className="text-[color:var(--green)] mt-0.5 flex-shrink-0">
                   <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                     <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
                   </svg>
                 </span>
                 <div>
-                  <span className="text-gray-200 text-sm font-medium">Timing Analysis</span>
-                  <p className="text-gray-500 text-xs mt-0.5">
+                  <span className="text-[color:var(--fg)] text-sm font-medium">Timing Analysis</span>
+                  <p className="text-[color:var(--fainter)] text-xs mt-0.5">
                     Random delays make it impossible to identify the originating node by relay timing.
                   </p>
                 </div>
               </li>
               <li className="flex items-start gap-2">
-                <span className="text-green-400 mt-0.5 flex-shrink-0">
+                <span className="text-[color:var(--green)] mt-0.5 flex-shrink-0">
                   <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                     <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
                   </svg>
                 </span>
                 <div>
-                  <span className="text-gray-200 text-sm font-medium">Topology Mapping</span>
-                  <p className="text-gray-500 text-xs mt-0.5">
+                  <span className="text-[color:var(--fg)] text-sm font-medium">Topology Mapping</span>
+                  <p className="text-[color:var(--fainter)] text-xs mt-0.5">
                     Obscures the network graph by preventing relay order inference between peers.
                   </p>
                 </div>
@@ -187,8 +187,8 @@ export default function ShroudPage() {
           </div>
 
           {/* Does Not Protect Against */}
-          <div className="p-4 bg-gray-800/50 rounded-lg border border-gray-700">
-            <h4 className="text-sm font-medium text-gray-400 mb-3 flex items-center gap-2">
+          <div className="p-4 bg-[var(--surface)] rounded-lg border border-[var(--rule-strong)]">
+            <h4 className="text-sm font-medium text-[color:var(--dim)] mb-3 flex items-center gap-2">
               <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                 <path strokeLinecap="round" strokeLinejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
               </svg>
@@ -196,27 +196,27 @@ export default function ShroudPage() {
             </h4>
             <ul className="space-y-3">
               <li className="flex items-start gap-2">
-                <span className="text-gray-500 mt-0.5 flex-shrink-0">
+                <span className="text-[color:var(--fainter)] mt-0.5 flex-shrink-0">
                   <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                     <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
                   </svg>
                 </span>
                 <div>
-                  <span className="text-gray-300 text-sm font-medium">Content Encryption</span>
-                  <p className="text-gray-500 text-xs mt-0.5">
+                  <span className="text-[color:var(--dim)] text-sm font-medium">Content Encryption</span>
+                  <p className="text-[color:var(--fainter)] text-xs mt-0.5">
                     Transaction contents are not encrypted. Shroud only affects relay timing, not data.
                   </p>
                 </div>
               </li>
               <li className="flex items-start gap-2">
-                <span className="text-gray-500 mt-0.5 flex-shrink-0">
+                <span className="text-[color:var(--fainter)] mt-0.5 flex-shrink-0">
                   <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                     <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
                   </svg>
                 </span>
                 <div>
-                  <span className="text-gray-300 text-sm font-medium">Global Observer</span>
-                  <p className="text-gray-500 text-xs mt-0.5">
+                  <span className="text-[color:var(--dim)] text-sm font-medium">Global Observer</span>
+                  <p className="text-[color:var(--fainter)] text-xs mt-0.5">
                     An adversary monitoring all network links simultaneously may still correlate transactions.
                   </p>
                 </div>

--- a/dashboard/src/app/(dashboard)/storage/page.tsx
+++ b/dashboard/src/app/(dashboard)/storage/page.tsx
@@ -50,7 +50,7 @@ export default function StoragePage() {
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold text-gray-100">Storage & Pruning</h1>
+        <h1 className="text-2xl font-bold text-[color:var(--fg)]">Storage & Pruning</h1>
         {archiveMode && <Badge variant="success">+5 Shares (Archive)</Badge>}
       </div>
 
@@ -72,11 +72,11 @@ export default function StoragePage() {
             />
             <div className="space-y-4">
               {!ghostPayRunning ? (
-                <div className="p-4 bg-yellow-900/20 border border-yellow-800 rounded-lg">
+                <div className="p-4 bg-[var(--surface)] border border-[color:var(--accent)] rounded-lg">
                   <div className="flex items-center gap-2">
                     <Badge variant="warning">Ghost Pay Not Running</Badge>
                   </div>
-                  <p className="text-sm text-yellow-300 mt-2">
+                  <p className="text-sm text-[color:var(--accent)] mt-2">
                     Start ghost-pay-node to enable L2 functionality and see pruning status.
                   </p>
                 </div>
@@ -86,33 +86,33 @@ export default function StoragePage() {
                 <>
                   {/* L2 Pruning Config */}
                   <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-                    <div className="p-4 bg-gray-800/50 rounded-lg">
-                      <div className="text-sm text-gray-400">Retention Period</div>
-                      <div className="text-xl font-bold text-gray-100 mt-1">
+                    <div className="p-4 bg-[var(--surface)] rounded-lg">
+                      <div className="text-sm text-[color:var(--dim)]">Retention Period</div>
+                      <div className="text-xl font-bold text-[color:var(--fg)] mt-1">
                         {l2Pruning.retention_days} days
                       </div>
                     </div>
-                    <div className="p-4 bg-gray-800/50 rounded-lg">
-                      <div className="text-sm text-gray-400">Auto Prune</div>
+                    <div className="p-4 bg-[var(--surface)] rounded-lg">
+                      <div className="text-sm text-[color:var(--dim)]">Auto Prune</div>
                       <div className="mt-1">
                         <Badge variant="success">Always On</Badge>
                       </div>
-                      <div className="text-xs text-gray-500 mt-1">
+                      <div className="text-xs text-[color:var(--fainter)] mt-1">
                         Every {l2Pruning.prune_interval_hours}h
                       </div>
                     </div>
-                    <div className="p-4 bg-gray-800/50 rounded-lg">
-                      <div className="text-sm text-gray-400">Last Prune</div>
-                      <div className="text-lg font-medium text-gray-100 mt-1">
+                    <div className="p-4 bg-[var(--surface)] rounded-lg">
+                      <div className="text-sm text-[color:var(--dim)]">Last Prune</div>
+                      <div className="text-lg font-medium text-[color:var(--fg)] mt-1">
                         {formatTimeAgo(l2Pruning.last_prune_timestamp ?? 0)}
                       </div>
-                      <div className="text-xs text-gray-500 mt-1">
+                      <div className="text-xs text-[color:var(--fainter)] mt-1">
                         {formatTimestamp(l2Pruning.last_prune_timestamp ?? 0)}
                       </div>
                     </div>
-                    <div className="p-4 bg-gray-800/50 rounded-lg">
-                      <div className="text-sm text-gray-400">Last Run Stats</div>
-                      <div className="text-sm text-gray-300 mt-2 space-y-1">
+                    <div className="p-4 bg-[var(--surface)] rounded-lg">
+                      <div className="text-sm text-[color:var(--dim)]">Last Run Stats</div>
+                      <div className="text-sm text-[color:var(--dim)] mt-2 space-y-1">
                         <div>Payments: {l2Pruning.payments_pruned}</div>
                         <div>Attestations: {l2Pruning.attestations_pruned}</div>
                         <div>Locks: {l2Pruning.locks_pruned}</div>
@@ -122,32 +122,32 @@ export default function StoragePage() {
 
                   {/* L2 Pruning Info - Two Columns */}
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                    <div className="p-4 bg-red-900/20 border border-red-800 rounded-lg">
-                      <h4 className="text-red-300 font-medium mb-3">What Gets Pruned</h4>
-                      <ul className="text-sm text-red-200/80 space-y-2">
+                    <div className="p-4 bg-[var(--surface)] border border-[color:var(--red)] rounded-lg">
+                      <h4 className="text-[color:var(--red)] font-medium mb-3">What Gets Pruned</h4>
+                      <ul className="text-sm text-[color:var(--red)] space-y-2">
                         <li className="flex items-start gap-2">
-                          <span className="text-red-400 mt-0.5">•</span>
+                          <span className="text-[color:var(--red)] mt-0.5">•</span>
                           <span>Payments (with ZK proofs) older than {l2Pruning.retention_days} days</span>
                         </li>
                         <li className="flex items-start gap-2">
-                          <span className="text-red-400 mt-0.5">•</span>
+                          <span className="text-[color:var(--red)] mt-0.5">•</span>
                           <span>Attestations older than {l2Pruning.retention_days} days</span>
                         </li>
                         <li className="flex items-start gap-2">
-                          <span className="text-red-400 mt-0.5">•</span>
+                          <span className="text-[color:var(--red)] mt-0.5">•</span>
                           <span>Closed locks (reconciled or jumped) older than {l2Pruning.retention_days} days</span>
                         </li>
                       </ul>
                     </div>
-                    <div className="p-4 bg-green-900/20 border border-green-800 rounded-lg">
-                      <h4 className="text-green-300 font-medium mb-3">What is Never Pruned</h4>
-                      <ul className="text-sm text-green-200/80 space-y-2">
+                    <div className="p-4 bg-[var(--surface)] border border-[color:var(--green)] rounded-lg">
+                      <h4 className="text-[color:var(--green)] font-medium mb-3">What is Never Pruned</h4>
+                      <ul className="text-sm text-[color:var(--green)] space-y-2">
                         <li className="flex items-start gap-2">
-                          <span className="text-green-400 mt-0.5">•</span>
+                          <span className="text-[color:var(--green)] mt-0.5">•</span>
                           <span>Active locks (regardless of age)</span>
                         </li>
                         <li className="flex items-start gap-2">
-                          <span className="text-green-400 mt-0.5">•</span>
+                          <span className="text-[color:var(--green)] mt-0.5">•</span>
                           <span>L2 block headers (contain state_root commitments)</span>
                         </li>
                       </ul>
@@ -155,7 +155,7 @@ export default function StoragePage() {
                   </div>
                 </>
               ) : (
-                <div className="p-4 bg-gray-800/50 rounded-lg text-gray-400">
+                <div className="p-4 bg-[var(--surface)] rounded-lg text-[color:var(--dim)]">
                   Unable to fetch L2 pruning status. Ensure ghost-pay-node API is accessible.
                 </div>
               )}
@@ -168,21 +168,21 @@ export default function StoragePage() {
             <div className="overflow-x-auto">
               <table className="w-full text-sm">
                 <thead>
-                  <tr className="text-left text-gray-400 border-b border-gray-800">
+                  <tr className="text-left text-[color:var(--dim)] border-b border-[var(--rule)]">
                     <th className="pb-3 font-medium">Layer</th>
                     <th className="pb-3 font-medium">Window</th>
                     <th className="pb-3 font-medium">Duration</th>
                     <th className="pb-3 font-medium">Behavior</th>
                   </tr>
                 </thead>
-                <tbody className="text-gray-300">
-                  <tr className="border-b border-gray-800/50">
+                <tbody className="text-[color:var(--dim)]">
+                  <tr className="border-b border-[var(--rule)]">
                     <td className="py-3">L1</td>
                     <td className="py-3">Validator (VW)</td>
                     <td className="py-3">288 blocks (~2 days)</td>
                     <td className="py-3">Full retention - Bitcoin Core minimum</td>
                   </tr>
-                  <tr className="border-b border-gray-800/50">
+                  <tr className="border-b border-[var(--rule)]">
                     <td className="py-3">L1</td>
                     <td className="py-3">Operator (OW)</td>
                     <td className="py-3">{fullConfig?.pruning?.ow_blocks ?? 2016} blocks (~{formatDuration(fullConfig?.pruning?.ow_blocks ?? 2016)})</td>
@@ -190,7 +190,7 @@ export default function StoragePage() {
                       {archiveMode ? "Archive Mode - no pruning" : `BUDS pruning (${fullConfig?.pruning?.prune_profile ?? "default"})`}
                     </td>
                   </tr>
-                  <tr className="border-b border-gray-800/50">
+                  <tr className="border-b border-[var(--rule)]">
                     <td className="py-3">L1</td>
                     <td className="py-3">Archive (AW)</td>
                     <td className="py-3">{archiveMode ? "Infinite" : "N/A"}</td>

--- a/dashboard/src/app/(dashboard)/swarm/page.tsx
+++ b/dashboard/src/app/(dashboard)/swarm/page.tsx
@@ -47,7 +47,7 @@ function formatHashrate(th: number): string {
 // is wrapped in a <Tooltip> that carries the explanatory copy.
 function InfoIcon() {
   return (
-    <svg className="w-3 h-3 text-gray-600 inline-block mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+    <svg className="w-3 h-3 text-[color:var(--fainter)] inline-block mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
       <circle cx="12" cy="12" r="10" />
       <path d="M12 16v-4M12 8h.01" />
     </svg>
@@ -366,13 +366,13 @@ export default function SwarmPage() {
         actions={
           <>
             <Tooltip content={TOOLTIPS.viewToggle}>
-              <div className="flex rounded-lg border border-gray-700 overflow-hidden">
+              <div className="flex rounded-lg border border-[var(--rule-strong)] overflow-hidden">
                 <button
                   onClick={() => setViewMode("list")}
                   className={`px-3 py-1.5 text-sm ${
                     viewMode === "list"
-                      ? "bg-gray-700 text-white"
-                      : "bg-gray-800 text-gray-400 hover:text-white"
+                      ? "bg-[var(--accent)] text-white"
+                      : "bg-[var(--surface)] text-[color:var(--dim)] hover:text-[color:var(--fg)]"
                   }`}
                 >
                   List
@@ -381,8 +381,8 @@ export default function SwarmPage() {
                   onClick={() => setViewMode("grid")}
                   className={`px-3 py-1.5 text-sm ${
                     viewMode === "grid"
-                      ? "bg-gray-700 text-white"
-                      : "bg-gray-800 text-gray-400 hover:text-white"
+                      ? "bg-[var(--accent)] text-white"
+                      : "bg-[var(--surface)] text-[color:var(--dim)] hover:text-[color:var(--fg)]"
                   }`}
                 >
                   Grid
@@ -450,30 +450,30 @@ export default function SwarmPage() {
       {/* Local Node Setup Info */}
       <SectionErrorBoundary section="This Node">
         {nodeInfo && (
-          <Card className="border-orange-600/50">
+          <Card className="border-[color:var(--accent)]">
             <CardHeader
               title="This Node"
               subtitle="Use these details when adding this node to another swarm"
             />
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              <div className="p-3 bg-gray-800/50 rounded-lg">
+              <div className="p-3 bg-[var(--surface)] rounded-lg">
                 <Tooltip content={TOOLTIPS.nodeId}>
-                  <div className="text-xs text-gray-500 uppercase tracking-wide mb-1 inline-block"><InfoIcon /> Node ID</div>
+                  <div className="text-xs text-[color:var(--fainter)] uppercase tracking-wide mb-1 inline-block"><InfoIcon /> Node ID</div>
                 </Tooltip>
-                <div className="font-mono text-sm text-gray-100 break-all select-all">
+                <div className="font-mono text-sm text-[color:var(--fg)] break-all select-all">
                   {nodeInfo.node_id}
                 </div>
               </div>
-              <div className="p-3 bg-gray-800/50 rounded-lg">
+              <div className="p-3 bg-[var(--surface)] rounded-lg">
                 <Tooltip content={TOOLTIPS.connectionAddress}>
-                  <div className="text-xs text-gray-500 uppercase tracking-wide mb-1 inline-block"><InfoIcon /> Connection Address</div>
+                  <div className="text-xs text-[color:var(--fainter)] uppercase tracking-wide mb-1 inline-block"><InfoIcon /> Connection Address</div>
                 </Tooltip>
-                <div className="font-mono text-sm text-gray-100 mb-2 select-all">
+                <div className="font-mono text-sm text-[color:var(--fg)] mb-2 select-all">
                   {swarmData?.self?.address
                     ? `http://${swarmData.self.address}`
                     : "http://<your-ip>:8080"}
                 </div>
-                <p className="text-xs text-gray-500">
+                <p className="text-xs text-[color:var(--fainter)]">
                   {swarmData?.self?.address
                     ? "Other nodes can add this address to their swarm."
                     : "Template — replace <your-ip> with your public IP or hostname, then other nodes can add this address to their swarm."}
@@ -502,13 +502,13 @@ export default function SwarmPage() {
           /* Grid View - Compact cards */
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
             {nodes.map((node) => (
-              <Card key={node.node_id} className={node.address === "localhost" ? "border-orange-600/50" : ""}>
+              <Card key={node.node_id} className={node.address === "localhost" ? "border-[color:var(--accent)]" : ""}>
                 <div className="flex items-center justify-between mb-3">
                   <div className="flex items-center gap-2">
                     <span
                       className={`w-2.5 h-2.5 rounded-full ${node.online ? "bg-green-500" : "bg-red-500"}`}
                     />
-                    <span className="font-semibold text-gray-100">{node.name}</span>
+                    <span className="font-semibold text-[color:var(--fg)]">{node.name}</span>
                     {node.is_self && (
                       <Tooltip content={TOOLTIPS.you}>
                         <Badge variant="info" className="text-xs">
@@ -548,31 +548,31 @@ export default function SwarmPage() {
                   </div>
                 </div>
 
-                <div className="text-xs text-gray-400 mb-3 font-mono truncate">{node.address}</div>
+                <div className="text-xs text-[color:var(--dim)] mb-3 font-mono truncate">{node.address}</div>
 
                 <div className="grid grid-cols-2 gap-2 text-xs mb-3">
                   <Tooltip content={TOOLTIPS.l1Height}>
                     <div>
-                      <span className="text-gray-500"><InfoIcon /> L1:</span>{" "}
-                      <span className="text-gray-300">{orDash(node.l1_height, (v) => v.toLocaleString())}</span>
+                      <span className="text-[color:var(--fainter)]"><InfoIcon /> L1:</span>{" "}
+                      <span className="text-[color:var(--dim)]">{orDash(node.l1_height, (v) => v.toLocaleString())}</span>
                     </div>
                   </Tooltip>
                   <Tooltip content={TOOLTIPS.l2Height}>
                     <div>
-                      <span className="text-gray-500"><InfoIcon /> L2:</span>{" "}
-                      <span className="text-gray-300">{orDash(node.l2_height, (v) => v.toLocaleString())}</span>
+                      <span className="text-[color:var(--fainter)]"><InfoIcon /> L2:</span>{" "}
+                      <span className="text-[color:var(--dim)]">{orDash(node.l2_height, (v) => v.toLocaleString())}</span>
                     </div>
                   </Tooltip>
                   <Tooltip content={TOOLTIPS.peers}>
                     <div>
-                      <span className="text-gray-500"><InfoIcon /> Peers:</span>{" "}
-                      <span className="text-gray-300">{orDash(node.peer_count, (v) => String(v))}</span>
+                      <span className="text-[color:var(--fainter)]"><InfoIcon /> Peers:</span>{" "}
+                      <span className="text-[color:var(--dim)]">{orDash(node.peer_count, (v) => String(v))}</span>
                     </div>
                   </Tooltip>
                   <Tooltip content={TOOLTIPS.shares}>
                     <div>
-                      <span className="text-gray-500"><InfoIcon /> Shares:</span>{" "}
-                      <span className="text-gray-300">{node.shares ?? 0}/{node.max_shares ?? 15}</span>
+                      <span className="text-[color:var(--fainter)]"><InfoIcon /> Shares:</span>{" "}
+                      <span className="text-[color:var(--dim)]">{node.shares ?? 0}/{node.max_shares ?? 15}</span>
                     </div>
                   </Tooltip>
                 </div>
@@ -587,7 +587,7 @@ export default function SwarmPage() {
                   </div>
                 </Tooltip>
 
-                <div className="flex gap-1 pt-2 border-t border-gray-800">
+                <div className="flex gap-1 pt-2 border-t border-[var(--rule)]">
                   <Tooltip content={TOOLTIPS.edit}>
                     <Button variant="ghost" size="sm" onClick={() => handleEditClick(node)} className="text-xs px-2">
                       Edit
@@ -615,7 +615,7 @@ export default function SwarmPage() {
           /* List View - Full detail cards */
           <div className="space-y-4">
             {nodes.map((node) => (
-              <Card key={node.node_id} className={node.address === "localhost" ? "border-orange-600/50" : ""}>
+              <Card key={node.node_id} className={node.address === "localhost" ? "border-[color:var(--accent)]" : ""}>
                 <div className="flex flex-wrap items-start justify-between gap-4">
                   <div className="flex items-center gap-3">
                     <span
@@ -623,8 +623,8 @@ export default function SwarmPage() {
                     />
                     <div>
                       <div className="flex items-center gap-2">
-                        <span className="text-lg font-semibold text-gray-100">{node.name}</span>
-                        <span className="text-gray-500 font-mono text-sm">
+                        <span className="text-lg font-semibold text-[color:var(--fg)]">{node.name}</span>
+                        <span className="text-[color:var(--fainter)] font-mono text-sm">
                           ({truncateId(node.node_id, 6)})
                         </span>
                         <Tooltip content={TOOLTIPS.statusOnline}>
@@ -650,15 +650,15 @@ export default function SwarmPage() {
                           </Badge>
                         )}
                       </div>
-                      <div className="text-sm text-gray-400 mt-1">{node.address}</div>
+                      <div className="text-sm text-[color:var(--dim)] mt-1">{node.address}</div>
                     </div>
                   </div>
                   <div className="text-right">
-                    <div className="text-lg font-bold text-gray-100">
+                    <div className="text-lg font-bold text-[color:var(--fg)]">
                       {orDash(node.balance_btc, (v) => `${formatBtc(v)} BTC`)}
                     </div>
                     <Tooltip content={TOOLTIPS.shares}>
-                      <div className="text-sm text-gray-400 inline-block">
+                      <div className="text-sm text-[color:var(--dim)] inline-block">
                         <InfoIcon /> {node.shares ?? 0}/{node.max_shares ?? 15} shares
                       </div>
                     </Tooltip>
@@ -668,16 +668,16 @@ export default function SwarmPage() {
                 <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mt-4 text-sm">
                   <Tooltip content={TOOLTIPS.uptime}>
                     <div>
-                      <span className="text-gray-500"><InfoIcon /> Uptime</span>
+                      <span className="text-[color:var(--fainter)]"><InfoIcon /> Uptime</span>
                       <div
                         className={`font-medium ${
                           node.uptime_percent === undefined || node.uptime_percent === null
-                            ? "text-gray-400"
+                            ? "text-[color:var(--dim)]"
                             : node.uptime_percent >= 95
-                              ? "text-green-400"
+                              ? "text-[color:var(--green)]"
                               : node.uptime_percent >= 90
-                                ? "text-yellow-400"
-                                : "text-red-400"
+                                ? "text-[color:var(--accent)]"
+                                : "text-[color:var(--red)]"
                         }`}
                       >
                         {orDash(node.uptime_percent, formatUptime)}
@@ -686,20 +686,20 @@ export default function SwarmPage() {
                   </Tooltip>
                   <Tooltip content={TOOLTIPS.peers}>
                     <div>
-                      <span className="text-gray-500"><InfoIcon /> Peers</span>
-                      <div className="text-gray-100">{orDash(node.peer_count, (v) => String(v))}</div>
+                      <span className="text-[color:var(--fainter)]"><InfoIcon /> Peers</span>
+                      <div className="text-[color:var(--fg)]">{orDash(node.peer_count, (v) => String(v))}</div>
                     </div>
                   </Tooltip>
                   <Tooltip content={TOOLTIPS.l1Height}>
                     <div>
-                      <span className="text-gray-500"><InfoIcon /> L1 Height</span>
-                      <div className="text-gray-100 font-mono">{orDash(node.l1_height, (v) => v.toLocaleString())}</div>
+                      <span className="text-[color:var(--fainter)]"><InfoIcon /> L1 Height</span>
+                      <div className="text-[color:var(--fg)] font-mono">{orDash(node.l1_height, (v) => v.toLocaleString())}</div>
                     </div>
                   </Tooltip>
                   <Tooltip content={TOOLTIPS.l2Height}>
                     <div>
-                      <span className="text-gray-500"><InfoIcon /> L2 Height</span>
-                      <div className="text-gray-100 font-mono">{orDash(node.l2_height, (v) => v.toLocaleString())}</div>
+                      <span className="text-[color:var(--fainter)]"><InfoIcon /> L2 Height</span>
+                      <div className="text-[color:var(--fg)] font-mono">{orDash(node.l2_height, (v) => v.toLocaleString())}</div>
                     </div>
                   </Tooltip>
                 </div>
@@ -716,7 +716,7 @@ export default function SwarmPage() {
                   </div>
                 </Tooltip>
 
-                <div className="flex gap-2 mt-4 pt-4 border-t border-gray-800">
+                <div className="flex gap-2 mt-4 pt-4 border-t border-[var(--rule)]">
                   <Tooltip content={TOOLTIPS.edit}>
                     <Button
                       variant="secondary"
@@ -778,10 +778,10 @@ export default function SwarmPage() {
                   key={alert.id}
                   className={`p-3 rounded-lg flex items-start gap-3 ${
                     alert.severity === "error"
-                      ? "bg-red-900/20 border border-red-800"
+                      ? "bg-[var(--surface)] border border-[color:var(--red)]"
                       : alert.severity === "warning"
-                        ? "bg-yellow-900/20 border border-yellow-800"
-                        : "bg-orange-900/20 border border-orange-800"
+                        ? "bg-[var(--surface)] border border-[color:var(--accent)]"
+                        : "bg-[var(--surface)] border border-[color:var(--accent)]"
                   }`}
                 >
                   <span
@@ -799,15 +799,15 @@ export default function SwarmPage() {
                     <p
                       className={`${
                         alert.severity === "error"
-                          ? "text-red-400"
+                          ? "text-[color:var(--red)]"
                           : alert.severity === "warning"
-                            ? "text-yellow-400"
-                            : "text-orange-400"
+                            ? "text-[color:var(--accent)]"
+                            : "text-[color:var(--accent)]"
                       }`}
                     >
                       {alert.message}
                     </p>
-                    <p className="text-xs text-gray-500 mt-1">
+                    <p className="text-xs text-[color:var(--fainter)] mt-1">
                       {new Date((alert.timestamp ?? 0) * 1000).toLocaleString()}
                     </p>
                   </div>
@@ -826,7 +826,7 @@ export default function SwarmPage() {
       >
         <div className="space-y-4">
           <div>
-            <label className="block text-sm text-gray-400 mb-1">Node Name</label>
+            <label className="block text-sm text-[color:var(--dim)] mb-1">Node Name</label>
             <Input
               value={newNodeName}
               onChange={(e) => setNewNodeName(e.target.value)}
@@ -835,18 +835,18 @@ export default function SwarmPage() {
           </div>
 
           <div>
-            <label className="block text-sm text-gray-400 mb-1">Node Address</label>
+            <label className="block text-sm text-[color:var(--dim)] mb-1">Node Address</label>
             <Input
               value={newNodeAddress}
               onChange={(e) => setNewNodeAddress(e.target.value)}
               placeholder="e.g., 192.168.1.100:8080"
             />
-            <p className="text-xs text-gray-500 mt-1">
+            <p className="text-xs text-[color:var(--fainter)] mt-1">
               The node must have API access enabled for remote connections
             </p>
           </div>
 
-          <div className="flex gap-3 pt-4 border-t border-gray-800">
+          <div className="flex gap-3 pt-4 border-t border-[var(--rule)]">
             <Button variant="ghost" className="flex-1" onClick={() => setAddDialogOpen(false)}>
               Cancel
             </Button>
@@ -871,7 +871,7 @@ export default function SwarmPage() {
       >
         <div className="space-y-4">
           <div>
-            <label className="block text-sm text-gray-400 mb-1">Node Name</label>
+            <label className="block text-sm text-[color:var(--dim)] mb-1">Node Name</label>
             <Input
               value={editNodeName}
               onChange={(e) => setEditNodeName(e.target.value)}
@@ -881,19 +881,19 @@ export default function SwarmPage() {
 
           {selectedNode?.address !== "localhost" && (
             <div>
-              <label className="block text-sm text-gray-400 mb-1">Node Address</label>
+              <label className="block text-sm text-[color:var(--dim)] mb-1">Node Address</label>
               <Input
                 value={editNodeAddress}
                 onChange={(e) => setEditNodeAddress(e.target.value)}
                 placeholder="e.g., 192.168.1.100:8080"
               />
-              <p className="text-xs text-gray-500 mt-1">
+              <p className="text-xs text-[color:var(--fainter)] mt-1">
                 Do not include http:// prefix
               </p>
             </div>
           )}
 
-          <div className="flex gap-3 pt-4 border-t border-gray-800">
+          <div className="flex gap-3 pt-4 border-t border-[var(--rule)]">
             <Button variant="ghost" className="flex-1" onClick={() => setEditDialogOpen(false)}>
               Cancel
             </Button>
@@ -917,9 +917,9 @@ export default function SwarmPage() {
         title="Update All Swarm Nodes"
       >
         <div className="space-y-4">
-          <div className="p-4 bg-yellow-900/20 border border-yellow-800 rounded-lg">
-            <p className="text-yellow-300 text-sm font-medium mb-2">Warning</p>
-            <p className="text-yellow-200/80 text-sm">
+          <div className="p-4 bg-[var(--surface)] border border-[color:var(--accent)] rounded-lg">
+            <p className="text-[color:var(--accent)] text-sm font-medium mb-2">Warning</p>
+            <p className="text-[color:var(--accent)] text-sm">
               This will initiate updates on ALL {nodes.length} nodes in the swarm.
               Each node will download the update from GitHub and restart.
               Rollback must be done individually on each node if needed.
@@ -927,19 +927,19 @@ export default function SwarmPage() {
           </div>
 
           <div>
-            <label className="block text-sm text-gray-400 mb-1">Version</label>
+            <label className="block text-sm text-[color:var(--dim)] mb-1">Version</label>
             <Input
               value={updateVersion}
               onChange={(e) => setUpdateVersion(e.target.value)}
               placeholder="e.g., 0.2.0 or v0.2.0"
             />
-            <p className="text-xs text-gray-500 mt-1">
+            <p className="text-xs text-[color:var(--fainter)] mt-1">
               Enter the release version from GitHub (e.g., 0.2.0)
             </p>
           </div>
 
-          <div className="p-3 bg-gray-800/50 rounded-lg">
-            <p className="text-sm text-gray-300 mb-2">Nodes to update:</p>
+          <div className="p-3 bg-[var(--surface)] rounded-lg">
+            <p className="text-sm text-[color:var(--dim)] mb-2">Nodes to update:</p>
             <div className="flex flex-wrap gap-2">
               {nodes.map((node) => (
                 <Badge
@@ -952,7 +952,7 @@ export default function SwarmPage() {
             </div>
           </div>
 
-          <div className="flex gap-3 pt-4 border-t border-gray-800">
+          <div className="flex gap-3 pt-4 border-t border-[var(--rule)]">
             <Button
               variant="ghost"
               className="flex-1"

--- a/dashboard/src/app/(dashboard)/system/page.tsx
+++ b/dashboard/src/app/(dashboard)/system/page.tsx
@@ -405,21 +405,21 @@ export default function SystemPage() {
           <Card>
             <CardHeader title="Version" />
             <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-              <div className="p-4 bg-gray-800/50 rounded-lg">
-                <div className="text-sm text-gray-400 mb-1">Version</div>
-                <div className="text-xl font-bold text-orange-400">
+              <div className="p-4 bg-[var(--surface)] rounded-lg">
+                <div className="text-sm text-[color:var(--dim)] mb-1">Version</div>
+                <div className="text-xl font-bold text-[color:var(--accent)]">
                   {version?.version ?? version?.node_version ?? "Unknown"}
                 </div>
               </div>
-              <div className="p-4 bg-gray-800/50 rounded-lg">
-                <div className="text-sm text-gray-400 mb-1">Build Date</div>
-                <div className="text-gray-100">
+              <div className="p-4 bg-[var(--surface)] rounded-lg">
+                <div className="text-sm text-[color:var(--dim)] mb-1">Build Date</div>
+                <div className="text-[color:var(--fg)]">
                   {version?.build_time ? formatDate(version.build_time) : "Unknown"}
                 </div>
               </div>
-              <div className="p-4 bg-gray-800/50 rounded-lg">
-                <div className="text-sm text-gray-400 mb-1">Git Commit</div>
-                <code className="text-gray-300 text-sm">
+              <div className="p-4 bg-[var(--surface)] rounded-lg">
+                <div className="text-sm text-[color:var(--dim)] mb-1">Git Commit</div>
+                <code className="text-[color:var(--dim)] text-sm">
                   {version?.git_hash?.substring(0, 8) ?? "Unknown"}
                 </code>
               </div>
@@ -444,9 +444,9 @@ export default function SystemPage() {
             <div className="space-y-6">
               {/* Update Progress (visible only while updating) */}
               {isUpdating && updateStatus && (
-                <div className="space-y-4 p-4 bg-gray-800/50 rounded-lg">
+                <div className="space-y-4 p-4 bg-[var(--surface)] rounded-lg">
                   <div className="flex items-center justify-between">
-                    <span className="text-gray-300">Status</span>
+                    <span className="text-[color:var(--dim)]">Status</span>
                     <Badge variant={getStatusBadge(updateStatus.status).variant}>
                       {getStatusBadge(updateStatus.status).label}
                     </Badge>
@@ -460,14 +460,14 @@ export default function SystemPage() {
                         sublabel={`${updateStatus.progress.progress_percent}%`}
                         color="orange"
                       />
-                      <p className="text-sm text-gray-500">{updateStatus.progress.message}</p>
+                      <p className="text-sm text-[color:var(--fainter)]">{updateStatus.progress.message}</p>
                     </>
                   )}
 
                   {updateStatus.status === "verifying" && (
                     <div className="flex items-center gap-2">
-                      <div className="animate-spin w-4 h-4 border-2 border-orange-500 border-t-transparent rounded-full" />
-                      <span className="text-gray-400">Verifying SHA256 checksum...</span>
+                      <div className="animate-spin w-4 h-4 border-2 border-[color:var(--accent)] border-t-transparent rounded-full" />
+                      <span className="text-[color:var(--dim)]">Verifying SHA256 checksum...</span>
                     </div>
                   )}
                 </div>
@@ -476,16 +476,16 @@ export default function SystemPage() {
               {/* Available Update */}
               {hasUpdate && updateInfo ? (
                 <>
-                  <div className="p-4 bg-orange-900/20 border border-orange-700 rounded-lg">
+                  <div className="p-4 bg-[var(--surface)] border border-[color:var(--accent)] rounded-lg">
                     <div className="flex items-start justify-between">
                       <div>
                         <div className="flex items-center gap-3 mb-2">
-                          <h3 className="text-lg font-bold text-orange-300">
+                          <h3 className="text-lg font-bold text-[color:var(--accent)]">
                             Version {updateInfo.version}
                           </h3>
                           <Badge variant="success">New</Badge>
                         </div>
-                        <p className="text-sm text-gray-400">
+                        <p className="text-sm text-[color:var(--dim)]">
                           Released {formatDate(updateInfo.release_date ?? "")} &middot;{" "}
                           {formatBytes(updateInfo.size_bytes ?? 0)}
                         </p>
@@ -501,10 +501,10 @@ export default function SystemPage() {
                   </div>
 
                   {updateInfo.changelog && (
-                    <div className="p-4 bg-gray-800/50 rounded-lg">
-                      <h4 className="text-sm font-medium text-gray-300 mb-3">Release Notes</h4>
+                    <div className="p-4 bg-[var(--surface)] rounded-lg">
+                      <h4 className="text-sm font-medium text-[color:var(--dim)] mb-3">Release Notes</h4>
                       <div className="prose prose-sm prose-invert max-w-none">
-                        <pre className="text-sm text-gray-400 whitespace-pre-wrap font-sans">
+                        <pre className="text-sm text-[color:var(--dim)] whitespace-pre-wrap font-sans">
                           {updateInfo.changelog}
                         </pre>
                       </div>
@@ -514,10 +514,10 @@ export default function SystemPage() {
               ) : (
                 <div className="text-center py-6">
                   <div className="text-4xl mb-3">&#10003;</div>
-                  <h3 className="text-lg font-medium text-gray-100 mb-1">
+                  <h3 className="text-lg font-medium text-[color:var(--fg)] mb-1">
                     You&apos;re up to date!
                   </h3>
-                  <p className="text-gray-400 mb-4">
+                  <p className="text-[color:var(--dim)] mb-4">
                     Running version {updateCheck?.current_version ?? version?.version ?? version?.node_version}
                   </p>
                 </div>
@@ -534,16 +534,16 @@ export default function SystemPage() {
               </Button>
 
               {/* Automatic Updates (opt-in, default OFF). Shared with /settings/system. */}
-              <div className="pt-4 border-t border-gray-800">
+              <div className="pt-4 border-t border-[var(--rule)]">
                 <AutoUpdateSection />
               </div>
 
               {/* Rollback */}
-              <div className="pt-4 border-t border-gray-800">
+              <div className="pt-4 border-t border-[var(--rule)]">
                 <div className="flex items-center justify-between">
                   <div>
-                    <div className="text-sm font-medium text-gray-300">Rollback</div>
-                    <p className="text-xs text-gray-500 mt-0.5">
+                    <div className="text-sm font-medium text-[color:var(--dim)]">Rollback</div>
+                    <p className="text-xs text-[color:var(--fainter)] mt-0.5">
                       Revert to the previous version if an update causes issues. The node will restart.
                     </p>
                   </div>
@@ -560,9 +560,9 @@ export default function SystemPage() {
               </div>
 
               {/* About Updates */}
-              <div className="p-4 bg-orange-900/20 border border-orange-800 rounded-lg">
-                <h4 className="text-orange-300 font-medium mb-2">About Updates</h4>
-                <ul className="text-sm text-orange-300/80 space-y-1 list-disc list-inside">
+              <div className="p-4 bg-[var(--surface)] border border-[color:var(--accent)] rounded-lg">
+                <h4 className="text-[color:var(--accent)] font-medium mb-2">About Updates</h4>
+                <ul className="text-sm text-[color:var(--accent)] space-y-1 list-disc list-inside">
                   <li>Updates are downloaded from official GitHub releases</li>
                   <li>SHA256 checksums are verified before installation</li>
                   <li>Current binaries are backed up before updating</li>
@@ -592,17 +592,17 @@ export default function SystemPage() {
             <div className="space-y-6">
               {/* ---------- L1 Pruning ---------- */}
               <div className="space-y-6">
-                <h4 className="text-sm font-medium text-gray-300 uppercase tracking-wider">L1 Pruning</h4>
+                <h4 className="text-sm font-medium text-[color:var(--dim)] uppercase tracking-wider">L1 Pruning</h4>
 
                 {/* Archive Mode Toggle */}
-                <div className="p-4 bg-gray-800/50 rounded-lg">
+                <div className="p-4 bg-[var(--surface)] rounded-lg">
                   <div className="flex items-center justify-between">
                     <div>
                       <div className="flex items-center gap-2">
-                        <span className="text-gray-100 font-medium">Archive Mode</span>
+                        <span className="text-[color:var(--fg)] font-medium">Archive Mode</span>
                         {archiveMode && <Badge variant="success">+5 Shares</Badge>}
                       </div>
-                      <p className="text-sm text-gray-400 mt-1">
+                      <p className="text-sm text-[color:var(--dim)] mt-1">
                         Store complete blockchain history. Disables all pruning and earns bonus shares.
                       </p>
                     </div>
@@ -618,41 +618,41 @@ export default function SystemPage() {
 
                 {/* Window Visualization */}
                 <div className="grid grid-cols-3 gap-4">
-                  <div className="p-4 bg-orange-900/20 border border-orange-800 rounded-lg">
-                    <div className="text-orange-400 font-medium mb-2">Validator Window (VW)</div>
-                    <div className="text-2xl font-bold text-gray-100">288 blocks</div>
-                    <div className="text-sm text-gray-400 mt-1">~2 days</div>
-                    <div className="mt-3 text-xs text-orange-300">
+                  <div className="p-4 bg-[var(--surface)] border border-[color:var(--accent)] rounded-lg">
+                    <div className="text-[color:var(--accent)] font-medium mb-2">Validator Window (VW)</div>
+                    <div className="text-2xl font-bold text-[color:var(--fg)]">288 blocks</div>
+                    <div className="text-sm text-[color:var(--dim)] mt-1">~2 days</div>
+                    <div className="mt-3 text-xs text-[color:var(--accent)]">
                       Fixed - Bitcoin Core minimum for reorg safety
                     </div>
                   </div>
 
-                  <div className={`p-4 rounded-lg border ${archiveMode ? "bg-gray-800/30 border-gray-700" : "bg-orange-900/20 border-orange-800"}`}>
-                    <div className={`font-medium mb-2 ${archiveMode ? "text-gray-500" : "text-orange-400"}`}>
+                  <div className={`p-4 rounded-lg border ${archiveMode ? "bg-[var(--surface)] border-[var(--rule-strong)]" : "bg-[var(--surface)] border-[color:var(--accent)]"}`}>
+                    <div className={`font-medium mb-2 ${archiveMode ? "text-[color:var(--fainter)]" : "text-[color:var(--accent)]"}`}>
                       Operator Window (OW)
                     </div>
-                    <div className={`text-2xl font-bold ${archiveMode ? "text-gray-500" : "text-gray-100"}`}>
+                    <div className={`text-2xl font-bold ${archiveMode ? "text-[color:var(--fainter)]" : "text-[color:var(--fg)]"}`}>
                       {fullConfig?.pruning?.ow_blocks ?? 2016} blocks
                     </div>
-                    <div className="text-sm text-gray-400 mt-1">
+                    <div className="text-sm text-[color:var(--dim)] mt-1">
                       ~{formatDuration(fullConfig?.pruning?.ow_blocks ?? 2016)}
                     </div>
-                    <div className={`mt-3 text-xs ${archiveMode ? "text-gray-500" : "text-orange-300"}`}>
+                    <div className={`mt-3 text-xs ${archiveMode ? "text-[color:var(--fainter)]" : "text-[color:var(--accent)]"}`}>
                       {archiveMode ? "Disabled (Archive Mode)" : "BUDS-based pruning applied here"}
                     </div>
                   </div>
 
-                  <div className={`p-4 rounded-lg border ${archiveMode ? "bg-green-900/20 border-green-800" : "bg-gray-800/30 border-gray-700"}`}>
-                    <div className={`font-medium mb-2 ${archiveMode ? "text-green-400" : "text-gray-500"}`}>
+                  <div className={`p-4 rounded-lg border ${archiveMode ? "bg-[var(--surface)] border-[color:var(--green)]" : "bg-[var(--surface)] border-[var(--rule-strong)]"}`}>
+                    <div className={`font-medium mb-2 ${archiveMode ? "text-[color:var(--green)]" : "text-[color:var(--fainter)]"}`}>
                       Archive Window (AW)
                     </div>
-                    <div className={`text-2xl font-bold ${archiveMode ? "text-gray-100" : "text-gray-500"}`}>
+                    <div className={`text-2xl font-bold ${archiveMode ? "text-[color:var(--fg)]" : "text-[color:var(--fainter)]"}`}>
                       {archiveMode ? "Infinite" : "Pruned"}
                     </div>
-                    <div className="text-sm text-gray-400 mt-1">
+                    <div className="text-sm text-[color:var(--dim)] mt-1">
                       {archiveMode ? "All history retained" : "Data beyond OW is deleted"}
                     </div>
-                    <div className={`mt-3 text-xs ${archiveMode ? "text-green-300" : "text-gray-500"}`}>
+                    <div className={`mt-3 text-xs ${archiveMode ? "text-[color:var(--green)]" : "text-[color:var(--fainter)]"}`}>
                       {archiveMode ? "Full chain storage enabled" : "Enable Archive Mode for +5 shares"}
                     </div>
                   </div>
@@ -661,7 +661,7 @@ export default function SystemPage() {
                 {/* Operator Window Selection */}
                 {!archiveMode && (
                   <div className="space-y-3">
-                    <label className="text-sm font-medium text-gray-300">Operator Window Size</label>
+                    <label className="text-sm font-medium text-[color:var(--dim)]">Operator Window Size</label>
                     <div className="grid grid-cols-3 gap-3">
                       {OW_PRESETS.map((preset) => (
                         <button
@@ -670,13 +670,13 @@ export default function SystemPage() {
                           disabled={setOperatorWindow.isPending}
                           className={`p-3 rounded-lg border transition-colors text-left ${
                             fullConfig?.pruning?.ow_blocks === preset.blocks
-                              ? "bg-orange-900/30 border-orange-600 text-orange-300"
-                              : "bg-gray-800/50 border-gray-700 text-gray-300 hover:border-gray-500"
+                              ? "bg-[var(--surface)] border-[color:var(--accent)] text-[color:var(--accent)]"
+                              : "bg-[var(--surface)] border-[var(--rule-strong)] text-[color:var(--dim)] hover:border-[var(--rule-strong)]"
                           }`}
                         >
                           <div className="font-medium">{preset.label}</div>
-                          <div className="text-xs text-gray-500 mt-1">{preset.blocks} blocks</div>
-                          <div className="text-xs text-gray-400 mt-1">{preset.description}</div>
+                          <div className="text-xs text-[color:var(--fainter)] mt-1">{preset.blocks} blocks</div>
+                          <div className="text-xs text-[color:var(--dim)] mt-1">{preset.description}</div>
                         </button>
                       ))}
                     </div>
@@ -686,8 +686,8 @@ export default function SystemPage() {
                 {/* Prune Profile Selection */}
                 {!archiveMode && (
                   <div className="space-y-3">
-                    <label className="text-sm font-medium text-gray-300">BUDS Prune Profile</label>
-                    <p className="text-xs text-gray-500">
+                    <label className="text-sm font-medium text-[color:var(--dim)]">BUDS Prune Profile</label>
+                    <p className="text-xs text-[color:var(--fainter)]">
                       Controls which BUDS tiers are retained in the Operator Window
                     </p>
                     <div className="grid grid-cols-2 md:grid-cols-5 gap-2">
@@ -698,13 +698,13 @@ export default function SystemPage() {
                           disabled={setPruneProfile.isPending}
                           className={`p-3 rounded-lg border transition-colors text-left ${
                             fullConfig?.pruning?.prune_profile === profile.value
-                              ? "bg-orange-900/30 border-orange-600 text-orange-300"
-                              : "bg-gray-800/50 border-gray-700 text-gray-300 hover:border-gray-500"
+                              ? "bg-[var(--surface)] border-[color:var(--accent)] text-[color:var(--accent)]"
+                              : "bg-[var(--surface)] border-[var(--rule-strong)] text-[color:var(--dim)] hover:border-[var(--rule-strong)]"
                           }`}
                         >
                           <div className="font-medium capitalize">{profile.label}</div>
-                          <div className="text-xs text-green-400 mt-1">Keep: {profile.keep}</div>
-                          <div className="text-xs text-red-400">Prune: {profile.prune}</div>
+                          <div className="text-xs text-[color:var(--green)] mt-1">Keep: {profile.keep}</div>
+                          <div className="text-xs text-[color:var(--red)]">Prune: {profile.prune}</div>
                         </button>
                       ))}
                     </div>
@@ -713,15 +713,15 @@ export default function SystemPage() {
               </div>
 
               {/* ---------- L2 Pruning ---------- */}
-              <div className="space-y-4 pt-4 border-t border-gray-800">
-                <h4 className="text-sm font-medium text-gray-300 uppercase tracking-wider">L2 Pruning (Ghost Pay)</h4>
+              <div className="space-y-4 pt-4 border-t border-[var(--rule)]">
+                <h4 className="text-sm font-medium text-[color:var(--dim)] uppercase tracking-wider">L2 Pruning (Ghost Pay)</h4>
 
                 {!ghostPayRunning ? (
-                  <div className="p-4 bg-yellow-900/20 border border-yellow-800 rounded-lg">
+                  <div className="p-4 bg-[var(--surface)] border border-[color:var(--accent)] rounded-lg">
                     <div className="flex items-center gap-2">
                       <Badge variant="warning">Ghost Pay Not Running</Badge>
                     </div>
-                    <p className="text-sm text-yellow-300 mt-2">
+                    <p className="text-sm text-[color:var(--accent)] mt-2">
                       Start ghost-pay-node to enable L2 functionality and see pruning status.
                     </p>
                   </div>
@@ -730,33 +730,33 @@ export default function SystemPage() {
                 ) : l2Pruning ? (
                   <>
                     <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-                      <div className="p-4 bg-gray-800/50 rounded-lg">
-                        <div className="text-sm text-gray-400">Retention Period</div>
-                        <div className="text-xl font-bold text-gray-100 mt-1">
+                      <div className="p-4 bg-[var(--surface)] rounded-lg">
+                        <div className="text-sm text-[color:var(--dim)]">Retention Period</div>
+                        <div className="text-xl font-bold text-[color:var(--fg)] mt-1">
                           {l2Pruning.retention_days} days
                         </div>
                       </div>
-                      <div className="p-4 bg-gray-800/50 rounded-lg">
-                        <div className="text-sm text-gray-400">Auto Prune</div>
+                      <div className="p-4 bg-[var(--surface)] rounded-lg">
+                        <div className="text-sm text-[color:var(--dim)]">Auto Prune</div>
                         <div className="mt-1">
                           <Badge variant="success">Always On</Badge>
                         </div>
-                        <div className="text-xs text-gray-500 mt-1">
+                        <div className="text-xs text-[color:var(--fainter)] mt-1">
                           Every {l2Pruning.prune_interval_hours}h
                         </div>
                       </div>
-                      <div className="p-4 bg-gray-800/50 rounded-lg">
-                        <div className="text-sm text-gray-400">Last Prune</div>
-                        <div className="text-lg font-medium text-gray-100 mt-1">
+                      <div className="p-4 bg-[var(--surface)] rounded-lg">
+                        <div className="text-sm text-[color:var(--dim)]">Last Prune</div>
+                        <div className="text-lg font-medium text-[color:var(--fg)] mt-1">
                           {formatTimeAgo(l2Pruning.last_prune_timestamp ?? 0)}
                         </div>
-                        <div className="text-xs text-gray-500 mt-1">
+                        <div className="text-xs text-[color:var(--fainter)] mt-1">
                           {formatTimestamp(l2Pruning.last_prune_timestamp ?? 0)}
                         </div>
                       </div>
-                      <div className="p-4 bg-gray-800/50 rounded-lg">
-                        <div className="text-sm text-gray-400">Last Run Stats</div>
-                        <div className="text-sm text-gray-300 mt-2 space-y-1">
+                      <div className="p-4 bg-[var(--surface)] rounded-lg">
+                        <div className="text-sm text-[color:var(--dim)]">Last Run Stats</div>
+                        <div className="text-sm text-[color:var(--dim)] mt-2 space-y-1">
                           <div>Payments: {l2Pruning.payments_pruned}</div>
                           <div>Attestations: {l2Pruning.attestations_pruned}</div>
                           <div>Locks: {l2Pruning.locks_pruned}</div>
@@ -765,32 +765,32 @@ export default function SystemPage() {
                     </div>
 
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                      <div className="p-4 bg-red-900/20 border border-red-800 rounded-lg">
-                        <h4 className="text-red-300 font-medium mb-3">What Gets Pruned</h4>
-                        <ul className="text-sm text-red-200/80 space-y-2">
+                      <div className="p-4 bg-[var(--surface)] border border-[color:var(--red)] rounded-lg">
+                        <h4 className="text-[color:var(--red)] font-medium mb-3">What Gets Pruned</h4>
+                        <ul className="text-sm text-[color:var(--red)] space-y-2">
                           <li className="flex items-start gap-2">
-                            <span className="text-red-400 mt-0.5">&bull;</span>
+                            <span className="text-[color:var(--red)] mt-0.5">&bull;</span>
                             <span>Payments (with ZK proofs) older than {l2Pruning.retention_days} days</span>
                           </li>
                           <li className="flex items-start gap-2">
-                            <span className="text-red-400 mt-0.5">&bull;</span>
+                            <span className="text-[color:var(--red)] mt-0.5">&bull;</span>
                             <span>Attestations older than {l2Pruning.retention_days} days</span>
                           </li>
                           <li className="flex items-start gap-2">
-                            <span className="text-red-400 mt-0.5">&bull;</span>
+                            <span className="text-[color:var(--red)] mt-0.5">&bull;</span>
                             <span>Closed locks (reconciled or jumped) older than {l2Pruning.retention_days} days</span>
                           </li>
                         </ul>
                       </div>
-                      <div className="p-4 bg-green-900/20 border border-green-800 rounded-lg">
-                        <h4 className="text-green-300 font-medium mb-3">What is Never Pruned</h4>
-                        <ul className="text-sm text-green-200/80 space-y-2">
+                      <div className="p-4 bg-[var(--surface)] border border-[color:var(--green)] rounded-lg">
+                        <h4 className="text-[color:var(--green)] font-medium mb-3">What is Never Pruned</h4>
+                        <ul className="text-sm text-[color:var(--green)] space-y-2">
                           <li className="flex items-start gap-2">
-                            <span className="text-green-400 mt-0.5">&bull;</span>
+                            <span className="text-[color:var(--green)] mt-0.5">&bull;</span>
                             <span>Active locks (regardless of age)</span>
                           </li>
                           <li className="flex items-start gap-2">
-                            <span className="text-green-400 mt-0.5">&bull;</span>
+                            <span className="text-[color:var(--green)] mt-0.5">&bull;</span>
                             <span>L2 block headers (contain state_root commitments)</span>
                           </li>
                         </ul>
@@ -798,33 +798,33 @@ export default function SystemPage() {
                     </div>
                   </>
                 ) : (
-                  <div className="p-4 bg-gray-800/50 rounded-lg text-gray-400">
+                  <div className="p-4 bg-[var(--surface)] rounded-lg text-[color:var(--dim)]">
                     Unable to fetch L2 pruning status. Ensure ghost-pay-node API is accessible.
                   </div>
                 )}
               </div>
 
               {/* Quick Reference Table */}
-              <div className="pt-4 border-t border-gray-800">
-                <h4 className="text-sm font-medium text-gray-300 mb-3">Quick Reference</h4>
+              <div className="pt-4 border-t border-[var(--rule)]">
+                <h4 className="text-sm font-medium text-[color:var(--dim)] mb-3">Quick Reference</h4>
                 <div className="overflow-x-auto">
                   <table className="w-full text-sm">
                     <thead>
-                      <tr className="text-left text-gray-400 border-b border-gray-800">
+                      <tr className="text-left text-[color:var(--dim)] border-b border-[var(--rule)]">
                         <th className="pb-3 font-medium">Layer</th>
                         <th className="pb-3 font-medium">Window</th>
                         <th className="pb-3 font-medium">Duration</th>
                         <th className="pb-3 font-medium">Behavior</th>
                       </tr>
                     </thead>
-                    <tbody className="text-gray-300">
-                      <tr className="border-b border-gray-800/50">
+                    <tbody className="text-[color:var(--dim)]">
+                      <tr className="border-b border-[var(--rule)]">
                         <td className="py-3">L1</td>
                         <td className="py-3">Validator (VW)</td>
                         <td className="py-3">288 blocks (~2 days)</td>
                         <td className="py-3">Full retention - Bitcoin Core minimum</td>
                       </tr>
-                      <tr className="border-b border-gray-800/50">
+                      <tr className="border-b border-[var(--rule)]">
                         <td className="py-3">L1</td>
                         <td className="py-3">Operator (OW)</td>
                         <td className="py-3">
@@ -836,7 +836,7 @@ export default function SystemPage() {
                             : `BUDS pruning (${fullConfig?.pruning?.prune_profile ?? "default"})`}
                         </td>
                       </tr>
-                      <tr className="border-b border-gray-800/50">
+                      <tr className="border-b border-[var(--rule)]">
                         <td className="py-3">L1</td>
                         <td className="py-3">Archive (AW)</td>
                         <td className="py-3">{archiveMode ? "Infinite" : "N/A"}</td>
@@ -869,9 +869,9 @@ export default function SystemPage() {
           <div className="space-y-6">
             {/* Export / Import buttons */}
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              <div className="p-4 bg-gray-800/50 rounded-lg">
-                <div className="text-gray-100 font-medium mb-1">Export Backup</div>
-                <p className="text-gray-400 text-sm mb-3">
+              <div className="p-4 bg-[var(--surface)] rounded-lg">
+                <div className="text-[color:var(--fg)] font-medium mb-1">Export Backup</div>
+                <p className="text-[color:var(--dim)] text-sm mb-3">
                   Create a full snapshot of this node&apos;s pool database (miners, shares,
                   rounds, payouts) and download it. The artifact is encrypted with this
                   node&apos;s own key.
@@ -881,9 +881,9 @@ export default function SystemPage() {
                 </Button>
               </div>
 
-              <div className="p-4 bg-gray-800/50 rounded-lg">
-                <div className="text-gray-100 font-medium mb-1">Import Backup</div>
-                <p className="text-gray-400 text-sm mb-3">
+              <div className="p-4 bg-[var(--surface)] rounded-lg">
+                <div className="text-[color:var(--fg)] font-medium mb-1">Import Backup</div>
+                <p className="text-[color:var(--dim)] text-sm mb-3">
                   Restore from a backup file. The artifact is verified, then staged and applied
                   atomically on the next ghost-pool restart (your current database is copied to a
                   safety backup first).
@@ -895,9 +895,9 @@ export default function SystemPage() {
             </div>
 
             {/* Backup History */}
-            <div className="pt-4 border-t border-gray-800">
+            <div className="pt-4 border-t border-[var(--rule)]">
               <div className="flex items-center justify-between mb-4">
-                <h4 className="text-sm font-medium text-gray-300">
+                <h4 className="text-sm font-medium text-[color:var(--dim)]">
                   Backup History ({backupHistory.length})
                 </h4>
               </div>
@@ -906,8 +906,8 @@ export default function SystemPage() {
                 <SkeletonCard />
               ) : backupHistory.length === 0 ? (
                 <div className="text-center py-6">
-                  <p className="text-gray-400">No backups created yet</p>
-                  <p className="text-sm text-gray-500 mt-1">
+                  <p className="text-[color:var(--dim)]">No backups created yet</p>
+                  <p className="text-sm text-[color:var(--fainter)] mt-1">
                     Create your first backup to protect your node data
                   </p>
                 </div>
@@ -916,15 +916,15 @@ export default function SystemPage() {
                   {backupHistory.map((backup, idx) => (
                     <div
                       key={`${backup.filename}-${idx}`}
-                      className="p-4 bg-gray-800/50 rounded-lg border border-gray-700"
+                      className="p-4 bg-[var(--surface)] rounded-lg border border-[var(--rule-strong)]"
                     >
                       <div className="flex items-center justify-between">
                         <div>
                           <div className="flex items-center gap-2">
-                            <span className="text-gray-100 font-medium">{backup.filename}</span>
+                            <span className="text-[color:var(--fg)] font-medium">{backup.filename}</span>
                             <Badge variant="info">{formatBytes(backup.size_bytes ?? 0)}</Badge>
                           </div>
-                          <div className="text-sm text-gray-400 mt-1">
+                          <div className="text-sm text-[color:var(--dim)] mt-1">
                             Created: {formatTimestampDate(backup.created_at ?? 0)}
                           </div>
                         </div>
@@ -954,9 +954,9 @@ export default function SystemPage() {
             </div>
 
             {/* Backup Best Practices */}
-            <div className="p-4 bg-orange-900/20 border border-orange-800 rounded-lg">
-              <h4 className="text-orange-300 font-medium mb-2">Backup Best Practices</h4>
-              <ul className="text-sm text-orange-300/80 space-y-1 list-disc list-inside">
+            <div className="p-4 bg-[var(--surface)] border border-[color:var(--accent)] rounded-lg">
+              <h4 className="text-[color:var(--accent)] font-medium mb-2">Backup Best Practices</h4>
+              <ul className="text-sm text-[color:var(--accent)] space-y-1 list-disc list-inside">
                 <li>Create regular backups before making configuration changes</li>
                 <li>Store backup files in a secure location separate from your node</li>
                 <li>The artifact is encrypted with this node&apos;s key — restore it on this node</li>
@@ -986,17 +986,17 @@ export default function SystemPage() {
         title="Install Update"
       >
         <div className="space-y-4">
-          <p className="text-gray-300">
+          <p className="text-[color:var(--dim)]">
             Are you sure you want to update to version{" "}
-            <strong className="text-white">{updateInfo?.version}</strong>?
+            <strong className="text-[color:var(--fg)]">{updateInfo?.version}</strong>?
           </p>
-          <div className="p-3 bg-orange-900/20 border border-orange-800 rounded">
-            <p className="text-sm text-orange-400">
+          <div className="p-3 bg-[var(--surface)] border border-[color:var(--accent)] rounded">
+            <p className="text-sm text-[color:var(--accent)]">
               The node will be stopped during the update and automatically restarted once complete.
               Your current version will be backed up in case you need to rollback.
             </p>
           </div>
-          <div className="flex gap-3 pt-4 border-t border-gray-800">
+          <div className="flex gap-3 pt-4 border-t border-[var(--rule)]">
             <Button
               variant="ghost"
               className="flex-1"
@@ -1023,16 +1023,16 @@ export default function SystemPage() {
         title="Rollback to Previous Version"
       >
         <div className="space-y-4">
-          <p className="text-gray-300">
+          <p className="text-[color:var(--dim)]">
             Are you sure you want to rollback to the previous version?
           </p>
-          <div className="p-3 bg-yellow-900/20 border border-yellow-800 rounded">
-            <p className="text-sm text-yellow-400">
+          <div className="p-3 bg-[var(--surface)] border border-[color:var(--accent)] rounded">
+            <p className="text-sm text-[color:var(--accent)]">
               This will restore the backup of your previous Ghost Node version.
               The node will restart after the rollback completes.
             </p>
           </div>
-          <div className="flex gap-3 pt-4 border-t border-gray-800">
+          <div className="flex gap-3 pt-4 border-t border-[var(--rule)]">
             <Button
               variant="ghost"
               className="flex-1"
@@ -1059,27 +1059,27 @@ export default function SystemPage() {
         title="Create Backup"
       >
         <div className="space-y-4">
-          <p className="text-sm text-gray-300">
+          <p className="text-sm text-[color:var(--dim)]">
             This creates a consistent, compact snapshot of this node&apos;s pool database
-            (<span className="font-mono text-gray-200">VACUUM INTO</span>) — miners, shares,
+            (<span className="font-mono text-[color:var(--fg)]">VACUUM INTO</span>) — miners, shares,
             rounds and payout records — and downloads it as a timestamped
-            <span className="font-mono text-gray-200"> .db</span> file.
+            <span className="font-mono text-[color:var(--fg)]"> .db</span> file.
           </p>
 
-          <div className="p-3 bg-gray-800/50 border border-gray-700 rounded space-y-1">
-            <p className="text-sm text-gray-300">
+          <div className="p-3 bg-[var(--surface)] border border-[var(--rule-strong)] rounded space-y-1">
+            <p className="text-sm text-[color:var(--dim)]">
               The artifact is encrypted with this node&apos;s own key: payout addresses stay
               field-encrypted, so no separate backup password is needed.
             </p>
           </div>
 
-          <div className="p-3 bg-yellow-900/20 border border-yellow-800 rounded">
-            <p className="text-yellow-400 text-sm">
+          <div className="p-3 bg-[var(--surface)] border border-[color:var(--accent)] rounded">
+            <p className="text-[color:var(--accent)] text-sm">
               Because it is bound to this node&apos;s key, restore this backup on this same node.
             </p>
           </div>
 
-          <div className="flex gap-3 pt-4 border-t border-gray-800">
+          <div className="flex gap-3 pt-4 border-t border-[var(--rule)]">
             <Button variant="ghost" className="flex-1" onClick={() => setExportDialogOpen(false)}>
               Cancel
             </Button>
@@ -1108,7 +1108,7 @@ export default function SystemPage() {
       >
         <div className="space-y-4">
           <div>
-            <label className="block text-sm text-gray-400 mb-1">Backup File</label>
+            <label className="block text-sm text-[color:var(--dim)] mb-1">Backup File</label>
             <input
               ref={fileInputRef}
               type="file"
@@ -1153,20 +1153,20 @@ export default function SystemPage() {
             <div
               className={`p-4 rounded-lg border ${
                 verifyResult.valid
-                  ? "bg-green-900/20 border-green-800"
-                  : "bg-red-900/20 border-red-800"
+                  ? "bg-[var(--surface)] border-[color:var(--green)]"
+                  : "bg-[var(--surface)] border-[color:var(--red)]"
               }`}
             >
               <div className="flex items-center gap-2 mb-2">
                 <Badge variant={verifyResult.valid ? "success" : "error"}>
                   {verifyResult.valid ? "Valid" : "Invalid"}
                 </Badge>
-                <span className={verifyResult.valid ? "text-green-400" : "text-red-400"}>
+                <span className={verifyResult.valid ? "text-[color:var(--green)]" : "text-[color:var(--red)]"}>
                   {verifyResult.valid ? "Passed integrity + schema checks" : verifyResult.error}
                 </span>
               </div>
               {verifyResult.valid && verifyResult.info && (
-                <div className="text-sm text-gray-400 space-y-1">
+                <div className="text-sm text-[color:var(--dim)] space-y-1">
                   <p>Integrity: {verifyResult.info.integrity_ok ? "ok" : "failed"}</p>
                   <p>Schema version: {verifyResult.info.schema_version ?? "?"}</p>
                   <p>Tables: {verifyResult.info.table_count ?? 0}</p>
@@ -1181,8 +1181,8 @@ export default function SystemPage() {
           )}
 
           {!restartRequired && verifyResult?.valid && (
-            <div className="p-3 bg-yellow-900/20 border border-yellow-800 rounded">
-              <p className="text-yellow-400 text-sm">
+            <div className="p-3 bg-[var(--surface)] border border-[color:var(--accent)] rounded">
+              <p className="text-[color:var(--accent)] text-sm">
                 Restoring stages this artifact and applies it on the next ghost-pool restart.
                 Your current database is copied to a timestamped safety backup first, then
                 replaced. Restart the node to complete the restore.
@@ -1196,7 +1196,7 @@ export default function SystemPage() {
                 <Badge variant="info">Restart required</Badge>
                 <span className="text-blue-300">Restore staged</span>
               </div>
-              <p className="text-sm text-gray-400">
+              <p className="text-sm text-[color:var(--dim)]">
                 The backup was verified and staged. Restart ghost-pool (System &gt; Restart, or
                 the node&apos;s service manager) to apply it. The current database is copied to a
                 <span className="font-mono"> .pre-restore-*.db </span> safety backup automatically
@@ -1205,7 +1205,7 @@ export default function SystemPage() {
             </div>
           )}
 
-          <div className="flex gap-3 pt-4 border-t border-gray-800">
+          <div className="flex gap-3 pt-4 border-t border-[var(--rule)]">
             <Button
               variant="ghost"
               className="flex-1"

--- a/dashboard/src/app/(dashboard)/treasury/page.tsx
+++ b/dashboard/src/app/(dashboard)/treasury/page.tsx
@@ -43,7 +43,7 @@ function TreasuryDetails() {
 
   const phase = treasury.phase ?? "bootstrap";
   const phaseLabel = { bootstrap: "Bootstrap", decay: "Decay", ossified: "Ossified" }[phase] ?? "Unknown";
-  const phaseColor = { bootstrap: "text-yellow-400", decay: "text-orange-400", ossified: "text-green-400" }[phase] ?? "text-gray-400";
+  const phaseColor = { bootstrap: "text-[color:var(--accent)]", decay: "text-[color:var(--accent)]", ossified: "text-[color:var(--green)]" }[phase] ?? "text-[color:var(--dim)]";
 
   return (
     <>
@@ -52,10 +52,10 @@ function TreasuryDetails() {
         <CardHeader title="Treasury Progress" />
         <div className="space-y-4">
           <div className="flex justify-between text-sm mb-1">
-            <span className="text-gray-400">Accumulated</span>
-            <span className="text-gray-100">
+            <span className="text-[color:var(--dim)]">Accumulated</span>
+            <span className="text-[color:var(--fg)]">
               {formatBtc(treasury.accumulated_btc ?? 0)} / {(treasury.target_btc ?? 21).toFixed(1)} BTC
-              <span className="text-gray-500 ml-2">({(treasury.progress_percent ?? 0).toFixed(1)}%)</span>
+              <span className="text-[color:var(--fainter)] ml-2">({(treasury.progress_percent ?? 0).toFixed(1)}%)</span>
             </span>
           </div>
           <ProgressBar value={treasury.progress_percent ?? 0} color="orange" size="lg" />
@@ -67,27 +67,27 @@ function TreasuryDetails() {
         <CardHeader title="Phase Details" />
         <div className="space-y-3">
           <div className="flex justify-between">
-            <span className="text-gray-400">Current Phase</span>
+            <span className="text-[color:var(--dim)]">Current Phase</span>
             <span className={`font-semibold ${phaseColor}`}>{phaseLabel}</span>
           </div>
           <div className="flex justify-between">
-            <span className="text-gray-400">Treasury Share</span>
-            <span className="font-mono text-gray-100">{(treasury.treasury_percent ?? 50).toFixed(0)}% of block rewards</span>
+            <span className="text-[color:var(--dim)]">Treasury Share</span>
+            <span className="font-mono text-[color:var(--fg)]">{(treasury.treasury_percent ?? 50).toFixed(0)}% of block rewards</span>
           </div>
           <div className="flex justify-between">
-            <span className="text-gray-400">Node Pool Share</span>
-            <span className="font-mono text-gray-100">{(treasury.node_pool_percent ?? 50).toFixed(0)}% of block rewards</span>
+            <span className="text-[color:var(--dim)]">Node Pool Share</span>
+            <span className="font-mono text-[color:var(--fg)]">{(treasury.node_pool_percent ?? 50).toFixed(0)}% of block rewards</span>
           </div>
           {treasury.decay_started && treasury.decay_year != null && (
             <div className="flex justify-between">
-              <span className="text-gray-400">Decay Year</span>
-              <span className="font-mono text-gray-100">Year {treasury.decay_year}</span>
+              <span className="text-[color:var(--dim)]">Decay Year</span>
+              <span className="font-mono text-[color:var(--fg)]">Year {treasury.decay_year}</span>
             </div>
           )}
           {treasury.blocks_until_full != null && treasury.blocks_until_full > 0 && (
             <div className="flex justify-between">
-              <span className="text-gray-400">Blocks Until Full</span>
-              <span className="font-mono text-gray-100">{treasury.blocks_until_full.toLocaleString()}</span>
+              <span className="text-[color:var(--dim)]">Blocks Until Full</span>
+              <span className="font-mono text-[color:var(--fg)]">{treasury.blocks_until_full.toLocaleString()}</span>
             </div>
           )}
         </div>
@@ -103,7 +103,7 @@ function TreasuryDetails() {
             const isPast = treasury.decay_started && treasury.decay_year != null && step.year < decayYear;
             const isOssified = treasury.phase === "ossified";
 
-            let dotColor = "bg-gray-600";
+            let dotColor = "bg-[var(--surface)]";
             if (isOssified && step.year === 5) dotColor = "bg-green-500";
             else if (isCurrentYear) dotColor = "bg-orange-500 animate-pulse";
             else if (isPast) dotColor = "bg-orange-400";
@@ -113,8 +113,8 @@ function TreasuryDetails() {
               <Tooltip key={step.year} content={`Treasury: ${(step.treasury * 100).toFixed(0)}% / Node Pool: ${(step.nodePool * 100).toFixed(0)}%`}>
                 <div className="flex flex-col items-center flex-1">
                   <div className={`w-3.5 h-3.5 rounded-full ${dotColor}`} />
-                  <div className="text-xs text-gray-500 mt-1.5">{step.label}</div>
-                  <div className="text-[10px] text-gray-600 mt-0.5">
+                  <div className="text-xs text-[color:var(--fainter)] mt-1.5">{step.label}</div>
+                  <div className="text-[10px] text-[color:var(--fainter)] mt-0.5">
                     {(step.treasury * 100).toFixed(0)}% / {(step.nodePool * 100).toFixed(0)}%
                   </div>
                 </div>

--- a/dashboard/src/app/(dashboard)/watchdog/page.tsx
+++ b/dashboard/src/app/(dashboard)/watchdog/page.tsx
@@ -241,7 +241,7 @@ export default function WatchdogPage() {
             <div className="space-y-4">
               {/* Resource Bars */}
               <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-                <div className="p-4 bg-gray-800/50 rounded-lg border border-gray-700">
+                <div className="p-4 bg-[var(--surface)] rounded-lg border border-[var(--rule-strong)]">
                   <ProgressBar
                     value={resourceStatus.cpu_percent}
                     label="CPU Usage"
@@ -249,13 +249,13 @@ export default function WatchdogPage() {
                     color={resourceColor(resourceStatus.cpu_percent, resourceStatus.warning_threshold_cpu, resourceStatus.critical_threshold_cpu)}
                     size="lg"
                   />
-                  <div className="flex justify-between mt-1.5 text-xs text-gray-500">
+                  <div className="flex justify-between mt-1.5 text-xs text-[color:var(--fainter)]">
                     <span>Warning: {resourceStatus.warning_threshold_cpu}%</span>
                     <span>Critical: {resourceStatus.critical_threshold_cpu}%</span>
                   </div>
                 </div>
 
-                <div className="p-4 bg-gray-800/50 rounded-lg border border-gray-700">
+                <div className="p-4 bg-[var(--surface)] rounded-lg border border-[var(--rule-strong)]">
                   <ProgressBar
                     value={resourceStatus.memory_percent}
                     label="Memory Usage"
@@ -263,12 +263,12 @@ export default function WatchdogPage() {
                     color={resourceColor(resourceStatus.memory_percent, resourceStatus.warning_threshold_memory, resourceStatus.critical_threshold_memory)}
                     size="lg"
                   />
-                  <div className="flex justify-between mt-1.5 text-xs text-gray-500">
+                  <div className="flex justify-between mt-1.5 text-xs text-[color:var(--fainter)]">
                     <span>{resourceStatus.memory_used_mb.toLocaleString()} / {resourceStatus.memory_total_mb.toLocaleString()} MB</span>
                   </div>
                 </div>
 
-                <div className="p-4 bg-gray-800/50 rounded-lg border border-gray-700">
+                <div className="p-4 bg-[var(--surface)] rounded-lg border border-[var(--rule-strong)]">
                   <ProgressBar
                     value={resourceStatus.disk_percent}
                     label="Disk Usage"
@@ -276,7 +276,7 @@ export default function WatchdogPage() {
                     color={resourceColor(resourceStatus.disk_percent, 75, 90)}
                     size="lg"
                   />
-                  <div className="flex justify-between mt-1.5 text-xs text-gray-500">
+                  <div className="flex justify-between mt-1.5 text-xs text-[color:var(--fainter)]">
                     <span>{resourceStatus.disk_used_gb.toLocaleString()} / {resourceStatus.disk_total_gb.toLocaleString()} GB</span>
                   </div>
                 </div>
@@ -312,15 +312,15 @@ export default function WatchdogPage() {
 
               {/* Warning/Critical Info */}
               {resourceStatus.status === "warning" && (
-                <div className="p-3 bg-yellow-900/20 border border-yellow-800 rounded-lg">
-                  <p className="text-yellow-400 text-sm">
+                <div className="p-3 bg-[var(--surface)] border border-[color:var(--accent)] rounded-lg">
+                  <p className="text-[color:var(--accent)] text-sm">
                     Resource usage is elevated. If usage continues to increase, low-hashrate miners may be redirected to other nodes.
                   </p>
                 </div>
               )}
               {resourceStatus.status === "critical" && (
-                <div className="p-3 bg-red-900/20 border border-red-800 rounded-lg">
-                  <p className="text-red-400 text-sm">
+                <div className="p-3 bg-[var(--surface)] border border-[color:var(--red)] rounded-lg">
+                  <p className="text-[color:var(--red)] text-sm">
                     Resource usage is critical! Low-hashrate miners are being redirected to other nodes to reduce load.
                   </p>
                 </div>
@@ -349,11 +349,11 @@ export default function WatchdogPage() {
                 return (
                   <div
                     key={service.name}
-                    className="p-4 bg-gray-800/50 rounded-lg border border-gray-700"
+                    className="p-4 bg-[var(--surface)] rounded-lg border border-[var(--rule-strong)]"
                   >
                     <div className="flex items-center justify-between">
                       <div className="flex items-center gap-3">
-                        <span className="text-gray-100 font-medium">{service.name}</span>
+                        <span className="text-[color:var(--fg)] font-medium">{service.name}</span>
                         <Badge variant={statusBadge.variant}>{statusBadge.label}</Badge>
                       </div>
                       <div className="flex gap-2">
@@ -390,8 +390,8 @@ export default function WatchdogPage() {
                       <div className="mt-3 grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
                         {Object.entries(service.details).map(([key, value]) => (
                           <div key={key}>
-                            <span className="text-gray-500">{key}: </span>
-                            <span className="text-gray-300">
+                            <span className="text-[color:var(--fainter)]">{key}: </span>
+                            <span className="text-[color:var(--dim)]">
                               {typeof value === "number"
                                 ? value.toLocaleString()
                                 : String(value)}
@@ -426,12 +426,12 @@ export default function WatchdogPage() {
             <div className="overflow-x-auto">
               <table className="w-full text-left">
                 <thead>
-                  <tr className="border-b border-gray-800">
-                    <th className="pb-3 text-gray-400 font-medium">Component</th>
-                    <th className="pb-3 text-gray-400 font-medium">Port</th>
-                    <th className="pb-3 text-gray-400 font-medium">Status</th>
-                    <th className="pb-3 text-gray-400 font-medium">PID</th>
-                    <th className="pb-3 text-gray-400 font-medium">Actions</th>
+                  <tr className="border-b border-[var(--rule)]">
+                    <th className="pb-3 text-[color:var(--dim)] font-medium">Component</th>
+                    <th className="pb-3 text-[color:var(--dim)] font-medium">Port</th>
+                    <th className="pb-3 text-[color:var(--dim)] font-medium">Status</th>
+                    <th className="pb-3 text-[color:var(--dim)] font-medium">PID</th>
+                    <th className="pb-3 text-[color:var(--dim)] font-medium">Actions</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -440,24 +440,24 @@ export default function WatchdogPage() {
                     return (
                       <tr
                         key={component.name}
-                        className="border-b border-gray-800/50 hover:bg-gray-800/30"
+                        className="border-b border-[var(--rule)] hover:bg-[var(--surface)]"
                       >
                         <td className="py-3">
                           <div>
-                            <div className="text-gray-100 font-medium">{component.name}</div>
+                            <div className="text-[color:var(--fg)] font-medium">{component.name}</div>
                             {component.process_name && (
-                              <div className="text-xs text-gray-500">{component.process_name}</div>
+                              <div className="text-xs text-[color:var(--fainter)]">{component.process_name}</div>
                             )}
                           </div>
                         </td>
                         <td className="py-3">
-                          <code className="text-orange-400">{component.port}</code>
+                          <code className="text-[color:var(--accent)]">{component.port}</code>
                         </td>
                         <td className="py-3">
                           <Badge variant={statusBadge.variant}>{statusBadge.label}</Badge>
                         </td>
                         <td className="py-3">
-                          <code className="text-gray-400">{component.pid ?? "N/A"}</code>
+                          <code className="text-[color:var(--dim)]">{component.pid ?? "N/A"}</code>
                         </td>
                         <td className="py-3">
                           <div className="flex gap-2">
@@ -523,22 +523,22 @@ export default function WatchdogPage() {
                     key={`${event.timestamp}-${idx}`}
                     className={`p-3 rounded-lg border ${
                       event.event_type === "failure"
-                        ? "bg-red-900/10 border-red-800/50"
+                        ? "bg-[var(--surface)] border-[color:var(--red)]"
                         : event.event_type === "recovery"
-                        ? "bg-green-900/10 border-green-800/50"
+                        ? "bg-[var(--surface)] border-[color:var(--green)]"
                         : event.event_type === "warning"
-                        ? "bg-yellow-900/10 border-yellow-800/50"
-                        : "bg-gray-800/30 border-gray-700/50"
+                        ? "bg-[var(--surface)] border-[color:var(--accent)]"
+                        : "bg-[var(--surface)] border-[var(--rule-strong)]"
                     }`}
                   >
                     <div className="flex items-center gap-3">
                       <Badge variant={eventBadge.variant}>{eventBadge.label}</Badge>
-                      <span className="text-gray-100 font-medium">{event.service}</span>
-                      <span className="text-gray-500 text-sm ml-auto">
+                      <span className="text-[color:var(--fg)] font-medium">{event.service}</span>
+                      <span className="text-[color:var(--fainter)] text-sm ml-auto">
                         {formatTimestamp(event.timestamp ?? 0)}
                       </span>
                     </div>
-                    <p className="text-gray-400 text-sm mt-1">{event.message}</p>
+                    <p className="text-[color:var(--dim)] text-sm mt-1">{event.message}</p>
                   </div>
                 );
               })}
@@ -549,9 +549,9 @@ export default function WatchdogPage() {
 
       {/* Info Card */}
       <Card>
-        <div className="p-4 bg-orange-900/20 border border-orange-800 rounded-lg">
-          <h4 className="text-orange-300 font-medium mb-2">About Watchdog</h4>
-          <ul className="text-sm text-orange-300/80 space-y-1 list-disc list-inside">
+        <div className="p-4 bg-[var(--surface)] border border-[color:var(--accent)] rounded-lg">
+          <h4 className="text-[color:var(--accent)] font-medium mb-2">About Watchdog</h4>
+          <ul className="text-sm text-[color:var(--accent)] space-y-1 list-disc list-inside">
             <li>Watchdog monitors all Ghost node components in real-time</li>
             <li>Components are automatically restarted if they crash</li>
             <li>Use the Restart button to manually restart a component</li>
@@ -571,22 +571,22 @@ export default function WatchdogPage() {
         title={`${selectedAction.charAt(0).toUpperCase() + selectedAction.slice(1)} Service`}
       >
         <div className="space-y-4">
-          <p className="text-gray-300">
-            Are you sure you want to {selectedAction} <strong className="text-white">{selectedService}</strong>?
+          <p className="text-[color:var(--dim)]">
+            Are you sure you want to {selectedAction} <strong className="text-[color:var(--fg)]">{selectedService}</strong>?
           </p>
           <div className={`p-3 rounded border ${
             selectedAction === "stop"
-              ? "bg-red-900/20 border-red-800"
+              ? "bg-[var(--surface)] border-[color:var(--red)]"
               : selectedAction === "start"
-              ? "bg-green-900/20 border-green-800"
-              : "bg-yellow-900/20 border-yellow-800"
+              ? "bg-[var(--surface)] border-[color:var(--green)]"
+              : "bg-[var(--surface)] border-[color:var(--accent)]"
           }`}>
             <p className={`text-sm ${
               selectedAction === "stop"
-                ? "text-red-400"
+                ? "text-[color:var(--red)]"
                 : selectedAction === "start"
-                ? "text-green-400"
-                : "text-yellow-400"
+                ? "text-[color:var(--green)]"
+                : "text-[color:var(--accent)]"
             }`}>
               {selectedAction === "stop"
                 ? "This will stop the service. It will not automatically restart until started manually."
@@ -595,7 +595,7 @@ export default function WatchdogPage() {
                 : "This will temporarily interrupt the service. Any in-progress operations may be affected."}
             </p>
           </div>
-          <div className="flex gap-3 pt-4 border-t border-gray-800">
+          <div className="flex gap-3 pt-4 border-t border-[var(--rule)]">
             <Button
               variant="ghost"
               className="flex-1"


### PR DESCRIPTION
## Summary

The top-level dashboard page components hardcoded dark-theme Tailwind colour classes (`text-white`, `text-gray-*`, `bg-gray-8xx/9xx`, `border-gray-7xx/8xx`, `text-green/red/orange-*`, dark colour tints) that do not flip with the theme. In light mode this made primary/secondary text effectively invisible on the cream palette and left cards/panels dark. This converts those classes to the theme CSS variables defined in `globals.css` so every page renders correctly in both light and dark.

## Scope

`page.tsx` components under `src/app/(dashboard)/**`. Does not touch `src/components/**`, `src/app/(dashboard)/settings/**`, or `globals.css`. 12 files changed (30 page components were in scope; 18 already used the theme vars).

## Mapping

- Grayscale text: `text-white` / `text-gray-50..200` -> `--fg`; `text-gray-300/400` -> `--dim`; `text-gray-500/600` -> `--fainter`
- Backgrounds: `bg-black` / `bg-gray-950` -> `--bg`; `bg-gray-600..900` -> `--surface`
- Borders: `border-gray-800` -> `--rule`; `border-gray-500..700` -> `--rule-strong`; `divide-gray-800` -> `--rule`
- Semantic text: `green` -> `--green`, `red` -> `--red`, `orange`/`amber`/`yellow` -> `--accent`
- Semantic borders map the same way
- Dark `900/950` colour tints on alert panels -> `--surface` (severity still signalled by the coloured border/icon/text)

Applied as Tailwind arbitrary-value classes (`text-[color:var(--x)]` / `bg-[var(--x)]` / `border-[var(--x)]`) so edits stay inside `className` and the JSX structure is untouched.

## Judgment calls (intentionally left / special-cased)

- Solid saturated status dots, severity badges and progress bars (`bg-*-400/500/600`) read correctly in both themes and were left as-is, with their `text-white` / `text-black` contrast text preserved.
- The amber action button on the haze page kept `text-white` (contrast on the solid fill).
- The swarm view toggle previously used `bg-gray-700` (active) vs `bg-gray-800` (inactive); mapping both to `--surface` would have collapsed the distinction, so the active state now uses `--accent` + white text and the inactive state uses `--surface` + `--dim`.
- `blue`/`purple` accents were left as-is per scope (none were clearly broken in light mode).

## Verification

- `tsc --noEmit`: clean
- `eslint` on changed files: 0 errors (2 pre-existing warnings in swarm, unrelated to colours)
- `next build`: succeeds
- Grep confirms no theme-meant `text-gray-*` / `bg-gray-8xx/9xx` / `border-gray-7xx/8xx` / `text-white` tokens remain outside the intentional solid-fill contrast cases.