### PR TITLE
dashboard(settings): Tor/Reaper cross-links, shared capability toggles, scheduled-backups mirror + type scale

### DIFF
--- a/dashboard/src/app/(dashboard)/settings/capabilities/page.tsx
+++ b/dashboard/src/app/(dashboard)/settings/capabilities/page.tsx
@@ -1,163 +1,20 @@
 "use client";
 
-import { Badge } from "@/components/ui/Badge";
-import {
-  useNodeStatus,
-  useConfig,
-  useSetArchiveMode,
-  useSetReaper,
-  useSetPublicMining,
-  useGhostPayStatus,
-  useShares,
-} from "@/hooks/queries";
-import { useToast } from "@/components/ui/Toast";
-import { SettingsSection, ToggleRow, StatusRow } from "../shared";
+import { CapabilityToggles } from "@/components/settings/CapabilityToggles";
+import { SettingsSection } from "../shared";
 
 export default function CapabilitiesSettingsPage() {
-  const { data: status } = useNodeStatus();
-  const { data: config } = useConfig();
-  const { data: ghostPayStatus } = useGhostPayStatus();
-  const { data: shares } = useShares();
-
-  const setArchiveMode = useSetArchiveMode();
-  const setReaper = useSetReaper();
-  const setPublicMining = useSetPublicMining();
-
-  const { success, error } = useToast();
-
-  // Ghost Mode and Public Mining are mutually exclusive: a Ghost Mode node
-  // builds near-empty blocks and forfeits all transaction-fee income, so it
-  // must not also accept public miners. Block enabling Public Mining while
-  // Ghost Mode is active (disabling it stays allowed). The backend enforces the
-  // same rule and answers a conflicting enable with a 409, surfaced below.
-  const ghostModeActive = status?.ghost_mode ?? false;
-  const publicMiningActive = status?.public_mining ?? false;
-  const publicMiningBlocked = ghostModeActive && !publicMiningActive;
-
-  // Ghost Pay running-state comes from the explicit `sync_state` flag, NOT
-  // `l2_height` — an L2 height of 0 is a perfectly valid running state (fresh
-  // node), so its truthiness would mislabel a running node as "Not Running".
-  const ghostPayRunning = ghostPayStatus?.sync_state === "synced";
-
-  const handlePublicMiningToggle = async (enabled: boolean) => {
-    try {
-      await setPublicMining.mutateAsync(enabled);
-      success("Mode Changed", `Public Mining ${enabled ? "enabled" : "disabled"}`);
-    } catch (err) {
-      error("Failed", err instanceof Error ? err.message : "Unknown error");
-    }
-  };
-
-  const handleArchiveModeToggle = async (enabled: boolean) => {
-    try {
-      await setArchiveMode.mutateAsync(enabled);
-      success("Mode Changed", `Archive Mode ${enabled ? "enabled" : "disabled"}`);
-    } catch (err) {
-      error("Failed", err instanceof Error ? err.message : "Unknown error");
-    }
-  };
-
-  const handleReaperToggle = async (enabled: boolean) => {
-    try {
-      await setReaper.mutateAsync(enabled);
-      success(
-        "Mode Changed",
-        enabled
-          ? "Ghost Reaper enabled — mempool filtering active"
-          : "Ghost Reaper disabled — filtering inactive"
-      );
-    } catch (err) {
-      error("Failed", err instanceof Error ? err.message : "Unknown error");
-    }
-  };
-
   return (
     <SettingsSection
       title="Node Capabilities"
       subtitle="Earn shares in the node reward pool — 5-4-3-2-1 system"
     >
-      <ToggleRow
-        label="Archive Mode"
-        description="Store full blockchain history (+5 shares bonus)"
-        enabled={status?.archive_mode ?? false}
-        onChange={handleArchiveModeToggle}
-        disabled={setArchiveMode.isPending}
-        badge={
-          status?.archive_mode ? (
-            <Badge variant="success">+5 Shares</Badge>
-          ) : null
-        }
-      />
-
-      <StatusRow
-        label="Ghost Pay"
-        description={`L2 payment network participation — requires ghost-pay-node${ghostPayRunning ? ` (L2 height: ${ghostPayStatus?.l2_height ?? 0})` : ''}`}
-        badge={
-          ghostPayRunning ? (
-            <Badge variant="success">+4 Shares</Badge>
-          ) : (
-            <Badge variant="warning">Not Running</Badge>
-          )
-        }
-      />
-
-      <ToggleRow
-        label="Public Mining"
-        description="Accept mining connections from public miners (+3 shares bonus)"
-        enabled={publicMiningActive}
-        onChange={handlePublicMiningToggle}
-        disabled={setPublicMining.isPending || publicMiningBlocked}
-        badge={
-          publicMiningActive ? (
-            <Badge variant="success">+3 Shares</Badge>
-          ) : null
-        }
-      />
-
-      {publicMiningBlocked && (
-        <div
-          className="p-3 rounded-lg"
-          style={{
-            background: "color-mix(in srgb, var(--yellow) 8%, transparent)",
-            border: "1px solid color-mix(in srgb, var(--yellow) 40%, transparent)",
-          }}
-        >
-          <p className="text-sm" style={{ color: "var(--fg)", lineHeight: "1.6" }}>
-            <span style={{ color: "var(--yellow)", fontWeight: 600 }}>Ghost Mode is active</span>{" "}
-            — disable it before enabling Public Mining. A Ghost Mode node builds empty blocks and
-            forfeits all transaction-fee income, so the two can&apos;t run together.
-          </p>
-        </div>
-      )}
-
-      <ToggleRow
-        label="Ghost Reaper"
-        description="Reject transactions with dead code in witness scripts. Filters inscriptions, drop stuffing, and other non-financial data from your mempool. (+2 shares)"
-        enabled={config?.reaper ?? false}
-        onChange={handleReaperToggle}
-        disabled={setReaper.isPending}
-        badge={
-          config?.reaper ? (
-            <Badge variant="success">+2 Shares</Badge>
-          ) : null
-        }
-      />
-
-      <StatusRow
-        label="Elder Status"
-        description={
-          shares?.elder
-            ? `MPC contributor — Elder slot #${shares.elder_slot ?? '?'}`
-            : "Contribute to the MPC ceremony to earn Elder status (+1 share)"
-        }
-        badge={
-          shares?.elder ? (
-            <Badge variant="success">+1 Share</Badge>
-          ) : (
-            <Badge variant="default">Not Elder</Badge>
-          )
-        }
-      />
+      {/*
+       * The five capability rows are shared with the Onboarding wizard via
+       * CapabilityToggles (single source of truth). Here Ghost Pay is read-only
+       * status, and the Reaper row links out to detector-level configuration.
+       */}
+      <CapabilityToggles reaperConfigHref="/filtering/advanced" />
     </SettingsSection>
   );
 }

