### PR TITLE
feat(pool): block-priority lever — max_fee (default) | payments_first

### DIFF
--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -2645,6 +2645,9 @@ async fn main() -> Result<()> {
         coinbase_extra: coinbase_tag,
         min_fee_rate: template_min_fee_rate,
         enforce_custom_policy_fields,
+        // Block-priority lever (max_fee default | payments_first). Resolved once
+        // here at startup from pool.toml; the dashboard POST persists + restarts.
+        block_priority: config.pool.block_priority,
         ..Default::default()
     };
     let template_processor = Arc::new(

--- a/bins/ghost-pool/src/template.rs
+++ b/bins/ghost-pool/src/template.rs
@@ -58,8 +58,8 @@ use tracing::{debug, error, info, warn};
 
 use bitcoin::consensus::deserialize;
 use ghost_accounting::CoinbaseBuilder;
-use ghost_buds::BudsClassifier;
-use ghost_common::config::{BitcoinNetwork, MiningMode};
+use ghost_buds::{BudsClassifier, BudsTier};
+use ghost_common::config::{BitcoinNetwork, BlockPriority, MiningMode};
 use ghost_common::rpc::{BitcoinRpc, BlockTemplate, TemplateTransaction};
 use ghost_common::types::{PayoutProposal, PayoutType, TreasuryAddress};
 use ghost_policy::PolicyProfile;
@@ -146,6 +146,13 @@ pub struct TemplateConfig {
     /// fields are NOT enforced at block-build time, preserving the historical
     /// preset behaviour. Custom is the "Advanced" opt-in that turns them on.
     pub enforce_custom_policy_fields: bool,
+    /// Block-priority lever governing the template's transaction ordering.
+    ///
+    /// `MaxFee` (default) preserves the historical package-fee-rate ordering
+    /// byte-for-byte. `PaymentsFirst` seats BUDS financial txs (T0/T1) ahead of
+    /// data txs (T2/T3) — a pure permutation of the same tx set (weight-safe).
+    /// Resolved once at startup from `pool.block_priority`; applied on restart.
+    pub block_priority: BlockPriority,
 }
 
 impl Default for TemplateConfig {
@@ -161,6 +168,7 @@ impl Default for TemplateConfig {
             mining_mode: MiningMode::PublicPool,
             solo_payout_address: None,
             enforce_custom_policy_fields: false,
+            block_priority: BlockPriority::MaxFee,
         }
     }
 }
