### PR TITLE
ghost-core: Ghost Mode local egress (own-tx broadcast) + config + dashboard

### DIFF
--- a/crates/ghost-common/src/config.rs
+++ b/crates/ghost-common/src/config.rs
@@ -1302,6 +1302,12 @@ pub struct NetworkConfig {
     /// Ghost Mode: privacy-enhanced relay + stealth addressing
     #[serde(default)]
     pub ghost_mode: bool,
+    /// Ghost Mode local egress: while ghost mode is on, still announce and serve
+    /// our OWN (locally-submitted) transactions so a connected wallet can reach
+    /// miners, while peer-received transactions stay fully suppressed. Only
+    /// meaningful alongside `ghost_mode`.
+    #[serde(default)]
+    pub ghost_mode_local_egress: bool,
     /// Ghost Shroud: random relay delay (0-5s) to prevent origin analysis
     #[serde(default)]
     pub shroud_enabled: bool,
@@ -1361,6 +1367,7 @@ impl Default for NetworkConfig {
             noise_enabled: true,
             tls: TlsConfig::default(),
             ghost_mode: false,
+            ghost_mode_local_egress: false,
             shroud_enabled: false,
             sv2_authority_public_key: None,
             rate_limit_trusted_ips: Vec::new(),

--- a/crates/ghost-common/src/rpc.rs
+++ b/crates/ghost-common/src/rpc.rs
@@ -1224,6 +1224,24 @@ impl BitcoinRpc {
         self.call("getghostmode", vec![]).await
     }
 
+    /// Set ghost mode local egress on the node
+    ///
+    /// Only meaningful while ghost mode is enabled. When on, the node still
+    /// announces and serves its own (locally-submitted) transactions so a
+    /// connected wallet can reach miners; peer-received txs stay suppressed.
+    pub async fn set_ghost_mode_local_egress(
+        &self,
+        enable: bool,
+    ) -> GhostResult<GhostModeResponse> {
+        self.call("setghostmodelocalegress", vec![json!(enable)])
+            .await
+    }
+
+    /// Get current ghost mode local egress state
+    pub async fn get_ghost_mode_local_egress(&self) -> GhostResult<GhostModeResponse> {
+        self.call("getghostmodelocalegress", vec![]).await
+    }
+
     // ============================================================
     // Ghost-Core Specific RPC Methods
     // ============================================================
@@ -1826,6 +1844,10 @@ pub struct MempoolInfo {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GhostModeResponse {
     pub ghost_mode: bool,
+    /// Whether local egress (own-tx broadcast) is enabled. Defaults to false so
+    /// responses from older ghost-core builds (which omit the field) still parse.
+    #[serde(default)]
+    pub ghost_mode_local_egress: bool,
 }
 
 // ============================================================

--- a/crates/ghost-common/src/setup.rs
+++ b/crates/ghost-common/src/setup.rs
@@ -207,6 +207,9 @@ pub fn apply_change_setup(
         if let Some(v) = fields.get("ghost_mode") {
             config.network.ghost_mode = v.as_bool();
         }
+        if let Some(v) = fields.get("ghost_mode_local_egress") {
+            config.network.ghost_mode_local_egress = v.as_bool();
+        }
         if let Some(v) = fields.get("mempool_profile") {
             config.policy.profile = match v.as_selected() {
                 1 => PolicyProfile::BitcoinPure,
@@ -367,6 +370,9 @@ pub fn apply_ghost_mode(
     load_and_modify(config_path, |config| {
         if let Some(v) = fields.get("ghost_mode") {
             config.network.ghost_mode = v.as_bool();
+        }
+        if let Some(v) = fields.get("ghost_mode_local_egress") {
+            config.network.ghost_mode_local_egress = v.as_bool();
         }
     })
 }

--- a/crates/ghost-verification/src/config.rs
+++ b/crates/ghost-verification/src/config.rs
@@ -35,6 +35,12 @@ use ghost_common::error::{GhostError, GhostResult};
 pub struct NodeConfig {
     /// Ghost mode: do not relay/announce unconfirmed transactions
     pub ghost_mode: bool,
+    /// Ghost mode local egress: while ghost mode is on, still announce and serve
+    /// our OWN (locally-submitted) transactions so a connected wallet can reach
+    /// miners, while peer-received transactions stay fully suppressed. Only
+    /// meaningful alongside `ghost_mode`.
+    #[serde(default)]
+    pub ghost_mode_local_egress: bool,
     /// Shroud: enable random relay delay (0-5s) for transaction origin privacy.
     /// Requires ghost-core restart with -shroud=1 flag to take effect.
     #[serde(default)]
@@ -119,6 +125,7 @@ mod tests {
     fn test_default_config() {
         let config = NodeConfig::default();
         assert!(!config.ghost_mode);
+        assert!(!config.ghost_mode_local_egress);
     }
 
     #[test]
@@ -128,6 +135,7 @@ mod tests {
 
         let config = NodeConfig {
             ghost_mode: true,
+            ghost_mode_local_egress: true,
             shroud_enabled: false,
             nickname: Some("my-node".to_string()),
         };
@@ -135,6 +143,7 @@ mod tests {
 
         let loaded = NodeConfig::load(path).unwrap();
         assert!(loaded.ghost_mode);
+        assert!(loaded.ghost_mode_local_egress);
         assert!(!loaded.shroud_enabled);
         assert_eq!(loaded.nickname.as_deref(), Some("my-node"));
     }

--- a/crates/ghost-verification/src/routes.rs
+++ b/crates/ghost-verification/src/routes.rs
@@ -481,6 +481,10 @@ pub fn create_router(state: Arc<VerificationState>) -> Router {
             post(api_config_ghost_mode_post_handler),
         )
         .route(
+            "/api/v1/config/ghost_mode_local_egress",
+            post(api_config_ghost_mode_local_egress_post_handler),
+        )
+        .route(
             "/api/v1/config/public_mining",
             post(api_config_public_mining_post_handler),
         )
@@ -1479,6 +1483,7 @@ async fn api_node_status_handler(State(state): State<Arc<VerificationState>>) ->
         "private_mining": false,
         "reaper": config.reaper,
         "ghost_mode": config.ghost_mode,
+        "ghost_mode_local_egress": config.ghost_mode_local_egress,
         "tor_mode": config.tor_mode,
         "onion_address": config.onion_address
     }))
@@ -3444,6 +3449,7 @@ async fn api_config_handler(State(state): State<Arc<VerificationState>>) -> impl
         "public_mining": config.public_mining,
         "reaper": config.reaper,
         "ghost_mode": config.ghost_mode,
+        "ghost_mode_local_egress": config.ghost_mode_local_egress,
         "mempool_profile": config.mempool_profile,
         "template_profile": config.template_profile
     }))
@@ -5396,6 +5402,7 @@ async fn api_config_full_handler(State(state): State<Arc<VerificationState>>) ->
         "public_mining": config.public_mining,
         "reaper": config.reaper,
         "ghost_mode": config.ghost_mode,
+        "ghost_mode_local_egress": config.ghost_mode_local_egress,
         "mempool_profile": config.mempool_profile,
         "template_profile": config.template_profile,
         "prune_profile": config.prune_profile,
@@ -5442,6 +5449,13 @@ async fn api_config_ghost_mode_handler(
                         );
                         config.ghost_mode = response.ghost_mode;
                     }
+                    if config.ghost_mode_local_egress != response.ghost_mode_local_egress {
+                        debug!(
+                            "Syncing ghost mode local egress from RPC: {} -> {}",
+                            config.ghost_mode_local_egress, response.ghost_mode_local_egress
+                        );
+                        config.ghost_mode_local_egress = response.ghost_mode_local_egress;
+                    }
                 }
                 Some(response.ghost_mode)
             }
