### PR TITLE
fix(dashboard): minor audit items — watchdog labels, swarm spinner, dates, dead links, invalidation

### DIFF
--- a/dashboard/src/app/(dashboard)/capabilities/page.tsx
+++ b/dashboard/src/app/(dashboard)/capabilities/page.tsx
@@ -219,11 +219,7 @@ export default function CapabilitiesPage() {
       )}
 
       <p style={{ color: "var(--fainter)", fontSize: "13px" }}>
-        Qualification is calculated from peer-issued verification challenges over a 7-day rolling window. A capability counts at payout when ≥10 challenges have completed at ≥95% pass rate (≥90% for Ghost Pay) from at least 2 unique peers. Source:{" "}
-        <a href="/docs/#" className="bare" style={{ color: "var(--dim)", textDecoration: "underline", textDecorationColor: "var(--rule-strong)" }}>
-          economics-deep-dive
-        </a>
-        .
+        Qualification is calculated from peer-issued verification challenges over a 7-day rolling window. A capability counts at payout when ≥10 challenges have completed at ≥95% pass rate (≥90% for Ghost Pay) from at least 2 unique peers.
       </p>
     </div>
   );

--- a/dashboard/src/app/(dashboard)/settings/MempoolProfileDialog.tsx
+++ b/dashboard/src/app/(dashboard)/settings/MempoolProfileDialog.tsx
@@ -85,8 +85,7 @@ export function MempoolProfileDialog({
                 cause your node to reject valid transactions or accept unwanted ones.
               </p>
               <p className="text-[color:var(--accent)]/80 text-sm mt-2">
-                If you&apos;re unsure, use one of the preset profiles instead. For guidance, refer to
-                the <a href="/docs/mempool-profiles" className="text-[color:var(--accent)] underline hover:text-[color:var(--accent)]">Mempool Profile Guide</a>.
+                If you&apos;re unsure, use one of the preset profiles instead.
               </p>
             </div>
           </div>

--- a/dashboard/src/app/(dashboard)/settings/TemplateProfileDialog.tsx
+++ b/dashboard/src/app/(dashboard)/settings/TemplateProfileDialog.tsx
@@ -84,8 +84,7 @@ export function TemplateProfileDialog({
                 affect your mining efficiency or block validity.
               </p>
               <p className="text-[color:var(--accent)]/80 text-sm mt-2">
-                If you&apos;re unsure, use one of the preset profiles instead. For guidance, refer to
-                the <a href="/docs/template-profiles" className="text-[color:var(--accent)] underline hover:text-[color:var(--accent)]">Block Template Guide</a>.
+                If you&apos;re unsure, use one of the preset profiles instead.
               </p>
             </div>
           </div>

--- a/dashboard/src/app/(dashboard)/swarm/page.tsx
+++ b/dashboard/src/app/(dashboard)/swarm/page.tsx
@@ -283,9 +283,19 @@ export default function SwarmPage() {
     }
   };
 
-  // Individual refresh button now refreshes ALL nodes
-  const handleRefreshNode = async (_node: SwarmNode) => {
-    await handleRefreshAll(true);
+  // Per-node refresh: poll just this node so the button's own spinner
+  // (loading={refreshNode.isPending}) reflects the in-flight request.
+  const handleRefreshNode = (node: SwarmNode) => {
+    refreshNode.mutate(node.node_id, {
+      onSuccess: () => {
+        markNodeStale(node.node_id, false);
+        success("Node Refreshed", `${node.name} updated`);
+      },
+      onError: (err) => {
+        markNodeStale(node.node_id, true);
+        error("Refresh Failed", err instanceof Error ? err.message : "Unknown error");
+      },
+    });
   };
 
   // Auto-refresh all nodes every 30 seconds
@@ -595,7 +605,7 @@ export default function SwarmPage() {
                   </Tooltip>
                   {node.address !== "localhost" && !isMeshNode(node) && (
                     <Tooltip content={TOOLTIPS.refresh}>
-                      <Button variant="ghost" size="sm" onClick={() => handleRefreshNode(node)} className="text-xs px-2">
+                      <Button variant="ghost" size="sm" onClick={() => handleRefreshNode(node)} loading={refreshNode.isPending} className="text-xs px-2">
                         Refresh
                       </Button>
                     </Tooltip>

--- a/dashboard/src/app/(dashboard)/system/page.tsx
+++ b/dashboard/src/app/(dashboard)/system/page.tsx
@@ -52,6 +52,7 @@ function formatBytes(bytes: number): string {
 }
 
 function formatDate(dateStr: string): string {
+  if (!dateStr) return "—";
   try {
     return new Date(dateStr).toLocaleDateString(undefined, {
       year: "numeric",
@@ -64,6 +65,7 @@ function formatDate(dateStr: string): string {
 }
 
 function formatTimestampDate(timestamp: number): string {
+  if (!timestamp) return "—";
   return new Date(timestamp * 1000).toLocaleString();
 }
 
@@ -224,8 +226,10 @@ export default function SystemPage() {
 
   const handleCheckForUpdates = async () => {
     try {
-      await recheckUpdates();
-      if (!updateCheck?.update_available) {
+      // Use the freshly refetched result, not the closure-captured value
+      // (updateCheck reflects the state from before this refetch).
+      const { data } = await recheckUpdates();
+      if (!data?.update_available) {
         success("Up to Date", "You are running the latest version");
       }
     } catch (err) {
@@ -457,7 +461,7 @@ export default function SystemPage() {
                       <ProgressBar
                         value={updateStatus.progress.progress_percent ?? 0}
                         label={updateStatus.progress.step}
-                        sublabel={`${updateStatus.progress.progress_percent}%`}
+                        sublabel={`${updateStatus.progress.progress_percent ?? 0}%`}
                         color="orange"
                       />
                       <p className="text-sm text-[color:var(--fainter)]">{updateStatus.progress.message}</p>

--- a/dashboard/src/app/(dashboard)/watchdog/page.tsx
+++ b/dashboard/src/app/(dashboard)/watchdog/page.tsx
@@ -19,7 +19,16 @@ type ServiceAction = "start" | "stop" | "restart";
 
 
 function formatTimestamp(timestamp: number): string {
-  return new Date(timestamp * 1000).toLocaleString();
+  if (!timestamp) return "—";
+  // Backend timestamps are Unix seconds; guard against values already in ms.
+  const ms = timestamp < 1e12 ? timestamp * 1000 : timestamp;
+  return new Date(ms).toLocaleString();
+}
+
+// A component/service is "running" when it reports an active state. Anything
+// else (stopped, error, unknown, not_enabled) should offer Start, not Stop.
+function isRunningStatus(status: string): boolean {
+  return status === "ok" || status === "running" || status === "syncing";
 }
 
 function getStatusBadge(status: string): { variant: "success" | "warning" | "error" | "info" | "default"; label: string } {
@@ -31,6 +40,8 @@ function getStatusBadge(status: string): { variant: "success" | "warning" | "err
       return { variant: "info", label: "Syncing" };
     case "stopped":
       return { variant: "default", label: "Stopped" };
+    case "not_enabled":
+      return { variant: "default", label: "Not Enabled" };
     case "error":
     case "unknown":
       return { variant: "error", label: "Error" };
@@ -357,16 +368,7 @@ export default function WatchdogPage() {
                         <Badge variant={statusBadge.variant}>{statusBadge.label}</Badge>
                       </div>
                       <div className="flex gap-2">
-                        {service.status === "stopped" || service.status === "error" ? (
-                          <Button
-                            size="sm"
-                            variant="success"
-                            onClick={() => handleActionClick(service.name, "start")}
-                            disabled={isPending}
-                          >
-                            Start
-                          </Button>
-                        ) : (
+                        {isRunningStatus(service.status) ? (
                           <Button
                             size="sm"
                             variant="danger"
@@ -374,6 +376,15 @@ export default function WatchdogPage() {
                             disabled={isPending}
                           >
                             Stop
+                          </Button>
+                        ) : (
+                          <Button
+                            size="sm"
+                            variant="success"
+                            onClick={() => handleActionClick(service.name, "start")}
+                            disabled={isPending}
+                          >
+                            Start
                           </Button>
                         )}
                         <Button
@@ -461,16 +472,7 @@ export default function WatchdogPage() {
                         </td>
                         <td className="py-3">
                           <div className="flex gap-2">
-                            {component.status === "error" || component.status === "unknown" ? (
-                              <Button
-                                size="sm"
-                                variant="success"
-                                onClick={() => handleActionClick(component.name, "start")}
-                                disabled={isPending}
-                              >
-                                Start
-                              </Button>
-                            ) : (
+                            {isRunningStatus(component.status) ? (
                               <Button
                                 size="sm"
                                 variant="danger"
@@ -478,6 +480,15 @@ export default function WatchdogPage() {
                                 disabled={isPending}
                               >
                                 Stop
+                              </Button>
+                            ) : (
+                              <Button
+                                size="sm"
+                                variant="success"
+                                onClick={() => handleActionClick(component.name, "start")}
+                                disabled={isPending}
+                              >
+                                Start
                               </Button>
                             )}
                             <Button

--- a/dashboard/src/components/PayoutHistoryCard.tsx
+++ b/dashboard/src/components/PayoutHistoryCard.tsx
@@ -17,6 +17,7 @@ function formatSats(satoshis: number): string {
 }
 
 function formatTimestamp(timestamp: number): string {
+  if (!timestamp) return "—";
   const date = new Date(timestamp * 1000);
   return date.toLocaleString(undefined, {
     month: "short",

--- a/dashboard/src/hooks/queries/useConfigQueries.ts
+++ b/dashboard/src/hooks/queries/useConfigQueries.ts
@@ -70,7 +70,10 @@ export function useSetGhostMode() {
   return useMutation({
     mutationFn: (enabled: boolean) => setGhostMode(enabled),
     onSuccess: () => {
+      // The toggle binds to node status (status.ghost_mode), so refresh both
+      // the config and node status caches to keep the control in sync.
       queryClient.invalidateQueries({ queryKey: configKeys.all });
+      queryClient.invalidateQueries({ queryKey: nodeKeys.status() });
     },
   });
 }
@@ -109,7 +112,10 @@ export function useSetArchiveMode() {
   return useMutation({
     mutationFn: (enabled: boolean) => setArchiveMode(enabled),
     onSuccess: () => {
+      // The toggle binds to node status (status.archive_mode), so refresh both
+      // the config and node status caches to keep the control in sync.
       queryClient.invalidateQueries({ queryKey: configKeys.all });
+      queryClient.invalidateQueries({ queryKey: nodeKeys.status() });
     },
   });
 }


### PR DESCRIPTION
Fixes a batch of minor/cosmetic dashboard defects surfaced by an audit. No behavioural risk beyond the described corrections; `tsc`, `eslint`, and `next build` all pass.

### Fixes
1. **Watchdog Start/Stop labels inverted** (`watchdog/page.tsx`) — the Service Status and Component Health action buttons offered `Stop` for components that were not actually running (e.g. `stopped`, `not_enabled`). Introduced an `isRunningStatus()` helper (`ok`/`running`/`syncing`) so the button offers `Start` unless the component is genuinely running. Added a `not_enabled` case to `getStatusBadge` so it no longer renders the raw status string.
2. **Swarm per-node Refresh spinner** (`swarm/page.tsx`) — `handleRefreshNode` called `handleRefreshAll()` instead of the per-node mutation, so `loading={refreshNode.isPending}` never fired. It now calls `refreshNode.mutate(node.node_id, …)` with stale-marking and toast feedback, and the grid-view Refresh button gained the missing `loading` prop.
3. **1970-epoch dates on missing timestamps** — guarded `formatTimestamp`/`formatTimestampDate`/`formatDate` so a missing/zero value renders `—` instead of a `1970` / `Invalid Date` string (`PayoutHistoryCard.tsx`, `system/page.tsx`, `watchdog/page.tsx`; watchdog also gained a seconds-vs-milliseconds guard). Also guarded the update progress `sublabel` so it no longer renders `undefined%`.
4. **Dead `/docs/*` links** — removed the anchors to the non-existent `/docs` route in `MempoolProfileDialog.tsx`, `TemplateProfileDialog.tsx`, and `capabilities/page.tsx` (the surrounding copy stays as plain text).
5. **React-query invalidation gaps** (`hooks/queries/useConfigQueries.ts`) — `useSetGhostMode` and `useSetArchiveMode` now also invalidate node status, mirroring `useSetTor`/`useSetGhostModeLocalEgress`, so the Ghost-mode / archive-mode toggles reflect the change immediately rather than waiting for the next status poll.
6. **System "Check for Updates" stale-closure toast** (`system/page.tsx`) — the handler now reads `update_available` from the value returned by `recheckUpdates()` instead of the closure-captured pre-refetch `updateCheck`, so the "Up to Date" toast reflects the fresh result.

### Verification
- `npx tsc --noEmit` — clean
- `eslint` on all touched files — 0 errors (one pre-existing `exhaustive-deps` warning in the untouched swarm auto-refresh `useEffect`; the change actually removes the previous `_node` unused-var warning)
- `npm run build` — succeeds