@@ -1894,6 +1902,10 @@ impl TemplateProcessor {
     ) -> (Vec<TemplateTransaction>, FilterStats) {
         let original_count = transactions.len();
         let mut kept = Vec::with_capacity(original_count);
+        // BUDS tier per kept tx, parallel to `kept` (kept_tiers[i] is the tier
+        // of kept[i]). Only consulted when `block_priority == PaymentsFirst`;
+        // under `MaxFee` it is built but never read, so ordering is unchanged.
+        let mut kept_tiers: Vec<BudsTier> = Vec::with_capacity(original_count);
         let mut removed_fees = 0u64;
         let mut reaped_count = 0usize;
         let mut reaped_dead_bytes = 0u64;
@@ -1994,6 +2006,10 @@ impl TemplateProcessor {
                         original_to_filtered.insert(idx, kept.len());
                         kept_indices.insert(idx);
                         kept.push(tx.clone());
+                        // Carry the already-computed BUDS tier so the
+                        // payments-first ordering can key on it without
+                        // re-classifying. Index stays aligned with `kept`.
+                        kept_tiers.push(tier);
                     } else {
                         // Dependency was filtered out, must reject this tx too
                         removed_fees += tx.fee;
@@ -2015,8 +2031,11 @@ impl TemplateProcessor {
             }
         }
 
-        // Sort by package fee rate while respecting dependencies
-        let kept = self.sort_by_package_fee_rate(kept, &original_to_filtered);
+        // Sort by package fee rate while respecting dependencies. Under
+        // `PaymentsFirst` the carried BUDS tiers additionally bias financial
+        // packages (T0/T1) ahead of data (T2/T3); under `MaxFee` the tiers are
+        // ignored and the ordering is byte-identical to the historical sort.
+        let kept = self.sort_by_package_fee_rate(kept, &kept_tiers, &original_to_filtered);
 
         let stats = FilterStats {
             original: original_count,
@@ -2047,18 +2066,51 @@ impl TemplateProcessor {
     /// 5. Sort clusters by package fee rate descending
     /// 6. Within each cluster, topological sort (parents before children)
     /// 7. Flatten into final transaction list
+    ///
+    /// `tiers` carries the BUDS tier of each input transaction (parallel to
+    /// `transactions`). It is only consulted when
+    /// `self.config.block_priority == PaymentsFirst`, where it adds a primary
+    /// sort key that seats **financial** packages (cluster-minimum tier ≤ T1)
+    /// ahead of **data** packages, each group still fee-rate-descending
+    /// internally. Under the default `MaxFee` the tiers are ignored and the
+    /// ordering is byte-identical to the historical package-fee-rate sort. This
+    /// is a permutation only — the tx set and total weight are invariant across
+    /// both modes, so no new weight accounting is needed.
     fn sort_by_package_fee_rate(
         &self,
         transactions: Vec<TemplateTransaction>,
+        tiers: &[BudsTier],
         original_to_filtered: &HashMap<usize, usize>,
     ) -> Vec<TemplateTransaction> {
         if transactions.len() <= 1 {
             return transactions;
         }
 
+        let payments_first = matches!(self.config.block_priority, BlockPriority::PaymentsFirst);
+
         // Fast path: if no transactions have dependencies, simple fee-rate sort
         let has_deps = transactions.iter().any(|tx| !tx.depends.is_empty());
         if !has_deps {
+            if payments_first {
+                // Pair each tx with a "financial" bit (BUDS tier ≤ T1) derived
+                // from its carried tier, then sort by (financial DESC, fee-rate
+                // DESC). No dependencies here, so every tx is its own package.
+                let mut paired: Vec<(TemplateTransaction, bool)> = transactions
+                    .into_iter()
+                    .zip(tiers.iter().copied())
+                    .map(|(tx, tier)| (tx, tier <= BudsTier::T1))
+                    .collect();
+                paired.sort_by(|a, b| {
+                    let rate_a = a.0.fee as f64 / (a.0.weight.max(1) as f64 / 4.0);
+                    let rate_b = b.0.fee as f64 / (b.0.weight.max(1) as f64 / 4.0);
+                    let fee_cmp = rate_b
+                        .partial_cmp(&rate_a)
+                        .unwrap_or(std::cmp::Ordering::Equal);
+                    // financial (true) first, then fee rate descending.
+                    b.1.cmp(&a.1).then(fee_cmp)
+                });
+                return paired.into_iter().map(|(tx, _)| tx).collect();
+            }
             let mut sorted = transactions;
             sorted.sort_by(|a, b| {
                 let rate_a = a.fee as f64 / (a.weight.max(1) as f64 / 4.0);
@@ -2145,6 +2197,14 @@ impl TemplateProcessor {
             tx_indices: Vec<usize>, // Indices into filtered array, topological order
             total_fee: u64,
             total_weight: u64,
+            // Whether this package counts as "financial" for payments-first
+            // ordering. A CPFP package may mix tiers (a payment child bumping a
+            // data parent, or vice-versa); we classify by the cluster's MINIMUM
+            // (most-financial) member tier and collapse to ≤ T1. This keeps
+            // parents-with-children intact — a package is never split — and errs
+            // toward seating any package that contains a payment. Only consulted
+            // under PaymentsFirst.
+            is_financial: bool,
         }
 
         let mut clusters: Vec<TxCluster> = Vec::with_capacity(components.len());
@@ -2152,6 +2212,14 @@ impl TemplateProcessor {
         for members in components.values() {
             let total_fee: u64 = members.iter().map(|&i| transactions[i].fee).sum();
             let total_weight: u64 = members.iter().map(|&i| transactions[i].weight).sum();
+            // Cluster-minimum tier → financial iff ≤ T1. `members` is never
+            // empty (every component has at least its root), so `.min()` is safe.
+            let is_financial = members
+                .iter()
+                .map(|&i| tiers[i])
+                .min()
+                .map(|t| t <= BudsTier::T1)
+                .unwrap_or(false);
 
             if members.len() == 1 {
                 // Single-tx cluster, no topo sort needed
@@ -2159,6 +2227,7 @@ impl TemplateProcessor {
                     tx_indices: members.clone(),
                     total_fee,
                     total_weight,
+                    is_financial,
                 });
                 continue;
             }
@@ -2205,23 +2274,35 @@ impl TemplateProcessor {
                     tx_indices: fallback,
                     total_fee,
                     total_weight,
+                    is_financial,
                 });
             } else {
                 clusters.push(TxCluster {
                     tx_indices: topo_order,
                     total_fee,
                     total_weight,
+                    is_financial,
                 });
             }
         }
 
-        // Sort clusters by package fee rate (sat/vB) descending
+        // Sort clusters. Under MaxFee this is the historical single key:
+        // package fee rate (sat/vB) descending. Under PaymentsFirst a primary
+        // key seats financial packages first, then fee rate descending within
+        // each group. The comparator is stable and, for MaxFee, byte-identical
+        // to the pre-change sort.
         clusters.sort_by(|a, b| {
             let rate_a = a.total_fee as f64 / (a.total_weight.max(1) as f64 / 4.0);
             let rate_b = b.total_fee as f64 / (b.total_weight.max(1) as f64 / 4.0);
-            rate_b
+            let fee_cmp = rate_b
                 .partial_cmp(&rate_a)
-                .unwrap_or(std::cmp::Ordering::Equal)
+                .unwrap_or(std::cmp::Ordering::Equal);
+            if payments_first {
+                // financial (true) first, then fee rate descending.
+                b.is_financial.cmp(&a.is_financial).then(fee_cmp)
+            } else {
+                fee_cmp
+            }
         });
 
         // Flatten clusters into final transaction list
@@ -3963,6 +4044,26 @@ mod tests {
         )
     }
 
+    /// Helper to create a TemplateProcessor with an explicit block-priority mode.
+    fn test_processor_with_priority(block_priority: BlockPriority) -> TemplateProcessor {
+        let rpc = Arc::new(BitcoinRpc::new("127.0.0.1", 8332, "user", "pass").unwrap());
+        TemplateProcessor::new(
+            TemplateConfig {
+                block_priority,
+                ..TemplateConfig::default()
+            },
+            rpc,
+            PolicyProfile::permissive(),
+            ReaperConfig::default(),
+        )
+    }
+
+    /// A tiers slice of `n` financial (T0) entries — used by the legacy sorting
+    /// tests, which exercise MaxFee where tiers are ignored.
+    fn t0_tiers(n: usize) -> Vec<BudsTier> {
+        vec![BudsTier::T0; n]
+    }
+
     /// Test that CPFP package with high package fee rate sorts above lower independent txs
     #[test]
     fn test_cpfp_package_sorted_by_package_fee_rate() {
@@ -3986,7 +4087,8 @@ mod tests {
         original_to_filtered.insert(2, 2);
 
         let txs = vec![tx_ind, tx_parent, tx_child];
-        let result = processor.sort_by_package_fee_rate(txs, &original_to_filtered);
+        let tiers = t0_tiers(txs.len());
+        let result = processor.sort_by_package_fee_rate(txs, &tiers, &original_to_filtered);
 
         // CPFP package (100 sat/vB) should come before independent tx (50 sat/vB)
         assert_eq!(result.len(), 3);
@@ -4018,7 +4120,8 @@ mod tests {
 
         let original_to_filtered = HashMap::new();
         let txs = vec![tx_a, tx_b, tx_c];
-        let result = processor.sort_by_package_fee_rate(txs, &original_to_filtered);
+        let tiers = t0_tiers(txs.len());
+        let result = processor.sort_by_package_fee_rate(txs, &tiers, &original_to_filtered);
 
         assert_eq!(result[0].txid, "b"); // 50 sat/vB
         assert_eq!(result[1].txid, "c"); // 30 sat/vB
@@ -4042,7 +4145,8 @@ mod tests {
         original_to_filtered.insert(2, 2);
 
         let txs = vec![tx_gp, tx_p, tx_c];
-        let result = processor.sort_by_package_fee_rate(txs, &original_to_filtered);
+        let tiers = t0_tiers(txs.len());
+        let result = processor.sort_by_package_fee_rate(txs, &tiers, &original_to_filtered);
 
         let gp_pos = result.iter().position(|t| t.txid == "grandparent").unwrap();
         let p_pos = result.iter().position(|t| t.txid == "parent").unwrap();
@@ -4071,7 +4175,8 @@ mod tests {
         original_to_filtered.insert(3, 3);
 
         let txs = vec![tx_ind1, tx_parent, tx_child, tx_ind2];
-        let result = processor.sort_by_package_fee_rate(txs, &original_to_filtered);
+        let tiers = t0_tiers(txs.len());
+        let result = processor.sort_by_package_fee_rate(txs, &tiers, &original_to_filtered);
 
         assert_eq!(result.len(), 4);
 
@@ -4090,7 +4195,7 @@ mod tests {
         let processor = test_processor();
         let tx = make_tx("only", 1000, 400, vec![]);
         let original_to_filtered = HashMap::new();
-        let result = processor.sort_by_package_fee_rate(vec![tx], &original_to_filtered);
+        let result = processor.sort_by_package_fee_rate(vec![tx], &t0_tiers(1), &original_to_filtered);
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].txid, "only");
     }
@@ -4110,12 +4215,210 @@ mod tests {
         original_to_filtered.insert(1, 1);
 
         let txs = vec![tx_a, tx_b];
-        let result = processor.sort_by_package_fee_rate(txs, &original_to_filtered);
+        let tiers = t0_tiers(txs.len());
+        let result = processor.sort_by_package_fee_rate(txs, &tiers, &original_to_filtered);
 
         // They should form a package; A must come before B
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].txid, "a");
         assert_eq!(result[1].txid, "b");
+    }
+
+    // ------------------------------------------------------------------
+    // Block-priority lever: PaymentsFirst vs MaxFee
+    // ------------------------------------------------------------------
+
+    /// A controlled tiered mempool used by the block-priority tests.
+    ///
+    /// Returns `(txs, tiers, original_to_filtered)` for a mix of independent
+    /// financial + data txs and a CPFP package that SPANS tiers (a T3 data
+    /// parent CPFP-bumped by a T0 payment child), so the cluster-minimum-tier
+    /// classification is exercised. All txs are kept 1:1 (identity remap).
+    ///
+    /// | idx | txid   | tier | fee   | weight | vB  | sat/vB | note                    |
+    /// |-----|--------|------|-------|--------|-----|--------|-------------------------|
+    /// | 0   | payA   | T0   | 1000  | 400    | 100 | 10     | low-fee payment         |
+    /// | 1   | dataC  | T3   | 8000  | 400    | 100 | 80     | high-fee inscription    |
+    /// | 2   | dataP  | T3   | 100   | 400    | 100 | 1      | package parent (data)   |
+    /// | 3   | payQ   | T0   | 5000  | 200    | 50  | —      | package child (payment) |
+    /// | 4   | payB   | T1   | 2000  | 400    | 100 | 20     | payment                 |
+    /// | 5   | dataD  | T2   | 1200  | 400    | 100 | 12     | low-fee data            |
+    ///
+    /// Package {dataP,payQ}: fee=5100, weight=600, vB=150 => 34 sat/vB;
+    /// cluster-minimum tier = T0 (payQ) => classified FINANCIAL.
+    fn tiered_mempool() -> (Vec<TemplateTransaction>, Vec<BudsTier>, HashMap<usize, usize>) {
+        let txs = vec![
+            make_tx("payA", 1000, 400, vec![]),
+            make_tx("dataC", 8000, 400, vec![]),
+            make_tx("dataP", 100, 400, vec![]),
+            make_tx("payQ", 5000, 200, vec![3]), // depends on dataP (orig idx 2 => 1-indexed 3)
+            make_tx("payB", 2000, 400, vec![]),
+            make_tx("dataD", 1200, 400, vec![]),
+        ];
+        let tiers = vec![
+            BudsTier::T0, // payA
+            BudsTier::T3, // dataC
+            BudsTier::T3, // dataP
+            BudsTier::T0, // payQ
+            BudsTier::T1, // payB
+            BudsTier::T2, // dataD
+        ];
+        let mut original_to_filtered = HashMap::new();
+        for i in 0..txs.len() {
+            original_to_filtered.insert(i, i);
+        }
+        (txs, tiers, original_to_filtered)
+    }
+
+    fn pos(result: &[TemplateTransaction], txid: &str) -> usize {
+        result
+            .iter()
+            .position(|t| t.txid == txid)
+            .unwrap_or_else(|| panic!("txid {txid} missing from result"))
+    }
+
+    /// PaymentsFirst seats all financial packages (T0/T1, or a CPFP package
+    /// whose minimum tier is financial) ahead of all data packages (T2/T3),
+    /// each group still internally ordered by package fee rate, and never
+    /// splits or reorders a CPFP package.
+    #[test]
+    fn test_payments_first_seats_financial_ahead_respecting_cpfp() {
+        let processor = test_processor_with_priority(BlockPriority::PaymentsFirst);
+        let (txs, tiers, o2f) = tiered_mempool();
+        let result = processor.sort_by_package_fee_rate(txs, &tiers, &o2f);
+
+        assert_eq!(result.len(), 6, "permutation must preserve the tx set");
+
+        // Financial txs (payA, payB, and the min-financial package dataP+payQ)
+        // must all precede the data txs (dataC, dataD).
+        let last_financial = ["payA", "payB", "dataP", "payQ"]
+            .iter()
+            .map(|t| pos(&result, t))
+            .max()
+            .unwrap();
+        let first_data = ["dataC", "dataD"]
+            .iter()
+            .map(|t| pos(&result, t))
+            .min()
+            .unwrap();
+        assert!(
+            last_financial < first_data,
+            "every financial tx must be seated ahead of every data tx (got financial max {last_financial} >= data min {first_data}): {:?}",
+            result.iter().map(|t| &t.txid).collect::<Vec<_>>()
+        );
+
+        // The mixed-tier CPFP package is classified financial by cluster-min
+        // tier and stays intact with parent before child.
+        assert!(
+            pos(&result, "dataP") < pos(&result, "payQ"),
+            "CPFP parent (dataP) must precede its child (payQ)"
+        );
+
+        // Financial group internally fee-rate descending: package (34 sat/vB) >
+        // payB (20) > payA (10).
+        assert!(pos(&result, "dataP") < pos(&result, "payB"));
+        assert!(pos(&result, "payB") < pos(&result, "payA"));
+        // Data group internally fee-rate descending: dataC (80) > dataD (12).
+        assert!(pos(&result, "dataC") < pos(&result, "dataD"));
+
+        // Exact expected permutation.
+        let order: Vec<&str> = result.iter().map(|t| t.txid.as_str()).collect();
+        assert_eq!(
+            order,
+            vec!["dataP", "payQ", "payB", "payA", "dataC", "dataD"],
+        );
+    }
+
+    /// MaxFee (the default) ignores tiers entirely: the ordering is identical to
+    /// the historical package-fee-rate sort, regardless of the carried tiers.
+    #[test]
+    fn test_max_fee_identical_to_pre_change_default() {
+        let (txs, tiers, o2f) = tiered_mempool();
+
+        // Explicit MaxFee processor.
+        let max_fee = test_processor_with_priority(BlockPriority::MaxFee);
+        let result_max = max_fee.sort_by_package_fee_rate(txs.clone(), &tiers, &o2f);
+
+        // The default processor (no block_priority set => MaxFee) must produce
+        // byte-identical ordering, proving the default path is untouched.
+        let default_proc = test_processor();
+        let result_default =
+            default_proc.sort_by_package_fee_rate(txs.clone(), &tiers, &o2f);
+        let ids_max: Vec<&str> = result_max.iter().map(|t| t.txid.as_str()).collect();
+        let ids_default: Vec<&str> = result_default.iter().map(|t| t.txid.as_str()).collect();
+        assert_eq!(ids_max, ids_default, "explicit MaxFee == default config");
+
+        // And it must equal the pure fee-rate ordering (tiers make no
+        // difference under MaxFee): dataC(80) > pkg(34: dataP->payQ) > payB(20)
+        // > dataD(12) > payA(10).
+        assert_eq!(
+            ids_max,
+            vec!["dataC", "dataP", "payQ", "payB", "dataD", "payA"],
+        );
+    }
+
+    /// PaymentsFirst is a pure permutation: the tx set and total block weight
+    /// are invariant vs MaxFee — only the order changes. This is the property
+    /// that keeps the submit-time MAX_BLOCK_WEIGHT guard sufficient (no new
+    /// weight accounting).
+    #[test]
+    fn test_payments_first_is_weight_safe_permutation() {
+        let (txs, tiers, o2f) = tiered_mempool();
+
+        let max_fee = test_processor_with_priority(BlockPriority::MaxFee);
+        let pay_first = test_processor_with_priority(BlockPriority::PaymentsFirst);
+
+        let r_max = max_fee.sort_by_package_fee_rate(txs.clone(), &tiers, &o2f);
+        let r_pay = pay_first.sort_by_package_fee_rate(txs.clone(), &tiers, &o2f);
+
+        // Same count.
+        assert_eq!(r_max.len(), r_pay.len());
+        assert_eq!(r_pay.len(), txs.len());
+
+        // Same total weight (permutation, not re-selection).
+        let w_max: u64 = r_max.iter().map(|t| t.weight).sum();
+        let w_pay: u64 = r_pay.iter().map(|t| t.weight).sum();
+        assert_eq!(w_max, w_pay, "total weight must be invariant across modes");
+        // The submit-time consensus cap (BIP141). Since PaymentsFirst only
+        // permutes the ghostd-selected set, this guard remains sufficient.
+        const MAX_BLOCK_WEIGHT: u64 = 4_000_000;
+        assert!(w_pay < MAX_BLOCK_WEIGHT, "template stays under the weight cap");
+
+        // Same multiset of txids (nothing added or dropped).
+        let mut ids_max: Vec<&str> = r_max.iter().map(|t| t.txid.as_str()).collect();
+        let mut ids_pay: Vec<&str> = r_pay.iter().map(|t| t.txid.as_str()).collect();
+        ids_max.sort_unstable();
+        ids_pay.sort_unstable();
+        assert_eq!(ids_max, ids_pay, "tx set must be identical, only reordered");
+
+        // The two orders actually differ (the lever does something here).
+        let ord_max: Vec<&str> = r_max.iter().map(|t| t.txid.as_str()).collect();
+        let ord_pay: Vec<&str> = r_pay.iter().map(|t| t.txid.as_str()).collect();
+        assert_ne!(ord_max, ord_pay);
+    }
+
+    /// Under a strict tier policy that admits only financial tiers, all kept
+    /// txs are T0/T1, so PaymentsFirst is a no-op — its ordering matches MaxFee
+    /// exactly. (Here every tier is financial, mirroring a strict-policy set.)
+    #[test]
+    fn test_payments_first_noop_when_all_financial() {
+        // A mempool of only financial txs (as a strict policy would leave).
+        let txs = vec![
+            make_tx("p_lo", 1000, 400, vec![]), // 10 sat/vB
+            make_tx("p_hi", 5000, 400, vec![]), // 50 sat/vB
+            make_tx("p_mid", 3000, 400, vec![]), // 30 sat/vB
+        ];
+        let tiers = vec![BudsTier::T0, BudsTier::T1, BudsTier::T0];
+        let o2f = HashMap::new();
+
+        let max_fee = test_processor_with_priority(BlockPriority::MaxFee);
+        let pay_first = test_processor_with_priority(BlockPriority::PaymentsFirst);
+        let r_max = max_fee.sort_by_package_fee_rate(txs.clone(), &tiers, &o2f);
+        let r_pay = pay_first.sort_by_package_fee_rate(txs, &tiers, &o2f);
+
+        let ord_max: Vec<&str> = r_max.iter().map(|t| t.txid.as_str()).collect();
+        let ord_pay: Vec<&str> = r_pay.iter().map(|t| t.txid.as_str()).collect();
+        assert_eq!(ord_max, ord_pay, "no-op when nothing but financial txs present");
     }
 
     /// H-MINE-3-TEST-2: Test that runtime script_len validation works

--- a/crates/ghost-common/src/config.rs
+++ b/crates/ghost-common/src/config.rs
@@ -2175,6 +2175,31 @@ pub struct BackupRunStatus {
     pub last_error: Option<String>,
 }
 
+/// Block-priority lever — how the pool orders the ghostd-selected transaction
+/// set when it builds a block template.
+///
+/// This is a pure **permutation** of the already-selected, weight-bounded set
+/// ghostd hands the pool: it never adds or drops a transaction, so it is
+/// weight-safe by construction. It is a per-node economic *policy*, not a
+/// consensus rule — nodes running different values still interoperate (each
+/// simply orders its own blocks).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum BlockPriority {
+    /// Order strictly by package fee rate, descending — pure revenue
+    /// maximisation. This is the historical behaviour and the default; the set
+    /// ghostd hands us is already fee-rate optimal, so `max_fee` re-sorts toward
+    /// exactly that.
+    #[default]
+    MaxFee,
+    /// Seat BUDS **financial** transactions (T0/T1) ahead of **data**
+    /// transactions (T2/T3), each group still internally ordered by package fee
+    /// rate. A values lever that deliberately forgoes some fee revenue whenever
+    /// a high-fee data transaction would otherwise out-bid a payment for the
+    /// last slots of block weight.
+    PaymentsFirst,
+}
+
 /// Pool configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PoolConfig {
@@ -2222,6 +2247,12 @@ pub struct PoolConfig {
     /// Prevents accidental dual-genesis if someone mistakenly runs --genesis.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub genesis_password: Option<String>,
+    /// Block-priority lever: `max_fee` (default) orders the block by package fee
+    /// rate; `payments_first` seats BUDS financial txs (T0/T1) ahead of data txs
+    /// (T2/T3). Additive with `#[serde(default)]` so existing pool.toml files
+    /// parse unchanged.
+    #[serde(default)]
+    pub block_priority: BlockPriority,
 }
 
 impl PoolConfig {
@@ -2266,6 +2297,7 @@ impl Default for PoolConfig {
             pool_name: None,
             coinbase_extra: None,
             genesis_password: None,
+            block_priority: BlockPriority::default(),
         }
     }
 }

--- a/crates/ghost-verification/src/routes.rs
+++ b/crates/ghost-verification/src/routes.rs
@@ -481,6 +481,10 @@ pub fn create_router(state: Arc<VerificationState>) -> Router {
             post(api_config_policy_profile_post_handler),
         )
         .route(
+            "/api/v1/config/block_priority",
+            post(api_config_block_priority_post_handler),
+        )
+        .route(
             "/api/v1/config/policy_custom",
             post(api_config_policy_custom_post_handler),
         )
@@ -5440,6 +5444,7 @@ async fn api_config_full_handler(State(state): State<Arc<VerificationState>>) ->
         "payout": payout,
         "pool_name": pool_name,
         "policy": policy,
+        "block_priority": block_priority_key(&state),
         "network": state.network.as_str(),
         "stratum_sv2_port": 4444,
         "stratum_sv1_port": 3333,
@@ -6322,6 +6327,116 @@ async fn api_config_policy_profile_post_handler(
         "restart_pending": true,
     }))
     .into_response()
+}
+
+/// Request body for the block-priority POST endpoint.
+#[derive(Debug, Deserialize)]
+struct BlockPriorityRequest {
+    /// One of `max_fee` (default) or `payments_first`.
+    block_priority: String,
+}
+
+/// API v1 Config block_priority POST handler.
+///
+/// Writes `[pool].block_priority` into the node config (pool.toml) via
+/// `save_atomic`, then requests a graceful ghost-pool restart. The lever is
+/// resolved once at startup into `TemplateConfig` (`main.rs`), so — like the
+/// tier policy — a restart is what actually applies the new ordering to block
+/// templates. This is a per-node economic policy, not a consensus rule.
+async fn api_config_block_priority_post_handler(
+    State(state): State<Arc<VerificationState>>,
+    Json(payload): Json<BlockPriorityRequest>,
+) -> impl IntoResponse {
+    use ghost_common::config::BlockPriority;
+
+    // Map the incoming string to the config enum; reject anything else 400.
+    let priority = match payload.block_priority.trim().to_ascii_lowercase().as_str() {
+        "max_fee" => BlockPriority::MaxFee,
+        "payments_first" => BlockPriority::PaymentsFirst,
+        other => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({
+                    "success": false,
+                    "error": format!("Unknown block priority: {other}"),
+                    "code": "INVALID_BLOCK_PRIORITY",
+                })),
+            )
+                .into_response();
+        }
+    };
+
+    // The canonical serialized name we echo back to the caller.
+    let priority_name = match priority {
+        BlockPriority::MaxFee => "max_fee",
+        BlockPriority::PaymentsFirst => "payments_first",
+    };
+
+    // Require the full node config + a path to persist to; otherwise the change
+    // can't survive a restart, so fail-closed with SERVICE_UNAVAILABLE.
+    let Some(ref full) = state.full_node_config else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(serde_json::json!({
+                "success": false,
+                "error": "Config update API not available: full node config not loaded",
+                "code": "CONFIG_NOT_LOADED",
+            })),
+        )
+            .into_response();
+    };
+    let Some(ref path) = state.full_node_config_path else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(serde_json::json!({
+                "success": false,
+                "error": "Config update API not available: no node config path configured",
+                "code": "CONFIG_NOT_LOADED",
+            })),
+        )
+            .into_response();
+    };
+
+    {
+        let mut cfg = full.write();
+        cfg.pool.block_priority = priority;
+        if let Err(e) = cfg.save_atomic(path) {
+            error!(error = %e, "Failed to persist block priority");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({
+                    "success": false,
+                    "error": format!("Failed to persist block priority: {e}"),
+                    "code": "PERSIST_FAILED",
+                })),
+            )
+                .into_response();
+        }
+    }
+
+    // The lever is resolved at startup, so a graceful restart applies it.
+    state.request_restart();
+
+    Json(serde_json::json!({
+        "success": true,
+        "block_priority": priority_name,
+        "restart_pending": true,
+    }))
+    .into_response()
+}
+
+/// Serialize the persisted block-priority lever to its wire key for config GETs.
+/// Returns `max_fee` when the full node config isn't loaded (test/minimal
+/// servers), matching the config default.
+fn block_priority_key(state: &Arc<VerificationState>) -> &'static str {
+    use ghost_common::config::BlockPriority;
+    let Some(ref full) = state.full_node_config else {
+        return "max_fee";
+    };
+    match full.read().pool.block_priority {
+        BlockPriority::MaxFee => "max_fee",
+        BlockPriority::PaymentsFirst => "payments_first",
+    }
 }
 
 /// Request body for the custom tier-policy POST endpoint. Carries the full set
