### PR TITLE
dashboard: drop duplicate Ghost Mode toggle + LED order + Tor note

### DIFF
--- a/dashboard/src/app/(dashboard)/network/page.tsx
+++ b/dashboard/src/app/(dashboard)/network/page.tsx
@@ -9,7 +9,7 @@ import { CopyButton } from "@/components/ui/CopyButton";
 import { SkeletonCard } from "@/components/ui/Skeleton";
 import { SectionErrorBoundary } from "@/components/ui/SectionErrorBoundary";
 import { useNodeStatus } from "@/hooks/queries/useNodeQueries";
-import { useSetGhostMode, useSetTor } from "@/hooks/queries/useConfigQueries";
+import { useSetTor } from "@/hooks/queries/useConfigQueries";
 import { useToast } from "@/components/ui/Toast";
 
 /**
@@ -23,86 +23,9 @@ import { useToast } from "@/components/ui/Toast";
  * "what's actually happening right now" plus the exposure controls.
  */
 
-interface ToggleRowProps {
-  label: string;
-  description: string;
-  enabled: boolean;
-  onChange?: (next: boolean) => void;
-  disabled?: boolean;
-  readOnly?: boolean;
-  badge?: string;
-}
-
-function ExposureRow({ label, description, enabled, onChange, disabled, readOnly, badge }: ToggleRowProps) {
-  return (
-    <div
-      className="flex items-start justify-between gap-6"
-      style={{
-        padding: "16px 0",
-        borderTop: "1px solid var(--rule)",
-      }}
-    >
-      <div style={{ flex: 1, minWidth: 0 }}>
-        <div className="flex items-center gap-2 mb-1">
-          <span style={{ color: "var(--fg)", fontWeight: 500, fontSize: "15px" }}>{label}</span>
-          {badge && <Badge variant={enabled ? "success" : "info"}>{badge}</Badge>}
-          {readOnly && <Badge variant="info">read-only</Badge>}
-        </div>
-        <p style={{ color: "var(--dim)", fontSize: "13px", lineHeight: "1.5", maxWidth: "60ch" }}>
-          {description}
-        </p>
-      </div>
-      {!readOnly && onChange ? (
-        <button
-          onClick={() => onChange(!enabled)}
-          disabled={disabled}
-          className="flex-shrink-0"
-          style={{
-            width: "44px",
-            height: "24px",
-            borderRadius: "12px",
-            background: enabled ? "var(--accent)" : "var(--rule-strong)",
-            border: "none",
-            cursor: disabled ? "not-allowed" : "pointer",
-            opacity: disabled ? 0.6 : 1,
-            position: "relative",
-            transition: "background 120ms",
-          }}
-          aria-pressed={enabled}
-        >
-          <span
-            style={{
-              position: "absolute",
-              top: "3px",
-              left: enabled ? "23px" : "3px",
-              width: "18px",
-              height: "18px",
-              borderRadius: "50%",
-              background: "white",
-              transition: "left 120ms",
-            }}
-          />
-        </button>
-      ) : (
-        <span
-          className="flex-shrink-0"
-          style={{
-            color: enabled ? "var(--green)" : "var(--dim)",
-            fontFamily: "var(--font-mono)",
-            fontSize: "13px",
-            paddingTop: "2px",
-          }}
-        >
-          {enabled ? "active" : "inactive"}
-        </span>
-      )}
-    </div>
-  );
-}
 
 export default function NetworkPage() {
   const { data: status, isLoading } = useNodeStatus();
-  const setGhostMode = useSetGhostMode();
   const setTor = useSetTor();
   const { success, error } = useToast();
 
@@ -121,7 +44,6 @@ export default function NetworkPage() {
 
   const torActive = !!status?.tor_mode;
   const onion = status?.onion_address;
-  const ghostMode = !!status?.ghost_mode;
   const peerCount = status?.peer_count ?? 0;
   const exposure = torActive ? (onion ? "tor" : "tor (no onion)") : "clearnet";
 
@@ -130,7 +52,7 @@ export default function NetworkPage() {
       <PageHeader
         eyebrow="network"
         title="How this node is exposed."
-        subtitle="Live view of your node's outbound transport, onion address, and relay-suppression state — with controls for Tor mode and Ghost Mode."
+        subtitle="Live view of your node's outbound transport, onion address, and relay-suppression state — with controls for Tor mode."
         actions={
           <Badge variant={torActive ? "success" : "info"}>
             {exposure}
@@ -177,7 +99,7 @@ export default function NetworkPage() {
           </h3>
           <p style={{ color: "var(--dim)", fontSize: "13px", marginBottom: "8px" }}>
             Tor mode is a ghostd startup flag (<code>-tormode</code>): toggling it restarts ghostd, so it asks
-            for confirmation. Ghost Mode is runtime-toggleable with no restart.
+            for confirmation. With Tor enabled, your node&rsquo;s real IP address is never leaked to peers.
           </p>
 
           <div>
@@ -199,29 +121,6 @@ export default function NetworkPage() {
                   );
                 }
               }}
-            />
-            <ExposureRow
-              label="Ghost Mode"
-              description="When enabled, your node accepts and validates blocks but never relays unconfirmed transactions or answers getdata for them. Mempool becomes opaque to peers — useful for privacy-maximising operators. Block relay is unaffected."
-              enabled={ghostMode}
-              onChange={async (next) => {
-                try {
-                  await setGhostMode.mutateAsync(next);
-                  success(
-                    "Ghost Mode " + (next ? "enabled" : "disabled"),
-                    next
-                      ? "Outbound transaction relay suppressed"
-                      : "Standard relay resumed"
-                  );
-                } catch (e) {
-                  error(
-                    "Failed to update Ghost Mode",
-                    e instanceof Error ? e.message : "Unknown error"
-                  );
-                }
-              }}
-              disabled={setGhostMode.isPending}
-              badge={ghostMode ? "active" : undefined}
             />
           </div>
         </Card>

--- a/dashboard/src/components/overlays/NodeVitalsOverlay.tsx
+++ b/dashboard/src/components/overlays/NodeVitalsOverlay.tsx
@@ -225,12 +225,20 @@ function deriveLeds(status: WatchdogStatus | undefined): Led[] {
     status.components && status.components.length > 0
       ? status.components.map((c) => ({ name: c.name, status: String(c.status) }))
       : (status.services ?? []).map((s) => ({ name: s.name, status: String(s.status) }));
-  return src.map((s) => ({
+  const leds = src.map((s) => ({
     name: s.name,
     label: shortName(s.name),
     tone: ledTone(s.status),
     title: `${s.name}: ${s.status}`,
   }));
+  // Preferred glance-row order: core (ghostd) before pool, then pay; any other
+  // service keeps its original order after these (Array.sort is stable).
+  const ORDER = ['core', 'pool', 'pay'];
+  const rank = (l: string) => {
+    const i = ORDER.indexOf(l.toLowerCase());
+    return i === -1 ? ORDER.length : i;
+  };
+  return leds.sort((a, b) => rank(a.label) - rank(b.label));
 }
 
 // Resource usage → tone, mirroring the Watchdog page's threshold colouring.


### PR DESCRIPTION
Remove the duplicate Ghost Mode toggle from Network (dedicated page remains); reorder Home LEDs to core·pool·pay; add Tor IP-leak note.