### PR TITLE
dashboard(components): theme-aware colours for light mode

### DIFF
--- a/dashboard/src/components/ConnectionStatus.tsx
+++ b/dashboard/src/components/ConnectionStatus.tsx
@@ -7,19 +7,19 @@ export function ConnectionStatus() {
 
   const statusConfig = {
     connected: {
-      color: "bg-green-500",
+      color: "bg-[var(--green)]",
       label: "Live",
     },
     connecting: {
-      color: "bg-yellow-500",
+      color: "bg-[var(--accent)]",
       label: "Connecting",
     },
     disconnected: {
-      color: "bg-gray-500",
+      color: "bg-[var(--fainter)]",
       label: "Offline",
     },
     error: {
-      color: "bg-red-500",
+      color: "bg-[var(--red)]",
       label: "Error",
     },
   };
@@ -30,11 +30,11 @@ export function ConnectionStatus() {
     <div className="flex items-center gap-2">
       <span className="relative flex h-2 w-2">
         {isConnected && (
-          <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75"></span>
+          <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-[var(--green)] opacity-75"></span>
         )}
         <span className={`relative inline-flex rounded-full h-2 w-2 ${config.color}`}></span>
       </span>
-      <span className="text-xs text-gray-500 hidden sm:inline">{config.label}</span>
+      <span className="text-xs text-[color:var(--fainter)] hidden sm:inline">{config.label}</span>
     </div>
   );
 }