@@ -10843,6 +10958,120 @@ mod tests {
             bad_resp.status(),
             StatusCode::BAD_REQUEST,
             "unknown policy profile must 400"
+        );
+    }
+
+    /// The block_priority POST is the real block-ordering lever: without HMAC it
+    /// must 401, and with a valid signature it must persist `[pool].block_priority`
+    /// to pool.toml and request a graceful restart. An unknown value must 400.
+    #[tokio::test]
+    async fn test_config_block_priority_post_persists_and_restarts() {
+        use ghost_common::config::BlockPriority;
+        use ghost_common::config::NodeConfig as FullNodeConfig;
+        use ghost_common::types::NodeCapabilities;
+        use ghost_policy::PolicyProfile;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("pool.toml");
+
+        let auth = crate::auth::InternalAuth::new(&test_secret()).unwrap();
+        let state = Arc::new(
+            crate::server::VerificationState::new(
+                "test_node".to_string(),
+                "1.0.0".to_string(),
+                PolicyProfile::default(),
+                NodeCapabilities::default(),
+            )
+            .with_internal_auth(auth.clone())
+            .with_full_node_config(FullNodeConfig::default(), path.clone()),
+        );
+
+        // Default is MaxFee before any write.
+        assert_eq!(
+            FullNodeConfig::default().pool.block_priority,
+            BlockPriority::MaxFee
+        );
+
+        // Without auth → 401.
+        let unauth = super::create_router(Arc::clone(&state))
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/config/block_priority")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(r#"{"block_priority": "payments_first"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            unauth.status(),
+            StatusCode::UNAUTHORIZED,
+            "block_priority POST without auth must 401"
+        );
+        assert!(!state.restart_requested());
+
+        // With valid HMAC → persists `payments_first` and requests restart.
+        let body = r#"{"block_priority": "payments_first"}"#;
+        let timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let signature = auth.sign(timestamp, body.as_bytes());
+        let response = super::create_router(Arc::clone(&state))
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/config/block_priority")
+                    .header("Content-Type", "application/json")
+                    .header("X-Ghost-Signature", signature)
+                    .header("X-Ghost-Timestamp", timestamp.to_string())
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(json["success"].as_bool(), Some(true));
+        assert_eq!(json["block_priority"].as_str(), Some("payments_first"));
+        assert_eq!(json["restart_pending"].as_bool(), Some(true));
+
+        // Persisted to disk as PaymentsFirst and restart requested.
+        let reloaded = FullNodeConfig::load(&path).unwrap();
+        assert_eq!(reloaded.pool.block_priority, BlockPriority::PaymentsFirst);
+        assert!(
+            state.restart_requested(),
+            "block_priority change must request a restart"
+        );
+
+        // Unknown value → 400.
+        let bad = r#"{"block_priority": "nonsense"}"#;
+        let timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let signature = auth.sign(timestamp, bad.as_bytes());
+        let bad_resp = super::create_router(Arc::clone(&state))
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/config/block_priority")
+                    .header("Content-Type", "application/json")
+                    .header("X-Ghost-Signature", signature)
+                    .header("X-Ghost-Timestamp", timestamp.to_string())
+                    .body(Body::from(bad))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            bad_resp.status(),
+            StatusCode::BAD_REQUEST,
+            "unknown block priority must 400"
         );
     }
 

