### PR TITLE
feat(haze): full page overhaul — storage-savings hero + Legal Pack + checkpoints (backend RPC wiring + redesign)

### DIFF
--- a/crates/ghost-common/src/rpc.rs
+++ b/crates/ghost-common/src/rpc.rs
@@ -1243,6 +1243,35 @@ impl BitcoinRpc {
     }
 
     // ============================================================
+    // Ghost Haze RPC Methods
+    // ============================================================
+
+    /// Get the current Ghost Haze operating status.
+    ///
+    /// Surfaces the Exorcism state and storage statistics — including
+    /// `bytes_stripped` (the arbitrary-content-kept-off-disk metric) and the
+    /// structural archive size — that `getblockchaininfo` does not expose.
+    pub async fn get_haze_status(&self) -> GhostResult<HazeRpcStatus> {
+        self.call("gethazestatus", vec![]).await
+    }
+
+    /// Generate the Legal Compliance Packet proving this node does not persist
+    /// hazeable content. Only available on hazed nodes; the RPC returns an error
+    /// on Full Archive / non-hazed nodes (surfaced here as `GhostError::Rpc`).
+    ///
+    /// Returned as a raw JSON value because the packet is a court-ready document
+    /// whose shape is defined by ghostd and forwarded verbatim to the dashboard.
+    pub async fn get_legal_packet(&self) -> GhostResult<Value> {
+        self.call("getlegalpacket", vec![]).await
+    }
+
+    /// Get the Ghost Haze signed-checkpoint status (serving / downloading /
+    /// neither), the trust anchor for a hazed node's UTXO snapshot.
+    pub async fn get_checkpoint_status(&self) -> GhostResult<Value> {
+        self.call("getcheckpointstatus", vec![]).await
+    }
+
+    // ============================================================
     // Ghost-Core Specific RPC Methods
     // ============================================================
 
@@ -1467,6 +1496,31 @@ pub struct BlockchainInfo {
     pub signet_challenge: Option<String>,
     #[serde(default)]
     pub warnings: Vec<String>,
+}
+
+/// Ghost Haze operating status, as returned by ghostd's `gethazestatus` RPC.
+///
+/// Distinct from the dashboard-facing `HazeStatus` response (which merges these
+/// fields with `getblockchaininfo`); this mirrors ghostd's raw RPC contract.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HazeRpcStatus {
+    /// Operating mode: "hazed" or "full_archive".
+    pub mode: String,
+    /// Whether Ghost Exorcism is stripping incoming blocks.
+    #[serde(default)]
+    pub exorcism_active: bool,
+    /// Total blocks processed through Exorcism.
+    #[serde(default)]
+    pub blocks_stripped: i64,
+    /// Total bytes stripped from blocks (arbitrary content kept off disk).
+    #[serde(default)]
+    pub bytes_stripped: i64,
+    /// Current chain tip height.
+    #[serde(default)]
+    pub chain_tip: i64,
+    /// Approximate structural archive size in GB (sum of `.gsb` files).
+    #[serde(default)]
+    pub storage_gb: f64,
 }
 
 /// Block header

--- a/crates/ghost-verification/src/routes.rs
+++ b/crates/ghost-verification/src/routes.rs
@@ -409,6 +409,8 @@ pub fn create_router(state: Arc<VerificationState>) -> Router {
         .route("/api/v1/mpc/votes/:position", get(api_mpc_votes_handler))
         // Ghost Haze & Shroud endpoints
         .route("/api/v1/haze/status", get(api_haze_status_handler))
+        .route("/api/v1/haze/legal-pack", get(api_haze_legal_pack_handler))
+        .route("/api/v1/haze/checkpoint", get(api_haze_checkpoint_handler))
         .route("/api/v1/shroud/status", get(api_shroud_status_handler))
         // Swarm endpoints
         .route("/api/v1/swarm/sync", get(api_swarm_sync_handler))
@@ -9062,6 +9064,41 @@ async fn api_haze_status_handler(State(state): State<Arc<VerificationState>>) ->
         None => (false, 0, 0, false, String::new(), "unknown"),
     };
 
+    // Surface the Exorcism storage metrics from `gethazestatus`. These are the
+    // headline "storage saved" numbers (`bytes_stripped`) that
+    // `getblockchaininfo` does not carry. Degrade gracefully to zeros if the
+    // node predates the Haze RPCs or the call fails.
+    let haze_rpc = match state.rpc {
+        Some(ref rpc) => {
+            match tokio::time::timeout(std::time::Duration::from_secs(5), rpc.get_haze_status())
+                .await
+            {
+                Ok(Ok(status)) => Some(status),
+                Ok(Err(e)) => {
+                    warn!("Failed to get haze exorcism status from RPC: {}", e);
+                    None
+                }
+                Err(_) => {
+                    warn!("Haze exorcism status RPC timed out");
+                    None
+                }
+            }
+        }
+        None => None,
+    };
+
+    let (exorcism_active, blocks_stripped, bytes_stripped, chain_tip, structural_archive_size_gb) =
+        match haze_rpc {
+            Some(s) => (
+                s.exorcism_active,
+                s.blocks_stripped,
+                s.bytes_stripped,
+                s.chain_tip,
+                s.storage_gb,
+            ),
+            None => (false, 0, 0, blocks as i64, 0.0),
+        };
+
     Json(serde_json::json!({
         "hazed": hazed,
         "archive_mode": archive_mode,
@@ -9069,8 +9106,110 @@ async fn api_haze_status_handler(State(state): State<Arc<VerificationState>>) ->
         "blocks": blocks,
         "size_on_disk": size_on_disk,
         "pruned": pruned,
-        "chain": chain
+        "chain": chain,
+        "exorcism_active": exorcism_active,
+        "blocks_stripped": blocks_stripped,
+        "bytes_stripped": bytes_stripped,
+        "chain_tip": chain_tip,
+        "structural_archive_size_gb": structural_archive_size_gb
     }))
+}
+
+/// Ghost Haze legal-pack handler — court-ready proof the node persists no
+/// hazeable content.
+///
+/// Proxies ghostd's `getlegalpacket`. The RPC only succeeds on a hazed node;
+/// on Full Archive / non-hazed nodes (or an older ghostd) it errors, which we
+/// translate into a clean `{ available: false, reason }` shape rather than a
+/// 500 so the dashboard can render the "enable Haze" path.
+async fn api_haze_legal_pack_handler(
+    State(state): State<Arc<VerificationState>>,
+) -> impl IntoResponse {
+    let rpc = match state.rpc {
+        Some(ref rpc) => rpc,
+        None => {
+            return Json(serde_json::json!({
+                "available": false,
+                "reason": "Ghost Core RPC is not connected."
+            }));
+        }
+    };
+
+    match tokio::time::timeout(std::time::Duration::from_secs(5), rpc.get_legal_packet()).await {
+        Ok(Ok(mut packet)) => {
+            // Forward the court-ready packet verbatim, tagging it available so
+            // the dashboard can branch without inspecting individual fields.
+            if let Some(obj) = packet.as_object_mut() {
+                obj.insert("available".to_string(), serde_json::Value::Bool(true));
+            }
+            Json(packet)
+        }
+        Ok(Err(e)) => {
+            // Expected on non-hazed nodes: the packet is only generated in Hazed
+            // mode. Not an error condition for the dashboard.
+            Json(serde_json::json!({
+                "available": false,
+                "reason": e.to_string()
+            }))
+        }
+        Err(_) => {
+            warn!("Legal packet RPC timed out");
+            Json(serde_json::json!({
+                "available": false,
+                "reason": "Ghost Core timed out generating the Legal Compliance Packet."
+            }))
+        }
+    }
+}
+
+/// Ghost Haze checkpoint handler — signed-checkpoint trust anchor status.
+///
+/// Proxies ghostd's `getcheckpointstatus`. Always returns a `{ serving,
+/// downloading, ... }` shape; on RPC failure it degrades to a neither-state
+/// with `available: false` rather than a 500.
+async fn api_haze_checkpoint_handler(
+    State(state): State<Arc<VerificationState>>,
+) -> impl IntoResponse {
+    let rpc = match state.rpc {
+        Some(ref rpc) => rpc,
+        None => {
+            return Json(serde_json::json!({
+                "serving": false,
+                "downloading": false,
+                "available": false,
+                "reason": "Ghost Core RPC is not connected."
+            }));
+        }
+    };
+
+    match tokio::time::timeout(std::time::Duration::from_secs(5), rpc.get_checkpoint_status())
+        .await
+    {
+        Ok(Ok(mut status)) => {
+            if let Some(obj) = status.as_object_mut() {
+                obj.insert("available".to_string(), serde_json::Value::Bool(true));
+            }
+            Json(status)
+        }
+        Ok(Err(e)) => {
+            warn!("Failed to get checkpoint status from RPC: {}", e);
+            Json(serde_json::json!({
+                "serving": false,
+                "downloading": false,
+                "available": false,
+                "reason": e.to_string()
+            }))
+        }
+        Err(_) => {
+            warn!("Checkpoint status RPC timed out");
+            Json(serde_json::json!({
+                "serving": false,
+                "downloading": false,
+                "available": false,
+                "reason": "Ghost Core timed out returning checkpoint status."
+            }))
+        }
+    }
 }
 
 /// Ghost Shroud status handler — returns relay privacy configuration