--- a/dashboard/src/components/PayoutHistoryCard.tsx
+++ b/dashboard/src/components/PayoutHistoryCard.tsx
@@ -46,8 +46,8 @@ function TimeFilterToggle({
         onClick={() => onChange("24h")}
         className={`px-2 py-1 text-xs rounded transition-colors ${
           value === "24h"
-            ? "bg-orange-600 text-white"
-            : "bg-gray-800 text-gray-400 hover:bg-gray-700"
+            ? "bg-[var(--accent)] text-[color:var(--fg)]"
+            : "bg-[var(--surface)] text-[color:var(--dim)] hover:bg-[var(--rule-strong)]"
         }`}
       >
         24h
@@ -56,8 +56,8 @@ function TimeFilterToggle({
         onClick={() => onChange("7d")}
         className={`px-2 py-1 text-xs rounded transition-colors ${
           value === "7d"
-            ? "bg-orange-600 text-white"
-            : "bg-gray-800 text-gray-400 hover:bg-gray-700"
+            ? "bg-[var(--accent)] text-[color:var(--fg)]"
+            : "bg-[var(--surface)] text-[color:var(--dim)] hover:bg-[var(--rule-strong)]"
         }`}
       >
         7d
@@ -132,7 +132,7 @@ export function NetworkPayoutHistoryCard({
       accessorKey: "timestamp",
       header: "Time",
       cell: ({ row }) => (
-        <span className="text-gray-400 text-sm">
+        <span className="text-[color:var(--dim)] text-sm">
           {formatTimestamp(row.original.timestamp ?? 0)}
         </span>
       ),
@@ -145,7 +145,7 @@ export function NetworkPayoutHistoryCard({
           href={makeBlockLink(row.original.block_height ?? 0)}
           target="_blank"
           rel="noopener noreferrer"
-          className="font-mono text-orange-400 hover:text-orange-300 hover:underline"
+          className="font-mono text-[color:var(--accent)] hover:text-[color:var(--accent)] hover:underline"
         >
           #{row.original.block_height ?? 0}
         </a>
@@ -160,7 +160,7 @@ export function NetworkPayoutHistoryCard({
       accessorKey: "amount_satoshis",
       header: "Amount",
       cell: ({ row }) => (
-        <span className="font-mono text-gray-100">
+        <span className="font-mono text-[color:var(--fg)]">
           {formatSats(row.original.amount_satoshis ?? 0)}
         </span>
       ),
@@ -169,7 +169,7 @@ export function NetworkPayoutHistoryCard({
       accessorKey: "recipient_node_id",
       header: "Recipient",
       cell: ({ row }) => (
-        <span className="font-mono text-gray-400 text-sm">
+        <span className="font-mono text-[color:var(--dim)] text-sm">
           {row.original.recipient_node_id
             ? row.original.recipient_node_id.slice(0, 8)
             : row.original.recipient_address
@@ -189,18 +189,18 @@ export function NetworkPayoutHistoryCard({
       />
 
       {/* Summary row */}
-      <div className="grid grid-cols-3 gap-4 mb-4 p-3 bg-gray-900 rounded">
+      <div className="grid grid-cols-3 gap-4 mb-4 p-3 bg-[var(--surface)] rounded">
         <div className="text-center">
-          <div className="text-yellow-400 font-mono">{formatSats(summary.total_treasury_satoshis)}</div>
-          <div className="text-xs text-gray-500">Treasury</div>
+          <div className="text-[color:var(--accent)] font-mono">{formatSats(summary.total_treasury_satoshis)}</div>
+          <div className="text-xs text-[color:var(--fainter)]">Treasury</div>
         </div>
         <div className="text-center">
-          <div className="text-green-400 font-mono">{formatSats(summary.total_node_rewards_satoshis)}</div>
-          <div className="text-xs text-gray-500">Node Rewards</div>
+          <div className="text-[color:var(--green)] font-mono">{formatSats(summary.total_node_rewards_satoshis)}</div>
+          <div className="text-xs text-[color:var(--fainter)]">Node Rewards</div>
         </div>
         <div className="text-center">
-          <div className="text-gray-300 font-mono">{formatSats(summary.total_miner_rewards_satoshis)}</div>
-          <div className="text-xs text-gray-500">Miner Rewards</div>
+          <div className="text-[color:var(--dim)] font-mono">{formatSats(summary.total_miner_rewards_satoshis)}</div>
+          <div className="text-xs text-[color:var(--fainter)]">Miner Rewards</div>
         </div>
       </div>
 
@@ -241,7 +241,7 @@ export function GhostPayPayoutHistoryCard({
       accessorKey: "timestamp",
       header: "Time",
       cell: ({ row }) => (
-        <span className="text-gray-400 text-sm">
+        <span className="text-[color:var(--dim)] text-sm">
           {formatTimestamp(row.original.timestamp ?? 0)}
         </span>
       ),
@@ -254,7 +254,7 @@ export function GhostPayPayoutHistoryCard({
           href={makeBlockLink(row.original.block_height ?? 0)}
           target="_blank"
           rel="noopener noreferrer"
-          className="font-mono text-orange-400 hover:text-orange-300 hover:underline"
+          className="font-mono text-[color:var(--accent)] hover:text-[color:var(--accent)] hover:underline"
         >
           #{row.original.block_height ?? 0}
         </a>
@@ -264,7 +264,7 @@ export function GhostPayPayoutHistoryCard({
       accessorKey: "batch_id",
       header: "Batch ID",
       cell: ({ row }) => (
-        <span className="font-mono text-gray-400 text-sm">
+        <span className="font-mono text-[color:var(--dim)] text-sm">
           {(row.original.batch_id ?? "").slice(0, 12)}...
         </span>
       ),
@@ -273,7 +273,7 @@ export function GhostPayPayoutHistoryCard({
       accessorKey: "fee_satoshis",
       header: "Fee",
       cell: ({ row }) => (
-        <span className="font-mono text-green-400">
+        <span className="font-mono text-[color:var(--green)]">
           {formatSats(row.original.fee_satoshis ?? 0)}
         </span>
       ),
@@ -282,7 +282,7 @@ export function GhostPayPayoutHistoryCard({
       accessorKey: "recipient_node_id",
       header: "Node",
       cell: ({ row }) => (
-        <span className="font-mono text-gray-400 text-sm">
+        <span className="font-mono text-[color:var(--dim)] text-sm">
           {row.original.recipient_node_id?.slice(0, 8) ?? "—"}
         </span>
       ),
@@ -294,7 +294,7 @@ export function GhostPayPayoutHistoryCard({
       accessorKey: "timestamp",
       header: "Time",
       cell: ({ row }) => (
-        <span className="text-gray-400 text-sm">
+        <span className="text-[color:var(--dim)] text-sm">
           {formatTimestamp(row.original.timestamp ?? 0)}
         </span>
       ),
@@ -307,7 +307,7 @@ export function GhostPayPayoutHistoryCard({
           href={makeBlockLink(row.original.block_height ?? 0)}
           target="_blank"
           rel="noopener noreferrer"
-          className="font-mono text-orange-400 hover:text-orange-300 hover:underline"
+          className="font-mono text-[color:var(--accent)] hover:text-[color:var(--accent)] hover:underline"
         >
           #{row.original.block_height ?? 0}
         </a>
@@ -317,7 +317,7 @@ export function GhostPayPayoutHistoryCard({
       accessorKey: "session_id",
       header: "Session ID",
       cell: ({ row }) => (
-        <span className="font-mono text-gray-400 text-sm">
+        <span className="font-mono text-[color:var(--dim)] text-sm">
           {(row.original.session_id ?? "").slice(0, 12)}...
         </span>
       ),
@@ -326,7 +326,7 @@ export function GhostPayPayoutHistoryCard({
       accessorKey: "fee_satoshis",
       header: "Fee",
       cell: ({ row }) => (
-        <span className="font-mono text-yellow-400">
+        <span className="font-mono text-[color:var(--accent)]">
           {formatSats(row.original.fee_satoshis ?? 0)}
         </span>
       ),
@@ -335,7 +335,7 @@ export function GhostPayPayoutHistoryCard({
       accessorKey: "recipient_node_id",
       header: "Node",
       cell: ({ row }) => (
-        <span className="font-mono text-gray-400 text-sm">
+        <span className="font-mono text-[color:var(--dim)] text-sm">
           {row.original.recipient_node_id?.slice(0, 8) ?? "—"}
         </span>
       ),
@@ -351,14 +351,14 @@ export function GhostPayPayoutHistoryCard({
       />
 
       {/* Summary row */}
-      <div className="grid grid-cols-2 gap-4 mb-4 p-3 bg-gray-900 rounded">
+      <div className="grid grid-cols-2 gap-4 mb-4 p-3 bg-[var(--surface)] rounded">
         <div className="text-center">
-          <div className="text-green-400 font-mono">{formatSats(summary.total_ghostpay_fees_satoshis)}</div>
-          <div className="text-xs text-gray-500">GhostPay Fees ({summary.ghostpay_sessions_count})</div>
+          <div className="text-[color:var(--green)] font-mono">{formatSats(summary.total_ghostpay_fees_satoshis)}</div>
+          <div className="text-xs text-[color:var(--fainter)]">GhostPay Fees ({summary.ghostpay_sessions_count})</div>
         </div>
         <div className="text-center">
-          <div className="text-yellow-400 font-mono">{formatSats(summary.total_wraith_fees_satoshis)}</div>
-          <div className="text-xs text-gray-500">Wraith Fees ({summary.wraith_sessions_count})</div>
+          <div className="text-[color:var(--accent)] font-mono">{formatSats(summary.total_wraith_fees_satoshis)}</div>
+          <div className="text-xs text-[color:var(--fainter)]">Wraith Fees ({summary.wraith_sessions_count})</div>
         </div>
       </div>
 
@@ -368,8 +368,8 @@ export function GhostPayPayoutHistoryCard({
           onClick={() => setActiveTab("ghostpay")}
           className={`px-3 py-1.5 text-sm rounded transition-colors ${
             activeTab === "ghostpay"
-              ? "bg-orange-600 text-white"
-              : "bg-gray-800 text-gray-400 hover:bg-gray-700"
+              ? "bg-[var(--accent)] text-[color:var(--fg)]"
+              : "bg-[var(--surface)] text-[color:var(--dim)] hover:bg-[var(--rule-strong)]"
           }`}
         >
           L2→L1 Reconciliation ({ghostpayFees.length})
@@ -378,8 +378,8 @@ export function GhostPayPayoutHistoryCard({
           onClick={() => setActiveTab("wraith")}
           className={`px-3 py-1.5 text-sm rounded transition-colors ${
             activeTab === "wraith"
-              ? "bg-yellow-600 text-white"
-              : "bg-gray-800 text-gray-400 hover:bg-gray-700"
+              ? "bg-[var(--accent)] text-[color:var(--fg)]"
+              : "bg-[var(--surface)] text-[color:var(--dim)] hover:bg-[var(--rule-strong)]"
           }`}
         >
           Wraith Sessions ({wraithFees.length})
@@ -430,7 +430,7 @@ export function NodePayoutHistoryCard({
       accessorKey: "timestamp",
       header: "Time",
       cell: ({ row }) => (
-        <span className="text-gray-400 text-sm">
+        <span className="text-[color:var(--dim)] text-sm">
           {formatTimestamp(row.original.timestamp ?? 0)}
         </span>
       ),
@@ -443,7 +443,7 @@ export function NodePayoutHistoryCard({
           href={makeBlockLink(row.original.block_height ?? 0)}
           target="_blank"
           rel="noopener noreferrer"
-          className="font-mono text-orange-400 hover:text-orange-300 hover:underline"
+          className="font-mono text-[color:var(--accent)] hover:text-[color:var(--accent)] hover:underline"
         >
           #{row.original.block_height ?? 0}
         </a>
@@ -458,7 +458,7 @@ export function NodePayoutHistoryCard({
       accessorKey: "amount_satoshis",
       header: "Amount",
       cell: ({ row }) => (
-        <span className="font-mono text-green-400">
+        <span className="font-mono text-[color:var(--green)]">
           {formatSats(row.original.amount_satoshis ?? 0)}
         </span>
       ),
@@ -467,7 +467,7 @@ export function NodePayoutHistoryCard({
       accessorKey: "share_percentage",
       header: "Share %",
       cell: ({ row }) => (
-        <span className="font-mono text-gray-400">
+        <span className="font-mono text-[color:var(--dim)]">
           {row.original.share_percentage
             ? `${(row.original.share_percentage * 100).toFixed(2)}%`
             : "—"}
@@ -491,8 +491,8 @@ export function NodePayoutHistoryCard({
             onClick={() => onPayoutTypeFilterChange(undefined)}
             className={`px-2 py-1 text-xs rounded transition-colors ${
               !payoutTypeFilter
-                ? "bg-orange-600 text-white"
-                : "bg-gray-800 text-gray-400 hover:bg-gray-700"
+                ? "bg-[var(--accent)] text-[color:var(--fg)]"
+                : "bg-[var(--surface)] text-[color:var(--dim)] hover:bg-[var(--rule-strong)]"
             }`}
           >
             All
@@ -501,8 +501,8 @@ export function NodePayoutHistoryCard({
             onClick={() => onPayoutTypeFilterChange("node_reward")}
             className={`px-2 py-1 text-xs rounded transition-colors ${
               payoutTypeFilter === "node_reward"
-                ? "bg-orange-600 text-white"
-                : "bg-gray-800 text-gray-400 hover:bg-gray-700"
+                ? "bg-[var(--accent)] text-[color:var(--fg)]"
+                : "bg-[var(--surface)] text-[color:var(--dim)] hover:bg-[var(--rule-strong)]"
             }`}
           >
             Node Rewards
@@ -511,8 +511,8 @@ export function NodePayoutHistoryCard({
             onClick={() => onPayoutTypeFilterChange("ghostpay_fee")}
             className={`px-2 py-1 text-xs rounded transition-colors ${
               payoutTypeFilter === "ghostpay_fee"
-                ? "bg-orange-600 text-white"
-                : "bg-gray-800 text-gray-400 hover:bg-gray-700"
+                ? "bg-[var(--accent)] text-[color:var(--fg)]"
+                : "bg-[var(--surface)] text-[color:var(--dim)] hover:bg-[var(--rule-strong)]"
             }`}
           >
             GhostPay Fees
@@ -521,8 +521,8 @@ export function NodePayoutHistoryCard({
             onClick={() => onPayoutTypeFilterChange("wraith_fee")}
             className={`px-2 py-1 text-xs rounded transition-colors ${
               payoutTypeFilter === "wraith_fee"
-                ? "bg-yellow-600 text-white"
-                : "bg-gray-800 text-gray-400 hover:bg-gray-700"
+                ? "bg-[var(--accent)] text-[color:var(--fg)]"
+                : "bg-[var(--surface)] text-[color:var(--dim)] hover:bg-[var(--rule-strong)]"
             }`}
           >
             Wraith Fees

--- a/dashboard/src/components/dashboard/ConfigCard.tsx
+++ b/dashboard/src/components/dashboard/ConfigCard.tsx
@@ -33,8 +33,8 @@ export function ConfigCard() {
       <Card>
         <CardHeader title="Configuration" />
         <div className="animate-pulse space-y-4">
-          <div className="h-6 bg-gray-800 rounded w-full"></div>
-          <div className="h-6 bg-gray-800 rounded w-full"></div>
+          <div className="h-6 bg-[var(--surface)] rounded w-full"></div>
+          <div className="h-6 bg-[var(--surface)] rounded w-full"></div>
         </div>
       </Card>
     );
@@ -44,7 +44,7 @@ export function ConfigCard() {
     return (
       <Card>
         <CardHeader title="Configuration" />
-        <p className="text-gray-400">
+        <p className="text-[color:var(--dim)]">
           {error ? `Error: ${error.message}` : "Unable to load configuration"}
         </p>
       </Card>
@@ -58,8 +58,8 @@ export function ConfigCard() {
       <div className="space-y-6">
         <div className="flex items-center justify-between">
           <div>
-            <div className="text-gray-100 font-medium">Ghost Mode</div>
-            <div className="text-sm text-gray-400">
+            <div className="text-[color:var(--fg)] font-medium">Ghost Mode</div>
+            <div className="text-sm text-[color:var(--dim)]">
               Private blocks-only peer mode
             </div>
           </div>
@@ -73,8 +73,8 @@ export function ConfigCard() {
 
         <div className="flex items-center justify-between">
           <div>
-            <div className="text-gray-100 font-medium">Archive Mode</div>
-            <div className="text-sm text-gray-400">
+            <div className="text-[color:var(--fg)] font-medium">Archive Mode</div>
+            <div className="text-sm text-[color:var(--dim)]">
               Full chain storage, no pruning
             </div>
           </div>
@@ -86,16 +86,16 @@ export function ConfigCard() {
           />
         </div>
 
-        <div className="pt-4 border-t border-gray-800">
+        <div className="pt-4 border-t border-[color:var(--rule)]">
           <div className="flex justify-between mb-2">
-            <span className="text-gray-400">Mempool Profile</span>
-            <span className="text-gray-100 capitalize">
+            <span className="text-[color:var(--dim)]">Mempool Profile</span>
+            <span className="text-[color:var(--fg)] capitalize">
               {(config.mempool_profile ?? "standard").replace("_", " ")}
             </span>
           </div>
           <div className="flex justify-between">
-            <span className="text-gray-400">Template Profile</span>
-            <span className="text-gray-100 capitalize">
+            <span className="text-[color:var(--dim)]">Template Profile</span>
+            <span className="text-[color:var(--fg)] capitalize">
               {(config.template_profile ?? "standard").replace("_", " ")}
             </span>
           </div>

--- a/dashboard/src/components/dashboard/DecentralisationCard.tsx
+++ b/dashboard/src/components/dashboard/DecentralisationCard.tsx
@@ -20,8 +20,8 @@ export function DecentralisationCard() {
       <Card className="col-span-full">
         <CardHeader title="Decentralisation Status" />
         <div className="animate-pulse space-y-4">
-          <div className="h-6 bg-gray-800 rounded w-full"></div>
-          <div className="h-20 bg-gray-800 rounded w-full"></div>
+          <div className="h-6 bg-[var(--surface)] rounded w-full"></div>
+          <div className="h-20 bg-[var(--surface)] rounded w-full"></div>
         </div>
       </Card>
     );
@@ -31,7 +31,7 @@ export function DecentralisationCard() {
     return (
       <Card className="col-span-full">
         <CardHeader title="Decentralisation Status" />
-        <p className="text-gray-400">
+        <p className="text-[color:var(--dim)]">
           {error ? `Error: ${error.message}` : "Unable to load treasury status"}
         </p>
       </Card>
@@ -46,10 +46,10 @@ export function DecentralisationCard() {
   }[phase] ?? "UNKNOWN";
 
   const phaseColor = {
-    bootstrap: "text-yellow-400",
-    decay: "text-orange-400",
-    ossified: "text-green-400",
-  }[phase] ?? "text-gray-400";
+    bootstrap: "text-[color:var(--accent)]",
+    decay: "text-[color:var(--accent)]",
+    ossified: "text-[color:var(--green)]",
+  }[phase] ?? "text-[color:var(--dim)]";
 
   return (
     <Card className="col-span-full">
@@ -59,15 +59,15 @@ export function DecentralisationCard() {
         {/* Treasury Progress Bar */}
         <div>
           <div className="flex justify-between text-sm mb-2">
-            <span className="text-gray-400">Treasury Progress</span>
-            <span className="text-gray-100">
+            <span className="text-[color:var(--dim)]">Treasury Progress</span>
+            <span className="text-[color:var(--fg)]">
               {(treasury.accumulated_btc ?? 0).toFixed(2)} / {(treasury.target_btc ?? 21).toFixed(1)} BTC
-              <span className="text-gray-500 ml-2">
+              <span className="text-[color:var(--fainter)] ml-2">
                 ({(treasury.progress_percent ?? 0).toFixed(1)}%)
               </span>
             </span>
           </div>
-          <div className="h-4 bg-gray-800 rounded-full overflow-hidden">
+          <div className="h-4 bg-[var(--surface)] rounded-full overflow-hidden">
             <div
               className="h-full bg-gradient-to-r from-orange-600 to-orange-400 transition-all duration-500"
               style={{ width: `${Math.min(treasury.progress_percent ?? 0, 100)}%` }}
@@ -76,28 +76,28 @@ export function DecentralisationCard() {
         </div>
 
         {/* Phase Info */}
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-4 p-4 bg-gray-800/50 rounded-lg">
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4 p-4 bg-[var(--surface)]/50 rounded-lg">
           <div>
-            <div className="text-xs text-gray-500 uppercase tracking-wide">Phase</div>
-            <div className={`text-lg font-semibold ${phaseColor ?? 'text-gray-400'}`}>{phaseLabel ?? 'Unknown'}</div>
+            <div className="text-xs text-[color:var(--fainter)] uppercase tracking-wide">Phase</div>
+            <div className={`text-lg font-semibold ${phaseColor ?? 'text-[color:var(--dim)]'}`}>{phaseLabel ?? 'Unknown'}</div>
           </div>
           <div>
-            <div className="text-xs text-gray-500 uppercase tracking-wide">Decay Year</div>
-            <div className="text-lg font-semibold text-gray-100">
+            <div className="text-xs text-[color:var(--fainter)] uppercase tracking-wide">Decay Year</div>
+            <div className="text-lg font-semibold text-[color:var(--fg)]">
               {treasury.decay_started && treasury.decay_year !== null
                 ? `Year ${treasury.decay_year}`
                 : "Not started"}
             </div>
           </div>
           <div>
-            <div className="text-xs text-gray-500 uppercase tracking-wide">Treasury</div>
-            <div className="text-lg font-semibold text-gray-100">
+            <div className="text-xs text-[color:var(--fainter)] uppercase tracking-wide">Treasury</div>
+            <div className="text-lg font-semibold text-[color:var(--fg)]">
               {(treasury.treasury_percent ?? 50).toFixed(2)}% of subsidy
             </div>
           </div>
           <div>
-            <div className="text-xs text-gray-500 uppercase tracking-wide">Node Pool</div>
-            <div className="text-lg font-semibold text-gray-100">
+            <div className="text-xs text-[color:var(--fainter)] uppercase tracking-wide">Node Pool</div>
+            <div className="text-lg font-semibold text-[color:var(--fg)]">
               {(treasury.node_pool_percent ?? 50).toFixed(2)}% of subsidy
             </div>
           </div>
@@ -105,7 +105,7 @@ export function DecentralisationCard() {
 
         {/* Ossification Timeline */}
         <div>
-          <div className="text-sm text-gray-400 mb-3">Ossification Timeline</div>
+          <div className="text-sm text-[color:var(--dim)] mb-3">Ossification Timeline</div>
           <div className="flex items-center justify-between">
             {DECAY_SCHEDULE.map((step) => {
               const decayYear = treasury.decay_year ?? 0;
@@ -113,19 +113,19 @@ export function DecentralisationCard() {
               const isPast = treasury.decay_started && treasury.decay_year != null && step.year < decayYear;
               const isOssified = treasury.phase === "ossified";
 
-              let dotColor = "bg-gray-600";
-              if (isOssified && step.year === 5) dotColor = "bg-green-500";
-              else if (isCurrentYear) dotColor = "bg-orange-500 animate-pulse";
-              else if (isPast) dotColor = "bg-orange-400";
-              else if (!treasury.decay_started && step.year === 0) dotColor = "bg-yellow-500";
+              let dotColor = "bg-[var(--rule-strong)]";
+              if (isOssified && step.year === 5) dotColor = "bg-[var(--green)]";
+              else if (isCurrentYear) dotColor = "bg-[var(--accent)] animate-pulse";
+              else if (isPast) dotColor = "bg-[var(--accent)]";
+              else if (!treasury.decay_started && step.year === 0) dotColor = "bg-[var(--accent)]";
 
               return (
                 <div key={step.year} className="flex flex-col items-center flex-1">
                   <div className={`w-3 h-3 rounded-full ${dotColor}`} />
-                  <div className="text-xs text-gray-500 mt-1">
+                  <div className="text-xs text-[color:var(--fainter)] mt-1">
                     {step.year === 0 ? "21 BTC" : `Yr ${step.year}`}
                   </div>
-                  <div className="text-xs text-gray-600 mt-0.5">
+                  <div className="text-xs text-[color:var(--fainter)] mt-0.5">
                     {step.treasury}%
                   </div>
                 </div>
@@ -133,8 +133,8 @@ export function DecentralisationCard() {
             })}
           </div>
           <div className="flex justify-between mt-2">
-            <span className="text-xs text-gray-500">Bootstrap</span>
-            <span className="text-xs text-gray-500">Fully Ossified</span>
+            <span className="text-xs text-[color:var(--fainter)]">Bootstrap</span>
+            <span className="text-xs text-[color:var(--fainter)]">Fully Ossified</span>
           </div>
         </div>
       </div>

--- a/dashboard/src/components/dashboard/NodeHeader.tsx
+++ b/dashboard/src/components/dashboard/NodeHeader.tsx
@@ -26,8 +26,8 @@ export function NodeHeader() {
     return (
       <header className="mb-8">
         <div className="animate-pulse">
-          <div className="h-8 bg-gray-800 rounded w-64 mb-2"></div>
-          <div className="h-4 bg-gray-800 rounded w-48"></div>
+          <div className="h-8 bg-[var(--surface)] rounded w-64 mb-2"></div>
+          <div className="h-4 bg-[var(--surface)] rounded w-48"></div>
         </div>
       </header>
     );
@@ -36,8 +36,8 @@ export function NodeHeader() {
   if (!info) {
     return (
       <header className="mb-8">
-        <h1 className="text-2xl font-bold text-gray-100">Ghost Node</h1>
-        <p className="text-gray-400">Unable to connect to node</p>
+        <h1 className="text-2xl font-bold text-[color:var(--fg)]">Ghost Node</h1>
+        <p className="text-[color:var(--dim)]">Unable to connect to node</p>
       </header>
     );
   }
@@ -47,30 +47,30 @@ export function NodeHeader() {
   return (
     <header className="mb-8">
       <div className="flex items-center gap-4 mb-2">
-        <h1 className="text-2xl font-bold text-gray-100">Ghost Node</h1>
+        <h1 className="text-2xl font-bold text-[color:var(--fg)]">Ghost Node</h1>
         <Badge variant="success">Online</Badge>
       </div>
 
-      <div className="flex items-center gap-6 text-sm text-gray-400 flex-wrap">
+      <div className="flex items-center gap-6 text-sm text-[color:var(--dim)] flex-wrap">
         {nickname && (
           <div className="flex items-center gap-2">
             <span>Node Name:</span>
-            <span className="text-gray-300 font-medium">{nickname}</span>
+            <span className="text-[color:var(--dim)] font-medium">{nickname}</span>
           </div>
         )}
         <div className="flex items-center gap-2">
           <span>Node ID:</span>
-          <code className="bg-gray-800 px-2 py-0.5 rounded font-mono">
+          <code className="bg-[var(--surface)] px-2 py-0.5 rounded font-mono">
             {info.node_id_short}
           </code>
         </div>
         <div>
           <span>Version:</span>{" "}
-          <span className="text-gray-300">v{info.version}</span>
+          <span className="text-[color:var(--dim)]">v{info.version}</span>
         </div>
         <div>
           <span>Uptime:</span>{" "}
-          <span className="text-gray-300">{formatUptime(info.uptime_seconds ?? info.uptime_secs ?? 0)}</span>
+          <span className="text-[color:var(--dim)]">{formatUptime(info.uptime_seconds ?? info.uptime_secs ?? 0)}</span>
         </div>
       </div>
     </header>

--- a/dashboard/src/components/dashboard/QuickStatsCard.tsx
+++ b/dashboard/src/components/dashboard/QuickStatsCard.tsx
@@ -24,9 +24,9 @@ export function QuickStatsCard() {
       <Card>
         <CardHeader title="Quick Stats" />
         <div className="animate-pulse space-y-3">
-          <div className="h-4 bg-gray-800 rounded w-3/4"></div>
-          <div className="h-4 bg-gray-800 rounded w-1/2"></div>
-          <div className="h-4 bg-gray-800 rounded w-2/3"></div>
+          <div className="h-4 bg-[var(--surface)] rounded w-3/4"></div>
+          <div className="h-4 bg-[var(--surface)] rounded w-1/2"></div>
+          <div className="h-4 bg-[var(--surface)] rounded w-2/3"></div>
         </div>
       </Card>
     );
@@ -46,80 +46,80 @@ export function QuickStatsCard() {
 
       <div className="space-y-4">
         {/* Total Earnings */}
-        <div className="p-4 bg-gradient-to-br from-yellow-900/30 to-orange-900/20 border border-yellow-800/50 rounded-lg">
-          <div className="text-xs text-yellow-500 uppercase tracking-wide mb-1">
+        <div className="p-4 bg-[var(--accent-weak)] border border-[color:color-mix(in_srgb,var(--accent)_40%,transparent)] rounded-lg">
+          <div className="text-xs text-[color:var(--accent)] uppercase tracking-wide mb-1">
             Total Earnings
           </div>
-          <div className="text-2xl font-bold text-yellow-400">
+          <div className="text-2xl font-bold text-[color:var(--accent)]">
             {totalEarned !== null ? formatBtc(totalEarned) : "--"}
           </div>
-          <div className="text-xs text-gray-500 mt-1">
+          <div className="text-xs text-[color:var(--fainter)] mt-1">
             Node rewards received
           </div>
         </div>
 
-        <div className="p-3 bg-gray-800/50 rounded-lg">
-          <div className="text-xs text-gray-500 uppercase tracking-wide mb-1">
+        <div className="p-3 bg-[var(--surface)]/50 rounded-lg">
+          <div className="text-xs text-[color:var(--fainter)] uppercase tracking-wide mb-1">
             Ghost Pay L2
           </div>
           <div className="flex justify-between items-center">
-            <span className="text-gray-400">Block Height</span>
-            <span className="font-mono text-gray-100">
+            <span className="text-[color:var(--dim)]">Block Height</span>
+            <span className="font-mono text-[color:var(--fg)]">
               {ghostPay?.block_height?.toLocaleString() ?? 0}
             </span>
           </div>
           <div className="flex justify-between items-center mt-1">
-            <span className="text-gray-400">Epoch</span>
-            <span className="font-mono text-gray-100">
+            <span className="text-[color:var(--dim)]">Epoch</span>
+            <span className="font-mono text-[color:var(--fg)]">
               {ghostPay?.epoch ?? 0}
             </span>
           </div>
           <div className="flex justify-between items-center mt-1">
-            <span className="text-gray-400">Peers</span>
-            <span className="font-mono text-gray-100">
+            <span className="text-[color:var(--dim)]">Peers</span>
+            <span className="font-mono text-[color:var(--fg)]">
               {ghostPay?.peer_count ?? 0}
             </span>
           </div>
         </div>
 
-        <div className="p-3 bg-gray-800/50 rounded-lg">
-          <div className="text-xs text-gray-500 uppercase tracking-wide mb-1">
+        <div className="p-3 bg-[var(--surface)]/50 rounded-lg">
+          <div className="text-xs text-[color:var(--fainter)] uppercase tracking-wide mb-1">
             Wraith Sessions
           </div>
           <div className="flex justify-between items-center">
-            <span className="text-gray-400">Active</span>
-            <span className="font-mono text-gray-100">
+            <span className="text-[color:var(--dim)]">Active</span>
+            <span className="font-mono text-[color:var(--fg)]">
               {wraithStats?.active_sessions ?? 0}
             </span>
           </div>
           <div className="flex justify-between items-center mt-1">
-            <span className="text-gray-400">Completed</span>
-            <span className="font-mono text-gray-100">
+            <span className="text-[color:var(--dim)]">Completed</span>
+            <span className="font-mono text-[color:var(--fg)]">
               {wraithStats?.sessions_completed ?? 0}
             </span>
           </div>
         </div>
 
-        <div className="p-3 bg-gray-800/50 rounded-lg">
-          <div className="text-xs text-gray-500 uppercase tracking-wide mb-1">
+        <div className="p-3 bg-[var(--surface)]/50 rounded-lg">
+          <div className="text-xs text-[color:var(--fainter)] uppercase tracking-wide mb-1">
             Settlements
           </div>
           <div className="flex justify-between items-center">
-            <span className="text-gray-400">Pending</span>
-            <span className="font-mono text-gray-100">
+            <span className="text-[color:var(--dim)]">Pending</span>
+            <span className="font-mono text-[color:var(--fg)]">
               {settlement?.pending_count ?? 0}
             </span>
           </div>
           <div className="flex justify-between items-center mt-1">
-            <span className="text-gray-400">Confirmed (24h)</span>
-            <span className="font-mono text-gray-100">
+            <span className="text-[color:var(--dim)]">Confirmed (24h)</span>
+            <span className="font-mono text-[color:var(--fg)]">
               {settlement?.batches_24h ?? 0}
             </span>
           </div>
         </div>
 
         {gpError && (
-          <p className="text-xs text-gray-500">
+          <p className="text-xs text-[color:var(--fainter)]">
             Ghost Pay not connected
           </p>
         )}

--- a/dashboard/src/components/dashboard/RecentActivityCard.tsx
+++ b/dashboard/src/components/dashboard/RecentActivityCard.tsx
@@ -47,13 +47,13 @@ export function RecentActivityCard() {
   const getLogColor = (level: string) => {
     switch (level) {
       case "error":
-        return "text-red-400";
+        return "text-[color:var(--red)]";
       case "warn":
-        return "text-yellow-400";
+        return "text-[color:var(--accent)]";
       case "info":
-        return "text-orange-400";
+        return "text-[color:var(--accent)]";
       default:
-        return "text-gray-400";
+        return "text-[color:var(--dim)]";
     }
   };
 
@@ -63,7 +63,7 @@ export function RecentActivityCard() {
         <CardHeader title="Recent Activity" />
         <div className="animate-pulse space-y-2">
           {[...Array(5)].map((_, i) => (
-            <div key={i} className="h-4 bg-gray-800 rounded w-full"></div>
+            <div key={i} className="h-4 bg-[var(--surface)] rounded w-full"></div>
           ))}
         </div>
       </Card>
@@ -75,7 +75,7 @@ export function RecentActivityCard() {
       <CardHeader
         title="Recent Activity"
         action={
-          <a href="/logs" className="text-sm text-gray-400 hover:text-gray-200">
+          <a href="/logs" className="text-sm text-[color:var(--dim)] hover:text-[color:var(--fg)]">
             View All
           </a>
         }
@@ -83,20 +83,20 @@ export function RecentActivityCard() {
 
       <div className="space-y-2 max-h-64 overflow-y-auto">
         {logs.length === 0 ? (
-          <p className="text-gray-500 text-sm">No recent activity</p>
+          <p className="text-[color:var(--fainter)] text-sm">No recent activity</p>
         ) : (
           logs.map((log, idx) => (
             <div
               key={idx}
-              className="flex items-start gap-3 text-sm py-1 border-b border-gray-800/50 last:border-0"
+              className="flex items-start gap-3 text-sm py-1 border-b border-[color:var(--rule)]/50 last:border-0"
             >
-              <span className="text-gray-500 font-mono text-xs whitespace-nowrap">
+              <span className="text-[color:var(--fainter)] font-mono text-xs whitespace-nowrap">
                 {formatTime(log.timestamp)}
               </span>
               <span className={getLogColor(log.level)}>
                 {getLogIcon(log.level, log.message)}
               </span>
-              <span className="text-gray-300 truncate">{log.message}</span>
+              <span className="text-[color:var(--dim)] truncate">{log.message}</span>
             </div>
           ))
         )}

--- a/dashboard/src/components/dashboard/SharesCard.tsx
+++ b/dashboard/src/components/dashboard/SharesCard.tsx
@@ -20,9 +20,9 @@ export function SharesCard() {
       <Card>
         <CardHeader title="Your Shares" subtitle="5-4-3-2-1 Reward System" />
         <div className="animate-pulse space-y-3">
-          <div className="h-12 bg-gray-800 rounded w-1/2 mx-auto"></div>
-          <div className="h-4 bg-gray-800 rounded w-3/4"></div>
-          <div className="h-4 bg-gray-800 rounded w-3/4"></div>
+          <div className="h-12 bg-[var(--surface)] rounded w-1/2 mx-auto"></div>
+          <div className="h-4 bg-[var(--surface)] rounded w-3/4"></div>
+          <div className="h-4 bg-[var(--surface)] rounded w-3/4"></div>
         </div>
       </Card>
     );
@@ -32,7 +32,7 @@ export function SharesCard() {
     return (
       <Card>
         <CardHeader title="Your Shares" />
-        <p className="text-gray-400">
+        <p className="text-[color:var(--dim)]">
           {error ? `Error: ${error.message}` : "Unable to load shares"}
         </p>
       </Card>
@@ -45,28 +45,28 @@ export function SharesCard() {
         title="Your Shares"
         subtitle="5-4-3-2-1 Reward System"
         action={
-          <span className="text-2xl font-bold text-gray-100">
+          <span className="text-2xl font-bold text-[color:var(--fg)]">
             {shares.total}
-            <span className="text-gray-500 text-lg"> / {shares.max_shares}</span>
+            <span className="text-[color:var(--fainter)] text-lg"> / {shares.max_shares}</span>
           </span>
         }
       />
 
       {/* Uptime Gatekeeper */}
-      <div className={`mb-4 p-3 rounded-lg ${shares.uptime_qualified ? "bg-green-900/20 border border-green-800" : "bg-red-900/20 border border-red-800"}`}>
+      <div className={`mb-4 p-3 rounded-lg ${shares.uptime_qualified ? "bg-[color-mix(in_srgb,var(--green)_16%,transparent)] border border-[color:var(--green)]" : "bg-[color-mix(in_srgb,var(--red)_16%,transparent)] border border-[color:var(--red)]"}`}>
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
-            <span className={shares.uptime_qualified ? "text-green-400" : "text-red-400"}>
+            <span className={shares.uptime_qualified ? "text-[color:var(--green)]" : "text-[color:var(--red)]"}>
               {shares.uptime_qualified ? "\u2713" : "\u2717"}
             </span>
-            <span className="text-sm text-gray-300">Uptime Gatekeeper</span>
+            <span className="text-sm text-[color:var(--dim)]">Uptime Gatekeeper</span>
           </div>
           <Badge variant={shares.uptime_qualified ? "success" : "error"}>
             {(shares.uptime_percent ?? 0).toFixed(1)}% (min 95%)
           </Badge>
         </div>
         {!shares.uptime_qualified && (
-          <p className="text-xs text-red-400 mt-2">
+          <p className="text-xs text-[color:var(--red)] mt-2">
             Below 95% uptime - all shares disabled until uptime recovers
           </p>
         )}
@@ -82,17 +82,17 @@ export function SharesCard() {
             <div
               key={tier.key}
               className={`flex items-center justify-between p-2 rounded ${
-                isActive && !isDisabled ? "bg-gray-800/50" : ""
+                isActive && !isDisabled ? "bg-[var(--surface)]/50" : ""
               }`}
             >
               <div className="flex items-center gap-3">
                 <span
                   className={`text-lg ${
                     isActive && !isDisabled
-                      ? "text-green-400"
+                      ? "text-[color:var(--green)]"
                       : isDisabled
-                      ? "text-gray-700"
-                      : "text-gray-600"
+                      ? "text-[color:var(--fainter)]"
+                      : "text-[color:var(--fainter)]"
                   }`}
                 >
                   {isActive ? "\u2713" : "\u2717"}
@@ -100,25 +100,25 @@ export function SharesCard() {
                 <span
                   className={
                     isActive && !isDisabled
-                      ? "text-gray-100"
+                      ? "text-[color:var(--fg)]"
                       : isDisabled
-                      ? "text-gray-600"
-                      : "text-gray-500"
+                      ? "text-[color:var(--fainter)]"
+                      : "text-[color:var(--fainter)]"
                   }
                 >
                   {tier.name}
                   {tier.key === "elder" && shares.elder && shares.elder_slot && (
-                    <span className="text-gray-500 ml-1">#{shares.elder_slot}</span>
+                    <span className="text-[color:var(--fainter)] ml-1">#{shares.elder_slot}</span>
                   )}
                 </span>
               </div>
               <span
                 className={`font-mono text-sm ${
                   isActive && !isDisabled
-                    ? "text-green-400"
+                    ? "text-[color:var(--green)]"
                     : isDisabled
-                    ? "text-gray-700"
-                    : "text-gray-600"
+                    ? "text-[color:var(--fainter)]"
+                    : "text-[color:var(--fainter)]"
                 }`}
               >
                 +{tier.bonus}
@@ -130,10 +130,10 @@ export function SharesCard() {
 
       {/* Estimated Reward */}
       {shares.estimated_reward_btc != null && (
-        <div className="mt-4 pt-4 border-t border-gray-800">
+        <div className="mt-4 pt-4 border-t border-[color:var(--rule)]">
           <div className="flex justify-between items-center">
-            <span className="text-sm text-gray-400">Est. Reward / Block</span>
-            <span className="font-mono text-gray-100">
+            <span className="text-sm text-[color:var(--dim)]">Est. Reward / Block</span>
+            <span className="font-mono text-[color:var(--fg)]">
               ~{(shares.estimated_reward_btc ?? 0).toFixed(8)} BTC
             </span>
           </div>

--- a/dashboard/src/components/dashboard/StatsGrid.tsx
+++ b/dashboard/src/components/dashboard/StatsGrid.tsx
@@ -12,20 +12,20 @@ interface StatBoxProps {
 function StatBox({ label, value, sublabel, loading }: StatBoxProps) {
   if (loading) {
     return (
-      <div className="bg-gray-800/50 rounded-lg p-4 text-center">
+      <div className="bg-[var(--surface)]/50 rounded-lg p-4 text-center">
         <div className="animate-pulse">
-          <div className="h-8 bg-gray-700 rounded w-16 mx-auto mb-2"></div>
-          <div className="h-4 bg-gray-700 rounded w-20 mx-auto"></div>
+          <div className="h-8 bg-[var(--rule-strong)] rounded w-16 mx-auto mb-2"></div>
+          <div className="h-4 bg-[var(--rule-strong)] rounded w-20 mx-auto"></div>
         </div>
       </div>
     );
   }
 
   return (
-    <div className="bg-gray-800/50 rounded-lg p-4 text-center">
-      <div className="text-2xl font-bold text-gray-100">{value}</div>
-      <div className="text-sm text-gray-400">{label}</div>
-      {sublabel && <div className="text-xs text-gray-500 mt-1">{sublabel}</div>}
+    <div className="bg-[var(--surface)]/50 rounded-lg p-4 text-center">
+      <div className="text-2xl font-bold text-[color:var(--fg)]">{value}</div>
+      <div className="text-sm text-[color:var(--dim)]">{label}</div>
+      {sublabel && <div className="text-xs text-[color:var(--fainter)] mt-1">{sublabel}</div>}
     </div>
   );
 }

--- a/dashboard/src/components/dashboard/StatusCard.tsx
+++ b/dashboard/src/components/dashboard/StatusCard.tsx
@@ -24,8 +24,8 @@ export function StatusCard() {
       <Card>
         <CardHeader title="Node Status" />
         <div className="animate-pulse space-y-3">
-          <div className="h-4 bg-gray-800 rounded w-3/4"></div>
-          <div className="h-4 bg-gray-800 rounded w-1/2"></div>
+          <div className="h-4 bg-[var(--surface)] rounded w-3/4"></div>
+          <div className="h-4 bg-[var(--surface)] rounded w-1/2"></div>
         </div>
       </Card>
     );
@@ -35,7 +35,7 @@ export function StatusCard() {
     return (
       <Card>
         <CardHeader title="Node Status" />
-        <p className="text-gray-400">
+        <p className="text-[color:var(--dim)]">
           {error ? `Error: ${error.message}` : "Unable to load status"}
         </p>
       </Card>
@@ -44,9 +44,9 @@ export function StatusCard() {
 
   const getColorClasses = (active: boolean) => {
     if (active) {
-      return { dot: "bg-green-500", badge: "success" as const };
+      return { dot: "bg-[var(--green)]", badge: "success" as const };
     }
-    return { dot: "bg-red-500", badge: "error" as const };
+    return { dot: "bg-[var(--red)]", badge: "error" as const };
   };
 
   return (
@@ -62,32 +62,32 @@ export function StatusCard() {
 
       <div className="space-y-4">
         <div className="flex justify-between items-center">
-          <span className="text-gray-400">Block Height</span>
-          <span className="font-mono text-gray-100">
+          <span className="text-[color:var(--dim)]">Block Height</span>
+          <span className="font-mono text-[color:var(--fg)]">
             {(status.sync_height ?? status.block_height ?? 0).toLocaleString()}
           </span>
         </div>
 
         <div className="flex justify-between items-center">
-          <span className="text-gray-400">Peers</span>
-          <span className="font-mono text-gray-100">{status.peer_count ?? 0}</span>
+          <span className="text-[color:var(--dim)]">Peers</span>
+          <span className="font-mono text-[color:var(--fg)]">{status.peer_count ?? 0}</span>
         </div>
 
         <div className="flex justify-between items-center">
-          <span className="text-gray-400">Mempool Profile</span>
-          <span className="font-mono text-gray-100 text-sm capitalize">
+          <span className="text-[color:var(--dim)]">Mempool Profile</span>
+          <span className="font-mono text-[color:var(--fg)] text-sm capitalize">
             {(status.mempool_profile ?? "standard").replace("_", " ")}
           </span>
         </div>
 
         <div className="flex justify-between items-center">
-          <span className="text-gray-400">Template Profile</span>
-          <span className="font-mono text-gray-100 text-sm capitalize">
+          <span className="text-[color:var(--dim)]">Template Profile</span>
+          <span className="font-mono text-[color:var(--fg)] text-sm capitalize">
             {(status.template_profile ?? "standard").replace("_", " ")}
           </span>
         </div>
 
-        <div className="pt-4 border-t border-gray-800 space-y-2">
+        <div className="pt-4 border-t border-[color:var(--rule)] space-y-2">
           {MODE_CONFIG_PRIMARY.map((mode) => {
             const isActive = status[mode.key as keyof typeof status] as boolean;
             const colors = getColorClasses(isActive);
@@ -95,7 +95,7 @@ export function StatusCard() {
             return (
               <div key={mode.key} className="flex items-center gap-2">
                 <span className={`w-2 h-2 rounded-full ${colors.dot}`} />
-                <span className="text-sm text-gray-300 flex-1">{mode.name}</span>
+                <span className="text-sm text-[color:var(--dim)] flex-1">{mode.name}</span>
                 <Badge variant={colors.badge}>
                   {isActive ? "Active" : "Off"}
                 </Badge>
@@ -104,7 +104,7 @@ export function StatusCard() {
           })}
         </div>
 
-        <div className="pt-3 border-t border-gray-800/50 space-y-2">
+        <div className="pt-3 border-t border-[color:var(--rule)]/50 space-y-2">
           {MODE_CONFIG_SECONDARY.map((mode) => {
             const isActive = status[mode.key as keyof typeof status] as boolean;
             const colors = getColorClasses(isActive);
@@ -112,7 +112,7 @@ export function StatusCard() {
             return (
               <div key={mode.key} className="flex items-center gap-2">
                 <span className={`w-2 h-2 rounded-full ${colors.dot}`} />
-                <span className="text-sm text-gray-300 flex-1">{mode.name}</span>
+                <span className="text-sm text-[color:var(--dim)] flex-1">{mode.name}</span>
                 <Badge variant={colors.badge}>
                   {isActive ? "Active" : "Off"}
                 </Badge>

--- a/dashboard/src/components/filtering/ReaperControls.tsx
+++ b/dashboard/src/components/filtering/ReaperControls.tsx
@@ -299,7 +299,7 @@ export function ReaperControls() {
         </div>
 
         {errorMsg && (
-          <p style={{ color: "var(--danger, #f87171)", fontSize: "13px" }}>{errorMsg}</p>
+          <p style={{ color: "var(--red)", fontSize: "13px" }}>{errorMsg}</p>
         )}
 
         <div

--- a/dashboard/src/components/layout/SidebarGroup.tsx
+++ b/dashboard/src/components/layout/SidebarGroup.tsx
@@ -34,8 +34,8 @@ export function SidebarGroup({ icon, label, items, collapsed = false }: SidebarG
           className={`
             flex items-center justify-center w-full px-3 py-2 rounded-lg transition-colors
             ${isAnyActive
-              ? 'bg-orange-500/20 text-orange-400'
-              : 'text-gray-400 hover:text-gray-200 hover:bg-gray-800/50'
+              ? 'bg-[var(--accent)]/20 text-[color:var(--accent)]'
+              : 'text-[color:var(--dim)] hover:text-[color:var(--fg)] hover:bg-[var(--surface)]/50'
             }
           `}
         >
@@ -44,8 +44,8 @@ export function SidebarGroup({ icon, label, items, collapsed = false }: SidebarG
 
         {/* Flyout menu on hover */}
         <div className="absolute left-full top-0 ml-2 hidden group-hover:block z-50">
-          <div className="bg-gray-900 border border-gray-700 rounded-lg shadow-xl py-1 min-w-40">
-            <div className="px-3 py-2 text-xs font-semibold text-gray-500 uppercase">
+          <div className="bg-[var(--surface)] border border-[color:var(--rule-strong)] rounded-lg shadow-xl py-1 min-w-40">
+            <div className="px-3 py-2 text-xs font-semibold text-[color:var(--fainter)] uppercase">
               {label}
             </div>
             {items.map((item) => (
@@ -55,8 +55,8 @@ export function SidebarGroup({ icon, label, items, collapsed = false }: SidebarG
                 className={`
                   block px-3 py-2 text-sm transition-colors
                   ${isPathActive(pathname, item.href)
-                    ? 'text-orange-400 bg-orange-500/10'
-                    : 'text-gray-300 hover:text-gray-100 hover:bg-gray-800'
+                    ? 'text-[color:var(--accent)] bg-[var(--accent)]/10'
+                    : 'text-[color:var(--dim)] hover:text-[color:var(--fg)] hover:bg-[var(--surface)]'
                   }
                 `}
               >
@@ -76,8 +76,8 @@ export function SidebarGroup({ icon, label, items, collapsed = false }: SidebarG
         className={`
           flex items-center justify-between w-full px-3 py-2 rounded-lg transition-colors
           ${isAnyActive
-            ? 'bg-orange-500/20 text-orange-400'
-            : 'text-gray-400 hover:text-gray-200 hover:bg-gray-800/50'
+            ? 'bg-[var(--accent)]/20 text-[color:var(--accent)]'
+            : 'text-[color:var(--dim)] hover:text-[color:var(--fg)] hover:bg-[var(--surface)]/50'
           }
         `}
       >
@@ -96,7 +96,7 @@ export function SidebarGroup({ icon, label, items, collapsed = false }: SidebarG
       </button>
 
       {isOpen && (
-        <div className="mt-1 ml-4 pl-4 border-l border-gray-800 space-y-1">
+        <div className="mt-1 ml-4 pl-4 border-l border-[color:var(--rule)] space-y-1">
           {items.map((item) => (
             <Link
               key={item.href}
@@ -104,8 +104,8 @@ export function SidebarGroup({ icon, label, items, collapsed = false }: SidebarG
               className={`
                 block px-3 py-2 text-sm rounded-lg transition-colors
                 ${isPathActive(pathname, item.href)
-                  ? 'text-orange-400 bg-orange-500/10'
-                  : 'text-gray-400 hover:text-gray-200 hover:bg-gray-800/50'
+                  ? 'text-[color:var(--accent)] bg-[var(--accent)]/10'
+                  : 'text-[color:var(--dim)] hover:text-[color:var(--fg)] hover:bg-[var(--surface)]/50'
                 }
               `}
             >

--- a/dashboard/src/components/settings/AutoUpdateSection.tsx
+++ b/dashboard/src/components/settings/AutoUpdateSection.tsx
@@ -50,19 +50,19 @@ export function AutoUpdateSection() {
     <div className="flex items-center justify-between">
       <div className="pr-4">
         <div className="flex items-center gap-2">
-          <span className="text-sm font-medium text-gray-300">Automatic updates</span>
+          <span className="text-sm font-medium text-[color:var(--dim)]">Automatic updates</span>
           <Badge variant={autoUpdateEnabled ? "success" : "default"}>
             {autoUpdateEnabled ? "On" : "Off"}
           </Badge>
         </div>
-        <p className="text-xs text-gray-500 mt-0.5">
+        <p className="text-xs text-[color:var(--fainter)] mt-0.5">
           When on, newer <strong>signed</strong> releases are applied automatically —
           the GPG signature and ghostd checksum are verified before any binary is
           swapped, and the node rolls back on a failed health check. Checked every 6h.
           Off by default.
         </p>
         {autoUpdate?.last_status?.result && (
-          <p className="text-xs text-gray-500 mt-1">
+          <p className="text-xs text-[color:var(--fainter)] mt-1">
             Last check: {autoUpdate.last_status.result}
             {autoUpdate.last_status.last_run
               ? ` · ${formatDate(autoUpdate.last_status.last_run)}`

--- a/dashboard/src/components/settings/ScheduledBackupsCard.tsx
+++ b/dashboard/src/components/settings/ScheduledBackupsCard.tsx
@@ -105,10 +105,10 @@ export function ScheduledBackupsCard() {
 
       <div className="space-y-6">
         {/* Enable */}
-        <div className="flex items-center justify-between p-4 bg-gray-800/50 rounded-lg">
+        <div className="flex items-center justify-between p-4 bg-[var(--surface)]/50 rounded-lg">
           <div>
-            <div className="text-gray-100 font-medium">Enable scheduled backups</div>
-            <p className="text-sm text-gray-400">
+            <div className="text-[color:var(--fg)] font-medium">Enable scheduled backups</div>
+            <p className="text-sm text-[color:var(--dim)]">
               Off by default. When on, the node writes an encrypted backup to the target
               directory on each interval and prunes old copies automatically.
             </p>
@@ -122,18 +122,18 @@ export function ScheduledBackupsCard() {
         {/* Settings */}
         <div className="grid gap-4 sm:grid-cols-2">
           <div className="space-y-1">
-            <label className="block text-sm font-medium text-gray-300">Interval</label>
+            <label className="block text-sm font-medium text-[color:var(--dim)]">Interval</label>
             <select
               value={intervalKind}
               onChange={(e) => setIntervalKind(e.target.value as IntervalKind)}
               disabled={!enabled}
-              className="w-full px-3 py-2 text-sm bg-gray-800 border border-gray-700 rounded-lg text-gray-100 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-transparent disabled:opacity-50 disabled:cursor-not-allowed"
+              className="w-full px-3 py-2 text-sm bg-[var(--surface)] border border-[color:var(--rule-strong)] rounded-lg text-[color:var(--fg)] focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-transparent disabled:opacity-50 disabled:cursor-not-allowed"
             >
               <option value="daily">Daily (every 24h)</option>
               <option value="weekly">Weekly (every 7 days)</option>
               <option value="custom">Custom (hours)</option>
             </select>
-            <p className="text-xs text-gray-500">How often a backup is created.</p>
+            <p className="text-xs text-[color:var(--fainter)]">How often a backup is created.</p>
           </div>
 
           {intervalKind === "custom" && (
@@ -169,20 +169,20 @@ export function ScheduledBackupsCard() {
         </div>
 
         {/* Last run status */}
-        <div className="p-4 bg-gray-800/50 rounded-lg border border-gray-700">
+        <div className="p-4 bg-[var(--surface)]/50 rounded-lg border border-[color:var(--rule-strong)]">
           <div className="flex items-center justify-between mb-2">
-            <h4 className="text-sm font-medium text-gray-300">Last run</h4>
+            <h4 className="text-sm font-medium text-[color:var(--dim)]">Last run</h4>
             {status?.last_success === true && <Badge variant="success">Success</Badge>}
             {status?.last_success === false && <Badge variant="error">Failed</Badge>}
             {status?.last_run_unix == null && <Badge variant="default">Never run</Badge>}
           </div>
-          <div className="text-sm text-gray-400 space-y-1">
+          <div className="text-sm text-[color:var(--dim)] space-y-1">
             <div>Time: {formatUnix(status?.last_run_unix)}</div>
             {status?.last_path && (
               <div className="break-all">Path: {status.last_path}</div>
             )}
             {status?.last_error && (
-              <div className="text-red-400 break-all">Error: {status.last_error}</div>
+              <div className="text-[color:var(--red)] break-all">Error: {status.last_error}</div>
             )}
           </div>
         </div>
@@ -196,7 +196,7 @@ export function ScheduledBackupsCard() {
           >
             Save schedule
           </Button>
-          <span className="text-xs text-gray-500">
+          <span className="text-xs text-[color:var(--fainter)]">
             Backups inherit the database encryption; store the target directory securely.
           </span>
         </div>

--- a/dashboard/src/components/settings/StoragePruningCard.tsx
+++ b/dashboard/src/components/settings/StoragePruningCard.tsx
@@ -97,14 +97,14 @@ export function StoragePruningCard() {
       />
       <div className="space-y-6">
         {/* Archive Mode Toggle */}
-        <div className="p-4 bg-gray-800/50 rounded-lg">
+        <div className="p-4 bg-[var(--surface)]/50 rounded-lg">
           <div className="flex items-center justify-between">
             <div>
               <div className="flex items-center gap-2">
-                <span className="text-gray-100 font-medium">Archive Mode</span>
+                <span className="text-[color:var(--fg)] font-medium">Archive Mode</span>
                 {archiveMode && <Badge variant="success">+5 Shares</Badge>}
               </div>
-              <p className="text-sm text-gray-400 mt-1">
+              <p className="text-sm text-[color:var(--dim)] mt-1">
                 Store complete blockchain history. Disables all pruning and earns bonus shares.
               </p>
             </div>
@@ -121,43 +121,43 @@ export function StoragePruningCard() {
         {/* Window Visualization */}
         <div className="grid grid-cols-3 gap-4">
           {/* Validator Window */}
-          <div className="p-4 bg-orange-900/20 border border-orange-800 rounded-lg">
-            <div className="text-orange-400 font-medium mb-2">Validator Window (VW)</div>
-            <div className="text-2xl font-bold text-gray-100">288 blocks</div>
-            <div className="text-sm text-gray-400 mt-1">~2 days</div>
-            <div className="mt-3 text-xs text-orange-300">
+          <div className="p-4 bg-[color-mix(in_srgb,var(--accent)_16%,transparent)] border border-[color:var(--accent)] rounded-lg">
+            <div className="text-[color:var(--accent)] font-medium mb-2">Validator Window (VW)</div>
+            <div className="text-2xl font-bold text-[color:var(--fg)]">288 blocks</div>
+            <div className="text-sm text-[color:var(--dim)] mt-1">~2 days</div>
+            <div className="mt-3 text-xs text-[color:var(--accent)]">
               Fixed - Bitcoin Core minimum for reorg safety
             </div>
           </div>
 
           {/* Operator Window */}
-          <div className={`p-4 rounded-lg border ${archiveMode ? "bg-gray-800/30 border-gray-700" : "bg-orange-900/20 border-orange-800"}`}>
-            <div className={`font-medium mb-2 ${archiveMode ? "text-gray-500" : "text-orange-400"}`}>
+          <div className={`p-4 rounded-lg border ${archiveMode ? "bg-[var(--surface)]/30 border-[color:var(--rule-strong)]" : "bg-[color-mix(in_srgb,var(--accent)_16%,transparent)] border-[color:var(--accent)]"}`}>
+            <div className={`font-medium mb-2 ${archiveMode ? "text-[color:var(--fainter)]" : "text-[color:var(--accent)]"}`}>
               Operator Window (OW)
             </div>
-            <div className={`text-2xl font-bold ${archiveMode ? "text-gray-500" : "text-gray-100"}`}>
+            <div className={`text-2xl font-bold ${archiveMode ? "text-[color:var(--fainter)]" : "text-[color:var(--fg)]"}`}>
               {fullConfig?.pruning?.ow_blocks ?? 2016} blocks
             </div>
-            <div className="text-sm text-gray-400 mt-1">
+            <div className="text-sm text-[color:var(--dim)] mt-1">
               ~{formatDuration(fullConfig?.pruning?.ow_blocks ?? 2016)}
             </div>
-            <div className={`mt-3 text-xs ${archiveMode ? "text-gray-500" : "text-orange-300"}`}>
+            <div className={`mt-3 text-xs ${archiveMode ? "text-[color:var(--fainter)]" : "text-[color:var(--accent)]"}`}>
               {archiveMode ? "Disabled (Archive Mode)" : "BUDS-based pruning applied here"}
             </div>
           </div>
 
           {/* Archive Window */}
-          <div className={`p-4 rounded-lg border ${archiveMode ? "bg-green-900/20 border-green-800" : "bg-gray-800/30 border-gray-700"}`}>
-            <div className={`font-medium mb-2 ${archiveMode ? "text-green-400" : "text-gray-500"}`}>
+          <div className={`p-4 rounded-lg border ${archiveMode ? "bg-[color-mix(in_srgb,var(--green)_16%,transparent)] border-[color:var(--green)]" : "bg-[var(--surface)]/30 border-[color:var(--rule-strong)]"}`}>
+            <div className={`font-medium mb-2 ${archiveMode ? "text-[color:var(--green)]" : "text-[color:var(--fainter)]"}`}>
               Archive Window (AW)
             </div>
-            <div className={`text-2xl font-bold ${archiveMode ? "text-gray-100" : "text-gray-500"}`}>
+            <div className={`text-2xl font-bold ${archiveMode ? "text-[color:var(--fg)]" : "text-[color:var(--fainter)]"}`}>
               {archiveMode ? "Infinite" : "Pruned"}
             </div>
-            <div className="text-sm text-gray-400 mt-1">
+            <div className="text-sm text-[color:var(--dim)] mt-1">
               {archiveMode ? "All history retained" : "Data beyond OW is deleted"}
             </div>
-            <div className={`mt-3 text-xs ${archiveMode ? "text-green-300" : "text-gray-500"}`}>
+            <div className={`mt-3 text-xs ${archiveMode ? "text-[color:var(--green)]" : "text-[color:var(--fainter)]"}`}>
               {archiveMode ? "Full chain storage enabled" : "Enable Archive Mode for +5 shares"}
             </div>
           </div>
@@ -166,7 +166,7 @@ export function StoragePruningCard() {
         {/* Operator Window Selection (only if not archive mode) */}
         {!archiveMode && (
           <div className="space-y-3">
-            <label className="text-sm font-medium text-gray-300">Operator Window Size</label>
+            <label className="text-sm font-medium text-[color:var(--dim)]">Operator Window Size</label>
             <div className="grid grid-cols-3 gap-3">
               {OW_PRESETS.map((preset) => (
                 <button
@@ -175,13 +175,13 @@ export function StoragePruningCard() {
                   disabled={setOperatorWindow.isPending}
                   className={`p-3 rounded-lg border transition-colors text-left ${
                     fullConfig?.pruning?.ow_blocks === preset.blocks
-                      ? "bg-orange-900/30 border-orange-600 text-orange-300"
-                      : "bg-gray-800/50 border-gray-700 text-gray-300 hover:border-gray-500"
+                      ? "bg-[color-mix(in_srgb,var(--accent)_16%,transparent)] border-[color:var(--accent)] text-[color:var(--accent)]"
+                      : "bg-[var(--surface)]/50 border-[color:var(--rule-strong)] text-[color:var(--dim)] hover:border-[color:var(--rule-strong)]"
                   }`}
                 >
                   <div className="font-medium">{preset.label}</div>
-                  <div className="text-xs text-gray-500 mt-1">{preset.blocks} blocks</div>
-                  <div className="text-xs text-gray-400 mt-1">{preset.description}</div>
+                  <div className="text-xs text-[color:var(--fainter)] mt-1">{preset.blocks} blocks</div>
+                  <div className="text-xs text-[color:var(--dim)] mt-1">{preset.description}</div>
                 </button>
               ))}
             </div>
@@ -191,8 +191,8 @@ export function StoragePruningCard() {
         {/* Prune Profile Selection (only if not archive mode) */}
         {!archiveMode && (
           <div className="space-y-3">
-            <label className="text-sm font-medium text-gray-300">BUDS Prune Profile</label>
-            <p className="text-xs text-gray-500">
+            <label className="text-sm font-medium text-[color:var(--dim)]">BUDS Prune Profile</label>
+            <p className="text-xs text-[color:var(--fainter)]">
               Controls which BUDS tiers are retained in the Operator Window
             </p>
             <div className="grid grid-cols-2 md:grid-cols-5 gap-2">
@@ -203,13 +203,13 @@ export function StoragePruningCard() {
                   disabled={setPruneProfile.isPending}
                   className={`p-3 rounded-lg border transition-colors text-left ${
                     fullConfig?.pruning?.prune_profile === profile.value
-                      ? "bg-orange-900/30 border-orange-600 text-orange-300"
-                      : "bg-gray-800/50 border-gray-700 text-gray-300 hover:border-gray-500"
+                      ? "bg-[color-mix(in_srgb,var(--accent)_16%,transparent)] border-[color:var(--accent)] text-[color:var(--accent)]"
+                      : "bg-[var(--surface)]/50 border-[color:var(--rule-strong)] text-[color:var(--dim)] hover:border-[color:var(--rule-strong)]"
                   }`}
                 >
                   <div className="font-medium capitalize">{profile.label}</div>
-                  <div className="text-xs text-green-400 mt-1">Keep: {profile.keep}</div>
-                  <div className="text-xs text-red-400">Prune: {profile.prune}</div>
+                  <div className="text-xs text-[color:var(--green)] mt-1">Keep: {profile.keep}</div>
+                  <div className="text-xs text-[color:var(--red)]">Prune: {profile.prune}</div>
                 </button>
               ))}
             </div>

--- a/dashboard/src/components/ui/Badge.tsx
+++ b/dashboard/src/components/ui/Badge.tsx
@@ -9,11 +9,11 @@ interface BadgeProps {
 }
 
 const variants: Record<BadgeVariant, string> = {
-  success: "bg-green-900 text-green-300 border-green-700",
-  warning: "bg-orange-900 text-orange-300 border-orange-700",
-  error: "bg-red-900 text-red-300 border-red-700",
+  success: "bg-[color-mix(in_srgb,var(--green)_16%,transparent)] text-[color:var(--green)] border-[color-mix(in_srgb,var(--green)_40%,transparent)]",
+  warning: "bg-[color-mix(in_srgb,var(--accent)_16%,transparent)] text-[color:var(--accent)] border-[color-mix(in_srgb,var(--accent)_40%,transparent)]",
+  error: "bg-[color-mix(in_srgb,var(--red)_16%,transparent)] text-[color:var(--red)] border-[color-mix(in_srgb,var(--red)_40%,transparent)]",
   info: "bg-blue-900 text-blue-300 border-blue-700",
-  default: "bg-gray-800 text-gray-300 border-gray-700",
+  default: "bg-[var(--surface)] text-[color:var(--dim)] border-[color:var(--rule-strong)]",
 };
 
 export function Badge({ children, variant = "default", className = "" }: BadgeProps) {

--- a/dashboard/src/components/ui/Button.tsx
+++ b/dashboard/src/components/ui/Button.tsx
@@ -12,14 +12,14 @@ interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 }
 
 const variantClasses: Record<ButtonVariant, string> = {
-  default: 'bg-gray-700 text-gray-100 hover:bg-gray-600 border-gray-600',
-  primary: 'bg-orange-600 text-white hover:bg-orange-500 border-orange-500',
-  secondary: 'bg-orange-600 text-white hover:bg-orange-500 border-orange-500',
-  outline: 'bg-transparent text-gray-300 hover:bg-gray-800 border-gray-600',
-  ghost: 'bg-transparent text-gray-300 hover:bg-gray-800 border-transparent',
-  danger: 'bg-red-600 text-white hover:bg-red-500 border-red-500',
-  success: 'bg-green-600 text-white hover:bg-green-500 border-green-500',
-  warning: 'bg-yellow-600 text-white hover:bg-yellow-500 border-yellow-500',
+  default: 'bg-[var(--rule-strong)] text-[color:var(--fg)] hover:bg-[var(--rule-strong)] border-[color:var(--rule-strong)]',
+  primary: 'bg-[var(--accent)] text-[color:var(--fg)] hover:bg-[var(--accent)] border-[color:var(--accent)]',
+  secondary: 'bg-[var(--accent)] text-[color:var(--fg)] hover:bg-[var(--accent)] border-[color:var(--accent)]',
+  outline: 'bg-transparent text-[color:var(--dim)] hover:bg-[var(--surface)] border-[color:var(--rule-strong)]',
+  ghost: 'bg-transparent text-[color:var(--dim)] hover:bg-[var(--surface)] border-transparent',
+  danger: 'bg-[var(--red)] text-[color:var(--fg)] hover:bg-[var(--red)] border-[color:var(--red)]',
+  success: 'bg-[var(--green)] text-[color:var(--fg)] hover:bg-[var(--green)] border-[color:var(--green)]',
+  warning: 'bg-[var(--accent)] text-[color:var(--fg)] hover:bg-[var(--accent)] border-[color:var(--accent)]',
 };
 
 const sizeClasses: Record<ButtonSize, string> = {
@@ -38,7 +38,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         disabled={isDisabled}
         className={`
           inline-flex items-center justify-center font-medium rounded-lg border transition-colors
-          focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-900 focus:ring-orange-500
+          focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[color:var(--surface)] focus:ring-orange-500
           disabled:opacity-50 disabled:cursor-not-allowed
           ${variantClasses[variant]}
           ${sizeClasses[size]}

--- a/dashboard/src/components/ui/Card.tsx
+++ b/dashboard/src/components/ui/Card.tsx
@@ -33,7 +33,7 @@ export function Card({ children, className = '', collapsible, defaultCollapsed =
   const body = childArray.slice(1);
 
   return (
-    <div className={`bg-gray-900 border border-gray-800 rounded-lg p-6 ${className}`}>
+    <div className={`bg-[var(--surface)] border border-[color:var(--rule)] rounded-lg p-6 ${className}`}>
       <div
         className="cursor-pointer select-none"
         onClick={() => setCollapsed(!collapsed)}
@@ -41,7 +41,7 @@ export function Card({ children, className = '', collapsible, defaultCollapsed =
         <div className="flex items-center justify-between">
           <div className="flex-1">{header}</div>
           <svg
-            className={`w-5 h-5 text-gray-400 transition-transform flex-shrink-0 ml-2 ${collapsed ? '' : 'rotate-180'}`}
+            className={`w-5 h-5 text-[color:var(--dim)] transition-transform flex-shrink-0 ml-2 ${collapsed ? '' : 'rotate-180'}`}
             fill="none"
             viewBox="0 0 24 24"
             stroke="currentColor"

--- a/dashboard/src/components/ui/CopyButton.tsx
+++ b/dashboard/src/components/ui/CopyButton.tsx
@@ -34,12 +34,12 @@ export function CopyButton({ text, label, className = '' }: CopyButtonProps) {
   return (
     <button
       onClick={handleCopy}
-      className={`inline-flex items-center gap-1.5 text-sm text-gray-400 hover:text-gray-200 transition-colors ${className}`}
+      className={`inline-flex items-center gap-1.5 text-sm text-[color:var(--dim)] hover:text-[color:var(--fg)] transition-colors ${className}`}
       title={copied ? 'Copied!' : 'Click to copy'}
     >
       {label && <span className="font-mono truncate">{label}</span>}
       <svg
-        className={`w-3.5 h-3.5 flex-shrink-0 ${copied ? 'text-green-400' : ''}`}
+        className={`w-3.5 h-3.5 flex-shrink-0 ${copied ? 'text-[color:var(--green)]' : ''}`}
         fill="none"
         viewBox="0 0 24 24"
         stroke="currentColor"

--- a/dashboard/src/components/ui/DataTable.tsx
+++ b/dashboard/src/components/ui/DataTable.tsx
@@ -66,7 +66,7 @@ export function DataTable<TData, TValue>({
       <div className="space-y-4">
         {searchColumn && (
           <div className="max-w-sm">
-            <div className="h-10 bg-gray-800 rounded-lg animate-pulse" />
+            <div className="h-10 bg-[var(--surface)] rounded-lg animate-pulse" />
           </div>
         )}
         <SkeletonTable rows={loadingRows} cols={columns.length} />
@@ -88,18 +88,18 @@ export function DataTable<TData, TValue>({
       )}
 
       {/* Table */}
-      <div className="rounded-lg border border-gray-800 overflow-hidden">
+      <div className="rounded-lg border border-[color:var(--rule)] overflow-hidden">
         <div className="overflow-x-auto">
           <table className="w-full">
-            <thead className="bg-gray-800/50">
+            <thead className="bg-[var(--surface)]/50">
               {table.getHeaderGroups().map((headerGroup) => (
                 <tr key={headerGroup.id}>
                   {headerGroup.headers.map((header) => (
                     <th
                       key={header.id}
                       className={`
-                        px-4 py-3 text-left text-sm font-medium text-gray-400
-                        ${header.column.getCanSort() ? 'cursor-pointer hover:text-gray-200 select-none' : ''}
+                        px-4 py-3 text-left text-sm font-medium text-[color:var(--dim)]
+                        ${header.column.getCanSort() ? 'cursor-pointer hover:text-[color:var(--fg)] select-none' : ''}
                       `}
                       onClick={header.column.getToggleSortingHandler()}
                     >
@@ -108,7 +108,7 @@ export function DataTable<TData, TValue>({
                           ? null
                           : flexRender(header.column.columnDef.header, header.getContext())}
                         {header.column.getIsSorted() && (
-                          <span className="text-orange-400">
+                          <span className="text-[color:var(--accent)]">
                             {header.column.getIsSorted() === 'asc' ? '\u2191' : '\u2193'}
                           </span>
                         )}
@@ -118,7 +118,7 @@ export function DataTable<TData, TValue>({
                 </tr>
               ))}
             </thead>
-            <tbody className="divide-y divide-gray-800">
+            <tbody className="divide-y divide-[color:var(--rule)]">
               {table.getRowModel().rows.length === 0 ? (
                 <tr>
                   <td colSpan={columns.length}>
@@ -133,10 +133,10 @@ export function DataTable<TData, TValue>({
                 table.getRowModel().rows.map((row) => (
                   <tr
                     key={row.id}
-                    className="hover:bg-gray-800/30 transition-colors"
+                    className="hover:bg-[var(--surface)]/30 transition-colors"
                   >
                     {row.getVisibleCells().map((cell) => (
-                      <td key={cell.id} className="px-4 py-3 text-sm text-gray-100">
+                      <td key={cell.id} className="px-4 py-3 text-sm text-[color:var(--fg)]">
                         {flexRender(cell.column.columnDef.cell, cell.getContext())}
                       </td>
                     ))}
@@ -151,7 +151,7 @@ export function DataTable<TData, TValue>({
       {/* Pagination */}
       {showPagination && table.getPageCount() > 1 && (
         <div className="flex items-center justify-between">
-          <span className="text-sm text-gray-400">
+          <span className="text-sm text-[color:var(--dim)]">
             Page {table.getState().pagination.pageIndex + 1} of {table.getPageCount()}
             {' \u00b7 '}
             {table.getFilteredRowModel().rows.length} total rows

--- a/dashboard/src/components/ui/Dialog.tsx
+++ b/dashboard/src/components/ui/Dialog.tsx
@@ -47,7 +47,7 @@ export function Dialog({ isOpen, onClose, title, description, children, footer, 
     <div className="fixed inset-0 z-50 flex items-center justify-center">
       {/* Backdrop */}
       <div
-        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+        className="absolute inset-0 bg-[var(--bg)]/60 backdrop-blur-sm"
         onClick={onClose}
       />
 
@@ -55,21 +55,21 @@ export function Dialog({ isOpen, onClose, title, description, children, footer, 
       <div
         className={`
           relative z-10 w-full ${sizeClasses[size]} mx-4
-          bg-gray-900 border border-gray-700 rounded-xl shadow-2xl
+          bg-[var(--surface)] border border-[color:var(--rule-strong)] rounded-xl shadow-2xl
           animate-in fade-in zoom-in-95 duration-200
         `}
       >
         {/* Header */}
-        <div className="flex items-start justify-between p-4 border-b border-gray-800">
+        <div className="flex items-start justify-between p-4 border-b border-[color:var(--rule)]">
           <div>
-            <h2 className="text-lg font-semibold text-gray-100">{title}</h2>
+            <h2 className="text-lg font-semibold text-[color:var(--fg)]">{title}</h2>
             {description && (
-              <p className="mt-1 text-sm text-gray-400">{description}</p>
+              <p className="mt-1 text-sm text-[color:var(--dim)]">{description}</p>
             )}
           </div>
           <button
             onClick={onClose}
-            className="p-1 text-gray-400 hover:text-gray-200 rounded-lg hover:bg-gray-800 transition-colors"
+            className="p-1 text-[color:var(--dim)] hover:text-[color:var(--fg)] rounded-lg hover:bg-[var(--surface)] transition-colors"
           >
             <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
@@ -84,7 +84,7 @@ export function Dialog({ isOpen, onClose, title, description, children, footer, 
 
         {/* Footer */}
         {footer && (
-          <div className="flex items-center justify-end gap-3 p-4 border-t border-gray-800">
+          <div className="flex items-center justify-end gap-3 p-4 border-t border-[color:var(--rule)]">
             {footer}
           </div>
         )}
@@ -150,7 +150,7 @@ export function ConfirmDialog({
         </>
       }
     >
-      <p className="text-gray-300">{message}</p>
+      <p className="text-[color:var(--dim)]">{message}</p>
     </Dialog>
   );
 }

--- a/dashboard/src/components/ui/EmptyState.tsx
+++ b/dashboard/src/components/ui/EmptyState.tsx
@@ -12,13 +12,13 @@ export function EmptyState({ icon, title, description, action, className = '' }:
   return (
     <div className={`flex flex-col items-center justify-center py-12 px-4 text-center ${className}`}>
       {icon && (
-        <div className="w-12 h-12 text-gray-600 mb-4">
+        <div className="w-12 h-12 text-[color:var(--fainter)] mb-4">
           {icon}
         </div>
       )}
-      <h3 className="text-sm font-medium text-gray-300 mb-1">{title}</h3>
+      <h3 className="text-sm font-medium text-[color:var(--dim)] mb-1">{title}</h3>
       {description && (
-        <p className="text-sm text-gray-500 max-w-sm">{description}</p>
+        <p className="text-sm text-[color:var(--fainter)] max-w-sm">{description}</p>
       )}
       {action && (
         <div className="mt-4">{action}</div>

--- a/dashboard/src/components/ui/FlowDiagram.tsx
+++ b/dashboard/src/components/ui/FlowDiagram.tsx
@@ -5,16 +5,16 @@ interface FlowDiagramStep {
 }
 
 const ACCENT_COLORS: Record<string, { bg: string; border: string; text: string }> = {
-  orange: { bg: "bg-orange-900/10", border: "border-orange-600/30", text: "text-orange-400" },
+  orange: { bg: "bg-[color-mix(in_srgb,var(--accent)_10%,transparent)]", border: "border-[color-mix(in_srgb,var(--accent)_30%,transparent)]", text: "text-[color:var(--accent)]" },
   blue:   { bg: "bg-blue-900/10",   border: "border-blue-600/30",   text: "text-blue-400" },
-  red:    { bg: "bg-red-900/10",    border: "border-red-600/30",    text: "text-red-400" },
-  green:  { bg: "bg-green-900/10",  border: "border-green-600/30",  text: "text-green-400" },
+  red:    { bg: "bg-[color-mix(in_srgb,var(--red)_10%,transparent)]",    border: "border-[color-mix(in_srgb,var(--red)_30%,transparent)]",    text: "text-[color:var(--red)]" },
+  green:  { bg: "bg-[color-mix(in_srgb,var(--green)_10%,transparent)]",  border: "border-[color-mix(in_srgb,var(--green)_30%,transparent)]",  text: "text-[color:var(--green)]" },
   purple: { bg: "bg-purple-900/10", border: "border-purple-600/30", text: "text-purple-400" },
 };
 
 function FlowArrow() {
   return (
-    <div className="flex items-center px-1 text-gray-600 flex-shrink-0">
+    <div className="flex items-center px-1 text-[color:var(--fainter)] flex-shrink-0">
       <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
         <path strokeLinecap="round" strokeLinejoin="round" d="M13 7l5 5m0 0l-5 5m5-5H6" />
       </svg>
@@ -38,12 +38,12 @@ export function FlowDiagram({ steps, accentColor = "blue" }: FlowDiagramProps) {
           <div className={`flex-1 text-center px-3 py-4 rounded-lg border ${
             step.accent
               ? `${colors.bg} ${colors.border}`
-              : "bg-gray-800/50 border-gray-700"
+              : "bg-[var(--surface)]/50 border-[color:var(--rule-strong)]"
           }`}>
-            <div className={`text-sm font-medium ${step.accent ? colors.text : "text-gray-100"}`}>
+            <div className={`text-sm font-medium ${step.accent ? colors.text : "text-[color:var(--fg)]"}`}>
               {step.label}
             </div>
-            <div className="text-xs text-gray-500 mt-1">{step.sublabel}</div>
+            <div className="text-xs text-[color:var(--fainter)] mt-1">{step.sublabel}</div>
           </div>
         </div>
       ))}

--- a/dashboard/src/components/ui/Input.tsx
+++ b/dashboard/src/components/ui/Input.tsx
@@ -13,7 +13,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
     return (
       <div className="space-y-1">
         {label && (
-          <label className="block text-sm font-medium text-gray-300">
+          <label className="block text-sm font-medium text-[color:var(--dim)]">
             {label}
           </label>
         )}
@@ -21,20 +21,20 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
           ref={ref}
           className={`
             w-full px-3 py-2 text-sm
-            bg-gray-800 border rounded-lg
-            text-gray-100 placeholder-gray-500
+            bg-[var(--surface)] border rounded-lg
+            text-[color:var(--fg)] placeholder-[color:var(--fainter)]
             focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-transparent
             disabled:opacity-50 disabled:cursor-not-allowed
-            ${error ? 'border-red-500' : 'border-gray-700'}
+            ${error ? 'border-[color:var(--red)]' : 'border-[color:var(--rule-strong)]'}
             ${className}
           `.trim()}
           {...props}
         />
         {error && (
-          <p className="text-xs text-red-400">{error}</p>
+          <p className="text-xs text-[color:var(--red)]">{error}</p>
         )}
         {helperText && !error && (
-          <p className="text-xs text-gray-500">{helperText}</p>
+          <p className="text-xs text-[color:var(--fainter)]">{helperText}</p>
         )}
       </div>
     );
@@ -54,7 +54,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
     return (
       <div className="space-y-1">
         {label && (
-          <label className="block text-sm font-medium text-gray-300">
+          <label className="block text-sm font-medium text-[color:var(--dim)]">
             {label}
           </label>
         )}
@@ -62,21 +62,21 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
           ref={ref}
           className={`
             w-full px-3 py-2 text-sm
-            bg-gray-800 border rounded-lg
-            text-gray-100 placeholder-gray-500
+            bg-[var(--surface)] border rounded-lg
+            text-[color:var(--fg)] placeholder-[color:var(--fainter)]
             focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-transparent
             disabled:opacity-50 disabled:cursor-not-allowed
             resize-none
-            ${error ? 'border-red-500' : 'border-gray-700'}
+            ${error ? 'border-[color:var(--red)]' : 'border-[color:var(--rule-strong)]'}
             ${className}
           `.trim()}
           {...props}
         />
         {error && (
-          <p className="text-xs text-red-400">{error}</p>
+          <p className="text-xs text-[color:var(--red)]">{error}</p>
         )}
         {helperText && !error && (
-          <p className="text-xs text-gray-500">{helperText}</p>
+          <p className="text-xs text-[color:var(--fainter)]">{helperText}</p>
         )}
       </div>
     );
@@ -97,7 +97,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
     return (
       <div className="space-y-1">
         {label && (
-          <label className="block text-sm font-medium text-gray-300">
+          <label className="block text-sm font-medium text-[color:var(--dim)]">
             {label}
           </label>
         )}
@@ -105,11 +105,11 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
           ref={ref}
           className={`
             w-full px-3 py-2 text-sm
-            bg-gray-800 border rounded-lg
-            text-gray-100
+            bg-[var(--surface)] border rounded-lg
+            text-[color:var(--fg)]
             focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-transparent
             disabled:opacity-50 disabled:cursor-not-allowed
-            ${error ? 'border-red-500' : 'border-gray-700'}
+            ${error ? 'border-[color:var(--red)]' : 'border-[color:var(--rule-strong)]'}
             ${className}
           `.trim()}
           {...(props as React.SelectHTMLAttributes<HTMLSelectElement>)}
@@ -121,10 +121,10 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
           ))}
         </select>
         {error && (
-          <p className="text-xs text-red-400">{error}</p>
+          <p className="text-xs text-[color:var(--red)]">{error}</p>
         )}
         {helperText && !error && (
-          <p className="text-xs text-gray-500">{helperText}</p>
+          <p className="text-xs text-[color:var(--fainter)]">{helperText}</p>
         )}
       </div>
     );

--- a/dashboard/src/components/ui/PageLoader.tsx
+++ b/dashboard/src/components/ui/PageLoader.tsx
@@ -4,7 +4,7 @@ export function PageLoader({ message }: { message?: string }) {
   return (
     <div className="flex flex-col items-center justify-center py-24">
       <svg
-        className="animate-spin h-8 w-8 text-orange-500"
+        className="animate-spin h-8 w-8 text-[color:var(--accent)]"
         xmlns="http://www.w3.org/2000/svg"
         fill="none"
         viewBox="0 0 24 24"
@@ -23,7 +23,7 @@ export function PageLoader({ message }: { message?: string }) {
           d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
         />
       </svg>
-      {message && <p className="mt-3 text-sm text-gray-500">{message}</p>}
+      {message && <p className="mt-3 text-sm text-[color:var(--fainter)]">{message}</p>}
     </div>
   );
 }

--- a/dashboard/src/components/ui/ProgressBar.tsx
+++ b/dashboard/src/components/ui/ProgressBar.tsx
@@ -9,12 +9,12 @@ interface ProgressBarProps {
 }
 
 const colorClasses = {
-  orange: 'bg-orange-500',
-  green: 'bg-green-500',
+  orange: 'bg-[var(--accent)]',
+  green: 'bg-[var(--green)]',
   blue: 'bg-blue-500',
-  red: 'bg-red-500',
-  yellow: 'bg-yellow-500',
-  gray: 'bg-gray-500',
+  red: 'bg-[var(--red)]',
+  yellow: 'bg-[var(--accent)]',
+  gray: 'bg-[var(--fainter)]',
 };
 
 const sizeClasses = {
@@ -38,11 +38,11 @@ export function ProgressBar({
     <div className={className}>
       {(label || sublabel) && (
         <div className="flex justify-between items-center mb-1.5">
-          {label && <span className="text-sm text-gray-400">{label}</span>}
-          {sublabel && <span className="text-sm text-gray-300 font-mono">{sublabel}</span>}
+          {label && <span className="text-sm text-[color:var(--dim)]">{label}</span>}
+          {sublabel && <span className="text-sm text-[color:var(--dim)] font-mono">{sublabel}</span>}
         </div>
       )}
-      <div className={`bg-gray-800 rounded-full overflow-hidden ${sizeClasses[size]}`}>
+      <div className={`bg-[var(--surface)] rounded-full overflow-hidden ${sizeClasses[size]}`}>
         <div
           className={`${colorClasses[color]} rounded-full transition-all duration-500 h-full`}
           style={{ width: `${percent}%` }}

--- a/dashboard/src/components/ui/QrCode.tsx
+++ b/dashboard/src/components/ui/QrCode.tsx
@@ -37,7 +37,7 @@ export function QrCode({ value, size = 160, ecc = "MEDIUM", margin = 4, classNam
   if (!path) {
     return (
       <div
-        className={`flex items-center justify-center text-xs text-gray-500 ${className}`}
+        className={`flex items-center justify-center text-xs text-[color:var(--fainter)] ${className}`}
         style={{ width: size, height: size, background: "#fff", borderRadius: 6 }}
       >
         —

--- a/dashboard/src/components/ui/SectionErrorBoundary.tsx
+++ b/dashboard/src/components/ui/SectionErrorBoundary.tsx
@@ -30,21 +30,21 @@ export class SectionErrorBoundary extends Component<Props, State> {
       }
 
       return (
-        <div className="bg-gray-900 border border-red-900/50 rounded-lg p-6">
+        <div className="bg-[var(--surface)] border border-[color-mix(in_srgb,var(--red)_50%,transparent)] rounded-lg p-6">
           <div className="flex items-center gap-2 mb-2">
-            <svg className="w-5 h-5 text-red-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <svg className="w-5 h-5 text-[color:var(--red)]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
               <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />
             </svg>
-            <h3 className="text-sm font-medium text-red-400">
+            <h3 className="text-sm font-medium text-[color:var(--red)]">
               {this.props.section ? `${this.props.section} failed to load` : 'Something went wrong'}
             </h3>
           </div>
-          <p className="text-xs text-gray-500">
+          <p className="text-xs text-[color:var(--fainter)]">
             {this.state.error?.message || 'An unexpected error occurred'}
           </p>
           <button
             onClick={() => this.setState({ hasError: false, error: null })}
-            className="mt-3 text-xs text-orange-400 hover:text-orange-300 transition-colors"
+            className="mt-3 text-xs text-[color:var(--accent)] hover:text-[color:var(--accent)] transition-colors"
           >
             Try again
           </button>

--- a/dashboard/src/components/ui/Skeleton.tsx
+++ b/dashboard/src/components/ui/Skeleton.tsx
@@ -7,7 +7,7 @@ interface SkeletonProps {
 export function Skeleton({ className = '' }: SkeletonProps) {
   return (
     <div
-      className={`animate-pulse bg-gray-800 rounded ${className}`}
+      className={`animate-pulse bg-[var(--surface)] rounded ${className}`}
     />
   );
 }
@@ -28,7 +28,7 @@ export function SkeletonText({ lines = 1, className = '' }: { lines?: number; cl
 
 export function SkeletonCard({ className = '' }: { className?: string }) {
   return (
-    <div className={`p-4 border border-gray-800 rounded-lg ${className}`}>
+    <div className={`p-4 border border-[color:var(--rule)] rounded-lg ${className}`}>
       <Skeleton className="h-6 w-1/3 mb-4" />
       <SkeletonText lines={3} />
     </div>
@@ -39,7 +39,7 @@ export function SkeletonTable({ rows = 5, cols = 4, className = '' }: { rows?: n
   return (
     <div className={`space-y-2 ${className}`}>
       {/* Header */}
-      <div className="flex gap-4 pb-2 border-b border-gray-800">
+      <div className="flex gap-4 pb-2 border-b border-[color:var(--rule)]">
         {Array.from({ length: cols }).map((_, i) => (
           <Skeleton key={i} className="h-4 flex-1" />
         ))}
@@ -60,7 +60,7 @@ export function SkeletonStats({ count = 4, className = '' }: { count?: number; c
   return (
     <div className={`grid grid-cols-2 md:grid-cols-4 gap-4 ${className}`}>
       {Array.from({ length: count }).map((_, i) => (
-        <div key={i} className="p-4 border border-gray-800 rounded-lg">
+        <div key={i} className="p-4 border border-[color:var(--rule)] rounded-lg">
           <Skeleton className="h-4 w-1/2 mb-2" />
           <Skeleton className="h-8 w-3/4" />
         </div>

--- a/dashboard/src/components/ui/StatCard.tsx
+++ b/dashboard/src/components/ui/StatCard.tsx
@@ -17,7 +17,7 @@ interface StatCardProps {
 export function StatCard({ label, value, tooltip, icon, sublabel, loading, className = '' }: StatCardProps) {
   if (loading) {
     return (
-      <div className={`bg-gray-900 border border-gray-800 rounded-lg p-4 h-[104px] ${className}`}>
+      <div className={`bg-[var(--surface)] border border-[color:var(--rule)] rounded-lg p-4 h-[104px] ${className}`}>
         <Skeleton className="h-4 w-20 mb-3" />
         <Skeleton className="h-7 w-24 mb-1" />
         <Skeleton className="h-3 w-16" />
@@ -26,20 +26,20 @@ export function StatCard({ label, value, tooltip, icon, sublabel, loading, class
   }
 
   const content = (
-    <div className={`bg-gray-900 border border-gray-800 rounded-lg p-4 h-[104px] flex flex-col justify-between ${className}`}>
-      <div className="flex items-center gap-2 text-sm text-gray-400">
+    <div className={`bg-[var(--surface)] border border-[color:var(--rule)] rounded-lg p-4 h-[104px] flex flex-col justify-between ${className}`}>
+      <div className="flex items-center gap-2 text-sm text-[color:var(--dim)]">
         {icon && <span className="w-4 h-4 flex-shrink-0">{icon}</span>}
         <span className="truncate">{label}</span>
         {tooltip && (
-          <svg className="w-3 h-3 text-gray-600 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+          <svg className="w-3 h-3 text-[color:var(--fainter)] flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
             <circle cx="12" cy="12" r="10" />
             <path d="M12 16v-4M12 8h.01" />
           </svg>
         )}
       </div>
       <div>
-        <div className="text-2xl font-bold text-gray-100 truncate">{value}</div>
-        {sublabel && <div className="text-xs text-gray-500 truncate">{sublabel}</div>}
+        <div className="text-2xl font-bold text-[color:var(--fg)] truncate">{value}</div>
+        {sublabel && <div className="text-xs text-[color:var(--fainter)] truncate">{sublabel}</div>}
       </div>
     </div>
   );

--- a/dashboard/src/components/ui/StatusDot.tsx
+++ b/dashboard/src/components/ui/StatusDot.tsx
@@ -7,10 +7,10 @@ interface StatusDotProps {
 }
 
 const colorClasses = {
-  online: 'bg-green-400',
-  warning: 'bg-yellow-400',
-  offline: 'bg-red-400',
-  unknown: 'bg-gray-500',
+  online: 'bg-[var(--green)]',
+  warning: 'bg-[var(--accent)]',
+  offline: 'bg-[var(--red)]',
+  unknown: 'bg-[var(--fainter)]',
 };
 
 const sizeClasses = {
@@ -28,7 +28,7 @@ export function StatusDot({ status, pulse, size = 'md', label, className = '' }:
           <span className={`absolute inset-0 rounded-full ${colorClasses[status]} animate-ping opacity-75`} />
         )}
       </span>
-      {label && <span className="text-sm text-gray-400">{label}</span>}
+      {label && <span className="text-sm text-[color:var(--dim)]">{label}</span>}
     </span>
   );
 }

--- a/dashboard/src/components/ui/StatusRow.tsx
+++ b/dashboard/src/components/ui/StatusRow.tsx
@@ -9,14 +9,14 @@ interface StatusRowProps {
 
 export function StatusRow({ label, tooltip, children }: StatusRowProps) {
   return (
-    <div className="flex items-center justify-between py-3 border-b border-gray-800 last:border-b-0">
+    <div className="flex items-center justify-between py-3 border-b border-[color:var(--rule)] last:border-b-0">
       <div className="flex items-center gap-2">
         {tooltip ? (
           <Tooltip content={tooltip}>
-            <span className="text-gray-400 text-sm cursor-help">{label}</span>
+            <span className="text-[color:var(--dim)] text-sm cursor-help">{label}</span>
           </Tooltip>
         ) : (
-          <span className="text-gray-400 text-sm">{label}</span>
+          <span className="text-[color:var(--dim)] text-sm">{label}</span>
         )}
       </div>
       <div>{children}</div>

--- a/dashboard/src/components/ui/TimeFilter.tsx
+++ b/dashboard/src/components/ui/TimeFilter.tsx
@@ -22,7 +22,7 @@ export function TimeFilter({
   className = '',
 }: TimeFilterProps) {
   return (
-    <div className={`inline-flex bg-gray-800 rounded-lg p-0.5 ${className}`}>
+    <div className={`inline-flex bg-[var(--surface)] rounded-lg p-0.5 ${className}`}>
       {options.map((opt) => (
         <button
           key={opt}
@@ -30,8 +30,8 @@ export function TimeFilter({
           className={`
             px-3 py-1 text-sm rounded-md transition-colors
             ${value === opt
-              ? 'bg-gray-700 text-gray-100 font-medium'
-              : 'text-gray-400 hover:text-gray-200'
+              ? 'bg-[var(--rule-strong)] text-[color:var(--fg)] font-medium'
+              : 'text-[color:var(--dim)] hover:text-[color:var(--fg)]'
             }
           `}
         >

--- a/dashboard/src/components/ui/Toast.tsx
+++ b/dashboard/src/components/ui/Toast.tsx
@@ -123,18 +123,18 @@ interface ToastItemProps {
 function ToastItem({ toast, onRemove }: ToastItemProps) {
   const typeStyles: Record<ToastType, { bg: string; border: string; icon: string }> = {
     success: {
-      bg: "bg-green-900/90",
-      border: "border-green-700",
+      bg: "bg-[color-mix(in_srgb,var(--green)_20%,var(--surface))]",
+      border: "border-[color-mix(in_srgb,var(--green)_40%,transparent)]",
       icon: "M5 13l4 4L19 7",
     },
     error: {
-      bg: "bg-red-900/90",
-      border: "border-red-700",
+      bg: "bg-[color-mix(in_srgb,var(--red)_20%,var(--surface))]",
+      border: "border-[color-mix(in_srgb,var(--red)_40%,transparent)]",
       icon: "M6 18L18 6M6 6l12 12",
     },
     warning: {
-      bg: "bg-yellow-900/90",
-      border: "border-yellow-700",
+      bg: "bg-[color-mix(in_srgb,var(--accent)_20%,var(--surface))]",
+      border: "border-[color-mix(in_srgb,var(--accent)_40%,transparent)]",
       icon: "M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z",
     },
     info: {
@@ -166,14 +166,14 @@ function ToastItem({ toast, onRemove }: ToastItemProps) {
           />
         </svg>
         <div className="flex-1 min-w-0">
-          <p className="text-sm font-medium text-gray-100">{toast.title}</p>
+          <p className="text-sm font-medium text-[color:var(--fg)]">{toast.title}</p>
           {toast.message && (
-            <p className="text-sm text-gray-300 mt-1">{toast.message}</p>
+            <p className="text-sm text-[color:var(--dim)] mt-1">{toast.message}</p>
           )}
         </div>
         <button
           onClick={() => onRemove(toast.id)}
-          className="flex-shrink-0 text-gray-400 hover:text-gray-200"
+          className="flex-shrink-0 text-[color:var(--dim)] hover:text-[color:var(--fg)]"
         >
           <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path

--- a/dashboard/src/components/ui/Toggle.tsx
+++ b/dashboard/src/components/ui/Toggle.tsx
@@ -17,8 +17,8 @@ export function Toggle({ enabled, onChange, label, disabled = false }: TogglePro
       disabled={disabled}
       className={`
         relative inline-flex h-6 w-11 min-w-[2.75rem] shrink-0 items-center rounded-full
-        transition-colors focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2 focus:ring-offset-gray-900
-        ${enabled ? "bg-orange-600" : "bg-gray-700"}
+        transition-colors focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2 focus:ring-offset-[color:var(--surface)]
+        ${enabled ? "bg-[var(--accent)]" : "bg-[var(--rule-strong)]"}
         ${disabled ? "opacity-50 cursor-not-allowed" : "cursor-pointer"}
       `}
     >

--- a/dashboard/src/components/ui/Tooltip.tsx
+++ b/dashboard/src/components/ui/Tooltip.tsx
@@ -20,10 +20,10 @@ const GAP = 8;
 const ARROW = 4;
 
 const arrowClasses: Record<Side, string> = {
-  top: 'border-t-gray-700 border-x-transparent border-b-transparent',
-  bottom: 'border-b-gray-700 border-x-transparent border-t-transparent',
-  left: 'border-l-gray-700 border-y-transparent border-r-transparent',
-  right: 'border-r-gray-700 border-y-transparent border-l-transparent',
+  top: 'border-t-[color:var(--rule-strong)] border-x-transparent border-b-transparent',
+  bottom: 'border-b-[color:var(--rule-strong)] border-x-transparent border-t-transparent',
+  left: 'border-l-[color:var(--rule-strong)] border-y-transparent border-r-transparent',
+  right: 'border-r-[color:var(--rule-strong)] border-y-transparent border-l-transparent',
 };
 
 function clamp(v: number, lo: number, hi: number): number {
@@ -138,7 +138,7 @@ export function Tooltip({ content, children, position = 'top' }: TooltipProps) {
             style={{ left: 0, top: 0, opacity: 0 }}
             className="fixed z-[9999] pointer-events-none transition-opacity duration-150"
           >
-            <div className="relative bg-gray-800 border border-gray-700 text-gray-200 text-xs rounded-lg px-3 py-2 w-72 max-w-[calc(100vw-1rem)] shadow-lg whitespace-normal">
+            <div className="relative bg-[var(--surface)] border border-[color:var(--rule-strong)] text-[color:var(--fg)] text-xs rounded-lg px-3 py-2 w-72 max-w-[calc(100vw-1rem)] shadow-lg whitespace-normal">
               {content}
               <div ref={arrowRef} className={`absolute w-0 h-0 border-4 ${arrowClasses[position]}`} />
             </div>

--- a/dashboard/src/components/ui/Wizard.tsx
+++ b/dashboard/src/components/ui/Wizard.tsx
@@ -24,15 +24,15 @@ export function StepIndicator({ steps, currentStep }: StepIndicatorProps) {
               {/* Dot */}
               <div className="relative flex items-center justify-center">
                 {isActive && (
-                  <span className="absolute inline-flex h-8 w-8 rounded-full bg-orange-500/20 animate-ping" />
+                  <span className="absolute inline-flex h-8 w-8 rounded-full bg-[var(--accent)]/20 animate-ping" />
                 )}
                 <div
                   className={`
                     relative z-10 flex items-center justify-center w-8 h-8 rounded-full text-sm font-semibold
                     transition-colors duration-200
-                    ${isCompleted ? 'bg-orange-600 text-white' : ''}
-                    ${isActive ? 'border-2 border-orange-500 text-orange-400 bg-gray-900' : ''}
-                    ${isPending ? 'bg-gray-700 text-gray-400' : ''}
+                    ${isCompleted ? 'bg-[var(--accent)] text-[color:var(--fg)]' : ''}
+                    ${isActive ? 'border-2 border-[color:var(--accent)] text-[color:var(--accent)] bg-[var(--surface)]' : ''}
+                    ${isPending ? 'bg-[var(--rule-strong)] text-[color:var(--dim)]' : ''}
                   `}
                 >
                   {isCompleted ? (
@@ -48,9 +48,9 @@ export function StepIndicator({ steps, currentStep }: StepIndicatorProps) {
               <span
                 className={`
                   hidden md:block mt-2 text-xs text-center truncate max-w-[80px]
-                  ${isCompleted ? 'text-orange-300' : ''}
-                  ${isActive ? 'text-orange-400 font-medium' : ''}
-                  ${isPending ? 'text-gray-500' : ''}
+                  ${isCompleted ? 'text-[color:var(--accent)]' : ''}
+                  ${isActive ? 'text-[color:var(--accent)] font-medium' : ''}
+                  ${isPending ? 'text-[color:var(--fainter)]' : ''}
                 `}
               >
                 {step.title}
@@ -63,7 +63,7 @@ export function StepIndicator({ steps, currentStep }: StepIndicatorProps) {
                 <div
                   className={`
                     h-0.5 w-full transition-colors duration-200
-                    ${index < currentStep ? 'bg-orange-600' : 'bg-gray-700'}
+                    ${index < currentStep ? 'bg-[var(--accent)]' : 'bg-[var(--rule-strong)]'}
                   `}
                 />
               </div>
@@ -128,7 +128,7 @@ export function WizardDialog<TData>({
 
       {/* Error Banner */}
       {wizard.error && (
-        <div className="mb-4 px-4 py-3 rounded-lg bg-red-900/50 border border-red-700 text-red-200 text-sm">
+        <div className="mb-4 px-4 py-3 rounded-lg bg-[color-mix(in_srgb,var(--red)_20%,var(--surface))] border border-[color-mix(in_srgb,var(--red)_40%,transparent)] text-[color:var(--red)] text-sm">
           {wizard.error}
         </div>
       )}


### PR DESCRIPTION
## Summary

Makes the dashboard's **shared components** theme-aware so they flip correctly in light mode. Previously these components hardcoded dark Tailwind tokens (`bg-gray-900`, `text-gray-100`, `border-gray-800`, etc.). Because `globals.css` `@theme inline` pins Tailwind's `--color-gray-*` scale to the warm-dark hex values, those classes never flipped — a component using `bg-gray-900 text-gray-100` rendered a dark card with light text in **both** themes, so in light mode it showed a dark card on a light page.

This PR converts those hardcoded darks to the palette CSS vars (`--bg`, `--surface`, `--fg`, `--dim`, `--fainter`, `--rule`, `--rule-strong`, `--accent`, `--accent-weak`, `--green`, `--red`), which resolve per theme. Dark mode is preserved (the vars resolve to essentially the same darks); light mode is now legible.

**Colours only** — no structural, logic, or prop changes.

## Scope

Only `dashboard/src/components/**` (37 files across `ui/`, `dashboard/`, `settings/`, `filtering/`, `layout/`, plus `PayoutHistoryCard`, `ConnectionStatus`). No `src/app/**` or `globals.css` changes.

## Mapping

- `text-white` / `text-gray-50/100/200` → `var(--fg)`; `text-gray-300/400` → `var(--dim)`; `text-gray-500/600` → `var(--fainter)`
- `bg-gray-950/black` → `var(--bg)`; `bg-gray-900/800` → `var(--surface)`
- `border-gray-800` → `var(--rule)`; `border-gray-700/600` → `var(--rule-strong)`
- `text-green-*` → `var(--green)`; `text-red-*` → `var(--red)`; `text-orange-*`/`text-yellow-*` → `var(--accent)`
- Semantic badge/pill tints → `color-mix(in srgb, var(--COLOUR) 16%, transparent)` background so they tint correctly in both themes
- `blue-*`/`purple-*` left unchanged; opacity modifiers preserved (`bg-gray-800/50` → `bg-[var(--surface)]/50`)

Each spot follows the component's existing pattern (inline `style` var vs Tailwind arbitrary `text-[color:var(--x)]`).

## Deliberately left alone

- **`GhostLogo`** — brand mascot with its own accent-colour system; its black silhouette (`#000000`) is intentional, and flipping it would break dark-mode parity.
- **`NodeVitalsOverlay`** — canvas/SVG that already reads CSS vars at runtime; the `#000` values there are alpha `mask-image` gradients, not colours.
- **`QrCode`** — QR SVG stays black-on-white for scanner reliability (only its placeholder text was converted).

## Verification

- `tsc --noEmit`: clean
- `eslint` on all 37 changed files: clean
- `npm run build`: succeeds
- Confirmed the Tailwind arbitrary classes (`color-mix(...)`, `/50` opacity on `var()`, `text-[color:var()]`) actually compiled into the output CSS (Tailwind silently drops malformed arbitrary classes, so this was checked explicitly).