--- a/dashboard/src/app/(dashboard)/settings/filtering/page.tsx
+++ b/dashboard/src/app/(dashboard)/settings/filtering/page.tsx
@@ -5,6 +5,7 @@ import { Card, CardHeader } from "@/components/ui/Card";
 import { Toggle } from "@/components/ui/Toggle";
 import { SectionErrorBoundary } from "@/components/ui/SectionErrorBoundary";
 import { PolicyProfileSelector } from "@/components/filtering/PolicyProfileSelector";
+import { BlockPrioritySelector } from "@/components/filtering/BlockPrioritySelector";
 import { ReaperControls } from "@/components/filtering/ReaperControls";
 import { AdvancedPolicyPanel } from "@/components/filtering/AdvancedPolicyPanel";
 import { useAdvancedFilteringGate } from "@/hooks/useAdvancedFilteringGate";
@@ -55,6 +56,16 @@ export default function FilteringSettingsPage() {
 
       {advancedEnabled && (
         <>
+          <SectionErrorBoundary section="Block priority">
+            <Card>
+              <CardHeader
+                title="Block priority"
+                subtitle="Ordering only — which admitted transactions this node seats first. Max fee maximises revenue; Payments first prioritises payments (BUDS T0/T1) over data (T2/T3), forgoing some fee income. Changing it restarts the node."
+              />
+              <BlockPrioritySelector />
+            </Card>
+          </SectionErrorBoundary>
+
           <SectionErrorBoundary section="Reaper">
             <ReaperControls />
           </SectionErrorBoundary>

--- a/dashboard/src/components/filtering/BlockPrioritySelector.tsx
+++ b/dashboard/src/components/filtering/BlockPrioritySelector.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { Button } from "@/components/ui/Button";
+import { useFullConfig } from "@/hooks/queries/useConfigQueries";
+import { setBlockPriority, type BlockPriorityType } from "@/lib/api/config";
+import { useToast } from "@/components/ui/Toast";
+
+// The two block-priority modes (pool.toml [pool].block_priority), with
+// plain-English labels and an honest statement of the revenue-vs-values
+// tradeoff. This lever only ORDERS the block — it never drops transactions, so
+// it composes with (and is strictly softer than) the tier policy above.
+export const BLOCK_PRIORITY_OPTIONS: {
+  value: BlockPriorityType;
+  label: string;
+  desc: string;
+}[] = [
+  {
+    value: "max_fee",
+    label: "Max fee",
+    desc: "Order the block purely by fee rate. Maximises this node's mining revenue. This is the default.",
+  },
+  {
+    value: "payments_first",
+    label: "Payments first",
+    desc: "Seat payments (BUDS T0/T1) ahead of data (T2/T3), each still fee-ordered within its group. Prioritises Bitcoin-as-money — you may earn less when data transactions are bidding high.",
+  },
+];
+
+// Normalise the stored value; anything unknown falls back to the default.
+export function normalizeBlockPriority(value?: string): BlockPriorityType {
+  return value === "payments_first" ? "payments_first" : "max_fee";
+}
+
+/**
+ * Editable block-priority selector — writes the real pool.toml
+ * [pool].block_priority via POST /api/v1/config/block_priority, which persists +
+ * triggers a graceful restart to apply. A pending-confirm step makes the restart
+ * explicit, matching the tier-policy selector it sits beside.
+ *
+ * This is the softer sibling of the tier policy: the policy decides WHICH tx
+ * classes are mined; this decides which of those admitted classes are seated
+ * FIRST. Under a strict policy (data tiers already dropped) it is a no-op.
+ */
+export function BlockPrioritySelector() {
+  const { data: fullConfig } = useFullConfig();
+  const { success, error } = useToast();
+  const queryClient = useQueryClient();
+  const current = normalizeBlockPriority(fullConfig?.block_priority);
+  const [pending, setPending] = useState<BlockPriorityType | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  const apply = async (value: BlockPriorityType) => {
+    setSaving(true);
+    try {
+      await setBlockPriority(value);
+      success("Block priority updated", "The node is restarting to apply the new block ordering.");
+      setPending(null);
+      queryClient.invalidateQueries({ queryKey: ["config"] });
+    } catch (e) {
+      error("Failed to update block priority", e instanceof Error ? e.message : "Unknown error");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+        {BLOCK_PRIORITY_OPTIONS.map((opt) => {
+          const isCurrent = current === opt.value;
+          return (
+            <button
+              key={opt.value}
+              onClick={() => !isCurrent && setPending(opt.value)}
+              disabled={isCurrent || saving}
+              style={{
+                textAlign: "left",
+                padding: "12px 14px",
+                borderRadius: "6px",
+                border: `1px solid ${isCurrent ? "var(--accent)" : "var(--rule)"}`,
+                background: isCurrent ? "var(--accent-weak)" : "var(--bg)",
+                cursor: isCurrent ? "default" : "pointer",
+              }}
+            >
+              <div className="flex items-center gap-2" style={{ marginBottom: "4px" }}>
+                <span style={{ color: "var(--fg)", fontSize: "14px", fontWeight: 600 }}>{opt.label}</span>
+                {isCurrent && (
+                  <span style={{ color: "var(--accent)", fontSize: "11px", fontWeight: 600 }}>· current</span>
+                )}
+              </div>
+              <div style={{ color: "var(--dim)", fontSize: "12px", lineHeight: "1.5" }}>{opt.desc}</div>
+            </button>
+          );
+        })}
+      </div>
+      <p className="text-xs text-[color:var(--fainter)] mt-3">
+        Ordering only — no transaction is ever dropped by this lever. Under a strict tier policy (data
+        tiers already filtered out) <strong>Payments first</strong> has nothing to reorder and is a no-op.
+      </p>
+      {pending && (
+        <div
+          style={{
+            marginTop: "12px",
+            padding: "12px 14px",
+            border: "1px solid var(--accent)",
+            borderRadius: "6px",
+            background: "var(--accent-weak)",
+          }}
+        >
+          <div style={{ color: "var(--fg)", fontSize: "13px", marginBottom: "10px" }}>
+            Switch block priority to{" "}
+            <strong>{BLOCK_PRIORITY_OPTIONS.find((o) => o.value === pending)?.label}</strong>? This writes the
+            config and <strong>restarts the node</strong> to apply.
+          </div>
+          <div className="flex items-center gap-2">
+            <Button variant="primary" size="sm" onClick={() => apply(pending)} disabled={saving}>
+              {saving ? "Applying…" : "Apply & restart"}
+            </Button>
+            <Button variant="ghost" size="sm" onClick={() => setPending(null)} disabled={saving}>
+              Cancel
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dashboard/src/hooks/queries/useConfigQueries.ts
+++ b/dashboard/src/hooks/queries/useConfigQueries.ts
@@ -14,6 +14,8 @@ import {
   type DaemonSettings,
   setPolicyProfile,
   type PolicyProfileType,
+  setBlockPriority,
+  type BlockPriorityType,
   setOperatorWindow,
   getL2PruningStatus,
   setGhostPayPayoutAddress,
@@ -155,6 +157,21 @@ export function useSetPolicyProfile() {
 
   return useMutation({
     mutationFn: (profile: PolicyProfileType) => setPolicyProfile(profile),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: configKeys.all });
+    },
+  });
+}
+
+// Block-priority lever (pool.toml [pool].block_priority). Writing it persists to
+// pool.toml and triggers a graceful restart so the new template ORDERING is
+// resolved at startup. `max_fee` maximises revenue; `payments_first` seats BUDS
+// financial txs (T0/T1) ahead of data txs (T2/T3), forgoing some fee income.
+export function useSetBlockPriority() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (blockPriority: BlockPriorityType) => setBlockPriority(blockPriority),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: configKeys.all });
     },

--- a/dashboard/src/lib/api/config.ts
+++ b/dashboard/src/lib/api/config.ts
@@ -237,6 +237,28 @@ export async function setPolicyProfile(profile: PolicyProfileType): Promise<Poli
   });
 }
 
