### PR TITLE
fix(dashboard): setup wizards — no stale-default revert + no 405 on Finish

### DIFF
--- a/dashboard/src/app/(dashboard)/settings/wizards/ChangeSetupWizard.tsx
+++ b/dashboard/src/app/(dashboard)/settings/wizards/ChangeSetupWizard.tsx
@@ -17,9 +17,8 @@ import {
   useSetArchiveMode,
   useSetReaper,
   useSetGhostPay,
-  useSetMempoolProfile,
+  useActivateMempoolProfile,
 } from '@/hooks/queries';
-import type { MempoolProfile } from '@/types/api';
 
 interface ChangeSetupData {
   nickname: string;
@@ -69,7 +68,9 @@ export default function ChangeSetupWizard({ isOpen, onClose }: ChangeSetupWizard
   const setArchiveMode = useSetArchiveMode();
   const setReaper = useSetReaper();
   const setGhostPay = useSetGhostPay();
-  const setMempoolProfile = useSetMempoolProfile();
+  // Cosmetic mempool_profile mirror is written via the profile-activate route;
+  // POST /config/mempool_profile is GET-only on the node and 405s.
+  const activateMempoolProfile = useActivateMempoolProfile();
   const toast = useToast();
 
   // Track original values to detect changes
@@ -191,7 +192,7 @@ export default function ChangeSetupWizard({ isOpen, onClose }: ChangeSetupWizard
           changeCount++;
         }
         if (data.mempool_profile !== original.mempool_profile) {
-          await setMempoolProfile.mutateAsync(data.mempool_profile as MempoolProfile);
+          await activateMempoolProfile.mutateAsync(data.mempool_profile);
           changeCount++;
         }
 
@@ -209,7 +210,7 @@ export default function ChangeSetupWizard({ isOpen, onClose }: ChangeSetupWizard
   ], [
     configLoading, setNickname, setPublicMiningConfig, setPayoutAddress,
     setGhostMode, setArchiveMode, setReaper, setGhostPay,
-    setMempoolProfile, toast, onClose,
+    activateMempoolProfile, toast, onClose,
   ]);
 
   const wizard = useWizard<ChangeSetupData>({

--- a/dashboard/src/app/(dashboard)/settings/wizards/GhostModeWizard.tsx
+++ b/dashboard/src/app/(dashboard)/settings/wizards/GhostModeWizard.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect, useRef } from 'react';
 import { useWizard, WizardStep } from '@/hooks/useWizard';
 import { WizardDialog } from '@/components/ui/Wizard';
 import { Toggle } from '@/components/ui/Toggle';
@@ -53,6 +54,23 @@ export default function GhostModeWizard({ isOpen, onClose }: GhostModeWizardProp
       enabled: config?.ghost_mode ?? false,
     },
   });
+
+  // The wizard seeds its editable data once at mount, before `useConfig` has
+  // resolved — so without this it would show the `false` fallback and an
+  // untouched Finish would write Ghost Mode OFF over a node that had it ON.
+  // Re-seed from live config each time the dialog opens (and once the query
+  // lands if it opens first), so an untouched Finish is a no-op.
+  const hydratedRef = useRef(false);
+  useEffect(() => {
+    if (!isOpen) {
+      hydratedRef.current = false;
+      return;
+    }
+    if (config && !hydratedRef.current) {
+      hydratedRef.current = true;
+      wizard.reset({ enabled: config.ghost_mode ?? false });
+    }
+  }, [isOpen, config]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <WizardDialog

--- a/dashboard/src/app/(dashboard)/settings/wizards/HazeWizard.tsx
+++ b/dashboard/src/app/(dashboard)/settings/wizards/HazeWizard.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect, useRef } from 'react';
 import { useWizard, WizardStep } from '@/hooks/useWizard';
 import { WizardDialog } from '@/components/ui/Wizard';
 import { Badge } from '@/components/ui/Badge';
@@ -69,6 +70,22 @@ export default function HazeWizard({ isOpen, onClose }: HazeWizardProps) {
       mode: currentMode as HazeMode,
     },
   });
