### PR TITLE
feat(ghostd): archive un-prune (-prune=0/one-shot reindex) + haze retroactive conversion (-hazemode/-exorcist) via managed drop-in

### DIFF
--- a/bins/ghost-setup/src/main.rs
+++ b/bins/ghost-setup/src/main.rs
@@ -136,17 +136,23 @@ fn apply_reaper_to_ghostd(
     let config = NodeConfig::load(&pool_toml)?;
     let settings = &config.reaper;
     let launch = &config.node_launch;
+    let storage = &config.storage;
 
     println!(
         "Ghost-managed ghostd flags (from {}):",
         pool_toml.display()
     );
-    for f in settings.ghostd_flags().iter().chain(launch.ghostd_flags().iter()) {
+    for f in settings
+        .ghostd_flags()
+        .iter()
+        .chain(launch.ghostd_flags().iter())
+        .chain(storage.ghostd_flags().iter())
+    {
         println!("  {f}");
     }
 
     let exec_argv = read_ghostd_exec_argv()?;
-    let dropin = setup::ghostd_managed_dropin(&exec_argv, settings, launch);
+    let dropin = setup::ghostd_managed_dropin(&exec_argv, settings, launch, storage);
 
     if dry_run {
         println!("\n--- drop-in {DROPIN_PATH} (dry-run, not written) ---\n{dropin}");

--- a/crates/ghost-common/src/config.rs
+++ b/crates/ghost-common/src/config.rs
@@ -1582,6 +1582,26 @@ pub struct StorageConfig {
     /// Ghost Haze storage mode
     #[serde(default)]
     pub haze_mode: HazeMode,
+    /// ONE-SHOT: emit ghostd `-reindex` for exactly the next drop-in apply.
+    ///
+    /// Armed when an already-PRUNED node is switched to archive mode — `-prune=0`
+    /// alone cannot recover blocks deleted while pruned, so a one-time reindex +
+    /// re-download is required. Cleared automatically by the reindex watcher once
+    /// the node has finished resyncing (so the flag is dropped from the drop-in).
+    /// `-reindex` must never persist in the drop-in or ghostd would reindex on
+    /// every restart.
+    #[serde(default)]
+    pub reindex_pending: bool,
+    /// ONE-SHOT: emit ghostd `-exorcist` for exactly the next drop-in apply.
+    ///
+    /// Armed when the operator converts an existing full archive to Hazed mode.
+    /// ghostd runs the retroactive `blk*.dat` → GSB conversion and then EXITS
+    /// (confirmed in ghost-core `init.cpp`: "-exorcist ... and exit"), so this
+    /// flag can NEVER persist in the drop-in (the node would run-and-exit on
+    /// every restart and never come up). Cleared automatically by the exorcist
+    /// watcher once the conversion finishes.
+    #[serde(default)]
+    pub exorcist_pending: bool,
 }
 
 impl Default for StorageConfig {
@@ -1592,7 +1612,64 @@ impl Default for StorageConfig {
             archive_mode: false,
             prune_height: 0,
             haze_mode: HazeMode::default(),
+            reindex_pending: false,
+            exorcist_pending: false,
         }
+    }
+}
+
+impl StorageConfig {
+    /// The ghostd (Bitcoin Core) CLI flags that mirror the storage-mode settings.
+    /// Only non-default values are emitted, so a standard (non-archive, non-hazed)
+    /// node adds nothing to ghostd's `ExecStart` and behaves exactly as before.
+    ///
+    /// Emitted via the same managed drop-in as the reaper / node-launch flags
+    /// (`ghostd_managed_dropin` in `setup.rs`). Every prefix here is listed in
+    /// `MANAGED_GHOSTD_FLAG_PREFIXES`, so stale copies are stripped on each
+    /// regeneration — which is what keeps the two one-shot flags below safe: a
+    /// one-shot flag only survives into the drop-in while its marker is set.
+    ///
+    /// All of these are read by ghostd only at startup, so a change needs a
+    /// ghostd restart to take effect.
+    pub fn ghostd_flags(&self) -> Vec<String> {
+        let mut flags = Vec::new();
+
+        // Archive un-prune: an archival node must never prune, so force
+        // `-prune=0` (overriding any pruning configured elsewhere). When archive
+        // mode is off we emit nothing and leave ghostd's own configured prune
+        // behaviour intact.
+        if self.archive_mode {
+            flags.push("-prune=0".to_string());
+        }
+
+        // ONE-SHOT reindex — see `reindex_pending`. Rebuilds the block/chainstate
+        // indexes and re-downloads blocks deleted while pruned. ghostd keeps
+        // running after the reindex; the watcher clears the marker once resync
+        // completes so this flag is dropped from the drop-in.
+        if self.reindex_pending {
+            flags.push("-reindex".to_string());
+        }
+
+        // Ghost Haze: run in hazed mode. ghostd persists the choice to its
+        // datadir mode-lock on first launch and the lock takes precedence
+        // thereafter, so this flag is inert (a documented fallback) once the node
+        // is hazed. Suppressed while an `-exorcist` conversion is pending:
+        // selecting hazed on a node that still holds full `blk*.dat` files is a
+        // FATAL start error in ghostd (it requires the retroactive conversion to
+        // run first, which the exorcist flag performs).
+        if self.haze_mode == HazeMode::Hazed && !self.exorcist_pending {
+            flags.push("-hazemode=hazed".to_string());
+        }
+
+        // ONE-SHOT exorcist — see `exorcist_pending`. Converts the existing full
+        // archive to stripped GSB and exits; the watcher clears the marker and
+        // re-applies (dropping this flag, adding `-hazemode=hazed`) to bring the
+        // node back up hazed.
+        if self.exorcist_pending {
+            flags.push("-exorcist".to_string());
+        }
+
+        flags
     }
 }
 
@@ -2680,6 +2757,81 @@ mod tests {
         assert!(flags.contains(&"-ghostreaper-rejectrunestone=0".to_string()));
         assert!(flags.contains(&"-ghostreaper-rejectopreturn=0".to_string()));
         assert!(flags.contains(&"-ghostreaper-rejectinscription=1".to_string()));
+    }
+
+    #[test]
+    fn test_storage_ghostd_flags_default_emits_nothing() {
+        // A standard node (archive off, haze standard, no one-shots) must add
+        // nothing to ghostd's ExecStart — deploying the feature changes nothing
+        // until an operator opts in.
+        assert!(StorageConfig::default().ghostd_flags().is_empty());
+    }
+
+    #[test]
+    fn test_storage_ghostd_flags_prune_zero_iff_archive() {
+        let archive = StorageConfig { archive_mode: true, ..Default::default() };
+        assert!(archive.ghostd_flags().contains(&"-prune=0".to_string()));
+
+        // Archive OFF must NOT emit -prune=0 (leave ghostd's own prune config).
+        let off = StorageConfig { archive_mode: false, ..Default::default() };
+        assert!(!off.ghostd_flags().iter().any(|f| f.starts_with("-prune")));
+    }
+
+    #[test]
+    fn test_storage_ghostd_flags_reindex_oneshot_arm_and_clear() {
+        // Armed: archive + one-shot reindex emit both flags.
+        let armed = StorageConfig {
+            archive_mode: true,
+            reindex_pending: true,
+            ..Default::default()
+        };
+        let f = armed.ghostd_flags();
+        assert!(f.contains(&"-prune=0".to_string()));
+        assert!(f.contains(&"-reindex".to_string()));
+
+        // Cleared: -reindex gone, -prune=0 retained (still archival).
+        let cleared = StorageConfig {
+            archive_mode: true,
+            reindex_pending: false,
+            ..Default::default()
+        };
+        let f = cleared.ghostd_flags();
+        assert!(!f.contains(&"-reindex".to_string()));
+        assert!(f.contains(&"-prune=0".to_string()));
+    }
+
+    #[test]
+    fn test_storage_ghostd_flags_haze_and_exorcist_oneshot() {
+        // Standard/full-archive haze modes emit no -hazemode flag (default).
+        assert!(!StorageConfig { haze_mode: HazeMode::Standard, ..Default::default() }
+            .ghostd_flags()
+            .iter()
+            .any(|f| f.starts_with("-hazemode")));
+        assert!(!StorageConfig { haze_mode: HazeMode::FullArchive, ..Default::default() }
+            .ghostd_flags()
+            .iter()
+            .any(|f| f.starts_with("-hazemode")));
+
+        // Converting (exorcist pending): emit -exorcist, SUPPRESS -hazemode=hazed
+        // (fatal in ghostd while blk*.dat still present).
+        let converting = StorageConfig {
+            haze_mode: HazeMode::Hazed,
+            exorcist_pending: true,
+            ..Default::default()
+        };
+        let f = converting.ghostd_flags();
+        assert!(f.contains(&"-exorcist".to_string()));
+        assert!(!f.contains(&"-hazemode=hazed".to_string()));
+
+        // Converted (marker cleared): emit persistent -hazemode=hazed, no exorcist.
+        let hazed = StorageConfig {
+            haze_mode: HazeMode::Hazed,
+            exorcist_pending: false,
+            ..Default::default()
+        };
+        let f = hazed.ghostd_flags();
+        assert!(f.contains(&"-hazemode=hazed".to_string()));
+        assert!(!f.contains(&"-exorcist".to_string()));
     }
 
     #[test]

--- a/crates/ghost-common/src/setup.rs
+++ b/crates/ghost-common/src/setup.rs
@@ -296,6 +296,14 @@ const MANAGED_GHOSTD_FLAG_PREFIXES: &[&str] = &[
     "-onlynet",
     "-i2psam",
     "-i2pacceptincoming",
+    // Storage mode (StorageConfig): archive un-prune + Ghost Haze. `-reindex`
+    // and `-exorcist` are ONE-SHOTs — listing their prefixes here guarantees a
+    // stale copy is stripped on every regeneration, so a one-shot flag can only
+    // ever be present while its `*_pending` marker is set.
+    "-prune",
+    "-reindex",
+    "-hazemode",
+    "-exorcist",
 ];
 
 /// True when `tok` is a ghostd flag that this codebase manages via the drop-in,
@@ -312,7 +320,7 @@ fn is_managed_ghostd_flag(tok: &str) -> bool {
 ///
 /// `exec_argv` is the daemon's resolved command line (e.g. the `argv[]` from
 /// `systemctl show ghostd -p ExecStart --value`). Any existing managed flags
-/// (`-ghostreaper*`, `-tormode`, and the daemon flags in
+/// (`-ghostreaper*`, `-tormode`, the daemon flags, and the storage-mode flags in
 /// `MANAGED_GHOSTD_FLAG_PREFIXES`) are stripped and the current set is appended,
 /// wrapped in a drop-in that resets and replaces `ExecStart` (the systemd
 /// override idiom: an empty `ExecStart=` clears the inherited value before the
@@ -322,6 +330,7 @@ pub fn ghostd_managed_dropin(
     exec_argv: &str,
     reaper: &crate::config::ReaperSettings,
     launch: &crate::config::NodeLaunchConfig,
+    storage: &crate::config::StorageConfig,
 ) -> String {
     let base: Vec<&str> = exec_argv
         .split_whitespace()
@@ -329,9 +338,10 @@ pub fn ghostd_managed_dropin(
         .collect();
     let mut flags = reaper.ghostd_flags();
     flags.extend(launch.ghostd_flags());
+    flags.extend(storage.ghostd_flags());
     format!(
-        "# Managed by `ghost-setup apply-reaper` — Ghost Reaper + node launch flags.\n\
-         # Do not edit by hand; regenerate from pool.toml [reaper]/[node_launch].\n\
+        "# Managed by `ghost-setup apply-reaper` — Ghost Reaper + node launch + storage flags.\n\
+         # Do not edit by hand; regenerate from pool.toml [reaper]/[node_launch]/[storage].\n\
          [Service]\n\
          ExecStart=\n\
          ExecStart={} {}\n",
@@ -424,7 +434,7 @@ pub fn apply_mempool_policy(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{NodeLaunchConfig, ReaperSettings};
+    use crate::config::{HazeMode, NodeLaunchConfig, ReaperSettings, StorageConfig};
 
     #[test]
     fn test_ghostd_managed_dropin_strips_and_appends() {
@@ -434,7 +444,8 @@ mod tests {
             ..Default::default()
         };
         let launch = NodeLaunchConfig::default();
-        let dropin = ghostd_managed_dropin(exec, &s, &launch);
+        let storage = StorageConfig::default();
+        let dropin = ghostd_managed_dropin(exec, &s, &launch, &storage);
 
         // resets ExecStart then re-emits the base (minus any managed flags)
         assert!(dropin.contains("[Service]\nExecStart=\nExecStart="));
@@ -450,6 +461,11 @@ mod tests {
         assert!(dropin.contains("-ghostreaper-dustfloodthreshold=330"));
         // Tor off by default → no -tormode flag emitted.
         assert!(!dropin.contains("-tormode"));
+        // Default storage (standard, non-archive) → no storage flags emitted.
+        assert!(!dropin.contains("-prune"));
+        assert!(!dropin.contains("-reindex"));
+        assert!(!dropin.contains("-hazemode"));
+        assert!(!dropin.contains("-exorcist"));
     }
 
     #[test]
@@ -460,10 +476,12 @@ mod tests {
         let exec = "/opt/ghost/bin/ghostd -signet -tormode=1 -ghostreaper=enabled";
         let reaper = ReaperSettings::default();
 
+        let storage = StorageConfig::default();
         let on = ghostd_managed_dropin(
             exec,
             &reaper,
             &NodeLaunchConfig { tor_mode: true, ..Default::default() },
+            &storage,
         );
         assert_eq!(on.matches("-tormode=1").count(), 1);
 
@@ -471,6 +489,7 @@ mod tests {
             exec,
             &reaper,
             &NodeLaunchConfig { tor_mode: false, ..Default::default() },
+            &storage,
         );
         assert!(!off.contains("-tormode"));
     }
@@ -499,7 +518,8 @@ mod tests {
             i2p_accept_incoming: Some(true),
         };
 
-        let dropin = ghostd_managed_dropin(exec, &reaper, &launch);
+        let storage = StorageConfig::default();
+        let dropin = ghostd_managed_dropin(exec, &reaper, &launch, &storage);
 
         // Base non-managed args survive.
         assert!(dropin.contains("/opt/ghost/bin/ghostd"));
@@ -540,9 +560,89 @@ mod tests {
             .find(|l| l.starts_with("ExecStart=/"))
             .unwrap()
             .trim_start_matches("ExecStart=");
-        let dropin2 = ghostd_managed_dropin(regen_exec, &reaper, &launch);
+        let dropin2 = ghostd_managed_dropin(regen_exec, &reaper, &launch, &storage);
         assert_eq!(dropin2.matches("-maxmempool=").count(), 1);
         assert_eq!(dropin2.matches("-onlynet=").count(), 2);
         assert_eq!(dropin2.matches("-tormode=1").count(), 1);
+    }
+
+    #[test]
+    fn test_ghostd_managed_dropin_archive_emits_prune_zero() {
+        // Archive mode ON → -prune=0 emitted so ghostd stops pruning. Archive
+        // OFF emits nothing (leaves ghostd's own configured prune behaviour).
+        let exec = "/opt/ghost/bin/ghostd -signet -datadir=/var/lib/bitcoin";
+        let reaper = ReaperSettings::default();
+        let launch = NodeLaunchConfig::default();
+
+        let on = ghostd_managed_dropin(
+            exec,
+            &reaper,
+            &launch,
+            &StorageConfig { archive_mode: true, ..Default::default() },
+        );
+        assert!(on.contains("-prune=0"));
+        // No reindex unless explicitly armed.
+        assert!(!on.contains("-reindex"));
+
+        let off = ghostd_managed_dropin(exec, &reaper, &launch, &StorageConfig::default());
+        assert!(!off.contains("-prune"));
+    }
+
+    #[test]
+    fn test_ghostd_managed_dropin_reindex_oneshot_strips_stale() {
+        // A prior drop-in armed the one-shot -reindex + -prune=0. Regenerating
+        // once the marker has been cleared must strip the stale -reindex, leaving
+        // -prune=0 (archive still on) with no reindex.
+        let exec = "/opt/ghost/bin/ghostd -signet -prune=0 -reindex";
+        let reaper = ReaperSettings::default();
+        let launch = NodeLaunchConfig::default();
+
+        let armed = ghostd_managed_dropin(
+            exec,
+            &reaper,
+            &launch,
+            &StorageConfig { archive_mode: true, reindex_pending: true, ..Default::default() },
+        );
+        assert_eq!(armed.matches("-reindex").count(), 1);
+        assert_eq!(armed.matches("-prune=0").count(), 1);
+
+        // Marker cleared: -reindex must be gone; -prune=0 retained.
+        let cleared = ghostd_managed_dropin(
+            exec,
+            &reaper,
+            &launch,
+            &StorageConfig { archive_mode: true, reindex_pending: false, ..Default::default() },
+        );
+        assert!(!cleared.contains("-reindex"));
+        assert_eq!(cleared.matches("-prune=0").count(), 1);
+    }
+
+    #[test]
+    fn test_ghostd_managed_dropin_haze_hazed_and_exorcist_oneshot() {
+        // While a retroactive conversion is pending, emit -exorcist and SUPPRESS
+        // -hazemode=hazed (selecting hazed with blk*.dat present is fatal in
+        // ghostd until the conversion runs). Once the marker clears, emit the
+        // persistent -hazemode=hazed and drop -exorcist.
+        let exec = "/opt/ghost/bin/ghostd -signet -hazemode=hazed -exorcist";
+        let reaper = ReaperSettings::default();
+        let launch = NodeLaunchConfig::default();
+
+        let converting = ghostd_managed_dropin(
+            exec,
+            &reaper,
+            &launch,
+            &StorageConfig { haze_mode: HazeMode::Hazed, exorcist_pending: true, ..Default::default() },
+        );
+        assert_eq!(converting.matches("-exorcist").count(), 1);
+        assert!(!converting.contains("-hazemode=hazed"));
+
+        let converted = ghostd_managed_dropin(
+            exec,
+            &reaper,
+            &launch,
+            &StorageConfig { haze_mode: HazeMode::Hazed, exorcist_pending: false, ..Default::default() },
+        );
+        assert!(!converted.contains("-exorcist"));
+        assert_eq!(converted.matches("-hazemode=hazed").count(), 1);
     }
 }

--- a/crates/ghost-verification/src/routes.rs
+++ b/crates/ghost-verification/src/routes.rs
@@ -152,6 +152,12 @@ fn get_system_resources(proc_paths_allowed: &[String]) -> (f64, f64, f64) {
 
 /// Create verification router
 pub fn create_router(state: Arc<VerificationState>) -> Router {
+    // Resume watching any one-shot ghostd flags (-reindex / -exorcist) that are
+    // still armed in pool.toml — e.g. ghost-pool restarted while a pruned→archive
+    // resync or a retroactive Haze conversion was in flight. This guarantees the
+    // one-shot flags are always eventually cleared from the drop-in.
+    resume_pending_ghostd_oneshots(&state);
+
     // Clone ws_state for the WebSocket handler
     let ws_state = Arc::clone(&state.ws_state);
 
@@ -5414,6 +5420,8 @@ async fn api_config_full_handler(State(state): State<Arc<VerificationState>>) ->
                     "vw_blocks": ghost_common::config::VALIDATOR_WINDOW_BLOCKS,
                     "ow_blocks": cfg.storage.prune_height,
                     "archive_mode": cfg.storage.archive_mode,
+                    // One-shot pruned→archive resync still in flight.
+                    "reindex_pending": cfg.storage.reindex_pending,
                 }),
             )
         } else {
@@ -5431,6 +5439,7 @@ async fn api_config_full_handler(State(state): State<Arc<VerificationState>>) ->
                     "vw_blocks": ghost_common::config::VALIDATOR_WINDOW_BLOCKS,
                     "ow_blocks": 0,
                     "archive_mode": config.archive_mode,
+                    "reindex_pending": false,
                 }),
             )
         };
@@ -5457,12 +5466,23 @@ async fn api_config_full_handler(State(state): State<Arc<VerificationState>>) ->
 }
 
 /// API v1 Config archive mode handler
+///
+/// Reads the persisted truth from pool.toml (`storage.archive_mode`) and
+/// surfaces whether a one-time reindex is still pending (the pruned→archive
+/// resync). Falls back to the live mirror when the full config isn't loaded.
 async fn api_config_archive_mode_handler(
     State(state): State<Arc<VerificationState>>,
 ) -> impl IntoResponse {
-    let config = state.dashboard_config.read();
+    let (enabled, reindex_pending) = match state.full_node_config {
+        Some(ref full) => {
+            let cfg = full.read();
+            (cfg.storage.archive_mode, cfg.storage.reindex_pending)
+        }
+        None => (state.dashboard_config.read().archive_mode, false),
+    };
     Json(serde_json::json!({
-        "enabled": config.archive_mode,
+        "enabled": enabled,
+        "reindex_pending": reindex_pending,
         "message": "Archive mode configuration"
     }))
 }
@@ -5628,18 +5648,144 @@ struct ToggleRequest {
     enabled: bool,
 }
 
-/// API v1 Config archive_mode POST handler
+/// API v1 Config archive_mode POST handler — Group F "archive un-prune".
+///
+/// Persists `storage.archive_mode` to pool.toml and reconfigures ghostd to
+/// actually stop pruning, via the same managed drop-in path as the reaper/tor
+/// settings: `StorageConfig::ghostd_flags()` now emits `-prune=0` while archive
+/// mode is on, and `spawn_ghostd_reaper_apply` regenerates the drop-in +
+/// restarts ghostd.
+///
+/// The reindex problem: enabling archive on a currently-PRUNED node cannot
+/// recover blocks already deleted by pruning — `-prune=0` alone is not enough.
+/// So when we detect (via `getblockchaininfo.pruned`) that the node is pruned,
+/// we arm a ONE-SHOT `-reindex` (`storage.reindex_pending`) that ghostd runs
+/// once to rebuild + re-download the chain. A background watcher clears the
+/// marker and drops `-reindex` from the drop-in once the resync completes, so it
+/// never reindexes on every restart.
 async fn api_config_archive_mode_post_handler(
     State(state): State<Arc<VerificationState>>,
     Json(payload): Json<ToggleRequest>,
 ) -> impl IntoResponse {
-    let mut config = state.dashboard_config.write();
-    config.archive_mode = payload.enabled;
+    let enabled = payload.enabled;
+
+    // Require the full node config + a path to persist to; otherwise the change
+    // can't survive a restart, so fail-closed with SERVICE_UNAVAILABLE.
+    let Some(ref full) = state.full_node_config else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(serde_json::json!({
+                "success": false,
+                "error": "Config update API not available: full node config not loaded",
+                "code": "CONFIG_NOT_LOADED",
+            })),
+        )
+            .into_response();
+    };
+    let Some(ref path) = state.full_node_config_path else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(serde_json::json!({
+                "success": false,
+                "error": "Config update API not available: no node config path configured",
+                "code": "CONFIG_NOT_LOADED",
+            })),
+        )
+            .into_response();
+    };
+
+    // Decide whether a one-time reindex is required. Only relevant when ENABLING
+    // archive on a node that is currently pruned (its historical blocks were
+    // deleted and must be rebuilt/re-downloaded). Query ghostd; if the RPC is
+    // unavailable we conservatively do NOT auto-arm a multi-hour reindex — the
+    // operator can re-toggle once ghostd is reachable, or the node may already
+    // be unpruned. (Do not hold any config lock across this await.)
+    let currently_pruned = if enabled {
+        match state.rpc {
+            Some(ref rpc) => {
+                match tokio::time::timeout(
+                    std::time::Duration::from_secs(5),
+                    rpc.get_blockchain_info(),
+                )
+                .await
+                {
+                    Ok(Ok(info)) => info.pruned,
+                    Ok(Err(e)) => {
+                        warn!("archive_mode: getblockchaininfo failed ({e}); not arming reindex");
+                        false
+                    }
+                    Err(_) => {
+                        warn!("archive_mode: getblockchaininfo timed out; not arming reindex");
+                        false
+                    }
+                }
+            }
+            None => false,
+        }
+    } else {
+        false
+    };
+
+    // Persist to pool.toml (storage.archive_mode + the one-shot reindex marker).
+    {
+        let mut cfg = full.write();
+        cfg.storage.archive_mode = enabled;
+        if enabled {
+            // Arm the one-shot only when we positively observed the node pruned.
+            if currently_pruned {
+                cfg.storage.reindex_pending = true;
+            }
+        } else {
+            // Turning archive off makes any pending reindex moot.
+            cfg.storage.reindex_pending = false;
+        }
+        if let Err(e) = cfg.save_atomic(path) {
+            error!(error = %e, "Failed to persist archive mode");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({
+                    "success": false,
+                    "error": format!("Failed to persist archive mode: {e}"),
+                    "code": "PERSIST_FAILED",
+                })),
+            )
+                .into_response();
+        }
+    }
+
+    // Keep the live status mirror in sync so GET /node/status reflects the change
+    // immediately (it is also re-seeded from pool.toml on restart).
+    state.dashboard_config.write().archive_mode = enabled;
+
+    let reindex_armed = enabled && currently_pruned;
+
+    // Regenerate the drop-in (now carrying -prune=0 [+ one-shot -reindex]) and
+    // restart ghostd, then bounce the pool.
+    spawn_ghostd_reaper_apply(Arc::clone(&state));
+
+    // If a one-shot reindex was armed, watch for the resync to finish so we can
+    // clear the marker and drop -reindex from the drop-in.
+    if reindex_armed {
+        spawn_ghostd_oneshot_watcher(Arc::clone(&state), GhostdOneShot::Reindex);
+    }
+
+    let apply = serde_json::to_value(&*state.ghostd_reaper_apply.read())
+        .unwrap_or_else(|_| serde_json::json!({}));
+    let message = if !enabled {
+        "Archive mode disabled. ghostd is restarting; the pool will bounce once it settles."
+    } else if reindex_armed {
+        "Archive mode enabled. This node is pruned, so ghostd is restarting with -prune=0 and a one-time -reindex to rebuild and re-download the full chain — this is a long resync. The dashboard will clear the reindex flag automatically once it completes."
+    } else {
+        "Archive mode enabled. ghostd is restarting with -prune=0 and will stop pruning; the pool will bounce once it settles."
+    };
     Json(serde_json::json!({
         "success": true,
-        "enabled": payload.enabled,
-        "message": "Archive mode updated"
+        "enabled": enabled,
+        "reindex_pending": reindex_armed,
+        "ghostd_apply": apply,
+        "message": message,
     }))