@@ -5462,6 +5476,7 @@ async fn api_config_ghost_mode_handler(
     Json(serde_json::json!({
         "enabled": config.ghost_mode,
         "ghost_mode": config.ghost_mode,
+        "ghost_mode_local_egress": config.ghost_mode_local_egress,
         "rpc_synced": rpc_state.is_some(),
         "message": "Ghost mode configuration"
     }))
@@ -5674,6 +5689,74 @@ async fn api_config_ghost_mode_post_handler(
             "Ghost mode updated and synced with ghost-core"
         } else {
             "Ghost mode updated (RPC sync unavailable)"
+        }
+    }))
+}
+
+/// API v1 Config ghost_mode_local_egress POST handler
+///
+/// Toggles the ghost-mode local-egress sub-setting on the node:
+/// 1. Calls ghost-core RPC to set it (if RPC client available)
+/// 2. Updates the in-memory dashboard config
+/// 3. Persists the setting to disk (if config path available)
+///
+/// Only meaningful while ghost mode is enabled; the sub-setting is stored
+/// independently so it is remembered when ghost mode is toggled back on.
+async fn api_config_ghost_mode_local_egress_post_handler(
+    State(state): State<Arc<VerificationState>>,
+    Json(payload): Json<ToggleRequest>,
+) -> impl IntoResponse {
+    let enabled = payload.enabled;
+
+    // Try to call ghost-core RPC to set the local egress sub-setting
+    let rpc_result = if let Some(ref rpc) = state.rpc {
+        match rpc.set_ghost_mode_local_egress(enabled).await {
+            Ok(response) => {
+                debug!(
+                    "Ghost mode local egress RPC call successful: {:?}",
+                    response
+                );
+                Some(response.ghost_mode_local_egress)
+            }
+            Err(e) => {
+                warn!("Failed to set ghost mode local egress via RPC: {}", e);
+                None
+            }
+        }
+    } else {
+        debug!("No RPC client available, updating local state only");
+        None
+    };
+
+    // Use RPC response if available, otherwise use requested value
+    let actual_enabled = rpc_result.unwrap_or(enabled);
+
+    // Update dashboard config
+    {
+        let mut config = state.dashboard_config.write();
+        config.ghost_mode_local_egress = actual_enabled;
+    }
+
+    // Update and persist node config
+    {
+        let mut node_config = state.node_config.write();
+        node_config.ghost_mode_local_egress = actual_enabled;
+
+        if let Some(ref path) = state.node_config_path {
+            if let Err(e) = node_config.save(path) {
+                error!("Failed to persist node config: {}", e);
+            }
+        }
+    }
+
+    Json(serde_json::json!({
+        "success": true,
+        "enabled": actual_enabled,
+        "rpc_synced": rpc_result.is_some(),
+        "message": if rpc_result.is_some() {
+            "Ghost mode local egress updated and synced with ghost-core"
+        } else {
+            "Ghost mode local egress updated (RPC sync unavailable)"
         }
     }))
 }