+// The block-priority lever (pool.toml [pool].block_priority). Governs how the
+// block template is ORDERED — either by max fee (revenue) or by seating BUDS
+// financial txs (T0/T1) ahead of data txs (T2/T3). It never adds or drops txs
+// (permutation only), so it is weight-safe. Writing it persists to pool.toml and
+// triggers a graceful restart to apply.
+export type BlockPriorityType = 'max_fee' | 'payments_first';
+
+export interface BlockPriorityResult {
+  success: boolean;
+  block_priority: BlockPriorityType;
+  restart_pending: boolean;
+}
+
+export async function setBlockPriority(
+  blockPriority: BlockPriorityType,
+): Promise<BlockPriorityResult> {
+  return fetchApi<BlockPriorityResult>('/api/v1/config/block_priority', {
+    method: 'POST',
+    body: JSON.stringify({ block_priority: blockPriority }),
+  });
+}
+
 // Map a setup-wizard's coarse mempool-policy choice onto the REAL tier-policy
 // profile. The wizards present simplified labels ("standard"/permissive vs
 // "strict"); anything more permissive than strict maps to `full_open`.

--- a/dashboard/src/types/api.ts
+++ b/dashboard/src/types/api.ts
@@ -133,6 +133,10 @@ export interface FullNodeConfig {
     min_payout: number;
     auto_payout: boolean;
   };
