### PR TITLE
dashboard: center collapsed brand with nav icons

### DIFF
--- a/dashboard/src/components/layout/Sidebar.tsx
+++ b/dashboard/src/components/layout/Sidebar.tsx
@@ -205,7 +205,7 @@ export function Sidebar() {
       >
         {/* Brand + collapse toggle */}
         <div
-          className="flex items-center justify-between px-4"
+          className={`flex items-center ${collapsed ? "justify-center" : "justify-between px-4"}`}
           style={{ height: "60px", borderBottom: "1px solid var(--rule)" }}
         >
           {!collapsed ? (


### PR DESCRIPTION
Drop px-4 on the collapsed header so the ghost brand centers in the same full width as the nav icons.