@@ -10714,6 +10797,7 @@ mod tests {
         let config_endpoints = [
             "/api/v1/config/archive_mode",
             "/api/v1/config/ghost_mode",
+            "/api/v1/config/ghost_mode_local_egress",
             "/api/v1/config/policy_profile",
             "/api/v1/config/policy_custom",
             "/api/v1/config/public_mining",

--- a/crates/ghost-verification/src/server.rs
+++ b/crates/ghost-verification/src/server.rs
@@ -966,6 +966,8 @@ fn parse_user_identity(user_identity: &str) -> (String, String) {
 #[derive(Debug, Clone)]
 pub struct DashboardConfig {
     pub ghost_mode: bool,
+    /// Ghost mode local egress: announce/serve our own txs while ghost mode is on
+    pub ghost_mode_local_egress: bool,
     pub archive_mode: bool,
     pub ghost_pay: bool,
     pub public_mining: bool,
@@ -1021,6 +1023,10 @@ impl Default for DashboardConfig {
     fn default() -> Self {
         Self {
             ghost_mode: true,
+            // Opt-in sub-toggle: only announces our own txs, and only while
+            // ghost mode is on. Off by default so a default ghost node never
+            // reveals any transactions to peers.
+            ghost_mode_local_egress: false,
             // Opt-in: archiving needs the full unpruned chain plus lots of disk,
             // so the node must never advertise the Archive capability by default.
             // The real value is synced from `storage.archive_mode` in
@@ -1825,6 +1831,7 @@ impl VerificationState {
         {
             let mut dashboard = self.dashboard_config.write();
             dashboard.ghost_mode = config.ghost_mode;
+            dashboard.ghost_mode_local_egress = config.ghost_mode_local_egress;
             if config.nickname.is_some() {
                 dashboard.nickname = config.nickname.clone();
             }
@@ -1954,7 +1961,10 @@ impl VerificationState {
         };
 
         // Get local config state
-        let local_ghost_mode = self.node_config.read().ghost_mode;
+        let (local_ghost_mode, local_local_egress) = {
+            let cfg = self.node_config.read();
+            (cfg.ghost_mode, cfg.ghost_mode_local_egress)
+        };
 
         // Query ghost-core for current state
         match rpc.get_ghost_mode().await {
@@ -1980,10 +1990,32 @@ impl VerificationState {
                     debug!("Ghost mode already in sync: {}", local_ghost_mode);
                 }
 
+                // Sync local egress sub-toggle the same way (local persisted wins).
+                if response.ghost_mode_local_egress != local_local_egress {
+                    info!(
+                        "Ghost mode local egress mismatch: local={}, core={}. Syncing core to local.",
+                        local_local_egress, response.ghost_mode_local_egress
+                    );
+                    match rpc.set_ghost_mode_local_egress(local_local_egress).await {
+                        Ok(_) => {
+                            info!(
+                                "Successfully synced ghost-core to ghost_mode_local_egress={}",
+                                local_local_egress
+                            );
+                        }
+                        Err(e) => {
+                            warn!("Failed to sync ghost mode local egress to ghost-core: {}", e);
+                        }
+                    }
+                } else {
+                    debug!("Ghost mode local egress already in sync: {}", local_local_egress);
+                }
+
                 // Sync dashboard config
                 {
                     let mut dashboard = self.dashboard_config.write();
                     dashboard.ghost_mode = local_ghost_mode;
+                    dashboard.ghost_mode_local_egress = local_local_egress;
                 }
             }
             Err(e) => {

--- a/dashboard/src/app/(dashboard)/ghost-mode/page.tsx
+++ b/dashboard/src/app/(dashboard)/ghost-mode/page.tsx
@@ -6,7 +6,7 @@ import { Badge } from "@/components/ui/Badge";
 import { SkeletonCard } from "@/components/ui/Skeleton";
 import { SectionErrorBoundary } from "@/components/ui/SectionErrorBoundary";
 import { useNodeStatus } from "@/hooks/queries/useNodeQueries";
-import { useSetGhostMode } from "@/hooks/queries/useConfigQueries";
+import { useSetGhostMode, useSetGhostModeLocalEgress } from "@/hooks/queries/useConfigQueries";
 import { useToast } from "@/components/ui/Toast";
 
 /**
@@ -46,6 +46,7 @@ function InfoRow({ threat, protection, strong }: { threat: string; protection: s
 export default function GhostModePage() {
   const { data: status, isLoading } = useNodeStatus();
   const setGhostMode = useSetGhostMode();
+  const setLocalEgress = useSetGhostModeLocalEgress();
   const { success, error } = useToast();
 
   if (isLoading) {
@@ -62,6 +63,10 @@ export default function GhostModePage() {
   }
 
   const ghostMode = !!status?.ghost_mode;
+  const localEgress = !!status?.ghost_mode_local_egress;
+  // The sub-toggle only has any effect while Ghost Mode is on; grey it out
+  // otherwise so operators can't arm a setting that does nothing.
+  const localEgressDisabled = !ghostMode || setLocalEgress.isPending;
 
   return (
     <div className="space-y-6">
@@ -129,6 +134,103 @@ export default function GhostModePage() {
               />
             </button>
           </div>
+
+          {/* Sub-toggle: local egress (own-tx broadcast) */}
+          <div
+            className="flex items-start justify-between gap-6"
+            style={{
+              marginTop: "16px",
+              paddingTop: "16px",
+              borderTop: "1px solid var(--rule)",
+              opacity: ghostMode ? 1 : 0.5,
+            }}
+          >
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div className="flex items-center gap-2 mb-1">
+                <span style={{ color: "var(--fg)", fontWeight: 500, fontSize: "15px" }}>
+                  Allow my own wallet broadcasts
+                </span>
+                {ghostMode && localEgress && <Badge variant="success">on</Badge>}
+              </div>
+              <p style={{ color: "var(--dim)", fontSize: "13px", lineHeight: "1.5", maxWidth: "60ch" }}>
+                Keep transactions your own node submits (via <code>sendrawtransaction</code> or a connected
+                wallet) flowing to peers so they can reach a miner, while transactions received from other
+                peers stay fully suppressed. Only your <em>own</em> still-unbroadcast transactions are
+                announced and served. {!ghostMode && "Enable Ghost Mode to use this."}
+              </p>
+            </div>
+            <button
+              onClick={async () => {
+                const next = !localEgress;
+                try {
+                  await setLocalEgress.mutateAsync(next);
+                  success(
+                    "Own-tx broadcast " + (next ? "enabled" : "disabled"),
+                    next
+                      ? "Your node will announce its own transactions to peers"
+                      : "Your node is silent about all transactions again"
+                  );
+                } catch (e) {
+                  error("Failed to update own-tx broadcast", e instanceof Error ? e.message : "Unknown error");
+                }
+              }}
+              disabled={localEgressDisabled}
+              className="flex-shrink-0"
+              style={{
+                width: "44px",
+                height: "24px",
+                borderRadius: "12px",
+                background: localEgress && ghostMode ? "var(--accent)" : "var(--rule-strong)",
+                border: "none",
+                cursor: localEgressDisabled ? "not-allowed" : "pointer",
+                opacity: setLocalEgress.isPending ? 0.6 : 1,
+                position: "relative",
+                transition: "background 120ms",
+              }}
+              aria-pressed={localEgress && ghostMode}
+              aria-disabled={localEgressDisabled}
+            >
+              <span
+                style={{
+                  position: "absolute",
+                  top: "3px",
+                  left: localEgress && ghostMode ? "23px" : "3px",
+                  width: "18px",
+                  height: "18px",
+                  borderRadius: "50%",
+                  background: "white",
+                  transition: "left 120ms",
+                }}
+              />
+            </button>
+          </div>
+
+          {/* Privacy caution: broadcasting reveals your txs to peers */}
+          {ghostMode && localEgress && (
+            <div
+              style={{
+                marginTop: "14px",
+                padding: "12px 14px",
+                background: "color-mix(in srgb, var(--yellow) 8%, transparent)",
+                border: "1px solid color-mix(in srgb, var(--yellow) 40%, transparent)",
+                borderRadius: "6px",
+              }}
+            >
+              <p style={{ color: "var(--fg)", fontSize: "13px", lineHeight: "1.6" }}>
+                <span style={{ color: "var(--yellow)", fontWeight: 600 }}>Heads up:</span> broadcasting your
+                own transactions reveals them to the peers you announce to, which can tie a transaction to
+                your node&apos;s IP address. Enable{" "}
+                <a
+                  href="/network"
+                  className="bare"
+                  style={{ color: "var(--fg)", textDecoration: "underline", textDecorationColor: "var(--yellow)" }}
+                >
+                  Tor mode on the Network page
+                </a>{" "}
+                to keep your IP private while broadcasting.
+              </p>
+            </div>
+          )}
         </Card>
       </SectionErrorBoundary>
 
@@ -159,9 +261,11 @@ export default function GhostModePage() {
         >
           <p style={{ color: "var(--fainter)", fontSize: "13px", lineHeight: "1.6" }}>
             <span style={{ color: "var(--accent)", fontWeight: 500 }}>Trade-off:</span> Ghost Mode is a
-            suppression of the standard relay path, not a replacement transport. A wallet on a Ghost Mode
-            node must find another route to reach miners — an out-of-band relay over Tor, a separate
-            broadcasting node, or a paid broadcast service — otherwise its transactions never confirm.
+            suppression of the standard relay path, not a replacement transport. Without local egress, a
+            wallet on a Ghost Mode node must find another route to reach miners — an out-of-band relay over
+            Tor, a separate broadcasting node, or a paid broadcast service — otherwise its transactions
+            never confirm. Turn on <em>Allow my own wallet broadcasts</em> above to let the node relay its
+            own transactions while staying silent about everyone else&apos;s.
           </p>
         </div>
       </Card>

--- a/dashboard/src/hooks/queries/useConfigQueries.ts
+++ b/dashboard/src/hooks/queries/useConfigQueries.ts
@@ -3,6 +3,7 @@ import {
   getConfig,
   getFullConfig,
   setGhostMode,
+  setGhostModeLocalEgress,
   setTor,
   setArchiveMode,
   setReaper,
@@ -70,6 +71,20 @@ export function useSetGhostMode() {
     mutationFn: (enabled: boolean) => setGhostMode(enabled),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: configKeys.all });
+    },
+  });
+}
+
+export function useSetGhostModeLocalEgress() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (enabled: boolean) => setGhostModeLocalEgress(enabled),
+    onSuccess: () => {
+      // The toggle state is surfaced on node status (ghost_mode_local_egress),
+      // so refresh both config and status caches.
+      queryClient.invalidateQueries({ queryKey: configKeys.all });
+      queryClient.invalidateQueries({ queryKey: nodeKeys.status() });
     },
   });
 }

--- a/dashboard/src/lib/api/config.ts
+++ b/dashboard/src/lib/api/config.ts
@@ -37,6 +37,16 @@ export async function setGhostMode(enabled: boolean): Promise<NodeConfig> {
   });
 }
 
+// Ghost Mode local egress: while ghost mode is on, still announce and serve our
+// OWN (locally-submitted) transactions so a connected wallet can reach miners,
+// while peer-received transactions stay fully suppressed. Toggles live.
+export async function setGhostModeLocalEgress(enabled: boolean): Promise<NodeConfig> {
+  return fetchApi<NodeConfig>('/api/v1/config/ghost_mode_local_egress', {
+    method: 'POST',
+    body: JSON.stringify({ enabled }),
+  });
+}
+
 // Result of toggling ghostd Tor mode. The apply happens off the request path
 // (ghostd restarts, then the pool bounces); poll the reaper GET's ghostd_apply
 // for the terminal state.

--- a/dashboard/src/types/api.ts
+++ b/dashboard/src/types/api.ts
@@ -37,6 +37,7 @@ export interface NodeStatus {
   uptime_seconds?: number;
   uptime_secs?: number;
   ghost_mode?: boolean;
+  ghost_mode_local_egress?: boolean;
   tor_mode?: boolean;
   onion_address?: string;
   archive_mode?: boolean;
@@ -72,6 +73,7 @@ export interface BlockchainStatus {
 
 export interface NodeConfig {
   ghost_mode?: boolean;
+  ghost_mode_local_egress?: boolean;
   archive_mode?: boolean;
   reaper?: boolean;
   public_mining?: boolean;
@@ -93,6 +95,7 @@ export interface FullNodeConfig {
   // Backend may return flat or nested structure
   node?: {
     ghost_mode: boolean;
+    ghost_mode_local_egress?: boolean;
     archive_mode: boolean;
     public_mining: boolean;
     mempool_profile: string;
@@ -135,6 +138,7 @@ export interface FullNodeConfig {
   };
   // Flat fields from backend
   ghost_mode?: boolean;
+  ghost_mode_local_egress?: boolean;
   archive_mode?: boolean;
   public_mining?: boolean;
   reaper?: boolean;
@@ -266,6 +270,7 @@ export interface NodeStatusSnapshot {
   uptime_seconds?: number;
   uptime_secs?: number;
   ghost_mode?: boolean;
+  ghost_mode_local_egress?: boolean;
   archive_mode?: boolean;
 }
 

--- a/ghost-core/src/init.cpp
+++ b/ghost-core/src/init.cpp
@@ -527,6 +527,7 @@ void SetupServerArgs(ArgsManager& argsman, bool can_listen_ipc)
     argsman.AddArg("-blockreconstructionextratxn=<n>", strprintf("Extra transactions to keep in memory for compact block reconstructions (default: %u)", DEFAULT_BLOCK_RECONSTRUCTION_EXTRA_TXN), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-blocksonly", strprintf("Whether to reject transactions from network peers. Disables automatic broadcast and rebroadcast of transactions, unless the source peer has the 'forcerelay' permission. RPC transactions are not affected. (default: %u)", DEFAULT_BLOCKSONLY), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-ghostmode", "Operate in ghost mode: do not request, relay, or announce unconfirmed transactions. Similar to -blocksonly but can be toggled at runtime via RPC (default: 0)", ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
+    argsman.AddArg("-ghostmodelocalegress", "In ghost mode, still announce and serve our OWN (locally-submitted) transactions so a connected wallet can reach miners, while peer-received transactions stay fully suppressed. Only meaningful alongside -ghostmode. Can be toggled at runtime via RPC (default: 0)", ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-shroud", "Add random delay (0-5s) before relaying transactions to peers, "
         "preventing timing-based origin detection. Does not affect mining. "
         "(default: 1)", ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
@@ -1742,6 +1743,13 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     if (args.GetBoolArg("-ghostmode", false)) {
         node.connman->SetGhostMode(true);
         LogPrintf("Ghost mode enabled: no transaction relay/announce\n");
+    }
+
+    // Initialize ghost mode local egress from startup flag (only meaningful
+    // alongside -ghostmode: announce/serve our own locally-submitted txs).
+    if (args.GetBoolArg("-ghostmodelocalegress", false)) {
+        node.connman->SetGhostModeLocalEgress(true);
+        LogPrintf("Ghost mode local egress enabled: own transactions announced to peers\n");
     }
 
     // Initialize tor mode flag on connman

--- a/ghost-core/src/net.h
+++ b/ghost-core/src/net.h
@@ -1143,6 +1143,12 @@ public:
     bool GetGhostMode() const { return m_ghost_mode.load(std::memory_order_relaxed); }
     void SetGhostMode(bool enable) { m_ghost_mode.store(enable, std::memory_order_relaxed); }
 
+    // Ghost mode local egress: when ghost mode is on, still announce and serve
+    // our OWN (locally-submitted) transactions so a connected wallet can reach
+    // miners. Peer-received transactions remain fully suppressed.
+    bool GetGhostModeLocalEgress() const { return m_ghost_mode_local_egress.load(std::memory_order_relaxed); }
+    void SetGhostModeLocalEgress(bool enable) { m_ghost_mode_local_egress.store(enable, std::memory_order_relaxed); }
+
     /** Tor mode: all connections through Tor, onion-only networking */
     bool GetTorMode() const { return m_tor_mode.load(std::memory_order_relaxed); }
     void SetTorMode(bool enable) { m_tor_mode.store(enable, std::memory_order_relaxed); }

--- a/ghost-core/src/net.h
+++ b/ghost-core/src/net.h
@@ -1461,6 +1461,8 @@ private:
     std::atomic<bool> fNetworkActive{true};
     /** Ghost mode: do not request, relay, or announce unconfirmed transactions */
     std::atomic<bool> m_ghost_mode{false};
+    /** Ghost mode local egress: still announce/serve our own (locally-submitted) txs while ghost mode suppresses the rest */
+    std::atomic<bool> m_ghost_mode_local_egress{false};
     /** Tor mode: all connections routed through Tor, suppress clearnet addresses */
     std::atomic<bool> m_tor_mode{false};
     bool fAddressesInitialized{false};

--- a/ghost-core/src/net_processing.cpp
+++ b/ghost-core/src/net_processing.cpp
@@ -2214,8 +2214,12 @@ void PeerManagerImpl::RelayTransactionDirect(const Txid& txid, const Wtxid& wtxi
 
 void PeerManagerImpl::RelayTransaction(const Txid& txid, const Wtxid& wtxid)
 {
-    // Ghost mode: do not relay transactions to peers
-    if (m_connman.GetGhostMode()) return;
+    // Ghost mode: do not relay peer-received transactions. When local egress is
+    // enabled, still announce our OWN (locally-submitted, still-unbroadcast)
+    // transactions so a connected wallet can reach miners.
+    if (m_connman.GetGhostMode()) {
+        if (!m_connman.GetGhostModeLocalEgress() || !m_mempool.IsUnbroadcastTxThreadSafe(txid)) return;
+    }
 
     if (m_opts.shroud) {
         LOCK(m_shroud_mutex);
@@ -2558,17 +2562,27 @@ void PeerManagerImpl::ProcessGetData(CNode& pfrom, Peer& peer, const std::atomic
             continue;
         }
 
-        // Ghost mode: do not respond to transaction GETDATA requests
-        if (m_connman.GetGhostMode()) {
-            vNotFound.push_back(inv);
-            continue;
-        }
-
         if (auto tx{FindTxForGetData(*tx_relay, ToGenTxid(inv))}) {
+            // Ghost mode: only serve our OWN (locally-submitted, still
+            // unbroadcast) transactions, and only when local egress is enabled.
+            // Peer-received transactions are never served. The inv may be a
+            // MSG_TX (txid) or MSG_WTX (wtxid), so the unbroadcast-set lookup
+            // (keyed by txid) is done on the located tx's hash, not inv.hash.
+            if (m_connman.GetGhostMode() &&
+                (!m_connman.GetGhostModeLocalEgress() || !m_mempool.IsUnbroadcastTxThreadSafe(tx->GetHash()))) {
+                vNotFound.push_back(inv);
+                continue;
+            }
             // WTX and WITNESS_TX imply we serialize with witness
             const auto maybe_with_witness = (inv.IsMsgTx() ? TX_NO_WITNESS : TX_WITH_WITNESS);
             MakeAndPushMessage(pfrom, NetMsgType::TX, maybe_with_witness(*tx));
-            m_mempool.RemoveUnbroadcastTx(tx->GetHash());
+            // In ghost mode we keep our own tx in the unbroadcast set so we keep
+            // announcing and serving it to every peer until it confirms —
+            // removing it on the first GETDATA would cap egress at a single peer
+            // and the unbroadcast flag is precisely how we identify our own txs.
+            if (!m_connman.GetGhostMode()) {
+                m_mempool.RemoveUnbroadcastTx(tx->GetHash());
+            }
         } else {
             vNotFound.push_back(inv);
         }
@@ -6263,8 +6277,10 @@ bool PeerManagerImpl::SendMessages(CNode* pto)
             peer->m_blocks_for_inv_relay.clear();
         }
 
-        // Ghost mode: skip transaction inventory broadcast entirely
-        if (auto tx_relay = peer->GetTxRelay(); tx_relay != nullptr && !m_connman.GetGhostMode()) {
+        // Ghost mode: skip transaction inventory broadcast entirely. When local
+        // egress is enabled, run the broadcast so our OWN txs can be announced;
+        // the per-tx unbroadcast guards below ensure peer txs are never sent.
+        if (auto tx_relay = peer->GetTxRelay(); tx_relay != nullptr && (!m_connman.GetGhostMode() || m_connman.GetGhostModeLocalEgress())) {
                 LOCK(tx_relay->m_tx_inventory_mutex);
                 // Check whether periodic sends should happen
                 bool fSendTrickle = pto->HasPermission(NetPermissionFlags::NoBan);
@@ -6298,6 +6314,13 @@ bool PeerManagerImpl::SendMessages(CNode* pto)
                                              CInv{MSG_WTX, wtxid.ToUint256()} :
                                              CInv{MSG_TX, txid.ToUint256()};
                         tx_relay->m_tx_inventory_to_send.erase(wtxid);
+
+                        // Ghost mode (local egress): never leak our full mempool
+                        // in response to a BIP35 mempool request; only advertise
+                        // our own still-unbroadcast transactions.
+                        if (m_connman.GetGhostMode() && !m_mempool.IsUnbroadcastTxThreadSafe(txid)) {
+                            continue;
+                        }
 
                         // Don't send transactions that peers will not put into their mempool
                         if (txinfo.fee < filterrate.GetFee(txinfo.vsize)) {
@@ -6345,6 +6368,14 @@ bool PeerManagerImpl::SendMessages(CNode* pto)
                         // Not in the mempool anymore? don't bother sending it.
                         auto txinfo = m_mempool.info(wtxid);
                         if (!txinfo.tx) {
+                            continue;
+                        }
+                        // Ghost mode (local egress): only announce our own
+                        // still-unbroadcast transactions. Site-1 already gates
+                        // what is queued here in ghost mode; this defends against
+                        // stale peer-tx entries queued before ghost mode was
+                        // toggled on at runtime.
+                        if (m_connman.GetGhostMode() && !m_mempool.IsUnbroadcastTxThreadSafe(txinfo.tx->GetHash())) {
                             continue;
                         }
                         // `TxRelay::m_tx_inventory_known_filter` contains either txids or wtxids

--- a/ghost-core/src/rpc/net.cpp
+++ b/ghost-core/src/rpc/net.cpp
@@ -925,6 +925,7 @@ static RPCHelpMan setghostmode()
                 },
                 RPCResult{RPCResult::Type::OBJ, "", "", {
                     {RPCResult::Type::BOOL, "ghost_mode", "Current ghost mode state"},
+                    {RPCResult::Type::BOOL, "ghost_mode_local_egress", "Whether local egress (own-tx broadcast) is enabled"},
                 }},
                 RPCExamples{
                     HelpExampleCli("setghostmode", "true")
@@ -939,6 +940,7 @@ static RPCHelpMan setghostmode()
 
     UniValue result(UniValue::VOBJ);
     result.pushKV("ghost_mode", connman.GetGhostMode());
+    result.pushKV("ghost_mode_local_egress", connman.GetGhostModeLocalEgress());
     return result;
 },
     };
@@ -953,6 +955,7 @@ static RPCHelpMan getghostmode()
                 {},
                 RPCResult{RPCResult::Type::OBJ, "", "", {
                     {RPCResult::Type::BOOL, "ghost_mode", "Current ghost mode state"},
+                    {RPCResult::Type::BOOL, "ghost_mode_local_egress", "Whether local egress (own-tx broadcast) is enabled"},
                 }},
                 RPCExamples{
                     HelpExampleCli("getghostmode", "")
@@ -965,6 +968,68 @@ static RPCHelpMan getghostmode()
 
     UniValue result(UniValue::VOBJ);
     result.pushKV("ghost_mode", connman.GetGhostMode());
+    result.pushKV("ghost_mode_local_egress", connman.GetGhostModeLocalEgress());
+    return result;
+},
+    };
+}
+
+static RPCHelpMan setghostmodelocalegress()
+{
+    return RPCHelpMan{
+        "setghostmodelocalegress",
+        "Enable or disable ghost mode local egress.\n"
+        "Only meaningful while ghost mode is enabled. When on, the node still announces and\n"
+        "serves its OWN (locally-submitted) transactions so a connected wallet can reach miners,\n"
+        "while peer-received transactions remain fully suppressed.\n",
+                {
+                    {"enable", RPCArg::Type::BOOL, RPCArg::Optional::NO, "true to enable local egress, false to disable"},
+                },
+                RPCResult{RPCResult::Type::OBJ, "", "", {
+                    {RPCResult::Type::BOOL, "ghost_mode", "Current ghost mode state"},
+                    {RPCResult::Type::BOOL, "ghost_mode_local_egress", "Whether local egress (own-tx broadcast) is enabled"},
+                }},
+                RPCExamples{
+                    HelpExampleCli("setghostmodelocalegress", "true")
+                    + HelpExampleRpc("setghostmodelocalegress", "true")
+                },
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
+    NodeContext& node = EnsureAnyNodeContext(request.context);
+    CConnman& connman = EnsureConnman(node);
+
+    connman.SetGhostModeLocalEgress(request.params[0].get_bool());
+
+    UniValue result(UniValue::VOBJ);
+    result.pushKV("ghost_mode", connman.GetGhostMode());
+    result.pushKV("ghost_mode_local_egress", connman.GetGhostModeLocalEgress());
+    return result;
+},
+    };
+}
+
+static RPCHelpMan getghostmodelocalegress()
+{
+    return RPCHelpMan{
+        "getghostmodelocalegress",
+        "Returns whether ghost mode local egress (own-tx broadcast) is enabled.\n",
+                {},
+                RPCResult{RPCResult::Type::OBJ, "", "", {
+                    {RPCResult::Type::BOOL, "ghost_mode", "Current ghost mode state"},
+                    {RPCResult::Type::BOOL, "ghost_mode_local_egress", "Whether local egress (own-tx broadcast) is enabled"},
+                }},
+                RPCExamples{
+                    HelpExampleCli("getghostmodelocalegress", "")
+                    + HelpExampleRpc("getghostmodelocalegress", "")
+                },
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
+    NodeContext& node = EnsureAnyNodeContext(request.context);
+    CConnman& connman = EnsureConnman(node);
+
+    UniValue result(UniValue::VOBJ);
+    result.pushKV("ghost_mode", connman.GetGhostMode());
+    result.pushKV("ghost_mode_local_egress", connman.GetGhostModeLocalEgress());
     return result;
 },
     };
@@ -1427,6 +1492,8 @@ void RegisterNetRPCCommands(CRPCTable& t)
         {"network", &setnetworkactive},
         {"network", &setghostmode},
         {"network", &getghostmode},
+        {"network", &setghostmodelocalegress},
+        {"network", &getghostmodelocalegress},
         {"network", &gettormode},
         {"network", &getnodeaddresses},
         {"network", &getaddrmaninfo},

--- a/ghost-core/src/txmempool.h
+++ b/ghost-core/src/txmempool.h
@@ -691,6 +691,15 @@ public:
         return m_unbroadcast_txids.count(txid) != 0;
     }
 
+    /** Thread-safe variant of IsUnbroadcastTx: takes cs internally. For callers
+     *  (e.g. ghost-mode local egress checks in net_processing) that do not hold
+     *  the mempool lock. */
+    bool IsUnbroadcastTxThreadSafe(const Txid& txid) const EXCLUSIVE_LOCKS_REQUIRED(!cs)
+    {
+        LOCK(cs);
+        return m_unbroadcast_txids.count(txid) != 0;
+    }
+
     /** Guards this internal counter for external reporting */
     uint64_t GetAndIncrementSequence() const EXCLUSIVE_LOCKS_REQUIRED(cs) {
         return m_sequence_number++;

--- a/ghost-core/test/functional/feature_ghost_mode_local_egress.py
+++ b/ghost-core/test/functional/feature_ghost_mode_local_egress.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Bitcoin Ghost developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test Ghost Mode local egress (own-tx broadcast).
+
+Ghost Mode suppresses the P2P transaction-relay path entirely. Local egress is
+a sub-mode that keeps a node's OWN (locally-submitted) transactions flowing to
+peers so a connected wallet can reach miners, while transactions received from
+other peers stay fully suppressed.
+
+Topology (node A is the ghost node, in the centre of a star):
+
+        node1 (B, normal) ----> node0 (A, ghost+egress) <---- node2 (C, normal)
+
+B and C are NOT connected to each other, so any transaction that reaches C must
+transit A.
+
+Assertions:
+  (a) A transaction submitted LOCALLY on A (sendrawtransaction) propagates to
+      both B's and C's mempools — local egress works.
+  (b) A transaction originated on B does NOT propagate through A: it never
+      reaches A's or C's mempool (peer-received txs are black-holed). A also
+      advertises tx_relay=false, so it never asked B for txs in the first place.
+  (c) If a peer force-sends a raw tx to A anyway, A rejects it (disconnects the
+      peer, transaction never enters A's mempool) — RejectIncomingTxs is
+      unchanged by local egress.
+"""
+
+from test_framework.blocktools import COINBASE_MATURITY
+from test_framework.messages import msg_tx
+from test_framework.p2p import P2PInterface
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal
+from test_framework.wallet import MiniWallet
+
+
+class GhostModeLocalEgressTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 3
+        self.extra_args = [
+            # node0 (A): ghost mode + local egress. -shroud=0 removes the random
+            # relay delay so announcements are deterministic for the test.
+            ["-ghostmode", "-ghostmodelocalegress", "-shroud=0"],
+            # node1 (B): normal relaying node.
+            [],
+            # node2 (C): normal relaying node.
+            [],
+        ]
+
+    def setup_network(self):
+        self.setup_nodes()
+        # Star topology centred on A. Deliberately do NOT connect B and C, so a
+        # transaction can only reach C by transiting A.
+        self.connect_nodes(0, 1)
+        self.connect_nodes(0, 2)
+        # Only blocks need to be in sync during setup; the ghost node will never
+        # have a matching mempool, so do not sync mempools here.
+        self.sync_blocks()
+
+    def wait_for_mempool(self, node, txid, *, timeout=60):
+        self.wait_until(lambda: txid in node.getrawmempool(), timeout=timeout)
+
+    def assert_not_in_mempool(self, node, txid):
+        assert txid not in node.getrawmempool(), (
+            f"tx {txid} unexpectedly present in mempool of {node.index}"
+        )
+
+    def run_test(self):
+        node_a, node_b, node_c = self.nodes
+        self.wallet = MiniWallet(node_a)
+
+        self.log.info("Fund the MiniWallet on node A and sync the chain to B and C")
+        # Five coinbase UTXOs to the wallet (four are spent below), then mature
+        # them so create_self_transfer has confirmed inputs to draw from.
+        self.generate(self.wallet, 5, sync_fun=self.sync_blocks)
+        self.generate(node_a, COINBASE_MATURITY, sync_fun=self.sync_blocks)
+
+        self.log.info("A advertises tx_relay=false to its peers (like blocksonly)")
+        for info in node_b.getpeerinfo():
+            # From B's point of view, A is the peer that told us not to relay.
+            assert_equal(info["relaytxes"], False)
+        for info in node_c.getpeerinfo():
+            assert_equal(info["relaytxes"], False)
+
+        # ------------------------------------------------------------------
+        # (a) A's own transaction reaches both B and C.
+        # ------------------------------------------------------------------
+        self.log.info("Local egress: A's own tx propagates to B and C")
+        tx_a = self.wallet.create_self_transfer()
+        node_a.sendrawtransaction(tx_a["hex"])
+        assert tx_a["txid"] in node_a.getrawmempool()
+        self.wait_for_mempool(node_b, tx_a["txid"])
+        self.wait_for_mempool(node_c, tx_a["txid"])
+        self.log.info("A's own transaction reached both peers")
+
+        # ------------------------------------------------------------------
+        # (b) A transaction originated on B is black-holed at A.
+        # ------------------------------------------------------------------
+        self.log.info("A peer tx originated on B does not propagate through A")
+        tx_b = self.wallet.create_self_transfer()
+        node_b.sendrawtransaction(tx_b["hex"])
+        assert tx_b["txid"] in node_b.getrawmempool()
+
+        # Use a second egress tx from A as a "flush": once it has reached C we
+        # know enough gossip rounds have elapsed that tx_b would have arrived too
+        # if it were ever going to.
+        tx_a2 = self.wallet.create_self_transfer()
+        node_a.sendrawtransaction(tx_a2["hex"])
+        self.wait_for_mempool(node_c, tx_a2["txid"])
+
+        self.assert_not_in_mempool(node_a, tx_b["txid"])
+        self.assert_not_in_mempool(node_c, tx_b["txid"])
+        # The tx is perfectly valid — it simply has nowhere to go from B, whose
+        # only peer (A) refused transaction relay.
+        assert tx_b["txid"] in node_b.getrawmempool()
+        self.log.info("B's transaction stayed on B; A refused to relay it")
+
+        # ------------------------------------------------------------------
+        # (c) A rejects a tx that a peer force-sends over the wire.
+        # ------------------------------------------------------------------
+        self.log.info("A rejects and disconnects a peer that force-sends a tx")
+        mempool_before = set(node_a.getrawmempool())
+        forced = self.wallet.create_self_transfer()
+        peer = node_a.add_p2p_connection(P2PInterface())
+        with node_a.assert_debug_log(["transaction sent in violation of protocol"]):
+            peer.send_without_ping(msg_tx(forced["tx"]))
+            peer.wait_for_disconnect()
+        self.assert_not_in_mempool(node_a, forced["txid"])
+        assert_equal(set(node_a.getrawmempool()), mempool_before)
+        self.log.info("Force-sent peer tx was rejected; A's mempool unchanged")
+
+
+if __name__ == "__main__":
+    GhostModeLocalEgressTest(__file__).main()

--- a/ghost-core/test/functional/test_runner.py
+++ b/ghost-core/test/functional/test_runner.py
@@ -236,6 +236,7 @@ BASE_SCRIPTS = [
     'rpc_setban.py --v1transport',
     'rpc_setban.py --v2transport',
     'p2p_blocksonly.py',
+    'feature_ghost_mode_local_egress.py',
     'mining_prioritisetransaction.py',
     'p2p_invalid_locator.py',
     'p2p_invalid_block.py --v1transport',


### PR DESCRIPTION
Ghost Mode local egress: with ghost mode on, still announce/serve the node's own (unbroadcast) txs so a connected wallet reaches miners; peer txs stay black-holed. net_processing sites 1/2/4 patched; `-ghostmodelocalegress` flag + set/get RPCs; Rust config + sync + auth-protected POST route; dashboard sub-toggle (enabled only when Ghost Mode on) + Tor privacy note; regtest test passes. ghostd built + `feature_ghost_mode_local_egress.py` PASSED locally.