### PR TITLE
ghost: Ghost Mode and Public Mining are mutually exclusive (backend + dashboard)

### DIFF
--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -8656,7 +8656,7 @@ fn reaper_config_from_settings(s: &ReaperSettings) -> ReaperConfig {
 
 /// Load configuration from file
 fn load_config(path: &std::path::Path) -> Result<NodeConfig> {
-    let config = if path.exists() {
+    let mut config = if path.exists() {
         let content = std::fs::read_to_string(path)?;
 
         // One-shot deprecation check: the legacy `public_mining` bool was
@@ -8685,6 +8685,16 @@ fn load_config(path: &std::path::Path) -> Result<NodeConfig> {
         info!("No config file found at {}, using defaults", path.display());
         NodeConfig::default()
     };
+
+    // Enforce the Ghost Mode / Public Mining mutual exclusion at load time. A
+    // Ghost Mode node builds near-empty blocks and forfeits all transaction-fee
+    // income, so it must never also run as a public miner. If a config file sets
+    // both, Ghost Mode is disabled (Public Mining, the income-earning
+    // capability, is left active) and the change is logged loudly rather than
+    // silently allowed.
+    if let Some(warning) = config.reconcile_ghost_mode_mining_exclusion() {
+        warn!("{}", warning);
+    }
 
     // Validate pool configuration
     if let Err(e) = config.pool.validate() {

--- a/crates/ghost-common/src/config.rs
+++ b/crates/ghost-common/src/config.rs
@@ -415,6 +415,38 @@ impl NodeConfig {
         self.ghost_pay.as_ref().is_some_and(|gp| gp.wraith_enabled)
     }
 
+    /// Reconcile the mutually-exclusive Ghost Mode / Public Mining pair.
+    ///
+    /// A Ghost Mode node suppresses the peer transaction-relay path, so its
+    /// mempool never fills and the blocks it builds are near-empty — the
+    /// operator forfeits all transaction-fee income (fees accrue to the node
+    /// operator; miners are paid from the subsidy less the pool fee). Running
+    /// Ghost Mode alongside Public Mining (`mining_mode = PublicPool`) is
+    /// therefore self-harming and must never be allowed.
+    ///
+    /// If a config file enables both, this disables Ghost Mode and leaves
+    /// Public Mining active — Public Mining is the income-earning capability, so
+    /// keeping it and dropping the flag that zeroes its revenue is the safe
+    /// resolution. Returns `Some(message)` describing the change so the caller
+    /// can log it loudly, or `None` when there is no conflict.
+    #[must_use]
+    pub fn reconcile_ghost_mode_mining_exclusion(&mut self) -> Option<String> {
+        if self.network.ghost_mode && matches!(self.network.mining_mode, MiningMode::PublicPool) {
+            self.network.ghost_mode = false;
+            Some(
+                "CONFLICT: `ghost_mode = true` and `mining_mode = PublicPool` were both set. \
+                 A Ghost Mode node suppresses peer transactions and builds near-empty blocks, \
+                 forfeiting all transaction-fee income, so it cannot run as a public miner. \
+                 Ghost Mode has been DISABLED and Public Mining left active. Set \
+                 `ghost_mode = false` or switch `mining_mode` away from PublicPool in pool.toml \
+                 to silence this warning."
+                    .to_string(),
+            )
+        } else {
+            None
+        }
+    }
+
     /// Validate the configuration
     ///
     /// Returns validation result with any errors and warnings found.
@@ -2608,6 +2640,55 @@ mod tests {
             custom: None,
         };
         assert_eq!(config.profile, PolicyProfile::BitcoinPure);
+    }
+
+    #[test]
+    fn ghost_mode_and_public_mining_conflict_disables_ghost_mode() {
+        let mut config = NodeConfig::default();
+        config.network.mining_mode = MiningMode::PublicPool;
+        config.network.ghost_mode = true;
+
+        let warning = config.reconcile_ghost_mode_mining_exclusion();
+
+        assert!(
+            warning.is_some(),
+            "a config enabling both Ghost Mode and Public Mining must be reconciled"
+        );
+        assert!(
+            !config.network.ghost_mode,
+            "Ghost Mode must be disabled to preserve fee income"
+        );
+        assert!(
+            matches!(config.network.mining_mode, MiningMode::PublicPool),
+            "Public Mining (the income-earning capability) must be left active"
+        );
+    }
+
+    #[test]
+    fn ghost_mode_without_public_mining_is_left_untouched() {
+        let mut config = NodeConfig::default();
+        config.network.mining_mode = MiningMode::PrivateSolo;
+        config.network.ghost_mode = true;
+
+        let warning = config.reconcile_ghost_mode_mining_exclusion();
+
+        assert!(warning.is_none(), "no conflict without Public Mining");
+        assert!(config.network.ghost_mode, "Ghost Mode must be preserved when it is safe");
+    }
+
+    #[test]
+    fn public_mining_without_ghost_mode_is_left_untouched() {
+        let mut config = NodeConfig::default();
+        config.network.mining_mode = MiningMode::PublicPool;
+        config.network.ghost_mode = false;
+
+        let warning = config.reconcile_ghost_mode_mining_exclusion();
+
+        assert!(warning.is_none(), "no conflict when Ghost Mode is off");
+        assert!(
+            matches!(config.network.mining_mode, MiningMode::PublicPool),
+            "Public Mining must remain active"
+        );
     }
 
     #[test]

--- a/crates/ghost-verification/src/routes.rs
+++ b/crates/ghost-verification/src/routes.rs
@@ -5643,6 +5643,24 @@ async fn api_config_ghost_mode_post_handler(
 ) -> impl IntoResponse {
     let enabled = payload.enabled;
 
+    // Mutual exclusion with Public Mining. A Ghost Mode node suppresses the
+    // peer transaction-relay path, so its mempool never fills and the blocks it
+    // builds are near-empty — the operator forfeits all transaction-fee income
+    // (fees accrue to the node operator; miners are paid from the subsidy less
+    // the pool fee). Enabling Ghost Mode while Public Mining is active is
+    // therefore self-harming and is refused. Turning Ghost Mode OFF is always
+    // allowed, so this only guards the enable path. No state is mutated on
+    // rejection.
+    if enabled && state.dashboard_config.read().public_mining {
+        return (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({
+                "success": false,
+                "error": "Public Mining is active. Disable it before enabling Ghost Mode — a Ghost Mode node builds empty blocks and forfeits all transaction-fee income."
+            })),
+        );
+    }
+
     // Try to call ghost-core RPC to set ghost mode
     let rpc_result = if let Some(ref rpc) = state.rpc {
         match rpc.set_ghost_mode(enabled).await {
@@ -5681,16 +5699,19 @@ async fn api_config_ghost_mode_post_handler(
         }
     }
 
-    Json(serde_json::json!({
-        "success": true,
-        "enabled": actual_enabled,
-        "rpc_synced": rpc_result.is_some(),
-        "message": if rpc_result.is_some() {
-            "Ghost mode updated and synced with ghost-core"
-        } else {
-            "Ghost mode updated (RPC sync unavailable)"
-        }
-    }))
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({
+            "success": true,
+            "enabled": actual_enabled,
+            "rpc_synced": rpc_result.is_some(),
+            "message": if rpc_result.is_some() {
+                "Ghost mode updated and synced with ghost-core"
+            } else {
+                "Ghost mode updated (RPC sync unavailable)"
+            }
+        })),
+    )
 }
 
 /// API v1 Config ghost_mode_local_egress POST handler
@@ -5767,12 +5788,32 @@ async fn api_config_public_mining_post_handler(
     Json(payload): Json<ToggleRequest>,
 ) -> impl IntoResponse {
     let mut config = state.dashboard_config.write();
+
+    // Mutual exclusion with Ghost Mode (symmetric with the ghost_mode handler).
+    // A Ghost Mode node builds near-empty blocks and forfeits all
+    // transaction-fee income, so accepting public miners alongside it earns
+    // the operator nothing on fees. Refuse to enable Public Mining while Ghost
+    // Mode is active; disabling it is always allowed. Reject without mutating
+    // state.
+    if payload.enabled && config.ghost_mode {
+        return (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({
+                "success": false,
+                "error": "Ghost Mode is active. Disable it before enabling Public Mining."
+            })),
+        );
+    }
+
     config.public_mining = payload.enabled;
-    Json(serde_json::json!({
-        "success": true,
-        "enabled": payload.enabled,
-        "message": "Public mining updated"
-    }))
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({
+            "success": true,
+            "enabled": payload.enabled,
+            "message": "Public mining updated"
+        })),
+    )
 }
 
 /// Resolve the `ghost-setup` binary used to apply the ghostd mempool-reaper