+  // Block-priority lever from pool.toml [pool].block_priority. Governs template
+  // ORDERING: `max_fee` (default, revenue) or `payments_first` (seat BUDS
+  // financial txs ahead of data txs). Permutation only — weight-safe.
+  block_priority?: 'max_fee' | 'payments_first';
   // Flat fields from backend
   ghost_mode?: boolean;
   ghost_mode_local_egress?: boolean;

--- a/tests/integration_tests/config_validation.rs
+++ b/tests/integration_tests/config_validation.rs
@@ -533,6 +533,7 @@ fn test_pool_config_validate_success() {
         pool_name: None,
         coinbase_extra: None,
         genesis_password: None,
+        block_priority: Default::default(),
     };
 
     let result = config.validate();


### PR DESCRIPTION
## Summary

Adds a **consumed** block-priority lever that changes *which transactions land where* in a mined block, with an honest revenue-vs-values tradeoff. Implements `tasks/plan_block_priority_lever.md`.

| Value | Behaviour |
|-------|-----------|
| `max_fee` (default) | Order by package fee rate — today's behaviour, byte-identical. Revenue-maximising. |
| `payments_first` | Seat BUDS **financial** txs (T0/T1) ahead of **data** txs (T2/T3), each group still fee-rate-ordered internally. Values-biased. |