+    .into_response()
 }
 
 /// API v1 Config ghost_mode POST handler
@@ -5921,6 +6067,235 @@ fn spawn_ghostd_reaper_apply(state: Arc<VerificationState>) {
 /// type name everywhere.
 fn ghost_common_now(state: &str, message: impl Into<String>) -> crate::server::GhostdReaperApply {
     crate::server::GhostdReaperApply::now(state, message)
+}
+
+/// A one-shot ghostd maintenance flag the dashboard armed and must clear once the
+/// operation completes, so `-reindex` / `-exorcist` never linger in the drop-in.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum GhostdOneShot {
+    /// `-reindex` after a pruned→archive transition. ghostd keeps running while
+    /// it rebuilds/re-downloads; complete when the resync finishes.
+    Reindex,
+    /// `-exorcist` retroactive Haze conversion. ghostd converts the existing
+    /// archive and then EXITS; with the service's `Restart=on-failure` a clean
+    /// exit(0) leaves the unit inactive, which is our completion signal.
+    Exorcist,
+}
+
+impl GhostdOneShot {
+    fn label(self) -> &'static str {
+        match self {
+            GhostdOneShot::Reindex => "reindex",
+            GhostdOneShot::Exorcist => "exorcist",
+        }
+    }
+}
+
+/// True when `systemctl is-active ghostd` reports the unit as running. Reads
+/// stdout (which carries "active"/"inactive"/"failed" regardless of exit code),
+/// so a non-zero exit for an inactive unit is handled correctly. No privilege
+/// required.
+fn ghostd_unit_is_active() -> bool {
+    std::process::Command::new("systemctl")
+        .args(["is-active", "ghostd"])
+        .output()
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim() == "active")
+        .unwrap_or(false)
+}
+
+/// Clear a one-shot storage marker in pool.toml, then regenerate the drop-in
+/// (which now omits the one-shot flag) and restart ghostd, and bounce the pool.
+/// Runs the blocking apply off the async workers. Returns the terminal apply
+/// outcome for logging.
+async fn clear_oneshot_and_reapply(
+    state: &Arc<VerificationState>,
+    kind: GhostdOneShot,
+) -> Result<(), String> {
+    let Some(ref full) = state.full_node_config else {
+        return Err("full node config not loaded".into());
+    };
+    let Some(ref path) = state.full_node_config_path else {
+        return Err("no node config path configured".into());
+    };
+    {
+        let mut cfg = full.write();
+        match kind {
+            GhostdOneShot::Reindex => cfg.storage.reindex_pending = false,
+            GhostdOneShot::Exorcist => cfg.storage.exorcist_pending = false,
+        }
+        cfg.save_atomic(path)
+            .map_err(|e| format!("failed to persist cleared {} marker: {e}", kind.label()))?;
+    }
+
+    *state.ghostd_reaper_apply.write() = ghost_common_now(
+        "applying",
+        format!("Clearing one-shot {} flag and restarting ghostd…", kind.label()),
+    );
+    let outcome = match tokio::task::spawn_blocking(run_ghostd_apply_reaper).await {
+        Ok(Ok(msg)) => ghost_common_now("applied", msg),
+        Ok(Err(reason)) => ghost_common_now("failed", reason),
+        Err(join_err) => ghost_common_now("failed", format!("apply task panicked: {join_err}")),
+    };
+    let failed = outcome.state == "failed";
+    let detail = outcome.message.clone();
+    *state.ghostd_reaper_apply.write() = outcome;
+    state.request_restart();
+    if failed {
+        Err(detail)
+    } else {
+        Ok(())
+    }
+}
+
+/// Spawn the background lifecycle watcher for a one-shot ghostd flag. It polls
+/// for the operation to complete, then clears the marker and re-applies the
+/// drop-in so the one-shot flag is dropped (and, for the exorcist, the node is
+/// brought back up hazed). Resumed on startup for any marker still set in
+/// pool.toml, so it survives a ghost-pool restart mid-operation.
+fn spawn_ghostd_oneshot_watcher(state: Arc<VerificationState>, kind: GhostdOneShot) {
+    // Test hook: never poll systemd/RPC or shell out from unit tests.
+    if std::env::var("GHOST_REAPER_APPLY_TEST_MODE").is_ok() {
+        return;
+    }
+    // Can't clear the marker without a persisted config path — bail loudly rather
+    // than leaving a watcher that can never make progress.
+    if state.full_node_config.is_none() || state.full_node_config_path.is_none() {
+        error!(
+            oneshot = kind.label(),
+            "cannot watch one-shot ghostd flag: full node config/path unavailable"
+        );
+        return;
+    }
+
+    tokio::spawn(async move {
+        // Poll cadence and an upper bound so the task can't run forever. A resync
+        // or archive conversion can legitimately take many hours, so the cap is
+        // generous; on timeout we leave the marker set (a subsequent manual apply
+        // still carries the flag) and log for operator attention.
+        let (interval, max_polls, min_elapsed) = match kind {
+            // 60s × 2880 = 48h; ignore the first 2 min so a reindex has engaged.
+            GhostdOneShot::Reindex => (
+                std::time::Duration::from_secs(60),
+                2880u32,
+                std::time::Duration::from_secs(120),
+            ),
+            // 20s × 8640 = 48h; small grace so the unit has (re)started.
+            GhostdOneShot::Exorcist => (
+                std::time::Duration::from_secs(20),
+                8640u32,
+                std::time::Duration::from_secs(20),
+            ),
+        };
+        let started = std::time::Instant::now();
+        // For the exorcist we must first observe ghostd running the conversion
+        // before an "inactive" unit can mean "done" — otherwise a failed initial
+        // start (ghostd never came up) would be misread as completion and clear
+        // the marker without having converted.
+        let mut saw_active = false;
+        info!(oneshot = kind.label(), "watching one-shot ghostd flag to completion");
+
+        for _ in 0..max_polls {
+            tokio::time::sleep(interval).await;
+            if started.elapsed() < min_elapsed {
+                continue;
+            }
+
+            let complete = match kind {
+                GhostdOneShot::Reindex => {
+                    // ghostd stays up during a reindex; it's done once it is no
+                    // longer in initial-block-download and fully verified.
+                    match state.rpc {
+                        Some(ref rpc) => match tokio::time::timeout(
+                            std::time::Duration::from_secs(5),
+                            rpc.get_blockchain_info(),
+                        )
+                        .await
+                        {
+                            Ok(Ok(info)) => {
+                                !info.initialblockdownload
+                                    && info.verificationprogress > 0.9999
+                            }
+                            _ => false, // RPC down mid-reindex → keep waiting
+                        },
+                        None => false,
+                    }
+                }
+                GhostdOneShot::Exorcist => {
+                    // ghostd runs the conversion then exits(0); with
+                    // Restart=on-failure a clean exit leaves the unit inactive.
+                    // Require that we saw it running first so a failed start is
+                    // never misread as a completed conversion. A fallback RPC
+                    // check catches the case where ghostd was already brought back
+                    // up hazed by some other path.
+                    if ghostd_unit_is_active() {
+                        saw_active = true;
+                        false
+                    } else if saw_active {
+                        true
+                    } else {
+                        // Never observed the conversion running yet — probe the
+                        // RPC in case the node is already up and hazed.
+                        match state.rpc {
+                            Some(ref rpc) => matches!(
+                                tokio::time::timeout(
+                                    std::time::Duration::from_secs(5),
+                                    rpc.get_blockchain_info(),
+                                )
+                                .await,
+                                Ok(Ok(info)) if info.hazed
+                            ),
+                            None => false,
+                        }
+                    }
+                }
+            };
+
+            if complete {
+                info!(
+                    oneshot = kind.label(),
+                    "one-shot ghostd operation complete; clearing flag and re-applying"
+                );
+                match clear_oneshot_and_reapply(&state, kind).await {
+                    Ok(()) => info!(
+                        oneshot = kind.label(),
+                        "one-shot ghostd flag cleared and drop-in regenerated"
+                    ),
+                    Err(e) => error!(
+                        oneshot = kind.label(),
+                        error = %e,
+                        "failed to clear one-shot ghostd flag; marker left set for manual re-apply"
+                    ),
+                }
+                return;
+            }
+        }
+
+        error!(
+            oneshot = kind.label(),
+            "one-shot ghostd flag did not complete within the watch window; \
+             marker left set — re-apply from the dashboard once the node has settled"
+        );
+    });
+}
+
+/// On startup, resume watching any one-shot ghostd flags that are still armed in
+/// pool.toml (e.g. ghost-pool restarted while a reindex/conversion was running).
+fn resume_pending_ghostd_oneshots(state: &Arc<VerificationState>) {
+    let (reindex, exorcist) = match state.full_node_config {
+        Some(ref full) => {
+            let cfg = full.read();
+            (cfg.storage.reindex_pending, cfg.storage.exorcist_pending)
+        }
+        None => return,
+    };
+    if reindex {
+        info!("resuming reindex one-shot watcher (pool.toml marker still set)");
+        spawn_ghostd_oneshot_watcher(Arc::clone(state), GhostdOneShot::Reindex);
+    }
+    if exorcist {
+        info!("resuming exorcist one-shot watcher (pool.toml marker still set)");
+        spawn_ghostd_oneshot_watcher(Arc::clone(state), GhostdOneShot::Exorcist);
+    }
 }
 
 /// API v1 Config tor POST handler — toggles ghostd Tor mode (`-tormode`).