--- a/dashboard/src/app/(dashboard)/settings/filtering/page.tsx
+++ b/dashboard/src/app/(dashboard)/settings/filtering/page.tsx
@@ -44,8 +44,8 @@ export default function FilteringSettingsPage() {
       <Card>
         <div className="flex items-start justify-between gap-4">
           <div>
-            <div style={{ color: "var(--fg)", fontSize: "15px", fontWeight: 600 }}>Enable advanced controls</div>
-            <div style={{ color: "var(--dim)", fontSize: "13px", lineHeight: "1.6", marginTop: "4px" }}>
+            <div className="t-title" style={{ color: "var(--fg)" }}>Enable advanced controls</div>
+            <div className="t-caption" style={{ color: "var(--dim)", marginTop: "4px" }}>
               Off by default. When on, the reaper vectors and custom mining policy below become editable.
               This switch is per-browser only — it does not change your node until you save a control below.
             </div>

--- a/dashboard/src/app/(dashboard)/settings/onboarding/page.tsx
+++ b/dashboard/src/app/(dashboard)/settings/onboarding/page.tsx
@@ -8,6 +8,7 @@ import { Badge } from "@/components/ui/Badge";
 import { StepIndicator } from "@/components/ui/Wizard";
 import { useToast } from "@/components/ui/Toast";
 import { ToggleRow, StatusRow } from "../shared";
+import { CapabilityToggles } from "@/components/settings/CapabilityToggles";
 import ReaperWizard from "../wizards/ReaperWizard";
 import {
   useNodeStatus,
@@ -16,10 +17,6 @@ import {
   useConfig,
   useFullConfig,
   useGhostPayStatus,
-  useSetArchiveMode,
-  useSetPublicMining,
-  useSetReaper,
-  useSetGhostPay,
   useSetWraith,
   useSetPolicyProfile,
 } from "@/hooks/queries";
@@ -66,11 +63,9 @@ export default function OnboardingPage() {
   const { data: fullConfig } = useFullConfig();
   const { data: ghostPay } = useGhostPayStatus();
 
-  // Writes — the SAME hooks the Capabilities/Filtering settings pages use.
-  const setArchiveMode = useSetArchiveMode();
-  const setPublicMining = useSetPublicMining();
-  const setReaper = useSetReaper();
-  const setGhostPay = useSetGhostPay();
+  // Writes — Wraith mixing and the tier policy still live here; the five
+  // canonical capability rows are driven inside the shared CapabilityToggles
+  // component (the SAME hooks Settings › Capabilities uses).
   const setWraith = useSetWraith();
   const setPolicyProfile = useSetPolicyProfile();
 
@@ -79,49 +74,12 @@ export default function OnboardingPage() {
 
   const activePolicyProfile = String(fullConfig?.policy?.profile ?? "permissive");
   const ghostPayRunning = Boolean(ghostPay?.l2_height);
-  const ghostPayEnabled = status?.ghost_pay ?? false;
   const wraithEnabled = ghostPay?.wraith_enabled ?? false;
-
-  const handleArchiveToggle = async (enabled: boolean) => {
-    try {
-      await setArchiveMode.mutateAsync(enabled);
-      success("Saved", `Archive Mode ${enabled ? "enabled" : "disabled"}`);
-    } catch (err) {
-      error("Failed", err instanceof Error ? err.message : "Unknown error");
-    }
-  };
-
-  const handlePublicMiningToggle = async (enabled: boolean) => {
-    try {
-      await setPublicMining.mutateAsync(enabled);
-      success("Saved", `Public Mining ${enabled ? "enabled" : "disabled"}`);
-    } catch (err) {
-      error("Failed", err instanceof Error ? err.message : "Unknown error");
-    }
-  };
-
-  const handleGhostPayToggle = async (enabled: boolean) => {
-    try {
-      await setGhostPay.mutateAsync(enabled);
-      success("Saved", `Ghost Pay ${enabled ? "enabled" : "disabled"}`);
-    } catch (err) {
-      error("Failed", err instanceof Error ? err.message : "Unknown error");
-    }
-  };
 
   const handleWraithToggle = async (enabled: boolean) => {
     try {
       await setWraith.mutateAsync(enabled);
       success("Saved", `Wraith mixing ${enabled ? "enabled" : "disabled"} — restart ghost-pool to apply`);
-    } catch (err) {
-      error("Failed", err instanceof Error ? err.message : "Unknown error");
-    }
-  };
-
-  const handleReaperToggle = async (enabled: boolean) => {
-    try {
-      await setReaper.mutateAsync(enabled);
-      success("Saved", `Ghost Reaper ${enabled ? "enabled" : "disabled"}`);
     } catch (err) {
       error("Failed", err instanceof Error ? err.message : "Unknown error");
     }
@@ -216,67 +174,23 @@ export default function OnboardingPage() {
             subtitle="Capabilities earn shares in the node reward pool (5-4-3-2-1). Toggles are pre-set to your node's current values and save immediately."
           />
           <div className="space-y-3">
-            <ToggleRow
-              label="Archive Mode"
-              description="Store full blockchain history. Archive +5 shares."
-              enabled={archiveEnabled}
-              onChange={handleArchiveToggle}
-              disabled={setArchiveMode.isPending}
-              badge={archiveEnabled ? <Badge variant="success">+5 Shares</Badge> : null}
-            />
-            <ToggleRow
-              label="Ghost Pay"
-              description={`L2 payment network participation — requires ghost-pay-node${ghostPay?.l2_height ? ` (L2 height: ${ghostPay.l2_height})` : ""}. Ghost Pay +4 shares.`}
-              enabled={ghostPayEnabled}
-              onChange={handleGhostPayToggle}
-              disabled={setGhostPay.isPending}
-              badge={
-                ghostPayEnabled ? (
-                  ghostPayRunning ? (
-                    <Badge variant="success">+4 Shares</Badge>
-                  ) : (
-                    <Badge variant="warning">Not Running</Badge>
-                  )
-                ) : null
-              }
-            />
-            <ToggleRow
-              label="Wraith Mixing"
-              description="Let any L2 participant initiate a CoinJoin session through this node. Off means this node won't take part in mixing. Not a reward capability — a restart applies the change."
-              enabled={wraithEnabled}
-              onChange={handleWraithToggle}
-              disabled={setWraith.isPending}
-              badge={wraithEnabled ? <Badge variant="info">Mixing On</Badge> : null}
-            />
-            <ToggleRow
-              label="Public Mining"
-              description="Accept connections from public miners. Public Mining +3 shares."
-              enabled={publicMiningEnabled}
-              onChange={handlePublicMiningToggle}
-              disabled={setPublicMining.isPending}
-              badge={publicMiningEnabled ? <Badge variant="success">+3 Shares</Badge> : null}
-            />
-            <ToggleRow
-              label="Ghost Reaper"
-              description="Reject non-financial data (inscriptions, drop-stuffing, dust-flood) from your mempool and blocks. Reaper +2 shares."
-              enabled={reaperEnabled}
-              onChange={handleReaperToggle}
-              disabled={setReaper.isPending}
-              badge={reaperEnabled ? <Badge variant="success">+2 Shares</Badge> : null}
-            />
-            <StatusRow
-              label="Elder Status"
-              description={
-                shares?.elder
-                  ? `MPC contributor — Elder slot #${shares.elder_slot ?? "?"}`
-                  : "Contribute to the MPC ceremony to earn Elder status. Elder +1 share."
-              }
-              badge={
-                shares?.elder ? (
-                  <Badge variant="success">+1 Share</Badge>
-                ) : (
-                  <Badge variant="default">Not Elder</Badge>
-                )
+            {/*
+             * The five reward capabilities share their markup + hooks with
+             * Settings › Capabilities. Onboarding presents Ghost Pay as an
+             * editable toggle and slots its Wraith mixing control in right
+             * after it.
+             */}
+            <CapabilityToggles
+              ghostPayControl="toggle"
+              afterGhostPay={
+                <ToggleRow
+                  label="Wraith Mixing"
+                  description="Let any L2 participant initiate a CoinJoin session through this node. Off means this node won't take part in mixing. Not a reward capability — a restart applies the change."
+                  enabled={wraithEnabled}
+                  onChange={handleWraithToggle}
+                  disabled={setWraith.isPending}
+                  badge={wraithEnabled ? <Badge variant="info">Mixing On</Badge> : null}
+                />
               }
             />
           </div>

--- a/dashboard/src/app/(dashboard)/settings/privacy/page.tsx
+++ b/dashboard/src/app/(dashboard)/settings/privacy/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
 import { Badge } from "@/components/ui/Badge";
 import { Button } from "@/components/ui/Button";
 import {
@@ -110,10 +111,16 @@ export default function PrivacySettingsPage() {
               )}
               {!status?.tor_mode && (
                 <div className="text-xs text-[color:var(--fainter)] mt-1">
-                  Configure via Ghost Core startup flags (-proxy, -torcontrol). Set at startup, read-only here.
+                  Read-only here — Tor mode is a ghostd startup flag. Toggle it on Network.
                 </div>
               )}
             </div>
+            <Link
+              href="/network"
+              className="flex-shrink-0 self-start rounded-lg border border-[color:var(--rule-strong)] px-3 py-1.5 t-label text-[color:var(--accent)] transition-colors hover:border-[color:var(--accent)]"
+            >
+              Manage on Network →
+            </Link>
           </div>
 
           {/* Ghost Shroud — configurable via the same wizard as Settings › Wizards */}

--- a/dashboard/src/app/(dashboard)/settings/system/page.tsx
+++ b/dashboard/src/app/(dashboard)/settings/system/page.tsx
@@ -4,13 +4,16 @@ import Link from "next/link";
 import { Card, CardHeader } from "@/components/ui/Card";
 import { SectionErrorBoundary } from "@/components/ui/SectionErrorBoundary";
 import { AutoUpdateSection } from "@/components/settings/AutoUpdateSection";
+import { ScheduledBackupsCard } from "@/components/settings/ScheduledBackupsCard";
 
 /**
- * Settings › System — central mirror of the operator-adjustable system setting:
- * the automatic-updates opt-in. Reuses the same AutoUpdateSection component +
- * `useSetAutoUpdate` mutation as /system. Manual update install, rollback and
- * encrypted backups remain on /system (they are actions, not persisted
- * settings).
+ * Settings › System — central home for the operator-adjustable, persisted system
+ * settings: the automatic-updates opt-in and the scheduled-backups schedule.
+ * Reuses the same AutoUpdateSection (`useSetAutoUpdate`) and ScheduledBackupsCard
+ * (`useSetBackupSchedule`) components that /system renders, so the persisted
+ * settings have a Settings home consistent with the mirror pattern. Manual
+ * update install, rollback and one-off encrypted backups remain on /system
+ * (they are actions, not persisted settings).
  */
 export default function SystemSettingsPage() {
   return (
@@ -27,10 +30,14 @@ export default function SystemSettingsPage() {
         </Card>
       </SectionErrorBoundary>
 
+      <SectionErrorBoundary section="Scheduled backups">
+        <ScheduledBackupsCard />
+      </SectionErrorBoundary>
+
       <Card>
         <p className="text-sm text-[color:var(--dim)]">
-          Check for and install updates manually, roll back to a previous version, or manage encrypted
-          backups on{" "}
+          Check for and install updates manually, roll back to a previous version, or create a one-off
+          encrypted backup on{" "}
           <Link href="/system" className="text-[color:var(--accent)] hover:text-[color:var(--accent)] underline">
             System
           </Link>

--- a/dashboard/src/components/settings/CapabilityToggles.tsx
+++ b/dashboard/src/components/settings/CapabilityToggles.tsx
@@ -1,0 +1,232 @@
+"use client";
+
+import Link from "next/link";
+import { Badge } from "@/components/ui/Badge";
+import { useToast } from "@/components/ui/Toast";
+import {
+  useNodeStatus,
+  useConfig,
+  useGhostPayStatus,
+  useShares,
+  useSetArchiveMode,
+  useSetPublicMining,
+  useSetReaper,
+  useSetGhostPay,
+} from "@/hooks/queries";
+import { ToggleRow, StatusRow } from "@/app/(dashboard)/settings/shared";
+
+interface CapabilityTogglesProps {
+  /**
+   * How the Ghost Pay row is presented:
+   * - "status" (default): read-only StatusRow — enabling requires a running
+   *   ghost-pay-node, so Settings › Capabilities shows state only.
+   * - "toggle": an editable ToggleRow backed by `useSetGhostPay` (Onboarding).
+   */
+  ghostPayControl?: "status" | "toggle";
+  /**
+   * Extra content rendered immediately after the Ghost Pay row — used by
+   * Onboarding to slot in its Wraith mixing toggle without duplicating the
+   * five canonical capability rows.
+   */
+  afterGhostPay?: React.ReactNode;
+  /**
+   * When provided, a cross-link to detector-level Reaper configuration is
+   * rendered beneath the Reaper toggle (Settings › Capabilities points at
+   * `/filtering/advanced`).
+   */
+  reaperConfigHref?: string;
+}
+
+/**
+ * The five canonical node-capability rows (Archive / Ghost Pay / Public Mining /
+ * Reaper / Elder) that drive the 5-4-3-2-1 share system. Extracted from the
+ * duplicated markup that Settings › Capabilities and the Onboarding wizard both
+ * rendered, so there is a single source of truth wired to the same mutation
+ * hooks. Callers wrap this in their own Card/SettingsSection shell.
+ *
+ * The Public-Mining ↔ Ghost-Mode mutual-exclusion guard lives here: a Ghost Mode
+ * node builds near-empty blocks and forfeits all transaction-fee income, so it
+ * must not also accept public miners. Enabling Public Mining while Ghost Mode is
+ * active is blocked in the UI (disabling stays allowed); the backend enforces
+ * the same rule with a 409.
+ */
+export function CapabilityToggles({
+  ghostPayControl = "status",
+  afterGhostPay,
+  reaperConfigHref,
+}: CapabilityTogglesProps) {
+  const { data: status } = useNodeStatus();
+  const { data: config } = useConfig();
+  const { data: ghostPayStatus } = useGhostPayStatus();
+  const { data: shares } = useShares();
+
+  const setArchiveMode = useSetArchiveMode();
+  const setPublicMining = useSetPublicMining();
+  const setReaper = useSetReaper();
+  const setGhostPay = useSetGhostPay();
+
+  const { success, error } = useToast();
+
+  const ghostModeActive = status?.ghost_mode ?? false;
+  const publicMiningActive = status?.public_mining ?? false;
+  const publicMiningBlocked = ghostModeActive && !publicMiningActive;
+
+  // Ghost Pay running-state comes from the explicit `sync_state` flag, NOT
+  // `l2_height` — an L2 height of 0 is a perfectly valid running state (fresh
+  // node), so its truthiness would mislabel a running node as "Not Running".
+  const ghostPayRunning = ghostPayStatus?.sync_state === "synced";
+  const ghostPayEnabled = status?.ghost_pay ?? false;
+
+  const archiveEnabled = status?.archive_mode ?? false;
+  const reaperEnabled = config?.reaper ?? false;
+
+  const handleArchiveModeToggle = async (enabled: boolean) => {
+    try {
+      await setArchiveMode.mutateAsync(enabled);
+      success("Saved", `Archive Mode ${enabled ? "enabled" : "disabled"}`);
+    } catch (err) {
+      error("Failed", err instanceof Error ? err.message : "Unknown error");
+    }
+  };
+
+  const handleGhostPayToggle = async (enabled: boolean) => {
+    try {
+      await setGhostPay.mutateAsync(enabled);
+      success("Saved", `Ghost Pay ${enabled ? "enabled" : "disabled"}`);
+    } catch (err) {
+      error("Failed", err instanceof Error ? err.message : "Unknown error");
+    }
+  };
+
+  const handlePublicMiningToggle = async (enabled: boolean) => {
+    try {
+      await setPublicMining.mutateAsync(enabled);
+      success("Saved", `Public Mining ${enabled ? "enabled" : "disabled"}`);
+    } catch (err) {
+      error("Failed", err instanceof Error ? err.message : "Unknown error");
+    }
+  };
+
+  const handleReaperToggle = async (enabled: boolean) => {
+    try {
+      await setReaper.mutateAsync(enabled);
+      success(
+        "Saved",
+        enabled
+          ? "Ghost Reaper enabled — mempool filtering active"
+          : "Ghost Reaper disabled — filtering inactive"
+      );
+    } catch (err) {
+      error("Failed", err instanceof Error ? err.message : "Unknown error");
+    }
+  };
+
+  return (
+    <>
+      <ToggleRow
+        label="Archive Mode"
+        description="Store full blockchain history (+5 shares bonus)"
+        enabled={archiveEnabled}
+        onChange={handleArchiveModeToggle}
+        disabled={setArchiveMode.isPending}
+        badge={archiveEnabled ? <Badge variant="success">+5 Shares</Badge> : null}
+      />
+
+      {ghostPayControl === "toggle" ? (
+        <ToggleRow
+          label="Ghost Pay"
+          description={`L2 payment network participation — requires ghost-pay-node${
+            ghostPayRunning ? ` (L2 height: ${ghostPayStatus?.l2_height ?? 0})` : ""
+          } (+4 shares bonus)`}
+          enabled={ghostPayEnabled}
+          onChange={handleGhostPayToggle}
+          disabled={setGhostPay.isPending}
+          badge={
+            ghostPayEnabled ? (
+              ghostPayRunning ? (
+                <Badge variant="success">+4 Shares</Badge>
+              ) : (
+                <Badge variant="warning">Not Running</Badge>
+              )
+            ) : null
+          }
+        />
+      ) : (
+        <StatusRow
+          label="Ghost Pay"
+          description={`L2 payment network participation — requires ghost-pay-node${
+            ghostPayRunning ? ` (L2 height: ${ghostPayStatus?.l2_height ?? 0})` : ""
+          }`}
+          badge={
+            ghostPayRunning ? (
+              <Badge variant="success">+4 Shares</Badge>
+            ) : (
+              <Badge variant="warning">Not Running</Badge>
+            )
+          }
+        />
+      )}
+
+      {afterGhostPay}
+
+      <ToggleRow
+        label="Public Mining"
+        description="Accept mining connections from public miners (+3 shares bonus)"
+        enabled={publicMiningActive}
+        onChange={handlePublicMiningToggle}
+        disabled={setPublicMining.isPending || publicMiningBlocked}
+        badge={publicMiningActive ? <Badge variant="success">+3 Shares</Badge> : null}
+      />
+
+      {publicMiningBlocked && (
+        <div
+          className="p-3 rounded-lg"
+          style={{
+            background: "color-mix(in srgb, var(--yellow) 8%, transparent)",
+            border: "1px solid color-mix(in srgb, var(--yellow) 40%, transparent)",
+          }}
+        >
+          <p className="t-body" style={{ color: "var(--fg)" }}>
+            <span style={{ color: "var(--yellow)", fontWeight: 600 }}>Ghost Mode is active</span>{" "}
+            — disable it before enabling Public Mining. A Ghost Mode node builds empty blocks and
+            forfeits all transaction-fee income, so the two can&apos;t run together.
+          </p>
+        </div>
+      )}
+
+      <ToggleRow
+        label="Ghost Reaper"
+        description="Reject transactions with dead code in witness scripts. Filters inscriptions, drop stuffing, and other non-financial data from your mempool. (+2 shares)"
+        enabled={reaperEnabled}
+        onChange={handleReaperToggle}
+        disabled={setReaper.isPending}
+        badge={reaperEnabled ? <Badge variant="success">+2 Shares</Badge> : null}
+      />
+
+      {reaperConfigHref && (
+        <Link
+          href={reaperConfigHref}
+          className="block px-3 -mt-2 t-caption text-[color:var(--accent)] hover:underline"
+        >
+          Configure Reaper detectors and thresholds →
+        </Link>
+      )}
+
+      <StatusRow
+        label="Elder Status"
+        description={
+          shares?.elder
+            ? `MPC contributor — Elder slot #${shares.elder_slot ?? "?"}`
+            : "Contribute to the MPC ceremony to earn Elder status (+1 share)"
+        }
+        badge={
+          shares?.elder ? (
+            <Badge variant="success">+1 Share</Badge>
+          ) : (
+            <Badge variant="default">Not Elder</Badge>
+          )
+        }
+      />
+    </>
+  );
+}


### PR DESCRIPTION
## Settings catalogue fixes

### P-fixes
- **P1.5 — Tor link.** `/settings/privacy` showed Tor Mode as read-only with no way to change it. The row now carries a clear `Manage on Network →` link to `/network` (where Tor mode is actually editable via the `-tormode` startup flag), and the stale "set at startup, read-only here" note now points operators there.
- **P2.8 — Reaper cross-link.** `/settings/capabilities` gains a cross-link under the Ghost Reaper toggle to `/filtering/advanced` for detector-level configuration. The **Reaper** name is preserved throughout — it is the proper name of the filtering protocol.
- **P2.9 — Shared capability toggles.** The five capability rows (Archive / Ghost Pay / Public Mining / Reaper / Elder) that `/settings/capabilities` and `/settings/onboarding` duplicated are extracted into one `components/settings/CapabilityToggles.tsx`, driven by the existing mutation hooks (`useSetArchiveMode`, `useSetPublicMining`, `useSetReaper`, `useSetGhostPay`). Both pages consume it. The Public-Mining ↔ Ghost-Mode mutual-exclusion guard now lives in the shared component (so both surfaces enforce it), and the Reaper branding is kept. Ghost Pay renders as read-only status on Capabilities and as an editable toggle in Onboarding via a `ghostPayControl` prop; Onboarding slots its Wraith mixing toggle in through an `afterGhostPay` slot.
- **P3.11 — Scheduled-backups mirror.** `ScheduledBackupsCard` (a persisted `[backup]` setting) is now also rendered on `/settings/system`, importing the existing component unchanged, so the persisted setting has a Settings home consistent with the mirror pattern. Manual/one-off backup actions stay on `/system`.

### Typography
- Applied the canonical semantic type scale to the off-scale inline sizes on `/settings/filtering` (the advanced-controls gate: heading → `.t-title`, description → `.t-caption`). Colours and spacing preserved. The remaining settings pages were already on-scale (clean Tailwind `text-xs`/`text-sm`) and were left untouched.

### Verification
- `tsc --noEmit` — clean.
- `eslint` on all changed files — clean.