### PR TITLE
dashboard: canonical type scale foundation

### DIFF
--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -108,6 +108,25 @@ body {
 
 img, svg { display: block; }
 
+/* ── Canonical type scale ──────────────────────────────────────────────────
+   ONE system for every page. Reach for the semantic role, not a pixel value.
+   Kills the drift from ad-hoc inline `fontSize` and off-scale Tailwind sizes.
+   Steps (px): display 32 · stat 24 · title 18 · lead 15 · body 14 · label 13
+               · caption 12 · eyebrow 11.
+   Note: Tailwind text-xs/sm/lg/2xl already map to 12/14/18/24 and are fine to
+   keep; these classes give semantic names AND absorb the off-scale sizes
+   (13/15/16/20/22) that caused the drift. */
+.t-display  { font-size: 32px; line-height: 1.15; font-weight: 400; letter-spacing: -0.01em; }
+.t-stat     { font-size: 24px; line-height: 1.2;  font-weight: 600; letter-spacing: -0.01em; }
+.t-title    { font-size: 18px; line-height: 1.3;  font-weight: 500; }
+.t-lead     { font-size: 15px; line-height: 1.5;  font-weight: 400; }
+.t-body     { font-size: 14px; line-height: 1.5;  font-weight: 400; }
+.t-label    { font-size: 13px; line-height: 1.4;  font-weight: 400; }
+.t-caption  { font-size: 12px; line-height: 1.4;  font-weight: 400; }
+.t-eyebrow  { font-size: 11px; line-height: 1;    font-weight: 500; font-family: var(--font-mono); text-transform: uppercase; letter-spacing: 0.18em; }
+/* Mono uppercase field label (replaces the per-page `labelStyle` objects). */
+.t-label-mono { font-size: 13px; line-height: 1.4; font-weight: 400; font-family: var(--font-mono); text-transform: uppercase; letter-spacing: 0.06em; }
+
 /* Anchor styling matches website: subtle bottom-rule underline, accent on hover.
    Components using `class="bare"` or nav anchors opt out via .bare. */
 a:not(.bare):not([class*="text-"]):not(button) {

--- a/dashboard/src/components/ui/PageHeader.tsx
+++ b/dashboard/src/components/ui/PageHeader.tsx
@@ -23,32 +23,17 @@ export function PageHeader({ eyebrow, title, subtitle, subtitleFullWidth = true,
     <div className={`flex items-start justify-between gap-4 mb-8 ${className}`}>
       <div className="flex-1 min-w-0">
         {eyebrow && (
-          <div
-            className="font-mono uppercase mb-2"
-            style={{
-              color: 'var(--accent)',
-              fontSize: '11px',
-              letterSpacing: '0.18em',
-            }}
-          >
+          <div className="t-eyebrow mb-2" style={{ color: 'var(--accent)' }}>
             {eyebrow}
           </div>
         )}
-        <h1
-          className="font-normal"
-          style={{
-            color: 'var(--fg)',
-            fontSize: '32px',
-            lineHeight: '1.15',
-            letterSpacing: '-0.01em',
-          }}
-        >
+        <h1 className="t-display" style={{ color: 'var(--fg)' }}>
           {title}
         </h1>
         {subtitle && (
           <p
-            className="mt-2"
-            style={{ color: 'var(--dim)', fontSize: '15px', maxWidth: subtitleFullWidth ? 'none' : '60ch' }}
+            className="t-lead mt-2"
+            style={{ color: 'var(--dim)', maxWidth: subtitleFullWidth ? 'none' : '60ch' }}
           >
             {subtitle}
           </p>


### PR DESCRIPTION
One semantic type scale as CSS classes to kill inter-page font-size drift; PageHeader converted as reference.