--- a/dashboard/src/app/(dashboard)/haze/page.tsx
+++ b/dashboard/src/app/(dashboard)/haze/page.tsx
@@ -1,34 +1,49 @@
 "use client";
 
+import { useMemo } from "react";
 import { StatusRow } from "@/components/ui/StatusRow";
 import { Card, CardHeader } from "@/components/ui/Card";
 import { PageHeader } from "@/components/ui/PageHeader";
-import { StatCard } from "@/components/ui/StatCard";
 import { Badge } from "@/components/ui/Badge";
+import { Button } from "@/components/ui/Button";
 import { StatusDot } from "@/components/ui/StatusDot";
 import { SectionErrorBoundary } from "@/components/ui/SectionErrorBoundary";
 import { SkeletonCard } from "@/components/ui/Skeleton";
-import { useHazeStatus } from "@/hooks/queries/useHazeQueries";
+import { useToast } from "@/components/ui/Toast";
+import {
+  useHazeStatus,
+  useLegalPacket,
+  useCheckpointStatus,
+} from "@/hooks/queries/useHazeQueries";
+import { useConfigureHaze } from "@/hooks/queries/useConfigQueries";
+import type { LegalPacket } from "@/types/api";
 
-// --- Tooltips ---
+// --- Constants ---
 
-const TOOLTIPS = {
-  mode: "How your node stores block data. Hazed nodes strip classified content before storage. Full archive keeps everything. Standard is a normal Bitcoin Core node.",
-  blocks: "Total number of blocks your node has processed and stored.",
-  storage: "Total disk space used by blockchain data on this node.",
-  pruned: "Whether Bitcoin Core is running in pruned mode, discarding old block data to save disk space.",
-};
+// A full (unstripped) block averages ~1.6 MB near the chain tip. Used only to
+// estimate the full-archive baseline the hazed node avoids storing.
+const FULL_BLOCK_BYTES = 1.6 * 1024 * 1024;
+const BYTES_PER_GB = 1024 * 1024 * 1024;
 
 // --- Helpers ---
 