The pool already re-sorts every template build (`sort_by_package_fee_rate`); this adds an optional primary sort key. It is a **permutation of the ghostd-selected set only** — same txs, same total weight — so it is weight-safe and needs no new pool-side weight accounting. It is a per-node economic *policy*, not a consensus rule, so nodes on different settings still interoperate.

## Changes

- **`BlockPriority` enum** (`MaxFee` default | `PaymentsFirst`) on `PoolConfig` with `#[serde(default)]` (existing `pool.toml` parses unchanged), threaded into `TemplateConfig` and resolved once at startup in `main.rs`.
- **Sort injection** (`template.rs`): the per-tx BUDS tier already computed for the policy gate is now carried alongside each kept tx; each CPFP cluster is classified by its **minimum** tier (financial iff ≤ T1). Under `payments_first` the fast-path and cluster comparators gain a primary key `(financial DESC, package_fee_rate DESC)`. Under `max_fee` the comparator is the historical single key — stable sort, so the default ordering is unchanged. CPFP union-find + Kahn topological in-cluster order are untouched; a package is never split, so parents still precede children.
- **Config plumbing**: `POST /api/v1/config/block_priority` persists `[pool].block_priority` via `save_atomic` + `request_restart()`; emitted in `/api/v1/config/full`.
- **Dashboard**: a 2-option Block priority selector on the **Filtering** page (Advanced), with a one-line tradeoff explainer and a note that it is a no-op under a strict tier policy. New `useSetBlockPriority` hook + `setBlockPriority` api fn + `BlockPriorityType`.

## Honest limitation

Pool-side re-ordering cannot re-include txs ghostd already dropped for weight (that would need a ghostd-side selector, out of scope for v1). `payments_first` is a no-op under a strict tier policy (no data txs present). Both are documented in the UI copy.

## Tests

- `test_payments_first_seats_financial_ahead_respecting_cpfp` — payments (incl. a mixed-tier CPFP package classified financial by min tier) seated ahead of data; parent precedes child; groups internally fee-rate-ordered.
- `test_max_fee_identical_to_pre_change_default` — explicit `MaxFee` == default config == pure fee-rate order (tiers ignored).
- `test_payments_first_is_weight_safe_permutation` — identical tx set + total weight across modes, under the block-weight cap.
- `test_payments_first_noop_when_all_financial` — no-op when only financial tiers present.
- `test_config_block_priority_post_persists_and_restarts` — POST 401 without auth, persists + restarts with auth, 400 on unknown value.

All 50 `template::` tests pass, plus the new route test and the touched config-validation integration tests. Dashboard `tsc`, `eslint`, and `npm run build` all pass.