### PR TITLE
fix(dashboard): render robustness + settlement stats + Home crash guard

### DIFF
--- a/dashboard/src/app/(dashboard)/capacity/page.tsx
+++ b/dashboard/src/app/(dashboard)/capacity/page.tsx
@@ -27,7 +27,9 @@ import type { MeshNode } from "@/lib/api/meshNodes";
 function utilPct(n: MeshNode): number {
   const cap = n.max_capacity ?? 0;
   if (!cap) return 0;
-  return Math.round((n.deduped_miner_count * 100) / cap);
+  // Guard the miner count too — an undefined `deduped_miner_count` yields NaN%,
+  // which also destabilises the sort comparator below.
+  return Math.round(((n.deduped_miner_count ?? 0) * 100) / cap);
 }
 
 function hasCapacity(n: MeshNode): boolean {

--- a/dashboard/src/app/(dashboard)/haze/page.tsx
+++ b/dashboard/src/app/(dashboard)/haze/page.tsx
@@ -21,7 +21,9 @@ const TOOLTIPS = {
 
 // --- Helpers ---
 
-function formatStorageGB(bytes: number): string {
+function formatStorageGB(bytes: number | undefined | null): string {
+  // A missing/non-numeric size must render "--", never "NaN GB".
+  if (bytes == null || !Number.isFinite(bytes)) return "--";
   const gb = bytes / (1024 * 1024 * 1024);
   if (gb >= 1000) return `${(gb / 1024).toFixed(2)} TB`;
   if (gb >= 1) return `${gb.toFixed(2)} GB`;
@@ -101,7 +103,7 @@ export default function HazePage() {
         />
         <StatCard
           label="Blocks"
-          value={haze ? haze.blocks.toLocaleString() : "--"}
+          value={haze ? (haze.blocks ?? 0).toLocaleString() : "--"}
           sublabel={haze?.chain ?? undefined}
           tooltip={TOOLTIPS.blocks}
           loading={isLoading}
@@ -233,7 +235,7 @@ export default function HazePage() {
               </StatusRow>
               <StatusRow label="Blocks Processed">
                 <span className="font-mono text-sm text-[color:var(--fg)]">
-                  {haze?.blocks.toLocaleString() ?? 0}
+                  {(haze?.blocks ?? 0).toLocaleString()}
                 </span>
               </StatusRow>
               <StatusRow label="Storage on Disk">

--- a/dashboard/src/app/(dashboard)/home/page.tsx
+++ b/dashboard/src/app/(dashboard)/home/page.tsx
@@ -12,6 +12,7 @@
  */
 
 import { NodeVitalsOverlay } from '@/components/overlays/NodeVitalsOverlay';
+import { SectionErrorBoundary } from '@/components/ui/SectionErrorBoundary';
 
 export default function HomePage() {
   return (
@@ -19,9 +20,14 @@ export default function HomePage() {
       className="relative overflow-hidden -mt-14 -mx-4 -mb-4 md:-m-6 h-[100dvh]"
       style={{ background: 'var(--bg)' }}
     >
-      <div className="absolute inset-0">
-        <NodeVitalsOverlay active />
-      </div>
+      {/* A partial/degraded data response (e.g. a resources payload missing
+          fields) must never white-screen the whole Home route — contain any
+          render error to this section with a graceful fallback. */}
+      <SectionErrorBoundary section="Node Vitals">
+        <div className="absolute inset-0">
+          <NodeVitalsOverlay active />
+        </div>
+      </SectionErrorBoundary>
     </div>
   );
 }

--- a/dashboard/src/app/(dashboard)/network/page.tsx
+++ b/dashboard/src/app/(dashboard)/network/page.tsx
@@ -25,7 +25,7 @@ import { useToast } from "@/components/ui/Toast";
 
 
 export default function NetworkPage() {
-  const { data: status, isLoading } = useNodeStatus();
+  const { data: status, isLoading, error: statusError } = useNodeStatus();
   const setTor = useSetTor();
   const { success, error } = useToast();
 
@@ -38,6 +38,26 @@ export default function NetworkPage() {
           subtitle="Live view of your node's outbound transport, onion address, and relay-suppression state."
         />
         <SkeletonCard />
+      </div>
+    );
+  }
+
+  // Surface a fetch failure instead of rendering a healthy-looking clearnet
+  // page (peers 0, no onion) that is indistinguishable from a real state.
+  if (statusError || !status) {
+    return (
+      <div className="space-y-6">
+        <PageHeader
+          eyebrow="network"
+          title="How this node is exposed."
+          subtitle="Live view of your node's outbound transport, onion address, and relay-suppression state."
+        />
+        <Card>
+          <p style={{ color: "var(--dim)", fontSize: "14px" }}>
+            Could not reach the node status endpoint.{" "}
+            {statusError instanceof Error ? statusError.message : "Ensure Ghost Core is running."}
+          </p>
+        </Card>
       </div>
     );
   }

--- a/dashboard/src/app/(dashboard)/settings/PayoutSection.tsx
+++ b/dashboard/src/app/(dashboard)/settings/PayoutSection.tsx
@@ -22,6 +22,10 @@ export function PayoutSection() {
   const [miningPayoutAddress, setMiningPayoutAddress] = useState("");
   const [ghostPayPayoutAddress, setGhostPayPayoutAddress] = useState("");
 
+  // Running-state from the explicit `sync_state` flag, not `l2_height` (0 is a
+  // valid running height and would falsely trip the "not running" warning).
+  const ghostPayRunning = ghostPayStatus?.sync_state === "synced";
+
   useEffect(() => {
     if (fullConfig?.payout?.address && !miningPayoutAddress) {
       // eslint-disable-next-line react-hooks/set-state-in-effect
@@ -104,7 +108,7 @@ export function PayoutSection() {
             GhostPay L2 transaction fee distributions will be sent to this address.
             Requires Ghost Pay to be enabled.
           </p>
-          {!ghostPayStatus?.l2_height && (
+          {!ghostPayRunning && (
             <p className="text-xs text-[color:var(--yellow)] mt-1">
               Ghost Pay is not running - fee distributions require an active ghost-pay-node
             </p>

--- a/dashboard/src/app/(dashboard)/settings/capabilities/page.tsx
+++ b/dashboard/src/app/(dashboard)/settings/capabilities/page.tsx
@@ -34,6 +34,11 @@ export default function CapabilitiesSettingsPage() {
   const publicMiningActive = status?.public_mining ?? false;
   const publicMiningBlocked = ghostModeActive && !publicMiningActive;
 
+  // Ghost Pay running-state comes from the explicit `sync_state` flag, NOT
+  // `l2_height` — an L2 height of 0 is a perfectly valid running state (fresh
+  // node), so its truthiness would mislabel a running node as "Not Running".
+  const ghostPayRunning = ghostPayStatus?.sync_state === "synced";
+
   const handlePublicMiningToggle = async (enabled: boolean) => {
     try {
       await setPublicMining.mutateAsync(enabled);
@@ -86,9 +91,9 @@ export default function CapabilitiesSettingsPage() {
 
       <StatusRow
         label="Ghost Pay"
-        description={`L2 payment network participation — requires ghost-pay-node${ghostPayStatus?.l2_height ? ` (L2 height: ${ghostPayStatus.l2_height})` : ''}`}
+        description={`L2 payment network participation — requires ghost-pay-node${ghostPayRunning ? ` (L2 height: ${ghostPayStatus?.l2_height ?? 0})` : ''}`}
         badge={
-          ghostPayStatus?.l2_height ? (
+          ghostPayRunning ? (
             <Badge variant="success">+4 Shares</Badge>
           ) : (
             <Badge variant="warning">Not Running</Badge>

--- a/dashboard/src/app/(dashboard)/shroud/page.tsx
+++ b/dashboard/src/app/(dashboard)/shroud/page.tsx
@@ -21,7 +21,7 @@ const TOOLTIPS = {
 };
 
 export default function ShroudPage() {
-  const { data: status, isLoading } = useShroudStatus({ refetchInterval: 10_000 });
+  const { data: status, isLoading, error } = useShroudStatus({ refetchInterval: 10_000 });
 
   const showSkeleton = isLoading && !status;
 
@@ -57,13 +57,13 @@ export default function ShroudPage() {
         />
         <StatCard
           label="Max Delay"
-          value={status ? `${status.max_delay_ms} ms` : "--"}
+          value={status?.max_delay_ms != null ? `${status.max_delay_ms} ms` : "--"}
           tooltip={TOOLTIPS.max_delay}
           loading={showSkeleton}
         />
         <StatCard
           label="Avg Delay"
-          value={status ? `${status.avg_delay_ms} ms` : "--"}
+          value={status?.avg_delay_ms != null ? `${status.avg_delay_ms} ms` : "--"}
           tooltip={TOOLTIPS.avg_delay}
           loading={showSkeleton}
         />
@@ -105,6 +105,15 @@ export default function ShroudPage() {
       <SectionErrorBoundary section="Shroud Status">
         {showSkeleton ? (
           <SkeletonCard />
+        ) : error ? (
+          <Card>
+            <CardHeader title="Status" />
+            <div className="p-4 bg-[var(--surface)] border border-[color:var(--red)] rounded-lg">
+              <p className="text-[color:var(--red)] text-sm">
+                Unable to fetch Ghost Shroud status. Ensure Ghost Core is running and the Shroud module is enabled.
+              </p>
+            </div>
+          </Card>
         ) : status ? (
           <Card>
             <CardHeader
@@ -128,12 +137,12 @@ export default function ShroudPage() {
               </StatusRow>
               <StatusRow label="Max Delay" tooltip={TOOLTIPS.max_delay}>
                 <span className="text-[color:var(--fg)] font-mono text-sm">
-                  {status.max_delay_ms.toLocaleString()} ms
+                  {(status.max_delay_ms ?? 0).toLocaleString()} ms
                 </span>
               </StatusRow>
               <StatusRow label="Avg Delay" tooltip={TOOLTIPS.avg_delay}>
                 <span className="text-[color:var(--blue)] font-mono text-sm">
-                  {status.avg_delay_ms.toLocaleString()} ms
+                  {(status.avg_delay_ms ?? 0).toLocaleString()} ms
                 </span>
               </StatusRow>
             </div>

--- a/dashboard/src/app/(dashboard)/storage/page.tsx
+++ b/dashboard/src/app/(dashboard)/storage/page.tsx
@@ -45,7 +45,9 @@ export default function StoragePage() {
 
   const isLoading = configLoading;
   const archiveMode = status?.archive_mode ?? false;
-  const ghostPayRunning = !!ghostPayStatus?.l2_height;
+  // Running-state from the explicit `sync_state` flag, not `l2_height` (0 is a
+  // valid running height and would wrongly show "Ghost Pay Not Running").
+  const ghostPayRunning = ghostPayStatus?.sync_state === "synced";
 
   return (
     <div className="space-y-6">
@@ -89,7 +91,7 @@ export default function StoragePage() {
                     <div className="p-4 bg-[var(--surface)] rounded-lg">
                       <div className="text-sm text-[color:var(--dim)]">Retention Period</div>
                       <div className="text-xl font-bold text-[color:var(--fg)] mt-1">
-                        {l2Pruning.retention_days} days
+                        {l2Pruning.retention_days ?? 90} days
                       </div>
                     </div>
                     <div className="p-4 bg-[var(--surface)] rounded-lg">
@@ -98,7 +100,7 @@ export default function StoragePage() {
                         <Badge variant="success">Always On</Badge>
                       </div>
                       <div className="text-xs text-[color:var(--fainter)] mt-1">
-                        Every {l2Pruning.prune_interval_hours}h
+                        Every {l2Pruning.prune_interval_hours ?? 24}h
                       </div>
                     </div>
                     <div className="p-4 bg-[var(--surface)] rounded-lg">
@@ -113,9 +115,9 @@ export default function StoragePage() {
                     <div className="p-4 bg-[var(--surface)] rounded-lg">
                       <div className="text-sm text-[color:var(--dim)]">Last Run Stats</div>
                       <div className="text-sm text-[color:var(--dim)] mt-2 space-y-1">
-                        <div>Payments: {l2Pruning.payments_pruned}</div>
-                        <div>Attestations: {l2Pruning.attestations_pruned}</div>
-                        <div>Locks: {l2Pruning.locks_pruned}</div>
+                        <div>Payments: {l2Pruning.payments_pruned ?? 0}</div>
+                        <div>Attestations: {l2Pruning.attestations_pruned ?? 0}</div>
+                        <div>Locks: {l2Pruning.locks_pruned ?? 0}</div>
                       </div>
                     </div>
                   </div>
@@ -127,15 +129,15 @@ export default function StoragePage() {
                       <ul className="text-sm text-[color:var(--red)] space-y-2">
                         <li className="flex items-start gap-2">
                           <span className="text-[color:var(--red)] mt-0.5">•</span>
-                          <span>Payments (with ZK proofs) older than {l2Pruning.retention_days} days</span>
+                          <span>Payments (with ZK proofs) older than {l2Pruning.retention_days ?? 90} days</span>
                         </li>
                         <li className="flex items-start gap-2">
                           <span className="text-[color:var(--red)] mt-0.5">•</span>
-                          <span>Attestations older than {l2Pruning.retention_days} days</span>
+                          <span>Attestations older than {l2Pruning.retention_days ?? 90} days</span>
                         </li>
                         <li className="flex items-start gap-2">
                           <span className="text-[color:var(--red)] mt-0.5">•</span>
-                          <span>Closed locks (reconciled or jumped) older than {l2Pruning.retention_days} days</span>
+                          <span>Closed locks (reconciled or jumped) older than {l2Pruning.retention_days ?? 90} days</span>
                         </li>
                       </ul>
                     </div>

--- a/dashboard/src/components/overlays/NodeVitalsOverlay.tsx
+++ b/dashboard/src/components/overlays/NodeVitalsOverlay.tsx
@@ -278,7 +278,15 @@ export function NodeVitalsOverlay({ active }: OverlayProps) {
     height: syncHeight,
     target: blockHeight,
     isSyncing,
-    syncPct: isSyncing ? Math.min(100, (syncHeight / blockHeight) * 100) : status?.is_synced ? 100 : 0,
+    // When not actively syncing, a node reporting a height is treated as synced
+    // (100%) unless it explicitly reports is_synced=false. This keeps the bar in
+    // agreement with the "Synced · 100%" label and the eyebrow, which both read
+    // an omitted is_synced as synced (previously syncPct fell to 0 here).
+    syncPct: isSyncing
+      ? Math.min(100, (syncHeight / blockHeight) * 100)
+      : status?.is_synced === false
+        ? 0
+        : 100,
     peers: status?.peer_count ?? 0,
     miners: mining?.local_connected_miners ?? mining?.connected_miners ?? 0,
     // This node's own hashrate — the combined hashrate of miners connected to
@@ -301,39 +309,65 @@ export function NodeVitalsOverlay({ active }: OverlayProps) {
   const leds = deriveLeds(watchdog);
 
   // ── CPU / Memory / Disk gauges — real values, gracefully absent otherwise.
+  // Individual numeric fields are guarded (not just the `resources` object): a
+  // partial resources response with a missing cpu_percent / memory_used_mb /
+  // disk_used_gb must render '—'/0, never crash on `.toFixed` of undefined.
   const gauges: { key: string; label: string; pct: number | null; tone: Tone; detail: string }[] =
     resources
-      ? [
-          {
-            key: 'cpu',
-            label: 'CPU',
-            pct: resources.cpu_percent,
-            tone: usageTone(
-              resources.cpu_percent,
-              resources.warning_threshold_cpu,
-              resources.critical_threshold_cpu,
-            ),
-            detail: `${resources.cpu_percent.toFixed(0)}%`,
-          },
-          {
-            key: 'mem',
-            label: 'MEM',
-            pct: resources.memory_percent,
-            tone: usageTone(
-              resources.memory_percent,
-              resources.warning_threshold_memory,
-              resources.critical_threshold_memory,
-            ),
-            detail: `${(resources.memory_used_mb / 1024).toFixed(1)}/${(resources.memory_total_mb / 1024).toFixed(0)} GB`,
-          },
-          {
-            key: 'disk',
-            label: 'DISK',
-            pct: resources.disk_percent,
-            tone: usageTone(resources.disk_percent, 75, 90),
-            detail: `${resources.disk_used_gb.toFixed(0)}/${resources.disk_total_gb.toFixed(0)} GB`,
-          },
-        ]
+      ? (() => {
+          const num = (x: number | undefined | null): number | null =>
+            typeof x === 'number' && Number.isFinite(x) ? x : null;
+          const cpu = num(resources.cpu_percent);
+          const mem = num(resources.memory_percent);
+          const disk = num(resources.disk_percent);
+          const memUsed = num(resources.memory_used_mb);
+          const memTotal = num(resources.memory_total_mb);
+          const diskUsed = num(resources.disk_used_gb);
+          const diskTotal = num(resources.disk_total_gb);
+          return [
+            {
+              key: 'cpu',
+              label: 'CPU',
+              pct: cpu,
+              tone:
+                cpu === null
+                  ? ('ok' as Tone)
+                  : usageTone(
+                      cpu,
+                      resources.warning_threshold_cpu ?? 70,
+                      resources.critical_threshold_cpu ?? 90,
+                    ),
+              detail: cpu === null ? '—' : `${cpu.toFixed(0)}%`,
+            },
+            {
+              key: 'mem',
+              label: 'MEM',
+              pct: mem,
+              tone:
+                mem === null
+                  ? ('ok' as Tone)
+                  : usageTone(
+                      mem,
+                      resources.warning_threshold_memory ?? 70,
+                      resources.critical_threshold_memory ?? 90,
+                    ),
+              detail:
+                memUsed !== null && memTotal !== null
+                  ? `${(memUsed / 1024).toFixed(1)}/${(memTotal / 1024).toFixed(0)} GB`
+                  : '—',
+            },
+            {
+              key: 'disk',
+              label: 'DISK',
+              pct: disk,
+              tone: disk === null ? ('ok' as Tone) : usageTone(disk, 75, 90),
+              detail:
+                diskUsed !== null && diskTotal !== null
+                  ? `${diskUsed.toFixed(0)}/${diskTotal.toFixed(0)} GB`
+                  : '—',
+            },
+          ];
+        })()
       : [
           { key: 'cpu', label: 'CPU', pct: null, tone: 'ok', detail: '—' },
           { key: 'mem', label: 'MEM', pct: null, tone: 'ok', detail: '—' },

--- a/dashboard/src/lib/api/ghostpay.ts
+++ b/dashboard/src/lib/api/ghostpay.ts
@@ -143,34 +143,31 @@ export async function getWraithStats(): Promise<WraithStats> {
   }
 }
 
-// Settlement Status (node-level settlement service status)
+// Settlement Status (node-level settlement service status).
+//
+// The live `/settlement/status` endpoint returns a FLAT shape:
+//   { status, pending_settlements, pending_count, batches_24h,
+//     last_settlement, total_settled_sats }
+// There is no nested `stats` object or `batches` array, so we read the real
+// flat fields directly. The previous nested-shape mapping silently produced
+// all-zeros against the real backend (Settlement Quick-Stats always showed 0).
 export async function getSettlementStatus(): Promise<SettlementStatus> {
   try {
     const settlement = await fetchApi<SettlementResponse>('/api/v1/settlement/status');
     return {
-      l1_available: settlement.stats?.l1_connected ?? false,
-      l1_height: settlement.stats?.l1_height ?? 0,
-      active_count: settlement.stats?.active_batches ?? 0,
-      pending_count: settlement.stats?.pending_batches ?? 0,
-      batches_24h: settlement.stats?.confirmed_24h ?? 0,
-      total_settled_24h: settlement.stats?.total_settled_24h ?? 0,
-      current_epoch: settlement.stats?.current_epoch ?? 0,
-      avg_batch_size: (settlement.batches?.length ?? 0) > 0
-        ? settlement.batches!.reduce((sum, b) => sum + b.participant_count, 0) / settlement.batches!.length
-        : 0,
+      status: settlement.status ?? 'idle',
+      pending_count: settlement.pending_count ?? settlement.pending_settlements ?? 0,
+      batches_24h: settlement.batches_24h ?? 0,
+      total_settled_sats: settlement.total_settled_sats ?? 0,
     };
   } catch (e) {
     // See getWraithStats — log instead of silently returning all-zeros.
     console.error("getSettlementStatus: failed to fetch settlement status", e);
     return {
-      l1_available: false,
-      l1_height: 0,
-      active_count: 0,
+      status: 'idle',
       pending_count: 0,
       batches_24h: 0,
-      total_settled_24h: 0,
-      current_epoch: 0,
-      avg_batch_size: 0,
+      total_settled_sats: 0,
     };
   }
 }

--- a/dashboard/src/lib/geo/geoip.ts
+++ b/dashboard/src/lib/geo/geoip.ts
@@ -54,8 +54,11 @@ export interface GeoResult {
 const UNKNOWN_CC = 0xff;
 const GEOIP_URL = "/geo/geoip.bin";
 
-/** Strip a trailing `:port` and surrounding brackets to get the bare host. */
-export function extractHost(addressOrIp: string): string {
+/** Strip a trailing `:port` and surrounding brackets to get the bare host.
+ *  Returns "" for a missing/blank address (callers use it in top-level render
+ *  paths, so `.trim()` of undefined must never throw). */
+export function extractHost(addressOrIp: string | null | undefined): string {
+  if (!addressOrIp) return "";
   const host = addressOrIp.trim();
   const bracket = host.match(/^\[([^\]]+)\](?::\d+)?$/);
   if (bracket) return bracket[1];

--- a/dashboard/src/types/api.ts
+++ b/dashboard/src/types/api.ts
@@ -770,57 +770,22 @@ export interface PaymentsResponse {
 export type SettlementClass = "Express" | "Standard" | "Economy" | string;
 export type BatchStatus = "Forming" | "CollectingSignatures" | "Ready" | "Broadcast" | "Confirmed" | "Failed" | string;
 
-export interface SettlementBatch {
-  batch_id: string;
-  settlement_class: string;
-  epoch_id: number;
-  status: string;
-  participant_count: number;
-  signatures_collected: number;
-  your_lock_id?: string | null;
-  your_signature_submitted?: boolean;
-  txid?: string | null;
-  confirmations?: number;
-  created_at?: number;
-  total_amount_sats?: number;
-  l1_txid?: string | null;
-  finalized_at?: number | null;
-}
-
-export interface SettlementStats {
-  pending_batches?: number;
-  active_batches?: number;
-  confirmed_24h?: number;
-  total_settled_24h?: number;
-  your_settlements?: number;
-  current_epoch?: number;
-  l1_connected?: boolean;
-  l1_height?: number;
-}
-
+// Live `/settlement/status` response — a flat object (no nested `stats`/`batches`).
 export interface SettlementResponse {
-  // Backend fields
   status?: string;
   pending_settlements?: number;
   pending_count?: number;
   batches_24h?: number;
   last_settlement?: Record<string, unknown> | null;
   total_settled_sats?: number;
-  // Dashboard aliases
-  batches?: SettlementBatch[];
-  stats?: SettlementStats;
 }
 
-// Node-level settlement service status
+// Node-level settlement service status, derived from the flat SettlementResponse.
 export interface SettlementStatus {
-  l1_available?: boolean;
-  l1_height?: number;
-  active_count?: number;
+  status?: string;
   pending_count?: number;
   batches_24h?: number;
-  total_settled_24h?: number;
-  current_epoch?: number;
-  avg_batch_size?: number;
+  total_settled_sats?: number;
 }
 
 // Jump Queue types


### PR DESCRIPTION
Fixes a batch of confirmed render-robustness / crash / wrong-data defects in the node dashboard (from an audit). Each item reasons about the triggering input — a missing field, a valid `0`, or a fetch error — and no longer crashes or renders wrong data.

## Fixes
1. **Settlement Quick-Stats hardwired to 0** — `getSettlementStatus()` derived from a non-existent nested `stats`/`batches` object; the live `/settlement/status` returns a flat shape. Rewired to the real flat fields (`pending_count`, `batches_24h`, `total_settled_sats`) and trimmed the `SettlementResponse`/`SettlementStatus` types to reality (removed the unused `SettlementBatch`/`SettlementStats` aliases).
2. **Home overlay could white-screen the page** — null-guarded the `NodeVitalsOverlay` CPU/memory/disk fields (a partial `resources` payload now renders `—`) and wrapped the overlay in `SectionErrorBoundary` on `/home` so a degraded response degrades gracefully.
3. **Ghost Pay mislabelled "Not Running" at L2 height 0** — capabilities, payout and storage surfaces now key off the explicit `sync_state === "synced"` flag instead of `l2_height` truthiness (`0` is a valid running height).
4. **Sync bar contradicted "Synced · 100%"** — a node reporting a height with no explicit `is_synced=false` is treated as synced (100%), matching the eyebrow and label (previously `syncPct` fell to 0).
5. **Geo page could white-screen on a node lacking `address`** — `extractHost` now null-guards its input (returns `""`).
6. **Capacity `NaN%`** — guarded `deduped_miner_count` in `utilPct`, which also stabilises the sort comparator.
7. **Shroud + Network blanked silently on fetch error** — both now surface an error state instead of a healthy-looking empty page; Shroud delay fields are guarded against missing values.
8. **Storage + Haze rendered literal "undefined"/"NaN GB"** — guarded the optional `l2Pruning.*`, `haze.blocks` and `haze.size_on_disk` fields.

## Verification
- `tsc --noEmit`: clean.
- `eslint`: introduces no new problems (remaining warnings/errors all pre-exist on `main` in untouched files, verified by diffing base output).
- `next build`: succeeds; every affected route compiles.