-function formatStorageGB(bytes: number | undefined | null): string {
-  // A missing/non-numeric size must render "--", never "NaN GB".
+/** Human-readable byte size. Renders "--" for missing/non-finite input. */
+function formatBytes(bytes: number | undefined | null): string {
   if (bytes == null || !Number.isFinite(bytes)) return "--";
-  const gb = bytes / (1024 * 1024 * 1024);
+  const gb = bytes / BYTES_PER_GB;
   if (gb >= 1000) return `${(gb / 1024).toFixed(2)} TB`;
   if (gb >= 1) return `${gb.toFixed(2)} GB`;
   const mb = bytes / (1024 * 1024);
-  return `${mb.toFixed(0)} MB`;
+  if (mb >= 1) return `${mb.toFixed(1)} MB`;
+  const kb = bytes / 1024;
+  if (kb >= 1) return `${kb.toFixed(0)} KB`;
+  return `${bytes} B`;
+}
+
+/** GB (as reported by ghostd, base-1024) → bytes. */
+function gbToBytes(gb: number | undefined | null): number {
+  if (gb == null || !Number.isFinite(gb)) return 0;
+  return gb * BYTES_PER_GB;
 }
 
 function getModeLabel(mode: string): string {
@@ -44,7 +59,9 @@ function getModeLabel(mode: string): string {
   }
 }
 
-function getModeBadgeVariant(mode: string): "success" | "warning" | "info" | "default" {
+function getModeBadgeVariant(
+  mode: string,
+): "success" | "warning" | "info" | "default" {
   switch (mode) {
     case "hazed":
       return "success";
@@ -57,283 +74,785 @@ function getModeBadgeVariant(mode: string): "success" | "warning" | "info" | "de
   }
 }
 
-function getModeStatus(mode: string): "online" | "warning" | "offline" {
-  switch (mode) {
-    case "hazed":
-      return "online";
-    case "full_archive":
-      return "online";
-    case "standard":
-      return "warning";
-    default:
-      return "offline";
-  }
+function shortHash(hash: string | undefined | null): string {
+  if (!hash) return "--";
+  if (hash.length <= 20) return hash;
+  return `${hash.slice(0, 10)}…${hash.slice(-10)}`;
 }
+
+/** Render the Legal Compliance Packet as a readable court-ready text document. */
+function renderLegalText(packet: LegalPacket): string {
+  const line = (label: string, value: unknown): string =>
+    `${label.padEnd(30, " ")}: ${value ?? "—"}`;
+  const yn = (v: boolean | undefined): string =>
+    v === undefined ? "—" : v ? "Yes" : "No";
+
+  return [
+    "==============================================================",
+    "  GHOST HAZE — LEGAL COMPLIANCE PACKET",
+    "  Cryptographic, court-ready proof of non-persistence",
+    "==============================================================",
+    "",
+    packet.legal_summary ?? "",
+    "",
+    "--------------------------------------------------------------",
+    "  ATTESTATION",
+    "--------------------------------------------------------------",
+    line("Ghost Core version", packet.ghost_core_version),
+    line("Haze specification version", packet.specification_version),
+    line("Node mode", packet.node_mode),
+    line("Exorcism active", yn(packet.exorcism_active)),
+    line("Haze status", packet.haze_status),
+    line("Arbitrary content on disk", yn(packet.hazeable_content_on_disk)),
+    line("Blocks stripped", packet.blocks_stripped),
+    line("Chain tip height", packet.chain_tip),
+    line("Structural archive size", `${packet.structural_archive_size_gb ?? "—"} GB`),
+    "",
+    "--------------------------------------------------------------",
+    "  CHECKPOINT ANCHOR",
+    "--------------------------------------------------------------",
+    line("Checkpoint height", packet.checkpoint_height),
+    line("Checkpoint hash", packet.checkpoint_hash),
+    "",
+    "--------------------------------------------------------------",
+    "  CONVERSION",
+    "--------------------------------------------------------------",
+    line("Conversion method", packet.conversion_method),
+    line("Conversion date", packet.conversion_date),
+    "",
+    line("Packet generated at", packet.generated_at),
+    "==============================================================",
+    "",
+  ].join("\n");
+}
+
+function downloadLegalPacket(packet: LegalPacket, format: "txt" | "json"): void {
+  const tag = packet.chain_tip ?? "node";
+  const isJson = format === "json";
+  const content = isJson
+    ? JSON.stringify(packet, null, 2)
+    : renderLegalText(packet);
+  const blob = new Blob([content], {
+    type: isJson ? "application/json" : "text/plain;charset=utf-8",
+  });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `ghost-haze-legal-pack-${tag}.${format}`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+// The field types Ghost Haze's own classifier strips before a block hits disk.
+// This is haze::field_classifier in ghostd — NOT the BUDS policy system.
+const STRIPPED_FIELDS: { title: string; body: string }[] = [
+  {
+    title: "Witness data",
+    body: "Where inscriptions live. Taproot witness envelopes carrying images, text, and arbitrary files are removed once the signature has been validated.",
+  },
+  {
+    title: "scriptSig",
+    body: "Legacy input unlocking scripts. Their signatures are checked during validation, then the raw bytes are dropped from the stored block.",
+  },
+  {
+    title: "OP_RETURN payloads",
+    body: "The classic data-carrier output. The provably-unspendable payload bytes are stripped; the output's existence and value stay accounted for.",
+  },
+  {
+    title: "Coinbase scriptSig",
+    body: "The miner's free-form input field, frequently abused to embed arbitrary content. Its non-consensus bytes are removed after height validation.",
+  },
+];
 
 // --- Page ---
 
 export default function HazePage() {
-  const { data: haze, isLoading, error } = useHazeStatus();
+  const {
+    data: haze,
+    isLoading: hazeLoading,
+    error: hazeError,
+  } = useHazeStatus();
+  const { data: legal, isLoading: legalLoading } = useLegalPacket();
+  const { data: checkpoint, isLoading: checkpointLoading } =
+    useCheckpointStatus();
+  const configureHaze = useConfigureHaze();
+  const toast = useToast();
 
   const mode = haze?.mode ?? "unknown";
+  // A node is "actively hazing" when the Exorcist is stripping incoming blocks.
+  // The legal packet is only generated in that state, so it is the ground truth.
+  const active = Boolean(haze?.exorcism_active) || mode === "hazed";
+  const legalAvailable = legal?.available === true;
+
+  // Retroactive-conversion state. The Exorcist reports COMPLETE / IN_PROGRESS
+  // in the legal packet; blocks_stripped vs chain_tip gives a progress bar for
+  // the (long, resumable) batch job that strips an already-synced node.
+  const conversionState: "complete" | "in_progress" | "none" = legalAvailable
+    ? legal?.haze_status === "IN_PROGRESS"
+      ? "in_progress"
+      : "complete"
+    : "none";
+  const conversionInProgress = conversionState === "in_progress";
+  const convBlocks = haze?.blocks_stripped ?? 0;
+  const convTip = haze?.chain_tip ?? 0;
+  const convPercent =
+    convTip > 0 ? Math.min(100, (convBlocks / convTip) * 100) : null;
+
+  const savings = useMemo(() => {
+    const strippedBytes = haze?.bytes_stripped ?? 0;
+    const structuralBytes = gbToBytes(haze?.structural_archive_size_gb);
+    const tip = haze?.chain_tip ?? 0;
+    const fullArchiveBytes = tip > 0 ? tip * FULL_BLOCK_BYTES : 0;
+    // Percentage the on-disk structural archive is smaller than a full archive.
+    const percentSmaller =
+      fullArchiveBytes > 0 && structuralBytes > 0 && fullArchiveBytes > structuralBytes
+        ? (1 - structuralBytes / fullArchiveBytes) * 100
+        : null;
+    return { strippedBytes, structuralBytes, fullArchiveBytes, percentSmaller };
+  }, [haze?.bytes_stripped, haze?.structural_archive_size_gb, haze?.chain_tip]);
+
+  const handleSetMode = async (target: "hazed" | "full_archive" | "standard") => {
+    if (target === mode) return;
+    try {
+      await configureHaze.mutateAsync(target);
+      toast.success("Ghost Haze updated", `Storage mode set to ${getModeLabel(target)}`);
+    } catch (e) {
+      toast.error(
+        "Failed to update Haze mode",
+        e instanceof Error ? e.message : "Ghost Core did not accept the change.",
+      );
+    }
+  };
 
   return (
     <div className="space-y-6">
-      {/* 1. Page Header */}
+      {/* Page Header */}
       <PageHeader
         eyebrow="haze"
-        title="Block storage layer."
-        subtitle="Storage privacy layer for your Bitcoin node"
+        title="Storage privacy layer."
+        subtitle="Strip arbitrary embedded content before it ever touches your disk — while keeping full validation and UTXO integrity."
         actions={
           haze && (
-            <Badge variant={getModeBadgeVariant(mode)}>
-              {getModeLabel(mode)}
-            </Badge>
+            <div className="flex items-center gap-2">
+              <StatusDot
+                status={active ? "online" : "warning"}
+                label={active ? "Exorcism active" : "Not hazing"}
+                pulse={active}
+              />
+              <Badge variant={getModeBadgeVariant(mode)}>{getModeLabel(mode)}</Badge>
+            </div>
           )
         }
       />
 
-      {/* 2. Stat Cards */}
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-        <StatCard
-          label="Mode"
-          value={haze ? getModeLabel(mode) : "--"}
-          tooltip={TOOLTIPS.mode}
-          loading={isLoading}
-        />
-        <StatCard
-          label="Blocks"
-          value={haze ? (haze.blocks ?? 0).toLocaleString() : "--"}
-          sublabel={haze?.chain ?? undefined}
-          tooltip={TOOLTIPS.blocks}
-          loading={isLoading}
-        />
-        <StatCard
-          label="Storage"
-          value={haze ? formatStorageGB(haze.size_on_disk) : "--"}
-          tooltip={TOOLTIPS.storage}
-          loading={isLoading}
-        />
-        <StatCard
-          label="Pruned"
-          value={haze ? (haze.pruned ? "Yes" : "No") : "--"}
-          tooltip={TOOLTIPS.pruned}
-          loading={isLoading}
-        />
-      </div>
-
-      {/* 3. How It Works (collapsible) */}
-      <Card collapsible defaultCollapsed>
-        <CardHeader
-          title="How It Works"
-          subtitle="Ghost Haze exorcism pipeline and storage stripping"
-        />
-        <div className="space-y-5">
-          {/* Explanation */}
-          <p className="text-[color:var(--dim)] text-sm leading-relaxed">
-            Ghost Haze is a storage privacy layer that classifies and strips non-financial data from blocks
-            before writing them to disk. Hazed nodes retain full transaction validity and UTXO integrity
-            while ensuring no arbitrary embedded content is persisted locally. This lets node operators
-            store blockchain data without risk of hosting unwanted content.
-          </p>
-
-          {/* 4-step exorcism pipeline */}
-          <div>
-            <h4 className="text-[color:var(--fg)] font-medium text-sm mb-3">The Exorcism Pipeline</h4>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-              <div className="p-3 bg-[var(--surface)] rounded-lg border border-[var(--rule-strong)]">
-                <div className="flex items-center gap-2 mb-1.5">
-                  <span className="text-[color:var(--accent)] font-mono text-xs font-bold">1</span>
-                  <span className="text-[color:var(--fg)] text-sm font-medium">Field Classification</span>
+      {/* 1. HERO — Storage saved */}
+      <SectionErrorBoundary section="Storage Savings">
+        {hazeLoading ? (
+          <SkeletonCard />
+        ) : hazeError ? (
+          <Card>
+            <div className="p-4 bg-[var(--surface)] border border-[color:var(--red)] rounded-lg">
+              <p className="text-[color:var(--red)] text-sm">
+                Unable to reach Ghost Core. Ensure <code>ghostd</code> is running and the
+                Haze RPCs are available.
+              </p>
+            </div>
+          </Card>
+        ) : active ? (
+          <div
+            className="rounded-lg p-8 border"
+            style={{
+              borderColor: "color-mix(in srgb, var(--green) 40%, transparent)",
+              background:
+                "linear-gradient(135deg, color-mix(in srgb, var(--green) 12%, var(--surface)) 0%, var(--surface) 70%)",
+            }}
+          >
+            <div className="text-xs uppercase tracking-wider text-[color:var(--green)] font-semibold mb-2">
+              Arbitrary data kept off your disk
+            </div>
+            <div className="text-5xl md:text-6xl font-bold text-[color:var(--fg)] leading-none">
+              {formatBytes(savings.strippedBytes)}
+            </div>
+            <p className="text-[color:var(--dim)] text-sm mt-3 max-w-2xl leading-relaxed">
+              Ghost Exorcism has removed{" "}
+              <span className="text-[color:var(--fg)] font-medium">
+                {formatBytes(savings.strippedBytes)}
+              </span>{" "}
+              of non-consensus content across{" "}
+              <span className="text-[color:var(--fg)] font-medium">
+                {(haze?.blocks_stripped ?? 0).toLocaleString()}
+              </span>{" "}
+              blocks — inscriptions, spam and data-carrier payloads that never reached your
+              disk.
+            </p>
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mt-6">
+              <div className="rounded-lg p-4 bg-[var(--surface)] border border-[color:var(--rule)]">
+                <div className="text-xs text-[color:var(--dim)] mb-1">Structural archive on disk</div>
+                <div className="text-2xl font-bold text-[color:var(--fg)]">
+                  {formatBytes(savings.structuralBytes)}
                 </div>
-                <p className="text-[color:var(--dim)] text-xs leading-relaxed">
-                  The BUDS system classifies each field in a transaction — witness data, OP_RETURN payloads,
-                  script patterns — into financial and non-financial categories.
-                </p>
               </div>
-              <div className="p-3 bg-[var(--surface)] rounded-lg border border-[var(--rule-strong)]">
-                <div className="flex items-center gap-2 mb-1.5">
-                  <span className="text-[color:var(--accent)] font-mono text-xs font-bold">2</span>
-                  <span className="text-[color:var(--fg)] text-sm font-medium">Block Stripping</span>
+              <div className="rounded-lg p-4 bg-[var(--surface)] border border-[color:var(--rule)]">
+                <div className="text-xs text-[color:var(--dim)] mb-1">Full-archive estimate</div>
+                <div className="text-2xl font-bold text-[color:var(--fg)]">
+                  {savings.fullArchiveBytes > 0 ? formatBytes(savings.fullArchiveBytes) : "--"}
                 </div>
-                <p className="text-[color:var(--dim)] text-xs leading-relaxed">
-                  Non-financial data is stripped from the block at the validation layer, before the block
-                  is written to disk. Financial data and consensus-critical fields remain untouched.
-                </p>
+                <div className="text-[11px] text-[color:var(--fainter)] mt-0.5">
+                  {(haze?.chain_tip ?? 0).toLocaleString()} blocks × ~1.6 MB
+                </div>
               </div>
-              <div className="p-3 bg-[var(--surface)] rounded-lg border border-[var(--rule-strong)]">
-                <div className="flex items-center gap-2 mb-1.5">
-                  <span className="text-[color:var(--accent)] font-mono text-xs font-bold">3</span>
-                  <span className="text-[color:var(--fg)] text-sm font-medium">GSB Storage</span>
+              <div className="rounded-lg p-4 bg-[var(--surface)] border border-[color:var(--rule)]">
+                <div className="text-xs text-[color:var(--dim)] mb-1">Chain footprint</div>
+                <div className="text-2xl font-bold text-[color:var(--green)]">
+                  {savings.percentSmaller != null
+                    ? `${savings.percentSmaller.toFixed(1)}% smaller`
+                    : "--"}
                 </div>
-                <p className="text-[color:var(--dim)] text-xs leading-relaxed">
-                  Stripped blocks are stored in Ghost Stripped Block (<code className="text-[color:var(--accent)]">.gsb</code>) format —
-                  a compact representation that preserves all data needed for chain validation.
-                </p>
-              </div>
-              <div className="p-3 bg-[var(--surface)] rounded-lg border border-[var(--rule-strong)]">
-                <div className="flex items-center gap-2 mb-1.5">
-                  <span className="text-[color:var(--accent)] font-mono text-xs font-bold">4</span>
-                  <span className="text-[color:var(--fg)] text-sm font-medium">UTXO Preservation</span>
-                </div>
-                <p className="text-[color:var(--dim)] text-xs leading-relaxed">
-                  All financial data and the UTXO set integrity are preserved. Your node can fully validate
-                  the chain, spend coins, and participate in consensus without any embedded content on disk.
-                </p>
               </div>
             </div>
           </div>
+        ) : (
+          // Inactive: value proposition + enable path (no fabricated numbers).
+          <div
+            className="rounded-lg p-8 border"
+            style={{
+              borderColor: "color-mix(in srgb, var(--accent) 35%, transparent)",
+              background:
+                "linear-gradient(135deg, color-mix(in srgb, var(--accent) 10%, var(--surface)) 0%, var(--surface) 70%)",
+            }}
+          >
+            <div className="text-xs uppercase tracking-wider text-[color:var(--accent)] font-semibold mb-2">
+              Haze is not active on this node
+            </div>
+            <div className="text-3xl md:text-4xl font-bold text-[color:var(--fg)] leading-tight max-w-3xl">
+              Keep inscriptions, spam and arbitrary payloads off your disk.
+            </div>
+            <p className="text-[color:var(--dim)] text-sm mt-3 max-w-2xl leading-relaxed">
+              In Hazed mode, Ghost Exorcism strips non-consensus fields from every block
+              before it is written — you keep full validation and UTXO integrity while
+              shrinking your on-disk footprint and never persisting embedded content. Enable
+              it to start measuring your savings and generate a court-ready Legal Pack.
+            </p>
+            <div className="mt-6">
+              <Button
+                variant="primary"
+                onClick={() => handleSetMode("hazed")}
+                loading={configureHaze.isPending}
+              >
+                Enable Haze
+              </Button>
+            </div>
+          </div>
+        )}
+      </SectionErrorBoundary>
 
-          {/* Exorcist Mode A */}
-          <div className="p-3 bg-[var(--surface)] rounded-lg border border-[var(--rule-strong)]">
+      {/* 2. ⭐ Legal Pack — centerpiece */}
+      <SectionErrorBoundary section="Legal Pack">
+        <Card>
+          <CardHeader
+            title="Legal Compliance Pack"
+            subtitle="Cryptographic, court-ready proof this node does not persist arbitrary embedded content"
+            action={
+              legalAvailable ? (
+                <Badge variant="success">Available</Badge>
+              ) : (
+                <Badge variant="default">Enable Haze to generate</Badge>
+              )
+            }
+          />
+          {legalLoading ? (
+            <SkeletonCard />
+          ) : legalAvailable && legal ? (
+            <div className="space-y-5">
+              {/* Court-ready summary */}
+              {legal.legal_summary && (
+                <div className="p-4 rounded-lg bg-[var(--surface)] border border-[color:var(--green)]">
+                  <p className="text-[color:var(--fg)] text-sm leading-relaxed whitespace-pre-line">
+                    {legal.legal_summary}
+                  </p>
+                </div>
+              )}
+
+              {/* Headline attestation: arbitrary content on disk */}
+              <div className="flex items-center gap-3 p-4 rounded-lg bg-[var(--surface)] border border-[color:var(--rule-strong)]">
+                {legal.hazeable_content_on_disk ? (
+                  <svg
+                    className="w-8 h-8 text-[color:var(--red)] flex-shrink-0"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                  >
+                    <circle cx="12" cy="12" r="9" />
+                    <path strokeLinecap="round" d="M15 9l-6 6M9 9l6 6" />
+                  </svg>
+                ) : (
+                  <svg
+                    className="w-8 h-8 text-[color:var(--green)] flex-shrink-0"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                  >
+                    <circle cx="12" cy="12" r="9" />
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M8.5 12.5l2.5 2.5 4.5-5" />
+                  </svg>
+                )}
+                <div>
+                  <div className="text-[color:var(--fg)] font-medium text-sm">
+                    Arbitrary content on disk:{" "}
+                    <span
+                      className={
+                        legal.hazeable_content_on_disk
+                          ? "text-[color:var(--red)]"
+                          : "text-[color:var(--green)]"
+                      }
+                    >
+                      {legal.hazeable_content_on_disk ? "Present" : "None"}
+                    </span>
+                  </div>
+                  <p className="text-[color:var(--dim)] text-xs mt-0.5">
+                    {legal.hazeable_content_on_disk
+                      ? "Legacy full-block files were detected on disk."
+                      : "No blk*.dat files — only stripped structural blocks are stored."}
+                  </p>
+                </div>
+              </div>
+
+              {/* Attestation grid */}
+              <div className="divide-y divide-[var(--rule)]">
+                <StatusRow label="Ghost Core version">
+                  <span className="font-mono text-sm text-[color:var(--fg)]">
+                    {legal.ghost_core_version ?? "--"}
+                  </span>
+                </StatusRow>
+                <StatusRow label="Haze specification">
+                  <span className="font-mono text-sm text-[color:var(--fg)]">
+                    {legal.specification_version ?? "--"}
+                  </span>
+                </StatusRow>
+                <StatusRow label="Node mode">
+                  <Badge variant="success">{legal.node_mode ?? "--"}</Badge>
+                </StatusRow>
+                <StatusRow label="Haze status">
+                  <Badge variant={legal.haze_status === "COMPLETE" ? "success" : "warning"}>
+                    {legal.haze_status ?? "--"}
+                  </Badge>
+                </StatusRow>
+                <StatusRow label="Blocks stripped">
+                  <span className="font-mono text-sm text-[color:var(--fg)]">
+                    {(legal.blocks_stripped ?? 0).toLocaleString()}
+                  </span>
+                </StatusRow>
+                <StatusRow label="Checkpoint height">
+                  <span className="font-mono text-sm text-[color:var(--fg)]">
+                    {legal.checkpoint_height ? legal.checkpoint_height.toLocaleString() : "None"}
+                  </span>
+                </StatusRow>
+                <StatusRow label="Checkpoint hash">
+                  <span
+                    className="font-mono text-xs text-[color:var(--fg)]"
+                    title={legal.checkpoint_hash ?? undefined}
+                  >
+                    {shortHash(legal.checkpoint_hash)}
+                  </span>
+                </StatusRow>
+                <StatusRow label="Conversion method">
+                  <span className="font-mono text-sm text-[color:var(--fg)]">
+                    {legal.conversion_method ?? "--"}
+                  </span>
+                </StatusRow>
+                <StatusRow label="Conversion date">
+                  <span className="font-mono text-sm text-[color:var(--fg)]">
+                    {legal.conversion_date ?? "--"}
+                  </span>
+                </StatusRow>
+                <StatusRow label="Generated at">
+                  <span className="font-mono text-sm text-[color:var(--fg)]">
+                    {legal.generated_at ?? "--"}
+                  </span>
+                </StatusRow>
+              </div>
+
+              {/* Download */}
+              <div className="flex flex-wrap items-center gap-3 pt-2">
+                <Button variant="primary" onClick={() => downloadLegalPacket(legal, "txt")}>
+                  <svg
+                    className="w-4 h-4 mr-2"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3"
+                    />
+                  </svg>
+                  Download Legal Pack (.txt)
+                </Button>
+                <Button variant="outline" onClick={() => downloadLegalPacket(legal, "json")}>
+                  Download JSON
+                </Button>
+              </div>
+            </div>
+          ) : (
+            <div className="p-4 rounded-lg bg-[var(--surface)] border border-[color:var(--rule-strong)]">
+              <p className="text-[color:var(--dim)] text-sm leading-relaxed">
+                The Legal Compliance Pack is a signed, court-ready proof that your node does
+                not persist arbitrary embedded content. It is generated once{" "}
+                <span className="text-[color:var(--fg)] font-medium">Haze is enabled</span> and
+                the Exorcist is stripping blocks.
+                {legal?.reason && (
+                  <span className="block mt-2 text-xs text-[color:var(--fainter)]">
+                    Ghost Core: {legal.reason}
+                  </span>
+                )}
+              </p>
+            </div>
+          )}
+        </Card>
+      </SectionErrorBoundary>
+
+      {/* 3. What Haze keeps off your disk */}
+      <Card>
+        <CardHeader
+          title="What Haze keeps off your disk"
+          subtitle="Non-consensus fields removed by Ghost Haze's own field classifier"
+        />
+        <p className="text-[color:var(--dim)] text-sm leading-relaxed mb-4">
+          Ghost Haze uses its own <code className="text-[color:var(--accent)]">field_classifier</code>{" "}
+          — distinct from the BUDS policy system — to identify the non-consensus bytes where
+          inscriptions and spam live. These are stripped after full validation, so consensus and
+          the UTXO set are untouched while the arbitrary payloads never reach disk.
+        </p>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+          {STRIPPED_FIELDS.map((f) => (
+            <div
+              key={f.title}
+              className="p-3 bg-[var(--surface)] rounded-lg border border-[color:var(--rule-strong)]"
+            >
+              <div className="flex items-center gap-2 mb-1.5">
+                <span className="text-[color:var(--accent)] font-mono text-xs font-bold">✕</span>
+                <span className="text-[color:var(--fg)] text-sm font-medium">{f.title}</span>
+              </div>
+              <p className="text-[color:var(--dim)] text-xs leading-relaxed">{f.body}</p>
+            </div>
+          ))}
+        </div>
+      </Card>
+
+      {/* 4. Checkpoints & trust */}
+      <SectionErrorBoundary section="Checkpoints">
+        <Card>
+          <CardHeader
+            title="Checkpoints & trust"
+            subtitle="Signed UTXO checkpoints are the trust anchor for a hazed node"
+            action={
+              checkpoint && (
+                <StatusDot
+                  status={
+                    checkpoint.serving
+                      ? "online"
+                      : checkpoint.downloading
+                        ? "warning"
+                        : "offline"
+                  }
+                  label={
+                    checkpoint.serving
+                      ? "Serving"
+                      : checkpoint.downloading
+                        ? "Downloading"
+                        : "Idle"
+                  }
+                  pulse={checkpoint.downloading}
+                />
+              )
+            }
+          />
+          {checkpointLoading ? (
+            <SkeletonCard />
+          ) : checkpoint?.available === false ? (
+            <div className="p-4 rounded-lg bg-[var(--surface)] border border-[color:var(--rule-strong)]">
+              <p className="text-[color:var(--dim)] text-sm">
+                Checkpoint status is unavailable.
+                {checkpoint?.reason && (
+                  <span className="block mt-1 text-xs text-[color:var(--fainter)]">
+                    {checkpoint.reason}
+                  </span>
+                )}
+              </p>
+            </div>
+          ) : checkpoint?.serving ? (
+            <div className="divide-y divide-[var(--rule)]">
+              <StatusRow label="Role">
+                <Badge variant="success">Serving checkpoint</Badge>
+              </StatusRow>
+              <StatusRow label="Height">
+                <span className="font-mono text-sm text-[color:var(--fg)]">
+                  {checkpoint.height?.toLocaleString() ?? "--"}
+                </span>
+              </StatusRow>
+              <StatusRow label="Block hash">
+                <span
+                  className="font-mono text-xs text-[color:var(--fg)]"
+                  title={checkpoint.block_hash ?? undefined}
+                >
+                  {shortHash(checkpoint.block_hash)}
+                </span>
+              </StatusRow>
+              <StatusRow label="UTXO count">
+                <span className="font-mono text-sm text-[color:var(--fg)]">
+                  {checkpoint.utxo_count?.toLocaleString() ?? "--"}
+                </span>
+              </StatusRow>
+              <StatusRow label="Signed manifest">
+                <Badge variant={checkpoint.signed ? "success" : "warning"}>
+                  {checkpoint.signed ? "Signed" : "Unsigned"}
+                </Badge>
+              </StatusRow>
+            </div>
+          ) : checkpoint?.downloading ? (
+            <div className="divide-y divide-[var(--rule)]">
+              <StatusRow label="Role">
+                <Badge variant="warning">Downloading checkpoint</Badge>
+              </StatusRow>
+              <StatusRow label="Target height">
+                <span className="font-mono text-sm text-[color:var(--fg)]">
+                  {checkpoint.height?.toLocaleString() ?? "--"}
+                </span>
+              </StatusRow>
+              <StatusRow label="Progress">
+                <span className="font-mono text-sm text-[color:var(--fg)]">
+                  {checkpoint.chunks_received ?? 0} / {checkpoint.chunks_total ?? "--"} chunks
+                  {checkpoint.percent_complete != null &&
+                    ` (${checkpoint.percent_complete.toFixed(1)}%)`}
+                </span>
+              </StatusRow>
+            </div>
+          ) : (
+            <div className="p-4 rounded-lg bg-[var(--surface)] border border-[color:var(--rule-strong)]">
+              <p className="text-[color:var(--dim)] text-sm">
+                This node is neither serving nor downloading a checkpoint. It is validating the
+                chain from its local structural archive.
+              </p>
+            </div>
+          )}
+        </Card>
+      </SectionErrorBoundary>
+
+      {/* 5. The Exorcism pipeline */}
+      <Card collapsible defaultCollapsed>
+        <CardHeader
+          title="The Exorcism pipeline"
+          subtitle="How Ghost Haze strips blocks before they hit disk"
+        />
+        <div className="space-y-5">
+          <p className="text-[color:var(--dim)] text-sm leading-relaxed">
+            Ghost Haze classifies and strips non-consensus data from blocks before writing them
+            to disk. Hazed nodes retain full transaction validity and UTXO integrity while
+            ensuring no arbitrary embedded content is persisted locally.
+          </p>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+            <div className="p-3 bg-[var(--surface)] rounded-lg border border-[color:var(--rule-strong)]">
+              <div className="flex items-center gap-2 mb-1.5">
+                <span className="text-[color:var(--accent)] font-mono text-xs font-bold">1</span>
+                <span className="text-[color:var(--fg)] text-sm font-medium">Field Classification</span>
+              </div>
+              <p className="text-[color:var(--dim)] text-xs leading-relaxed">
+                Ghost Haze&apos;s own <code className="text-[color:var(--accent)]">field_classifier</code>{" "}
+                (not BUDS) marks each non-consensus field — witness data, scriptSig, OP_RETURN
+                payloads and coinbase scriptSig — as strippable once validated.
+              </p>
+            </div>
+            <div className="p-3 bg-[var(--surface)] rounded-lg border border-[color:var(--rule-strong)]">
+              <div className="flex items-center gap-2 mb-1.5">
+                <span className="text-[color:var(--accent)] font-mono text-xs font-bold">2</span>
+                <span className="text-[color:var(--fg)] text-sm font-medium">Block Stripping</span>
+              </div>
+              <p className="text-[color:var(--dim)] text-xs leading-relaxed">
+                Non-consensus data is stripped at the validation layer, before the block is
+                written to disk. Consensus-critical fields remain untouched.
+              </p>
+            </div>
+            <div className="p-3 bg-[var(--surface)] rounded-lg border border-[color:var(--rule-strong)]">
+              <div className="flex items-center gap-2 mb-1.5">
+                <span className="text-[color:var(--accent)] font-mono text-xs font-bold">3</span>
+                <span className="text-[color:var(--fg)] text-sm font-medium">GSB Storage</span>
+              </div>
+              <p className="text-[color:var(--dim)] text-xs leading-relaxed">
+                Stripped blocks are stored in Ghost Stripped Block (
+                <code className="text-[color:var(--accent)]">.gsb</code>) format — a compact
+                representation that preserves everything needed for chain validation.
+              </p>
+            </div>
+            <div className="p-3 bg-[var(--surface)] rounded-lg border border-[color:var(--rule-strong)]">
+              <div className="flex items-center gap-2 mb-1.5">
+                <span className="text-[color:var(--accent)] font-mono text-xs font-bold">4</span>
+                <span className="text-[color:var(--fg)] text-sm font-medium">UTXO Preservation</span>
+              </div>
+              <p className="text-[color:var(--dim)] text-xs leading-relaxed">
+                All financial data and UTXO set integrity are preserved. Your node fully
+                validates the chain, spends coins, and participates in consensus with no embedded
+                content on disk.
+              </p>
+            </div>
+          </div>
+
+          <div className="p-3 bg-[var(--surface)] rounded-lg border border-[color:var(--rule-strong)]">
             <h4 className="text-[color:var(--fg)] font-medium text-sm mb-1">The Exorcist</h4>
             <p className="text-[color:var(--dim)] text-xs leading-relaxed">
-              The Exorcist is the core component that performs the actual stripping. It runs inside
-              Ghost Core (<code className="text-[color:var(--accent)]">ghostd</code>) at the block acceptance layer,
-              intercepting blocks before they are serialized to disk.
+              The Exorcist is the component that performs the actual stripping. It runs inside
+              Ghost Core (<code className="text-[color:var(--accent)]">ghostd</code>) at the block
+              acceptance layer, intercepting blocks before they are serialized to disk.
             </p>
-            <div className="mt-2 p-2 bg-[var(--surface)] rounded border border-[var(--rule-strong)]">
+            <div className="mt-2 p-2 bg-[var(--surface)] rounded border border-[color:var(--rule-strong)]">
               <div className="text-xs text-[color:var(--dim)] leading-relaxed">
-                <span className="text-[color:var(--accent)] font-medium">Mode A (Active Stripping):</span> The Exorcist
-                strips classified content before the block is written to disk. This is the default mode for
-                hazed nodes — blocks arrive from the network, get stripped in memory, and only the clean
-                version is persisted.
+                <span className="text-[color:var(--accent)] font-medium">Mode A (Active Stripping):</span>{" "}
+                the Exorcist strips classified content before the block is written. Blocks arrive
+                from the network, get stripped in memory, and only the clean version is persisted.
               </div>
             </div>
           </div>
         </div>
       </Card>
 
-      {/* 4. Primary Content — Node Status */}
-      <SectionErrorBoundary section="Haze Status">
-        {isLoading ? <SkeletonCard /> : error ? (
-          <Card>
-            <CardHeader title="Node Status" />
-            <div className="p-4 bg-[var(--surface)] border border-[color:var(--red)] rounded-lg">
-              <p className="text-[color:var(--red)] text-sm">
-                Unable to fetch Ghost Haze status. Ensure Ghost Core is running and the Haze module is enabled.
-              </p>
+      {/* 6a. Retroactive conversion progress — prominent while running */}
+      {conversionInProgress && (
+        <Card>
+          <CardHeader
+            title="Retroactive conversion in progress"
+            subtitle="The Exorcist is stripping the blocks this node already holds"
+            action={<Badge variant="warning">IN_PROGRESS</Badge>}
+          />
+          <div className="space-y-3">
+            <div className="flex items-baseline justify-between">
+              <span className="text-2xl font-bold text-[color:var(--fg)]">
+                {convPercent != null ? `${convPercent.toFixed(1)}%` : "--"}
+              </span>
+              <span className="font-mono text-sm text-[color:var(--dim)]">
+                {convBlocks.toLocaleString()} / {convTip.toLocaleString()} blocks
+              </span>
             </div>
-          </Card>
-        ) : (
-          <Card>
-            <CardHeader
-              title="Node Status"
-              action={
-                <StatusDot
-                  status={getModeStatus(mode)}
-                  label={haze?.hazed ? "Haze Active" : "Haze Inactive"}
-                  pulse={haze?.hazed}
-                />
-              }
-            />
-            <div className="divide-y divide-[var(--rule)]">
-              <StatusRow label="Storage Mode">
-                <Badge variant={getModeBadgeVariant(mode)}>
-                  {getModeLabel(mode)}
-                </Badge>
-              </StatusRow>
-              <StatusRow label="Blocks Processed">
-                <span className="font-mono text-sm text-[color:var(--fg)]">
-                  {(haze?.blocks ?? 0).toLocaleString()}
-                </span>
-              </StatusRow>
-              <StatusRow label="Storage on Disk">
-                <span className="font-mono text-sm text-[color:var(--fg)]">
-                  {haze ? formatStorageGB(haze.size_on_disk) : "--"}
-                </span>
-              </StatusRow>
-              <StatusRow label="Pruned">
-                <Badge variant={haze?.pruned ? "warning" : "success"}>
-                  {haze?.pruned ? "Yes" : "No"}
-                </Badge>
-              </StatusRow>
-              <StatusRow label="Archive Mode">
-                <Badge variant={haze?.archive_mode ? "success" : "default"}>
-                  {haze?.archive_mode ? "Enabled" : "Disabled"}
-                </Badge>
-              </StatusRow>
-              <StatusRow label="Chain">
-                <span className="font-mono text-sm text-[color:var(--fg)]">
-                  {haze?.chain ?? "--"}
-                </span>
-              </StatusRow>
+            <div className="h-2.5 w-full rounded-full bg-[var(--rule-strong)] overflow-hidden">
+              <div
+                className="h-full rounded-full transition-[width] duration-500"
+                style={{
+                  width: `${convPercent ?? 0}%`,
+                  background: "var(--accent)",
+                }}
+              />
             </div>
-            {haze?.error && (
-              <div className="mt-4 p-3 bg-[var(--surface)] border border-[color:var(--red)] rounded-lg">
-                <p className="text-[color:var(--red)] text-sm">{haze.error}</p>
-              </div>
-            )}
-          </Card>
-        )}
-      </SectionErrorBoundary>
+            <p className="text-[color:var(--dim)] text-xs leading-relaxed">
+              This is a one-time batch job that rewrites existing block files into stripped
+              structural blocks. It is <span className="text-[color:var(--fg)]">resumable</span> —
+              if the node restarts, conversion continues from where it left off. Your Legal Pack
+              is finalised once it reads <span className="font-mono">COMPLETE</span>.
+            </p>
+          </div>
+        </Card>
+      )}
 
-      {/* 5. Technical Details (collapsible) */}
-      <Card collapsible defaultCollapsed>
+      {/* 6b. Mode control — two programmes: forward vs retroactive */}
+      <Card>
         <CardHeader
-          title="Technical Details"
-          subtitle="Legal compliance and data classification"
+          title="Storage mode"
+          subtitle="Choose how this node stores block data"
+          action={
+            haze && <Badge variant={getModeBadgeVariant(mode)}>{getModeLabel(mode)}</Badge>
+          }
         />
-        <div className="space-y-4">
-          <div className="p-4 bg-[var(--surface)] rounded-lg">
-            <h4 className="text-[color:var(--accent)] font-medium mb-2">No Illegal Content Storage</h4>
-            <p className="text-[color:var(--dim)] text-sm leading-relaxed">
-              Hazed nodes use the BUDS classification system to identify and strip non-financial data
-              (OP_RETURN payloads, witness bloat, inscriptions, and other arbitrary content) before
-              blocks are written to disk. This means your node never persists content that could
-              constitute illegal material under local jurisdiction laws.
+
+        {/* Explain the two ways to become hazed */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3 mb-5">
+          <div className="p-3 rounded-lg bg-[var(--surface)] border border-[color:var(--rule-strong)]">
+            <div className="text-[color:var(--fg)] text-sm font-medium mb-1">
+              Forward — haze from genesis
+            </div>
+            <p className="text-[color:var(--dim)] text-xs leading-relaxed">
+              A <span className="text-[color:var(--fg)]">fresh</span> node can start hazed and strip
+              every block as it syncs. Nothing arbitrary is ever written — no conversion needed.
             </p>
           </div>
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div className="p-4 bg-[var(--surface)] rounded-lg">
-              <div className="flex items-start gap-3">
-                <div className="w-8 h-8 rounded-full bg-[var(--surface)] border border-[color:var(--green)] flex items-center justify-center flex-shrink-0 mt-0.5">
-                  <svg className="w-4 h-4 text-[color:var(--green)]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" />
-                  </svg>
-                </div>
-                <div>
-                  <h5 className="text-[color:var(--fg)] font-medium text-sm">What is Preserved</h5>
-                  <p className="text-[color:var(--dim)] text-xs mt-1">
-                    All financial transaction data, UTXO set integrity, block headers, and consensus-critical
-                    information remain intact. Your node can fully validate the chain.
-                  </p>
-                </div>
-              </div>
+          <div className="p-3 rounded-lg bg-[var(--surface)] border border-[color:var(--rule-strong)]">
+            <div className="text-[color:var(--fg)] text-sm font-medium mb-1">
+              Retroactive — convert existing blocks
             </div>
-            <div className="p-4 bg-[var(--surface)] rounded-lg">
-              <div className="flex items-start gap-3">
-                <div className="w-8 h-8 rounded-full bg-[var(--surface)] border border-[color:var(--accent)] flex items-center justify-center flex-shrink-0 mt-0.5">
-                  <svg className="w-4 h-4 text-[color:var(--accent)]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m0-10.036A11.959 11.959 0 013.598 6 11.99 11.99 0 003 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285z" />
-                  </svg>
-                </div>
-                <div>
-                  <h5 className="text-[color:var(--fg)] font-medium text-sm">What is Stripped</h5>
-                  <p className="text-[color:var(--dim)] text-xs mt-1">
-                    Arbitrary data embedded in OP_RETURN outputs, oversized witness data, inscriptions, and
-                    other non-financial payloads are removed before storage.
-                  </p>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div className="pt-2 border-t border-[var(--rule-strong)]">
-            <p className="text-[color:var(--dim)] text-xs mb-3">
-              BUDS classification specification and legal framework for operating a hazed node.
+            <p className="text-[color:var(--dim)] text-xs leading-relaxed">
+              An <span className="text-[color:var(--fg)]">already-synced</span> full or pruned node
+              cannot simply flip to hazed — it must run a one-time, resumable conversion that strips
+              the blocks it already holds. This is the only path to haze later.
             </p>
-            <a
-              href="/ghost-haze-legal-pack.pdf"
-              download
-              className="inline-flex items-center gap-2 px-4 py-2 bg-amber-600 hover:bg-amber-700 text-white text-sm font-medium rounded-lg transition-colors"
-            >
-              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3" />
-              </svg>
-              Download Legal Pack
-            </a>
           </div>
         </div>
+
+        {/* Mode options */}
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+          {(() => {
+            // From a non-hazed node with blocks already on disk, selecting Hazed
+            // means a retroactive conversion — not an instant flip.
+            const retroactive = mode === "standard" || mode === "full_archive";
+            const options = [
+              {
+                key: "hazed" as const,
+                label: "Hazed",
+                action: retroactive ? "Convert existing blocks (retroactive)" : undefined,
+                desc: retroactive
+                  ? "Run the one-time Exorcist conversion to strip existing blocks. Smallest footprint; resumable; no embedded content left on disk."
+                  : "Strip non-consensus fields before storage. Smallest footprint, no embedded content on disk.",
+              },
+              {
+                key: "full_archive" as const,
+                label: "Full Archive",
+                action: undefined,
+                desc: "Keep the full archive — complete, unstripped blocks. Maximum data availability for archival serving.",
+              },
+              {
+                key: "standard" as const,
+                label: "Standard",
+                action: undefined,
+                desc: "A normal Bitcoin Core node — full blocks, no stripping and no haze metadata.",
+              },
+            ];
+            return options.map((opt) => {
+              const selected = mode === opt.key;
+              return (
+                <button
+                  key={opt.key}
+                  type="button"
+                  disabled={configureHaze.isPending || selected}
+                  onClick={() => handleSetMode(opt.key)}
+                  className="text-left rounded-lg p-4 border transition-colors disabled:cursor-default flex flex-col"
+                  style={{
+                    background: selected
+                      ? "color-mix(in srgb, var(--accent) 12%, var(--surface))"
+                      : "var(--surface)",
+                    borderColor: selected ? "var(--accent)" : "var(--rule-strong)",
+                  }}
+                >
+                  <div className="flex items-center justify-between mb-1">
+                    <span className="text-[color:var(--fg)] text-sm font-medium">{opt.label}</span>
+                    {selected && <Badge variant={getModeBadgeVariant(opt.key)}>Active</Badge>}
+                  </div>
+                  <p className="text-[color:var(--dim)] text-xs leading-relaxed flex-1">{opt.desc}</p>
+                  {opt.action && !selected && (
+                    <span className="mt-2 inline-block text-[11px] font-medium text-[color:var(--accent)]">
+                      {opt.action} →
+                    </span>
+                  )}
+                </button>
+              );
+            });
+          })()}
+        </div>
+        <p className="text-[color:var(--fainter)] text-xs mt-3">
+          Forward hazing and Full Archive take effect on the next node start. A retroactive
+          conversion runs as a background batch job and reports its progress above.
+        </p>
       </Card>
     </div>
   );

--- a/dashboard/src/hooks/queries/useHazeQueries.ts
+++ b/dashboard/src/hooks/queries/useHazeQueries.ts
@@ -1,15 +1,33 @@
 import { useQuery } from '@tanstack/react-query';
-import { getHazeStatus } from '@/lib/api/haze';
+import { getHazeStatus, getLegalPacket, getCheckpointStatus } from '@/lib/api/haze';
 
 export const hazeKeys = {
   all: ['haze'] as const,
   status: () => [...hazeKeys.all, 'status'] as const,
+  legalPacket: () => [...hazeKeys.all, 'legal-packet'] as const,
+  checkpoint: () => [...hazeKeys.all, 'checkpoint'] as const,
 };
 
 export function useHazeStatus(options?: { refetchInterval?: number }) {
   return useQuery({
     queryKey: hazeKeys.status(),
     queryFn: getHazeStatus,
+    refetchInterval: options?.refetchInterval ?? 30_000,
+  });
+}
+
+export function useLegalPacket(options?: { refetchInterval?: number }) {
+  return useQuery({
+    queryKey: hazeKeys.legalPacket(),
+    queryFn: getLegalPacket,
+    refetchInterval: options?.refetchInterval ?? 60_000,
+  });
+}
+
+export function useCheckpointStatus(options?: { refetchInterval?: number }) {
+  return useQuery({
+    queryKey: hazeKeys.checkpoint(),
+    queryFn: getCheckpointStatus,
     refetchInterval: options?.refetchInterval ?? 30_000,
   });
 }

--- a/dashboard/src/lib/api/haze.ts
+++ b/dashboard/src/lib/api/haze.ts
@@ -1,7 +1,20 @@
 // Haze API endpoints
 import { fetchApi } from './client';
-import type { HazeStatus } from '@/types/api';
+import type { HazeStatus, LegalPacket, CheckpointStatus } from '@/types/api';
 
 export async function getHazeStatus(): Promise<HazeStatus> {
   return fetchApi<HazeStatus>('/api/v1/haze/status');
+}
+
+/**
+ * Fetch the Legal Compliance Packet. Always resolves: on a non-hazed node the
+ * backend returns `{ available: false, reason }` rather than erroring.
+ */
+export async function getLegalPacket(): Promise<LegalPacket> {
+  return fetchApi<LegalPacket>('/api/v1/haze/legal-pack');
+}
+
+/** Fetch the signed-checkpoint status (the hazed node's trust anchor). */
+export async function getCheckpointStatus(): Promise<CheckpointStatus> {
+  return fetchApi<CheckpointStatus>('/api/v1/haze/checkpoint');
 }

--- a/dashboard/src/types/api.ts
+++ b/dashboard/src/types/api.ts
@@ -1141,7 +1141,61 @@ export interface HazeStatus {
   size_on_disk: number;
   pruned: boolean;
   chain: string;
+  // Exorcism storage metrics (from ghostd `gethazestatus`)
+  exorcism_active: boolean;
+  /** Total blocks processed through Exorcism. */
+  blocks_stripped: number;
+  /** Total bytes of arbitrary content kept off disk — the headline savings. */
+  bytes_stripped: number;
+  /** Chain tip height, used to estimate a full-archive baseline. */
+  chain_tip: number;
+  /** Size of the structural (`.gsb`) archive actually on disk, in GB. */
+  structural_archive_size_gb: number;
   error?: string;
+}
+
+// Ghost Haze — Legal Compliance Packet (court-ready proof of non-persistence).
+// Proxied from ghostd `getlegalpacket`. On non-hazed nodes the RPC is
+// unavailable, so the backend returns `{ available: false, reason }` instead.
+export interface LegalPacket {
+  /** True when the packet was generated (node is in Hazed mode). */
+  available: boolean;
+  /** Human-readable reason when `available` is false. */
+  reason?: string;
+  ghost_core_version?: string;
+  specification_version?: string;
+  node_mode?: string;
+  exorcism_active?: boolean;
+  haze_status?: string;
+  blocks_stripped?: number;
+  chain_tip?: number;
+  structural_archive_size_gb?: number;
+  hazeable_content_on_disk?: boolean;
+  checkpoint_height?: number;
+  checkpoint_hash?: string;
+  conversion_method?: string;
+  conversion_date?: string;
+  legal_summary?: string;
+  generated_at?: string;
+}
+
+// Ghost Haze — signed-checkpoint status (trust anchor), from ghostd
+// `getcheckpointstatus`.
+export interface CheckpointStatus {
+  serving: boolean;
+  downloading: boolean;
+  /** False when the RPC could not be reached. */
+  available?: boolean;
+  reason?: string;
+  height?: number;
+  block_hash?: string;
+  utxo_count?: number;
+  total_chunks?: number;
+  signed?: boolean;
+  checkpoint_dir?: string;
+  chunks_received?: number;
+  chunks_total?: number;
+  percent_complete?: number;
 }
 
 // Ghost Shroud — relay privacy configuration


### PR DESCRIPTION
## Summary

Overhauls the Ghost Node dashboard **Haze page** into a flagship feature showcase — leading with **storage savings** and the **Legal Pack** — and wires the ghostd Haze RPCs it needs through the `ghost-verification` dashboard API. No ghostd change: the RPCs already exist in `ghost-core/src/rpc/haze.cpp`; this only exposes them.

## Backend (RPC → dashboard)

New typed RPC methods on `BitcoinRpc` (`crates/ghost-common/src/rpc.rs`) mirroring the existing call pattern, plus a `HazeRpcStatus` struct matching ghostd's `gethazestatus` contract:
- `get_haze_status()` → `gethazestatus`
- `get_legal_packet()` → `getlegalpacket`
- `get_checkpoint_status()` → `getcheckpointstatus`

Routes in `crates/ghost-verification/src/routes.rs`:
- **Extended** `GET /api/v1/haze/status` — now also surfaces `bytes_stripped`, `exorcism_active`, `blocks_stripped`, `chain_tip` and `structural_archive_size_gb` (the storage-saved metrics the old handler dropped), merged from `gethazestatus`. Degrades to zeros if the node predates the Haze RPCs.
- **New** `GET /api/v1/haze/legal-pack` → `getlegalpacket`. Forwards the full packet verbatim with `available: true`. On a non-hazed node the RPC errors by design, so this returns a clean \`{ available: false, reason }\` shape — never a 500.
- **New** `GET /api/v1/haze/checkpoint` → `getcheckpointstatus`. Always returns a `{ serving, downloading, ... }` shape; degrades to a neither-state with `available: false` on RPC failure.

Both new routes registered beside the existing haze routes and keep the existing auth/proxy pattern.

## Frontend (redesign)

`dashboard/src/app/(dashboard)/haze/page.tsx` rebuilt around the briefed section priority, with new `useLegalPacket` / `useCheckpointStatus` hooks, `getLegalPacket` / `getCheckpointStatus` in `lib/api/haze.ts`, and `LegalPacket` / `CheckpointStatus` types plus the extended `HazeStatus` in `types/api.ts`.

Sections:
1. **Storage-saved hero** — `bytes_stripped` as the headline "X kept off your disk", structural archive vs a full-archive estimate (`chain_tip` × ~1.6 MB/block) → "N% smaller".
2. **⭐ Legal Pack (centerpiece)** — court-ready `legal_summary`, a clear ✓/✗ "arbitrary content on disk" attestation, all packet fields, and client-side blob **Download** as readable `.txt` and `.json`.
3. **What Haze keeps off your disk** — witness / scriptSig / OP_RETURN payloads / coinbase scriptSig.
4. **Checkpoints & trust** — serving / downloading / idle with height, hash, UTXO count, signed badge, download progress.
5. **The Exorcism pipeline** — 4-step flow, corrected copy.
6. **Mode control** — forward vs retroactive programmes, conversion progress, mode selection.

### Active vs inactive states
Every section handles both. When the Exorcist is active it renders real data; when the node is standard/full-archive it shows the value proposition and an **Enable Haze** path via the existing `/haze/configure` control — no fabricated numbers. Honest loading (skeletons), error and empty states throughout.

### Mode control — two programmes
The section distinguishes Haze's two paths and matches ghostd's `mode_selector.cpp` rules:
- **Forward** (haze from genesis) — a fresh node starts hazed.
- **Retroactive** (Exorcist conversion) — an already-synced full/pruned node cannot flip to hazed; it must run a one-time, resumable conversion that strips the blocks it holds. From a non-hazed node the Hazed option is surfaced as **"Convert existing blocks (retroactive)"**.
- **Conversion progress** is shown prominently while running: `getlegalpacket.haze_status` IN_PROGRESS vs COMPLETE, with a `blocks_stripped` / `chain_tip` progress bar and resumable-batch-job copy.

> **Parent follow-up:** the actual retroactive-conversion **trigger** (ghostd `--exorcist` / `-hazemode` launch flags, plus Archive un-prune) is not yet in `NodeLaunchConfig`. This PR builds the UI, accurate copy, progress display and mode-selection control against the existing `configureHaze` seam; the coordinator is wiring the endpoint to actually set those flags as a coupled follow-up.

### BUDS copy fix
The old page wrongly attributed field classification to **BUDS**. Corrected throughout: Haze uses its **own** `field_classifier` (explicitly *not* BUDS) — fixed in the "What Haze keeps off your disk" section and pipeline step 1.

## Verification (no release build, per instructions)
- `cargo check -p ghost-common -p ghost-verification -p ghost-pool` — clean (exit 0)
- `cargo test -p ghost-common --lib` — 265 passed, 0 failed
- Dashboard: `tsc --noEmit` clean, `eslint` on changed files clean, `npm run build` succeeds (exit 0)

The release build + elder-gated fleet deploy are left to the parent.