@@ -9459,6 +9500,20 @@ async fn api_mining_public_post_handler(
 ) -> impl IntoResponse {
     if let Some(enabled) = body.enabled {
         let mut config = state.dashboard_config.write();
+        // Mutual exclusion with Ghost Mode (this is the toggle the dashboard
+        // Capabilities page drives). A Ghost Mode node builds near-empty blocks
+        // and forfeits all transaction-fee income, so it must not also accept
+        // public miners. Refuse to enable Public Mining while Ghost Mode is
+        // active; disabling it is always allowed. Reject without mutating state.
+        if enabled && config.ghost_mode {
+            return (
+                StatusCode::CONFLICT,
+                Json(serde_json::json!({
+                    "error": "Ghost Mode is active. Disable it before enabling Public Mining."
+                })),
+            )
+                .into_response();
+        }
         config.public_mining = enabled;
     }
     api_mining_status_handler(State(state))

--- a/dashboard/src/app/(dashboard)/ghost-mode/page.tsx
+++ b/dashboard/src/app/(dashboard)/ghost-mode/page.tsx
@@ -64,6 +64,14 @@ export default function GhostModePage() {
 
   const ghostMode = !!status?.ghost_mode;
   const localEgress = !!status?.ghost_mode_local_egress;
+  const publicMining = !!status?.public_mining;
+  // Ghost Mode and Public Mining are mutually exclusive: a Ghost Mode node
+  // builds near-empty blocks and forfeits all transaction-fee income, so it
+  // must not also run as a public miner. Block the enable path while Public
+  // Mining is active (turning Ghost Mode OFF stays allowed). The backend
+  // enforces the same rule and answers a conflicting enable with a 409.
+  const ghostModeBlocked = publicMining && !ghostMode;
+  const ghostModeToggleDisabled = setGhostMode.isPending || ghostModeBlocked;
   // The sub-toggle only has any effect while Ghost Mode is on; grey it out
   // otherwise so operators can't arm a setting that does nothing.
   const localEgressDisabled = !ghostMode || setLocalEgress.isPending;
@@ -105,7 +113,7 @@ export default function GhostModePage() {
                   error("Failed to update Ghost Mode", e instanceof Error ? e.message : "Unknown error");
                 }
               }}