+
+  // Re-seed the selected mode from live haze status each time the dialog opens
+  // (the initial mount captured the `standard` fallback before the status query
+  // resolved), so an untouched Finish keeps the current mode instead of forcing
+  // the node back to Standard.
+  const hydratedRef = useRef(false);
+  useEffect(() => {
+    if (!isOpen) {
+      hydratedRef.current = false;
+      return;
+    }
+    if (hazeStatus && !hydratedRef.current) {
+      hydratedRef.current = true;
+      wizard.reset({ mode: (hazeStatus.mode ?? 'standard') as HazeMode });
+    }
+  }, [isOpen, hazeStatus]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <WizardDialog

--- a/dashboard/src/app/(dashboard)/settings/wizards/InitialSetupWizard.tsx
+++ b/dashboard/src/app/(dashboard)/settings/wizards/InitialSetupWizard.tsx
@@ -15,9 +15,8 @@ import {
   useSetArchiveMode,
   useSetReaper,
   useSetGhostPay,
-  useSetMempoolProfile,
+  useActivateMempoolProfile,
 } from '@/hooks/queries';
-import type { MempoolProfile } from '@/types/api';
 
 interface InitialSetupData {
   nickname: string;
@@ -67,7 +66,9 @@ export default function InitialSetupWizard({ isOpen, onClose }: InitialSetupWiza
   const setArchiveMode = useSetArchiveMode();
   const setReaper = useSetReaper();
   const setGhostPay = useSetGhostPay();
-  const setMempoolProfile = useSetMempoolProfile();
+  // The cosmetic `mempool_profile` field is written via the profile-activate
+  // route; POST /config/mempool_profile is GET-only on the node and 405s.
+  const activateMempoolProfile = useActivateMempoolProfile();
   const toast = useToast();
 
   const steps = useMemo<WizardStep<InitialSetupData>[]>(() => [
@@ -130,7 +131,7 @@ export default function InitialSetupWizard({ isOpen, onClose }: InitialSetupWiza
         await setArchiveMode.mutateAsync(data.archive_mode);
         await setReaper.mutateAsync(data.reaper);
         await setGhostPay.mutateAsync(data.ghost_pay);
-        await setMempoolProfile.mutateAsync(data.mempool_profile as MempoolProfile);
+        await activateMempoolProfile.mutateAsync(data.mempool_profile);
         toast.success(
           'Setup Complete',
           'Your node has been configured and is ready to operate.'
@@ -141,7 +142,7 @@ export default function InitialSetupWizard({ isOpen, onClose }: InitialSetupWiza
   ], [
     setNickname, setPublicMiningConfig, setPayoutAddress,
     setGhostMode, setArchiveMode, setReaper, setGhostPay,
-    setMempoolProfile, toast, onClose,
+    activateMempoolProfile, toast, onClose,
   ]);
 
   const wizard = useWizard<InitialSetupData>({

--- a/dashboard/src/app/(dashboard)/settings/wizards/MempoolPolicyWizard.tsx
+++ b/dashboard/src/app/(dashboard)/settings/wizards/MempoolPolicyWizard.tsx
@@ -8,13 +8,11 @@ import { Toggle } from '@/components/ui/Toggle';
 import { Badge } from '@/components/ui/Badge';
 import { useToast } from '@/components/ui/Toast';
 import {
-  useSetMempoolProfile,
-  useSetTemplateProfile,
   useSaveMempoolProfile,
   useActivateMempoolProfile,
+  useActivateTemplateProfile,
 } from '@/hooks/queries';
 import { DEFAULT_MEMPOOL_PROFILE } from '../MempoolProfileDialog';
-import type { MempoolProfile, TemplateProfile } from '@/types/api';
 import type { CustomMempoolProfile } from '@/lib/api/config';
 
 interface MempoolPolicyData {
@@ -72,10 +70,12 @@ const TEMPLATE_PROFILES = [
 ];
 
 export default function MempoolPolicyWizard({ isOpen, onClose }: MempoolPolicyWizardProps) {
-  const setMempoolProfile = useSetMempoolProfile();
-  const setTemplateProfile = useSetTemplateProfile();
+  // The mempool/template profile fields are the node's cosmetic dashboard
+  // mirror, written via the profile-activate routes. The old POST
+  // /config/{mempool,template}_profile endpoints are GET-only and 405.
   const saveMempoolProfile = useSaveMempoolProfile();
   const activateMempoolProfile = useActivateMempoolProfile();
+  const activateTemplateProfile = useActivateTemplateProfile();
   const toast = useToast();
 
   const steps = useMemo<WizardStep<MempoolPolicyData>[]>(() => {
@@ -144,9 +144,9 @@ export default function MempoolPolicyWizard({ isOpen, onClose }: MempoolPolicyWi
             await saveMempoolProfile.mutateAsync(customProfile);
             await activateMempoolProfile.mutateAsync(customProfile.name);
           } else {
-            await setMempoolProfile.mutateAsync(data.mempool_profile as MempoolProfile);
+            await activateMempoolProfile.mutateAsync(data.mempool_profile);
           }
-          await setTemplateProfile.mutateAsync(data.template_profile as TemplateProfile);
+          await activateTemplateProfile.mutateAsync(data.template_profile);
           toast.success(
             'Mempool Policy Updated',
             data.mempool_profile === 'custom'
@@ -158,7 +158,7 @@ export default function MempoolPolicyWizard({ isOpen, onClose }: MempoolPolicyWi
       },
     ];
     return allSteps;
-  }, [setMempoolProfile, setTemplateProfile, saveMempoolProfile, activateMempoolProfile, toast, onClose]);
+  }, [saveMempoolProfile, activateMempoolProfile, activateTemplateProfile, toast, onClose]);
 
   const wizard = useWizard<MempoolPolicyData>({
     steps,

--- a/dashboard/src/app/(dashboard)/settings/wizards/PoolSetupWizard.tsx
+++ b/dashboard/src/app/(dashboard)/settings/wizards/PoolSetupWizard.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect, useRef } from 'react';
 import { useWizard, WizardStep } from '@/hooks/useWizard';
 import { WizardDialog } from '@/components/ui/Wizard';
 import { Input } from '@/components/ui/Input';
@@ -130,6 +131,28 @@ export default function PoolSetupWizard({ isOpen, onClose }: PoolSetupWizardProp
       pool_name: '',
     },
   });
+
+  // The wizard captures its initial mining mode at mount, before the node/mining
+  // status queries resolve — so without this it defaults to `private_solo` and
+  // an untouched Finish would switch a public pool back to private solo. Re-seed
+  // the live mode each time the dialog opens. (payout_address / pool_name are
+  // write-only inputs the status endpoints don't return, so they start empty.)
+  const hydratedRef = useRef(false);
+  useEffect(() => {
+    if (!isOpen) {
+      hydratedRef.current = false;
+      return;
+    }
+    if ((miningStatus || nodeStatus) && !hydratedRef.current) {
+      hydratedRef.current = true;
+      wizard.reset({
+        mining_mode: currentMode,
+        public_mining: nodeStatus?.public_mining ?? false,
+        payout_address: '',
+        pool_name: '',
+      });
+    }
+  }, [isOpen, miningStatus, nodeStatus]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <WizardDialog

--- a/dashboard/src/app/(dashboard)/settings/wizards/ReaperWizard.tsx
+++ b/dashboard/src/app/(dashboard)/settings/wizards/ReaperWizard.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect, useRef } from 'react';
 import { useWizard, WizardStep } from '@/hooks/useWizard';
 import { WizardDialog } from '@/components/ui/Wizard';
 import { Toggle } from '@/components/ui/Toggle';
@@ -73,6 +74,22 @@ export default function ReaperWizard({ isOpen, onClose }: ReaperWizardProps) {
     steps,
     initialData: reaper?.settings ?? REAPER_DEFAULTS,
   });
+
+  // The wizard captures its initial data at mount, before `useReaperConfig` has
+  // resolved — so without this it would show REAPER_DEFAULTS and an untouched
+  // Finish would overwrite the node's live per-vector reaper config with
+  // all-on defaults. Re-seed from the live settings each time the dialog opens.
+  const hydratedRef = useRef(false);
+  useEffect(() => {
+    if (!isOpen) {
+      hydratedRef.current = false;
+      return;
+    }
+    if (reaper?.settings && !hydratedRef.current) {
+      hydratedRef.current = true;
+      wizard.reset(reaper.settings);
+    }
+  }, [isOpen, reaper]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const renderGroup = (
     title: string,

--- a/dashboard/src/app/(dashboard)/settings/wizards/ShroudWizard.tsx
+++ b/dashboard/src/app/(dashboard)/settings/wizards/ShroudWizard.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect, useRef } from 'react';
 import { useWizard, WizardStep } from '@/hooks/useWizard';
 import { WizardDialog } from '@/components/ui/Wizard';
 import { Toggle } from '@/components/ui/Toggle';
@@ -58,6 +59,22 @@ export default function ShroudWizard({ isOpen, onClose }: ShroudWizardProps) {
       enabled: shroudStatus?.enabled ?? false,
     },
   });
+
+  // Re-seed the editable toggle from live shroud status each time the dialog
+  // opens (the initial mount captured the `false` fallback before the status
+  // query resolved), so an untouched Finish writes back the live value rather
+  // than silently disabling Shroud.
+  const hydratedRef = useRef(false);
+  useEffect(() => {
+    if (!isOpen) {
+      hydratedRef.current = false;
+      return;
+    }
+    if (shroudStatus && !hydratedRef.current) {
+      hydratedRef.current = true;
+      wizard.reset({ enabled: shroudStatus.enabled ?? false });
+    }
+  }, [isOpen, shroudStatus]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <WizardDialog

--- a/dashboard/src/hooks/useWizard.ts
+++ b/dashboard/src/hooks/useWizard.ts
@@ -27,7 +27,7 @@ export interface UseWizardReturn<TData> {
   isSubmitting: boolean;
   next: () => Promise<void>;
   back: () => void;
-  reset: () => void;
+  reset: (overrideData?: TData) => void;
   isFirst: boolean;
   isLast: boolean;
   isComplete: boolean;
@@ -93,9 +93,13 @@ export function useWizard<TData>(config: UseWizardConfig<TData>): UseWizardRetur
     setError(null);
   }, []);
 
-  const reset = useCallback(() => {
+  // Reset the wizard to its first step. Pass `overrideData` to seed it with a
+  // freshly-resolved value (e.g. once an async config query lands) instead of
+  // the `initialData` captured at mount — this is what lets a re-opened wizard
+  // reflect live node state rather than a stale default.
+  const reset = useCallback((overrideData?: TData) => {
     setCurrentStep(0);
-    setDataState(initialData);
+    setDataState(overrideData ?? initialData);
     setError(null);
     setIsSubmitting(false);
     setIsComplete(false);


### PR DESCRIPTION
## Summary

Fixes two confirmed bugs in the Ghost node dashboard setup wizards (`settings/wizards/**`).

### Bug 1 — wizards reverted live settings on Finish

`useWizard` seeds its editable `data` once at mount via `useState`, before the underlying config query resolves. The control was therefore seeded with a fallback default rather than the node's live value, so an untouched **Finish** wrote that stale default back (e.g. turning Ghost Mode `off` on a node that had it `on`, or overwriting the per-vector reaper config with all-on defaults).

**Fix:** mirroring the existing correct pattern in `ChangeSetupWizard`, each affected wizard now re-seeds its data from the resolved query every time the dialog opens (and once the query lands if it opens first), guarded by a ref so in-progress edits are never clobbered. `useWizard.reset()` gained an optional `overrideData` argument so a re-opened wizard can be reset to step 0 *and* seeded with live state in one call. Affected: `GhostModeWizard`, `ShroudWizard`, `HazeWizard`, `PoolSetupWizard`, `ReaperWizard`. An untouched Finish is now a no-op instead of a revert.

`InitialSetupWizard` / `MempoolPolicyWizard` keep their static-default prefill by design (fresh-node setup), so they get Bug 2 only.

### Bug 2 — Finish threw a 405 on profile save

`InitialSetupWizard`, `MempoolPolicyWizard` and `ChangeSetupWizard` called `setMempoolProfile` / `setTemplateProfile`, which `POST /api/v1/config/{mempool,template}_profile`. The node registers those paths **GET-only**, so Finish 405'd after earlier settings had already been committed (partial apply, dialog never closed).

These two fields are the node's cosmetic dashboard mirror; the working write path is the profile **activate** route, which sets the very same field. Repointed each call to it (matching the pattern already used by the onboarding and policy pages):

| Wizard | Old (405) | New (works) |
| --- | --- | --- |
| InitialSetupWizard | `POST /config/mempool_profile` | `POST /config/profiles/mempool/:name/activate` |
| ChangeSetupWizard | `POST /config/mempool_profile` | `POST /config/profiles/mempool/:name/activate` |
| MempoolPolicyWizard (mempool, non-custom) | `POST /config/mempool_profile` | `POST /config/profiles/mempool/:name/activate` |
| MempoolPolicyWizard (template) | `POST /config/template_profile` | `POST /config/profiles/template/:name/activate` |

The MempoolPolicyWizard custom branch already used `save` + `activate` and is unchanged. Every endpoint each wizard's Finish path touches was cross-checked (method + path) against `crates/ghost-verification/src/routes.rs`; no other 405 remains.

## Verification
- `tsc --noEmit` clean
- `eslint` clean
- `npm run build` succeeds