### PR TITLE
dashboard: tooltips inline-left of labels + drop NODE VITALS title

### DIFF
--- a/dashboard/src/app/(dashboard)/page.tsx
+++ b/dashboard/src/app/(dashboard)/page.tsx
@@ -44,7 +44,7 @@ const SHARE_TIERS = [
 
 function InfoIcon() {
   return (
-    <svg className="w-3 h-3 text-[color:var(--fainter)] inline-block mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+    <svg className="w-3 h-3 text-[color:var(--fainter)] inline-block align-middle mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
       <circle cx="12" cy="12" r="10" />
       <path d="M12 16v-4M12 8h.01" />
     </svg>
@@ -79,7 +79,7 @@ function L1Card() {
       <div className="grid grid-cols-2 gap-3">
         <Tooltip content={TOOLTIPS.block_height}>
           <div className="p-3 bg-[var(--surface)] rounded-lg">
-            <div className="text-xs text-[color:var(--fainter)] mb-1"><InfoIcon /> Block Height</div>
+            <div className="text-xs text-[color:var(--fainter)] mb-1 flex items-center gap-1"><InfoIcon /> Block Height</div>
             <div className="text-lg font-mono font-semibold text-[color:var(--fg)]">
               {isLoading ? "..." : isSyncing
                 ? <span>{syncHeight.toLocaleString()} <span className="text-xs text-[color:var(--accent)]">/ {blockHeight.toLocaleString()}</span></span>
@@ -95,7 +95,7 @@ function L1Card() {
         </Tooltip>
         <Tooltip content={TOOLTIPS.l1_peers}>
           <div className="p-3 bg-[var(--surface)] rounded-lg">
-            <div className="text-xs text-[color:var(--fainter)] mb-1"><InfoIcon /> Mesh Peers</div>
+            <div className="text-xs text-[color:var(--fainter)] mb-1 flex items-center gap-1"><InfoIcon /> Mesh Peers</div>
             <div className="text-lg font-mono font-semibold text-[color:var(--fg)]">
               {isLoading ? "..." : `${status?.peer_count ?? 0} connected`}
             </div>
@@ -103,7 +103,7 @@ function L1Card() {
         </Tooltip>
         <Tooltip content={TOOLTIPS.network_hashrate}>
           <div className="p-3 bg-[var(--surface)] rounded-lg">
-            <div className="text-xs text-[color:var(--fainter)] mb-1"><InfoIcon /> Network Hashrate</div>
+            <div className="text-xs text-[color:var(--fainter)] mb-1 flex items-center gap-1"><InfoIcon /> Network Hashrate</div>
             <div className="text-lg font-mono font-semibold text-[color:var(--fg)]">
               {bestHashLoading ? "..." : bestHash?.network_hashrate ? formatHashrate(bestHash.network_hashrate) : "--"}
             </div>
@@ -111,7 +111,7 @@ function L1Card() {
         </Tooltip>
         <Tooltip content={TOOLTIPS.pool_hashrate}>
           <div className="p-3 bg-[var(--surface)] rounded-lg">
-            <div className="text-xs text-[color:var(--fainter)] mb-1"><InfoIcon /> Ghost Pool Hashrate</div>
+            <div className="text-xs text-[color:var(--fainter)] mb-1 flex items-center gap-1"><InfoIcon /> Ghost Pool Hashrate</div>
             <div className="text-lg font-mono font-semibold text-[color:var(--fg)]">
               {isLoading ? "..." : mining ? formatHashrate((mining.hashrate_th ?? 0) * 1e12) : "0 H/s"}
             </div>
@@ -119,7 +119,7 @@ function L1Card() {
         </Tooltip>
         <Tooltip content={TOOLTIPS.l1_hashrate}>
           <div className="p-3 bg-[var(--surface)] rounded-lg">
-            <div className="text-xs text-[color:var(--fainter)] mb-1"><InfoIcon /> Your Hashrate</div>
+            <div className="text-xs text-[color:var(--fainter)] mb-1 flex items-center gap-1"><InfoIcon /> Your Hashrate</div>
             <div className="text-lg font-mono font-semibold text-[color:var(--fg)]">
               {isLoading ? "..." : mining ? formatHashrate((mining.local_hashrate_th ?? 0) * 1e12) : "0 H/s"}
             </div>
@@ -171,7 +171,7 @@ function L2Card() {
       <div className="grid grid-cols-2 gap-3">
         <Tooltip content={TOOLTIPS.l2_height}>
           <div className="p-3 bg-purple-900/10 rounded-lg">
-            <div className="text-xs text-[color:var(--fainter)] mb-1"><InfoIcon /> L2 Height</div>
+            <div className="text-xs text-[color:var(--fainter)] mb-1 flex items-center gap-1"><InfoIcon /> L2 Height</div>
             <div className="text-lg font-mono font-semibold text-[color:var(--fg)]">
               {isLoading ? "..." : isSyncing ? <span className="text-purple-400">Syncing...</span> : height}
             </div>
@@ -184,7 +184,7 @@ function L2Card() {
         </Tooltip>
         <Tooltip content={TOOLTIPS.l2_peers}>
           <div className="p-3 bg-purple-900/10 rounded-lg">
-            <div className="text-xs text-[color:var(--fainter)] mb-1"><InfoIcon /> L2 Peers</div>
+            <div className="text-xs text-[color:var(--fainter)] mb-1 flex items-center gap-1"><InfoIcon /> L2 Peers</div>
             <div className="text-lg font-mono font-semibold text-[color:var(--fg)]">
               {isLoading ? "..." : `${gp?.peer_count ?? 0} connected`}
             </div>
@@ -192,7 +192,7 @@ function L2Card() {
         </Tooltip>
         <Tooltip content={TOOLTIPS.l2_wraith}>
           <div className="p-3 bg-purple-900/10 rounded-lg">
-            <div className="text-xs text-[color:var(--fainter)] mb-1"><InfoIcon /> Wraith</div>
+            <div className="text-xs text-[color:var(--fainter)] mb-1 flex items-center gap-1"><InfoIcon /> Wraith</div>
             <div className="flex items-center gap-2">
               <StatusDot
                 status={wraithActive ? "online" : "offline"}
@@ -361,7 +361,7 @@ function PrivacySection() {
       <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3">
         <Tooltip content={TOOLTIPS.ghost_mode}>
           <div className="p-3 bg-[var(--surface)] rounded-lg">
-            <div className="text-xs text-[color:var(--fainter)] mb-1"><InfoIcon /> Ghost Mode</div>
+            <div className="text-xs text-[color:var(--fainter)] mb-1 flex items-center gap-1"><InfoIcon /> Ghost Mode</div>
             <div className="flex items-center gap-2">
               <StatusDot
                 status={ghostModeActive ? "online" : "offline"}
@@ -373,7 +373,7 @@ function PrivacySection() {
         </Tooltip>
         <Tooltip content={TOOLTIPS.privacy_tor}>
           <div className="p-3 bg-[var(--surface)] rounded-lg">
-            <div className="text-xs text-[color:var(--fainter)] mb-1"><InfoIcon /> Tor Mode</div>
+            <div className="text-xs text-[color:var(--fainter)] mb-1 flex items-center gap-1"><InfoIcon /> Tor Mode</div>
             <div className="flex items-center gap-2">
               <StatusDot
                 status={torActive ? "online" : "offline"}
@@ -385,7 +385,7 @@ function PrivacySection() {
         </Tooltip>
         <Tooltip content={TOOLTIPS.privacy_haze}>
           <div className="p-3 bg-[var(--surface)] rounded-lg">
-            <div className="text-xs text-[color:var(--fainter)] mb-1"><InfoIcon /> Ghost Haze</div>
+            <div className="text-xs text-[color:var(--fainter)] mb-1 flex items-center gap-1"><InfoIcon /> Ghost Haze</div>
             <div className="flex items-center gap-2">
               <StatusDot
                 status={hazeActive ? "online" : "offline"}
@@ -397,7 +397,7 @@ function PrivacySection() {
         </Tooltip>
         <Tooltip content={TOOLTIPS.privacy_shroud}>
           <div className="p-3 bg-[var(--surface)] rounded-lg">
-            <div className="text-xs text-[color:var(--fainter)] mb-1"><InfoIcon /> Ghost Shroud</div>
+            <div className="text-xs text-[color:var(--fainter)] mb-1 flex items-center gap-1"><InfoIcon /> Ghost Shroud</div>
             <div className="flex items-center gap-2">
               <StatusDot
                 status={shroudActive ? "online" : "offline"}
@@ -409,7 +409,7 @@ function PrivacySection() {
         </Tooltip>
         <Tooltip content={TOOLTIPS.privacy_wraith}>
           <div className="p-3 bg-[var(--surface)] rounded-lg">
-            <div className="text-xs text-[color:var(--fainter)] mb-1"><InfoIcon /> Wraith</div>
+            <div className="text-xs text-[color:var(--fainter)] mb-1 flex items-center gap-1"><InfoIcon /> Wraith</div>
             <div className="flex items-center gap-2">
               <StatusDot
                 status={wraithActive ? "online" : "offline"}

--- a/dashboard/src/app/(dashboard)/swarm/page.tsx
+++ b/dashboard/src/app/(dashboard)/swarm/page.tsx
@@ -47,7 +47,7 @@ function formatHashrate(th: number): string {
 // is wrapped in a <Tooltip> that carries the explanatory copy.
 function InfoIcon() {
   return (
-    <svg className="w-3 h-3 text-[color:var(--fainter)] inline-block mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+    <svg className="w-3 h-3 text-[color:var(--fainter)] inline-block align-middle mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
       <circle cx="12" cy="12" r="10" />
       <path d="M12 16v-4M12 8h.01" />
     </svg>
@@ -458,7 +458,7 @@ export default function SwarmPage() {
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div className="p-3 bg-[var(--surface)] rounded-lg">
                 <Tooltip content={TOOLTIPS.nodeId}>
-                  <div className="text-xs text-[color:var(--fainter)] uppercase tracking-wide mb-1 inline-block"><InfoIcon /> Node ID</div>
+                  <div className="text-xs text-[color:var(--fainter)] uppercase tracking-wide mb-1 flex items-center gap-1"><InfoIcon /> Node ID</div>
                 </Tooltip>
                 <div className="font-mono text-sm text-[color:var(--fg)] break-all select-all">
                   {nodeInfo.node_id}
@@ -466,7 +466,7 @@ export default function SwarmPage() {
               </div>
               <div className="p-3 bg-[var(--surface)] rounded-lg">
                 <Tooltip content={TOOLTIPS.connectionAddress}>
-                  <div className="text-xs text-[color:var(--fainter)] uppercase tracking-wide mb-1 inline-block"><InfoIcon /> Connection Address</div>
+                  <div className="text-xs text-[color:var(--fainter)] uppercase tracking-wide mb-1 flex items-center gap-1"><InfoIcon /> Connection Address</div>
                 </Tooltip>
                 <div className="font-mono text-sm text-[color:var(--fg)] mb-2 select-all">
                   {swarmData?.self?.address

--- a/dashboard/src/components/overlays/NodeVitalsOverlay.tsx
+++ b/dashboard/src/components/overlays/NodeVitalsOverlay.tsx
@@ -627,8 +627,6 @@ export function NodeVitalsOverlay({ active }: OverlayProps) {
             boxShadow: `0 0 12px 2px rgba(${ACCENT_RGB}, ${v.isSyncing ? 0.6 : 0})`,
           }}
         />
-        <span>Node Vitals</span>
-        <span style={{ color: 'var(--fainter)' }}>·</span>
         <span style={{ color: v.isSyncing ? 'var(--accent)' : 'var(--dim)' }}>
           {!hasStatus ? 'Acquiring signal' : v.isSyncing ? 'Syncing' : 'Synced'}
         </span>

--- a/dashboard/src/components/ui/StatCard.tsx
+++ b/dashboard/src/components/ui/StatCard.tsx
@@ -27,15 +27,15 @@ export function StatCard({ label, value, tooltip, icon, sublabel, loading, class
 
   const content = (
     <div className={`bg-[var(--surface)] border border-[color:var(--rule)] rounded-lg p-4 h-[104px] flex flex-col justify-between ${className}`}>
-      <div className="flex items-center gap-2 text-sm text-[color:var(--dim)]">
-        {icon && <span className="w-4 h-4 flex-shrink-0">{icon}</span>}
-        <span className="truncate">{label}</span>
+      <div className="flex items-center gap-1.5 text-sm text-[color:var(--dim)]">
         {tooltip && (
           <svg className="w-3 h-3 text-[color:var(--fainter)] flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
             <circle cx="12" cy="12" r="10" />
             <path d="M12 16v-4M12 8h.01" />
           </svg>
         )}
+        {icon && <span className="w-4 h-4 flex-shrink-0">{icon}</span>}
+        <span className="truncate">{label}</span>
       </div>
       <div>
         <div className="text-2xl font-bold text-[color:var(--fg)] truncate">{value}</div>


### PR DESCRIPTION
Move tooltip icons to the left of every label (StatCard + Overview + Swarm); remove the Node Vitals title from the Home top line.