@@ -9250,16 +9625,26 @@ struct HazeConfigureRequest {
     mode: String,
 }
 
-/// POST /api/v1/haze/configure — Set Ghost Haze mode
+/// POST /api/v1/haze/configure — Set Ghost Haze storage mode.
 ///
-/// Changes the haze privacy mode for stripped blocks:
-/// - "standard": Normal block storage (no stripping)
-/// - "hazed": Strip witness/script data from stored blocks
-/// - "full_archive": Keep full blocks (archive node mode)
+/// Persists `storage.haze_mode` to pool.toml and reconfigures ghostd via the
+/// managed drop-in (the same path as the reaper/tor/archive settings):
+/// - "standard" / "full_archive": persist the mode; `full_archive` also enables
+///   `storage.archive_mode` (→ `-prune=0`). No conversion.
+/// - "hazed": select Hazed mode. On a node that still holds a full archive this
+///   requires a ONE-TIME retroactive conversion, so we arm `-exorcist`
+///   (`storage.exorcist_pending`). ghostd runs the `blk*.dat` → GSB conversion
+///   and EXITS (verified in ghost-core `init.cpp`); the exorcist watcher then
+///   clears the marker, drops `-exorcist`, adds the persistent `-hazemode=hazed`
+///   and brings the node back up hazed. `-hazemode=hazed` is deliberately NOT
+///   emitted while the conversion is pending — selecting hazed with `blk*.dat`
+///   still present is a fatal ghostd start error.
 async fn api_haze_configure_handler(
     State(state): State<Arc<VerificationState>>,
     Json(payload): Json<HazeConfigureRequest>,
 ) -> impl IntoResponse {
+    use ghost_common::config::HazeMode;
+
     let valid_modes = ["standard", "hazed", "full_archive"];
     if !valid_modes.contains(&payload.mode.as_str()) {
         return (
@@ -9268,50 +9653,129 @@ async fn api_haze_configure_handler(
                 "success": false,
                 "error": format!("Invalid mode '{}'. Must be one of: standard, hazed, full_archive", payload.mode)
             })),
-        );
+        )
+            .into_response();
     }
 
