### PR TITLE
dashboard(home): drop 'this node' subtitle on Hashrate tile

### DIFF
--- a/dashboard/src/components/overlays/NodeVitalsOverlay.tsx
+++ b/dashboard/src/components/overlays/NodeVitalsOverlay.tsx
@@ -889,7 +889,6 @@ export function NodeVitalsOverlay({ active }: OverlayProps) {
       >
         <Stat
           label="Hashrate"
-          sub="this node"
           value={
             v.nodeHashrateHs > 0
               ? formatHashrate(v.nodeHashrateHs)


### PR DESCRIPTION
Remove the redundant 'this node' sublabel.