-              disabled={setGhostMode.isPending}
+              disabled={ghostModeToggleDisabled}
               className="flex-shrink-0"
               style={{
                 width: "44px",
@@ -113,12 +121,13 @@ export default function GhostModePage() {
                 borderRadius: "12px",
                 background: ghostMode ? "var(--accent)" : "var(--rule-strong)",
                 border: "none",
-                cursor: setGhostMode.isPending ? "not-allowed" : "pointer",
-                opacity: setGhostMode.isPending ? 0.6 : 1,
+                cursor: ghostModeToggleDisabled ? "not-allowed" : "pointer",
+                opacity: ghostModeToggleDisabled ? 0.6 : 1,
                 position: "relative",
                 transition: "background 120ms",
               }}
               aria-pressed={ghostMode}
+              aria-disabled={ghostModeToggleDisabled}
             >
               <span
                 style={{
@@ -134,6 +143,33 @@ export default function GhostModePage() {
               />
             </button>
           </div>
+
+          {/* Mutual-exclusion guard: Public Mining active blocks Ghost Mode */}
+          {ghostModeBlocked && (
+            <div
+              style={{
+                marginTop: "14px",
+                padding: "12px 14px",
+                background: "color-mix(in srgb, var(--yellow) 8%, transparent)",
+                border: "1px solid color-mix(in srgb, var(--yellow) 40%, transparent)",
+                borderRadius: "6px",
+              }}
+            >
+              <p style={{ color: "var(--fg)", fontSize: "13px", lineHeight: "1.6" }}>
+                <span style={{ color: "var(--yellow)", fontWeight: 600 }}>Public Mining is active.</span>{" "}
+                Ghost Mode would make your node build empty blocks and forfeit all fee income, so the
+                two can&apos;t run together — disable Public Mining first on the{" "}
+                <a
+                  href="/settings/capabilities"
+                  className="bare"
+                  style={{ color: "var(--fg)", textDecoration: "underline", textDecorationColor: "var(--yellow)" }}
+                >
+                  Capabilities page
+                </a>
+                .
+              </p>
+            </div>
+          )}
 
           {/* Sub-toggle: local egress (own-tx broadcast) */}
           <div

--- a/dashboard/src/app/(dashboard)/settings/capabilities/page.tsx
+++ b/dashboard/src/app/(dashboard)/settings/capabilities/page.tsx
@@ -25,6 +25,24 @@ export default function CapabilitiesSettingsPage() {
 
   const { success, error } = useToast();
 
+  // Ghost Mode and Public Mining are mutually exclusive: a Ghost Mode node
+  // builds near-empty blocks and forfeits all transaction-fee income, so it
+  // must not also accept public miners. Block enabling Public Mining while
+  // Ghost Mode is active (disabling it stays allowed). The backend enforces the
+  // same rule and answers a conflicting enable with a 409, surfaced below.
+  const ghostModeActive = status?.ghost_mode ?? false;
+  const publicMiningActive = status?.public_mining ?? false;
+  const publicMiningBlocked = ghostModeActive && !publicMiningActive;
+
+  const handlePublicMiningToggle = async (enabled: boolean) => {
+    try {
+      await setPublicMining.mutateAsync(enabled);
+      success("Mode Changed", `Public Mining ${enabled ? "enabled" : "disabled"}`);
+    } catch (err) {
+      error("Failed", err instanceof Error ? err.message : "Unknown error");
+    }
+  };
+
   const handleArchiveModeToggle = async (enabled: boolean) => {
     try {
       await setArchiveMode.mutateAsync(enabled);
@@ -81,15 +99,31 @@ export default function CapabilitiesSettingsPage() {
       <ToggleRow
         label="Public Mining"
         description="Accept mining connections from public miners (+3 shares bonus)"
-        enabled={status?.public_mining ?? false}
-        onChange={(enabled) => setPublicMining.mutate(enabled)}
-        disabled={setPublicMining.isPending}
+        enabled={publicMiningActive}
+        onChange={handlePublicMiningToggle}
+        disabled={setPublicMining.isPending || publicMiningBlocked}
         badge={
-          status?.public_mining ? (
+          publicMiningActive ? (
             <Badge variant="success">+3 Shares</Badge>
           ) : null
         }
       />
+
+      {publicMiningBlocked && (
+        <div
+          className="p-3 rounded-lg"
+          style={{
+            background: "color-mix(in srgb, var(--yellow) 8%, transparent)",
+            border: "1px solid color-mix(in srgb, var(--yellow) 40%, transparent)",
+          }}
+        >
+          <p className="text-sm" style={{ color: "var(--fg)", lineHeight: "1.6" }}>
+            <span style={{ color: "var(--yellow)", fontWeight: 600 }}>Ghost Mode is active</span>{" "}
+            — disable it before enabling Public Mining. A Ghost Mode node builds empty blocks and
+            forfeits all transaction-fee income, so the two can&apos;t run together.
+          </p>
+        </div>
+      )}
 
       <ToggleRow
         label="Ghost Reaper"


### PR DESCRIPTION
## Summary

Ghost Mode and Public Mining are now **mutually exclusive**, enforced in the backend and surfaced in the dashboard.

**Why:** a node in Ghost Mode suppresses the peer transaction-relay path, so its mempool never fills and the blocks it builds are near-empty — coinbase subsidy only. Transaction fees accrue to the node operator (miners are paid from the subsidy, less the pool fee), so an empty block means the operator collects **zero fee income**. Running both is self-harming, so it is now blocked rather than merely warned about.

## Backend enforcement

- **`POST /api/v1/config/ghost_mode`** — enabling Ghost Mode while `public_mining` is active returns **409 Conflict** with `"Public Mining is active. Disable it before enabling Ghost Mode — a Ghost Mode node builds empty blocks and forfeits all transaction-fee income."` No state is mutated on rejection. Disabling Ghost Mode is always allowed.
- **`POST /api/v1/mining/public`** (the toggle the dashboard Capabilities page actually drives) **and** `POST /api/v1/config/public_mining` — symmetric: enabling Public Mining while `ghost_mode` is active returns **409** with `"Ghost Mode is active. Disable it before enabling Public Mining."` Disabling is always allowed.
- The existing auth and persistence behaviour is untouched on the allowed paths; each handler now returns a consistent `(StatusCode, Json)` so the 409 and 200 paths share a return type.

## Startup / config-load guard

- New `NodeConfig::reconcile_ghost_mode_mining_exclusion()` in `ghost-common`: if a `pool.toml` sets both `ghost_mode = true` and `mining_mode = PublicPool`, it **disables Ghost Mode** (leaving Public Mining, the income-earning capability, active) and returns a message. `ghost-pool`'s `load_config()` calls it and logs the message loudly via `warn!`. Both-true is never silently allowed.
- Covered by three unit tests (conflict resolves, and each flag alone is left untouched).

## Dashboard

- **Ghost Mode page** — when Public Mining is active, the Ghost Mode toggle is greyed and non-clickable, with a `--yellow` warning: *"Public Mining is active. Ghost Mode would make your node build empty blocks and forfeit all fee income, so the two can't run together — disable Public Mining first."* A 409 from a race is surfaced through the existing toast.
- **Capabilities page** (Public Mining toggle) — symmetric: greyed toggle + `--yellow` warning when Ghost Mode is active; the toggle now uses `mutateAsync` in a try/catch so a 409 surfaces via toast.
- Only the enable direction is blocked in both places, so an operator can always turn a capability back **off**.

## Verification

- `cargo check -p ghost-common -p ghost-verification` — pass. `cargo check -p ghost-pool` — pass (validates the `load_config` change).
- `cargo test -p ghost-common` reconciliation tests — 3/3 pass.
- Dashboard: `tsc --noEmit` clean, `eslint` on both changed pages clean, `npm run build` compiles successfully (54/54 pages).

## Not in this PR

The **ghost-pool release build and the elder-gated rolling deploy are the parent's** — this PR is code only, no deploy/merge.