-    // Update archive_mode based on selected mode
-    let archive_mode = payload.mode == "full_archive";
-    {
-        let mut config = state.dashboard_config.write();
-        config.archive_mode = archive_mode;
-    }
+    // Require the full node config + a path to persist to (fail-closed).
+    let Some(ref full) = state.full_node_config else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(serde_json::json!({
+                "success": false,
+                "error": "Config update API not available: full node config not loaded",
+                "code": "CONFIG_NOT_LOADED",
+            })),
+        )
+            .into_response();
+    };
+    let Some(ref path) = state.full_node_config_path else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(serde_json::json!({
+                "success": false,
+                "error": "Config update API not available: no node config path configured",
+                "code": "CONFIG_NOT_LOADED",
+            })),
+        )
+            .into_response();
+    };
 
-    // Try to sync with ghost-core via RPC if available
-    let rpc_synced = if let Some(ref rpc) = state.rpc {
-        match rpc.set_ghost_mode(payload.mode == "hazed").await {
-            Ok(_) => true,
-            Err(e) => {
-                warn!("Failed to sync haze mode with ghost-core: {}", e);
-                false
+    let haze_mode = match payload.mode.as_str() {
+        "hazed" => HazeMode::Hazed,
+        "full_archive" => HazeMode::FullArchive,
+        _ => HazeMode::Standard,
+    };
+    let archive_mode = haze_mode == HazeMode::FullArchive;
+
+    // For "hazed": decide whether a retroactive conversion is required. If the
+    // node already reports hazed we skip the conversion; otherwise (including
+    // when the RPC is unavailable) we arm the exorcist — that is the SAFE
+    // default, because emitting `-hazemode=hazed` on a node that still holds
+    // `blk*.dat` is a fatal ghostd start error, whereas `-exorcist` converts if
+    // there is an archive and cleanly no-ops-and-exits if the node is already
+    // hazed. (Do not hold any config lock across this await.)
+    let arm_exorcist = if haze_mode == HazeMode::Hazed {
+        match state.rpc {
+            Some(ref rpc) => {
+                match tokio::time::timeout(
+                    std::time::Duration::from_secs(5),
+                    rpc.get_blockchain_info(),
+                )
+                .await
+                {
+                    Ok(Ok(info)) => !info.hazed, // already hazed → no conversion
+                    Ok(Err(e)) => {
+                        warn!("haze/configure: getblockchaininfo failed ({e}); arming exorcist");
+                        true
+                    }
+                    Err(_) => {
+                        warn!("haze/configure: getblockchaininfo timed out; arming exorcist");
+                        true
+                    }
+                }
             }
+            None => true,
         }
     } else {
         false
     };
 
-    // Persist to node config
+    // Persist to pool.toml.
     {
-        let node_config = state.node_config.write();
-        // ghost_mode is the closest persisted field; haze is a ghost-core setting
-        if let Some(ref path) = state.node_config_path {
-            if let Err(e) = node_config.save(path) {
-                error!("Failed to persist node config: {}", e);
-            }
+        let mut cfg = full.write();
+        cfg.storage.haze_mode = haze_mode;
+        cfg.storage.archive_mode = archive_mode;
+        cfg.storage.exorcist_pending = arm_exorcist;
+        if let Err(e) = cfg.save_atomic(path) {
+            error!(error = %e, "Failed to persist haze mode");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({
+                    "success": false,
+                    "error": format!("Failed to persist haze mode: {e}"),
+                    "code": "PERSIST_FAILED",
+                })),
+            )
+                .into_response();
         }
     }
 
+    // Keep the live status mirror in sync (also re-seeded from pool.toml on restart).
+    state.dashboard_config.write().archive_mode = archive_mode;
+
+    // Regenerate the drop-in and restart ghostd, then bounce the pool.
+    spawn_ghostd_reaper_apply(Arc::clone(&state));
+
+    // Watch a pending retroactive conversion to completion (ghostd exits after
+    // converting; the watcher clears the marker and brings it back up hazed).
+    if arm_exorcist {
+        spawn_ghostd_oneshot_watcher(Arc::clone(&state), GhostdOneShot::Exorcist);
+    }
+
+    let apply = serde_json::to_value(&*state.ghostd_reaper_apply.read())
+        .unwrap_or_else(|_| serde_json::json!({}));
+    let message = if arm_exorcist {
+        "Ghost Haze set to Hazed. ghostd is restarting to run the one-time retroactive conversion of your existing block archive to stripped GSB format — this is a long batch job, after which the node comes back up hazed automatically."
+    } else if haze_mode == HazeMode::Hazed {
+        "Ghost Haze set to Hazed. ghostd is restarting with -hazemode=hazed; the pool will bounce once it settles."
+    } else if archive_mode {
+        "Ghost Haze set to Full Archive. ghostd is restarting with -prune=0 to keep the complete archive; the pool will bounce once it settles."
+    } else {
+        "Ghost Haze set to Standard. ghostd is restarting; the pool will bounce once it settles."
+    };
     (
         StatusCode::OK,
         Json(serde_json::json!({
             "success": true,
             "mode": payload.mode,
             "archive_mode": archive_mode,
-            "rpc_synced": rpc_synced,
-            "message": format!("Haze mode set to '{}'", payload.mode)
+            "exorcist_pending": arm_exorcist,
+            "ghostd_apply": apply,
+            "message": message,
         })),
     )
+        .into_response()
 }
 
 /// Request body for shroud configuration
@@ -10890,8 +11354,27 @@ mod tests {
     /// CRIT-6: Test that config POST with valid auth succeeds
     #[tokio::test]
     async fn test_config_post_with_valid_auth_succeeds() {
-        let state = create_test_state_with_auth();
+        use ghost_common::config::NodeConfig as FullNodeConfig;
+        use ghost_common::types::NodeCapabilities;
+        use ghost_policy::PolicyProfile;
+
+        // The archive_mode POST persists to pool.toml + regenerates the ghostd
+        // drop-in, so it fail-closes without a loaded config. Provide one (and the
+        // apply test-hook) so a valid-auth POST exercises the real success path.
+        std::env::set_var("GHOST_REAPER_APPLY_TEST_MODE", "success");
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("pool.toml");
         let auth = crate::auth::InternalAuth::new(&test_secret()).unwrap();
+        let state = Arc::new(
+            crate::server::VerificationState::new(
+                "test_node".to_string(),
+                "1.0.0".to_string(),
+                PolicyProfile::default(),
+                NodeCapabilities::default(),
+            )
+            .with_internal_auth(auth.clone())
+            .with_full_node_config(FullNodeConfig::default(), path.clone()),
+        );
         let app = super::create_router(state);
 
         let body = r#"{"enabled": true}"#;
@@ -10920,6 +11403,7 @@ mod tests {
             StatusCode::OK,
             "Config POST with valid auth should succeed"
         );
+        std::env::remove_var("GHOST_REAPER_APPLY_TEST_MODE");
     }
 
     /// The wraith toggle POST must persist `[ghost_pay] wraith_enabled` to the

--- a/dashboard/src/app/(dashboard)/haze/page.tsx
+++ b/dashboard/src/app/(dashboard)/haze/page.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { StatusRow } from "@/components/ui/StatusRow";
 import { Card, CardHeader } from "@/components/ui/Card";
+import { ConfirmDialog } from "@/components/ui/Dialog";
 import { PageHeader } from "@/components/ui/PageHeader";
 import { Badge } from "@/components/ui/Badge";
 import { Button } from "@/components/ui/Button";
@@ -213,8 +214,12 @@ export default function HazePage() {
     return { strippedBytes, structuralBytes, fullArchiveBytes, percentSmaller };
   }, [haze?.bytes_stripped, haze?.structural_archive_size_gb, haze?.chain_tip]);
 
-  const handleSetMode = async (target: "hazed" | "full_archive" | "standard") => {
-    if (target === mode) return;
+  // Selecting Hazed from a node that already holds blocks (standard / full
+  // archive) is a one-time, long, irreversible retroactive conversion — gate it
+  // behind an explicit confirmation.
+  const [confirmConvert, setConfirmConvert] = useState(false);
+
+  const doSetMode = async (target: "hazed" | "full_archive" | "standard") => {
     try {
       await configureHaze.mutateAsync(target);
       toast.success("Ghost Haze updated", `Storage mode set to ${getModeLabel(target)}`);
@@ -224,6 +229,17 @@ export default function HazePage() {
         e instanceof Error ? e.message : "Ghost Core did not accept the change.",
       );
     }
+  };
+
+  const handleSetMode = async (target: "hazed" | "full_archive" | "standard") => {
+    if (target === mode) return;
+    const retroactive =
+      target === "hazed" && (mode === "standard" || mode === "full_archive");
+    if (retroactive) {
+      setConfirmConvert(true);
+      return;
+    }
+    await doSetMode(target);
   };
 
   return (
@@ -854,6 +870,20 @@ export default function HazePage() {
           conversion runs as a background batch job and reports its progress above.
         </p>
       </Card>
+
+      <ConfirmDialog
+        isOpen={confirmConvert}
+        onClose={() => setConfirmConvert(false)}
+        onConfirm={async () => {
+          setConfirmConvert(false);
+          await doSetMode("hazed");
+        }}
+        title="Convert existing blocks to Hazed?"
+        message="This restarts ghostd to run the one-time Ghost Exorcist conversion of your existing block archive to stripped GSB format. It is a long, resumable batch job and is IRREVERSIBLE — witness, scriptSig, OP_RETURN and coinbase data are permanently stripped from local storage. The node comes back up hazed automatically once it finishes. Continue?"
+        confirmLabel="Convert & restart ghostd"
+        variant="danger"
+        loading={configureHaze.isPending}
+      />
     </div>
   );
 }

--- a/dashboard/src/app/(dashboard)/system/page.tsx
+++ b/dashboard/src/app/(dashboard)/system/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useRef } from "react";
 import { Card, CardHeader } from "@/components/ui/Card";
 import { Badge } from "@/components/ui/Badge";
 import { Button } from "@/components/ui/Button";
-import { Dialog } from "@/components/ui/Dialog";
+import { Dialog, ConfirmDialog } from "@/components/ui/Dialog";
 import { ProgressBar } from "@/components/ui/ProgressBar";
 import { PageHeader } from "@/components/ui/PageHeader";
 import { SectionErrorBoundary } from "@/components/ui/SectionErrorBoundary";
@@ -183,6 +183,7 @@ export default function SystemPage() {
   const [verifyResult, setVerifyResult] = useState<VerifyBackupResponse | null>(null);
   // Set after a successful import: the artifact is staged and a restart applies it.
   const [restartRequired, setRestartRequired] = useState(false);
+  const [confirmArchiveOpen, setConfirmArchiveOpen] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const backupHistory = historyData?.backups ?? [];
@@ -268,12 +269,27 @@ export default function SystemPage() {
     }
   };
 
-  const handleArchiveModeToggle = async () => {
+  const applyArchiveMode = async (enabled: boolean) => {
     try {
-      await setArchiveMode.mutateAsync(!archiveMode);
-      success("Mode Changed", `Archive Mode ${!archiveMode ? "enabled" : "disabled"}`);
+      await setArchiveMode.mutateAsync(enabled);
+      success(
+        "Mode Changed",
+        enabled
+          ? "Archive Mode enabled — ghostd is restarting to stop pruning."
+          : "Archive Mode disabled.",
+      );
     } catch (err) {
       toastError("Failed", err instanceof Error ? err.message : "Unknown error");
+    }
+  };
+
+  const handleArchiveModeToggle = async () => {
+    // Enabling restarts ghostd and, on a pruned node, kicks off a long reindex —
+    // confirm first. Disabling is safe, so apply directly.
+    if (!archiveMode) {
+      setConfirmArchiveOpen(true);
+    } else {
+      await applyArchiveMode(false);
     }
   };
 
@@ -598,7 +614,35 @@ export default function SystemPage() {
                       {archiveMode ? "Enabled" : "Disabled"}
                     </Button>
                   </div>
+
+                  {fullConfig?.pruning?.reindex_pending && (
+                    <div className="mt-3 flex items-start gap-2 p-3 rounded-lg bg-[color-mix(in_srgb,var(--yellow)_12%,transparent)] border border-[color:var(--yellow)]">
+                      <span
+                        className="mt-0.5 inline-block w-2 h-2 rounded-full bg-[color:var(--yellow)] animate-pulse"
+                        aria-hidden
+                      />
+                      <p className="text-xs text-[color:var(--dim)] leading-relaxed">
+                        <span className="text-[color:var(--fg)] font-medium">Re-indexing.</span>{" "}
+                        This node was pruned, so ghostd is rebuilding and re-downloading the full
+                        chain (a one-time <code>-reindex</code>). This can take hours; the flag
+                        clears itself once the resync completes.
+                      </p>
+                    </div>
+                  )}
                 </div>
+
+                <ConfirmDialog
+                  isOpen={confirmArchiveOpen}
+                  onClose={() => setConfirmArchiveOpen(false)}
+                  onConfirm={async () => {
+                    setConfirmArchiveOpen(false);
+                    await applyArchiveMode(true);
+                  }}
+                  title="Enable Archive Mode?"
+                  message="This restarts ghostd with pruning disabled (-prune=0). If this node is currently pruned, it also triggers a one-time full reindex and re-download of the chain — a long resync that can take hours. The node keeps validating throughout. Continue?"
+                  confirmLabel="Enable & restart ghostd"
+                  loading={setArchiveMode.isPending}
+                />
 
                 {/* Window Visualization */}
                 <div className="grid grid-cols-3 gap-4">

--- a/dashboard/src/components/settings/StoragePruningCard.tsx
+++ b/dashboard/src/components/settings/StoragePruningCard.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { Card, CardHeader } from "@/components/ui/Card";
 import { Badge } from "@/components/ui/Badge";
 import { Button } from "@/components/ui/Button";
+import { ConfirmDialog } from "@/components/ui/Dialog";
 import { SkeletonCard } from "@/components/ui/Skeleton";
 import {
   useFullConfig,
@@ -100,6 +101,10 @@ export function StoragePruningCard() {
   const archiveMode = status?.archive_mode ?? false;
   const vwBlocks = fullConfig?.pruning?.vw_blocks ?? 288;
   const owBlocks = fullConfig?.pruning?.ow_blocks ?? 0;
+  // A one-time pruned→archive resync (ghostd -reindex) is still running.
+  const reindexPending = fullConfig?.pruning?.reindex_pending ?? false;
+
+  const [confirmArchive, setConfirmArchive] = useState(false);
 
   const handleOperatorWindowChange = async (blocks: number) => {
     try {
@@ -110,12 +115,27 @@ export function StoragePruningCard() {
     }
   };
 
-  const handleArchiveModeToggle = async () => {
+  const applyArchiveMode = async (enabled: boolean) => {
     try {
-      await setArchiveMode.mutateAsync(!archiveMode);
-      success("Mode Changed", `Archive Mode ${!archiveMode ? "enabled" : "disabled"}`);
+      await setArchiveMode.mutateAsync(enabled);
+      success(
+        "Mode Changed",
+        enabled
+          ? "Archive Mode enabled — ghostd is restarting to stop pruning."
+          : "Archive Mode disabled.",
+      );
     } catch (err) {
       error("Failed", err instanceof Error ? err.message : "Unknown error");
+    }
+  };
+
+  const handleArchiveModeToggle = async () => {
+    // Enabling archive restarts ghostd and, on a pruned node, kicks off a long
+    // reindex/resync — confirm first. Disabling is safe, so apply directly.
+    if (!archiveMode) {
+      setConfirmArchive(true);
+    } else {
+      await applyArchiveMode(false);
     }
   };
 
@@ -150,7 +170,36 @@ export function StoragePruningCard() {
               {archiveMode ? "Enabled" : "Disabled"}
             </Button>
           </div>
+
+          {/* One-time pruned→archive resync in flight */}
+          {reindexPending && (
+            <div className="mt-3 flex items-start gap-2 p-3 rounded-lg bg-[color-mix(in_srgb,var(--yellow)_12%,transparent)] border border-[color:var(--yellow)]">
+              <span
+                className="mt-0.5 inline-block w-2 h-2 rounded-full bg-[color:var(--yellow)] animate-pulse"
+                aria-hidden
+              />
+              <p className="text-xs text-[color:var(--dim)] leading-relaxed">
+                <span className="text-[color:var(--fg)] font-medium">Re-indexing.</span>{" "}
+                This node was pruned, so ghostd is rebuilding and re-downloading the full
+                chain (a one-time <code>-reindex</code>). This can take hours; the flag clears
+                itself automatically once the resync completes.
+              </p>
+            </div>
+          )}
         </div>
+
+        <ConfirmDialog
+          isOpen={confirmArchive}
+          onClose={() => setConfirmArchive(false)}
+          onConfirm={async () => {
+            setConfirmArchive(false);
+            await applyArchiveMode(true);
+          }}
+          title="Enable Archive Mode?"
+          message="This restarts ghostd with pruning disabled (-prune=0). If this node is currently pruned, it also triggers a one-time full reindex and re-download of the chain — a long resync that can take hours. The node keeps validating throughout. Continue?"
+          confirmLabel="Enable & restart ghostd"
+          loading={setArchiveMode.isPending}
+        />
 
         {/* Window Visualization */}
         <div className="grid grid-cols-3 gap-4">

--- a/dashboard/src/hooks/useNodeData.ts
+++ b/dashboard/src/hooks/useNodeData.ts
@@ -103,10 +103,13 @@ export function useConfig() {
   }, []);
 
   const setArchiveMode = useCallback(async (enabled: boolean) => {
-    const newConfig = await api.setArchiveMode(enabled);
-    setData(newConfig);
-    return newConfig;
-  }, []);
+    // The archive POST returns a status envelope (not a full NodeConfig) — it
+    // persists to pool.toml and restarts ghostd. Reload the authoritative config
+    // afterwards rather than storing the envelope.
+    const result = await api.setArchiveMode(enabled);
+    refresh();
+    return result;
+  }, [refresh]);
 
   return { data, loading, error, refresh, setGhostMode, setArchiveMode };
 }

--- a/dashboard/src/lib/api/config.ts
+++ b/dashboard/src/lib/api/config.ts
@@ -113,8 +113,18 @@ export async function setDaemonSettings(settings: DaemonSettings): Promise<Daemo
   });
 }
 
-export async function setArchiveMode(enabled: boolean): Promise<NodeConfig> {
-  return fetchApi<NodeConfig>('/api/v1/config/archive_mode', {
+// Archive un-prune (Group F). The POST persists storage.archive_mode, emits
+// ghostd -prune=0 via the managed drop-in and restarts ghostd; on a pruned node
+// it also arms a one-time -reindex (reported via `reindex_pending`).
+export interface ArchiveModeResponse {
+  success: boolean;
+  enabled: boolean;
+  reindex_pending: boolean;
+  message: string;
+}
+
+export async function setArchiveMode(enabled: boolean): Promise<ArchiveModeResponse> {
+  return fetchApi<ArchiveModeResponse>('/api/v1/config/archive_mode', {
     method: 'POST',
     body: JSON.stringify({ enabled }),
   });

--- a/dashboard/src/types/api.ts
+++ b/dashboard/src/types/api.ts
@@ -88,6 +88,10 @@ export interface PruningConfig {
   ow_blocks?: number;
   // Archive Window: storage.archive_mode (when true, pruning is disabled).
   archive_mode?: boolean;
+  // A one-time pruned→archive reindex/resync is still in flight (ghostd is
+  // rebuilding and re-downloading the full chain). Cleared automatically once
+  // the resync completes.
+  reindex_pending?: boolean;
 }
 
 export interface FullNodeConfig {


### PR DESCRIPTION
## Summary

Wires two operator-chosen ghostd launch flags through the **existing** managed systemd drop-in pipeline (`ghost-setup apply-reaper` → `ghostd_managed_dropin`), mirroring how Tor mode and the per-vector reaper already work. No new sudoers command; no ghostd source change (ghostd already supports every flag used).

- **Group F — Archive un-prune**: enabling Archive Mode now durably persists `storage.archive_mode` and makes ghostd stop pruning (`-prune=0`), instead of only flipping an ephemeral in-memory claim.
- **Haze retroactive conversion**: selecting *Hazed* persists `storage.haze_mode` and triggers the one-time `blk*.dat` → GSB conversion (`-exorcist`), then brings the node back up hazed.

Defaults are unchanged (archive off, haze standard) — deploying this changes nothing until an operator opts in.

## Flag emission (`StorageConfig::ghostd_flags()`, new)

| Condition | Emits |
|---|---|
| `archive_mode` | `-prune=0` |
| `reindex_pending` (one-shot) | `-reindex` |
| `haze_mode == Hazed && !exorcist_pending` | `-hazemode=hazed` |
| `exorcist_pending` (one-shot) | `-exorcist` |

Added to `MANAGED_GHOSTD_FLAG_PREFIXES`: `-prune`, `-reindex`, `-hazemode`, `-exorcist`. Listing the two one-shot prefixes is a safety net — a stale copy is stripped on **every** regeneration, so a one-shot flag can only ever be present while its `*_pending` marker is set. `ghostd_managed_dropin()` now also chains `storage.ghostd_flags()` (signature gained a `&StorageConfig` param; `ghost-setup` and tests updated).

## ⚠️ Correction to the brief: `-exorcist` is NOT safe to leave in the drop-in

The task assumed `-exorcist` is idempotent and could stay permanently. **The code says otherwise** (`ghost-core/src/init.cpp:546,2075`): `-exorcist` converts the archive and then **exits the node** ("Node will now shut down. Restart without --exorcist to run in Hazed mode."). Left permanently in the drop-in it would run-and-exit on every start and take the node offline. So it is treated as a **one-shot**, exactly like `-reindex`.

Also confirmed (`haze/mode_selector.cpp:83`): emitting `-hazemode=hazed` on a node that still holds `blk*.dat` is a **fatal** start error — the conversion must run first. Hence `-hazemode=hazed` is **suppressed while `exorcist_pending`** and only emitted once the conversion has completed (by which point ghostd's datadir mode-lock already pins hazed, so the flag is an inert fallback).

## The one-shot `-reindex` / `-exorcist` design

Two `#[serde(default)]` markers on `StorageConfig`: `reindex_pending`, `exorcist_pending`. A background **watcher** (`spawn_ghostd_oneshot_watcher`) owns the full lifecycle: *arm → apply → detect completion → clear marker (`save_atomic`) → re-apply drop-in (dropping the one-shot flag) → bounce pool*. It is **resumed on startup** (`resume_pending_ghostd_oneshots` in `create_router`) for any marker still set in pool.toml, so it survives a ghost-pool restart mid-operation. The one-shot flags are therefore **never left permanently** in the drop-in.

Completion signals:
- **reindex** — ghostd stays up; done when `getblockchaininfo` reports `!initialblockdownload && verificationprogress > 0.9999`.
- **exorcist** — ghostd exits(0) after converting; with the unit's `Restart=on-failure` the clean exit leaves it inactive. Watcher requires it saw the unit **active** first (so a failed start can't be misread as completion), with an RPC `hazed==true` fallback. The follow-up re-apply's `systemctl restart` starts the stopped unit back up hazed.

## Backend handlers (`ghost-verification`)

- **`POST /api/v1/config/archive_mode`** — now persists `storage.archive_mode` + `save_atomic` (fail-closed if config not loaded; preserves the H-11 0600 behaviour via `save_atomic`), regenerates the drop-in + restarts ghostd. If `getblockchaininfo.pruned == true` it arms the one-shot `-reindex` and starts the watcher. GET + `/config/full` now read the persisted truth and surface `reindex_pending`.
- **`POST /api/v1/haze/configure`** — replaces the old handler (which just flipped an ephemeral `archive_mode` and mis-called `set_ghost_mode`). Now persists `storage.haze_mode` (+ `archive_mode` for full_archive) and, for *hazed*, arms `-exorcist` unless the node already reports hazed (safe default: convert rather than risk the fatal `-hazemode` path). `standard`/`full_archive` keep working.

## Dashboard

- **Storage** (`StoragePruningCard`, shared by `/storage` + `/settings/storage`; and the inline duplicate in `/system`): the Archive toggle already hit `/config/archive_mode` (now real). Added a confirm dialog ("this restarts ghostd and, on a pruned node, triggers a long reindex/resync") and a live "Re-indexing…" notice driven by `pruning.reindex_pending`.
- **Haze** (`/haze`): the mode control already called `configureHaze` (seam was the backend). Added a danger-confirm for the retroactive conversion ("irreversible, long, resumable; node comes back hazed"). The existing IN_PROGRESS/`blocks_stripped` progress display is unchanged and driven by `gethazestatus`.
- Types/lib tightened: `PruningConfig.reindex_pending`, `ArchiveModeResponse`.

## ⚙️ Deploy note

`ghost-setup` consumes `ghostd_flags()`/`MANAGED_GHOSTD_FLAG_PREFIXES`, so **`ghost-setup` must be rebuilt + redeployed alongside ghost-pool** (both link `ghost-common`). Reuses the existing `apply-reaper` scoped-sudoers command — no new privilege. On the fleet, `-prune` is not present in ghostd's `ExecStart` (it lives in ghost.conf), so adding `-prune` to the managed set does not disturb a pruned node's configured behaviour when archive is off.

## Verification

- `cargo check` — `ghost-common`, `ghost-verification`, `ghost-pool`, `ghost-setup` all clean.
- `cargo test -p ghost-common` (273) + `-p ghost-verification` (205) — pass. New tests cover `-prune=0` iff archive, `-hazemode`/`-exorcist` for hazed (+ suppression while converting), the reindex one-shot arm/clear, and drop-in strip idempotence.
- `cargo clippy` — no new warnings.
- Dashboard: `tsc --noEmit` clean, `eslint` clean on changed files, `npm run build` ✓.
- **Not** release-built (per instructions) — parent handles the release build + elder-gated rolling canary VM4→VM1.
