### PR TITLE
dashboard(privacy/pay): Wraith toggle to top, Shroud configure affordance + type scale (kill per-page label styles)

### DIFF
--- a/dashboard/src/app/(dashboard)/ghost-mode/page.tsx
+++ b/dashboard/src/app/(dashboard)/ghost-mode/page.tsx
@@ -26,12 +26,11 @@ function InfoRow({ threat, protection, strong }: { threat: string; protection: s
       className="flex items-start justify-between gap-6"
       style={{ padding: "12px 0", borderTop: "1px solid var(--rule)" }}
     >
-      <span style={{ color: "var(--fg)", fontSize: "14px", flex: 1, minWidth: 0 }}>{threat}</span>
+      <span className="t-body" style={{ color: "var(--fg)", flex: 1, minWidth: 0 }}>{threat}</span>
       <span
-        className="flex-shrink-0"
+        className="flex-shrink-0 t-label"
         style={{
           color: strong ? "var(--green)" : "var(--dim)",
-          fontSize: "13px",
           fontFamily: "var(--font-mono)",
           maxWidth: "24ch",
           textAlign: "right",
@@ -91,10 +90,10 @@ export default function GhostModePage() {
           <div className="flex items-start justify-between gap-6">
             <div style={{ flex: 1, minWidth: 0 }}>
               <div className="flex items-center gap-2 mb-1">
-                <span style={{ color: "var(--fg)", fontWeight: 500, fontSize: "15px" }}>Ghost Mode</span>
+                <span className="t-lead" style={{ color: "var(--fg)", fontWeight: 500 }}>Ghost Mode</span>
                 {ghostMode && <Badge variant="success">+privacy</Badge>}
               </div>
-              <p style={{ color: "var(--dim)", fontSize: "13px", lineHeight: "1.5" }}>
+              <p className="t-label" style={{ color: "var(--dim)", lineHeight: "1.5" }}>
                 When enabled, your node still accepts, validates and forwards blocks, but never relays
                 unconfirmed transactions, sends no <code>INV</code> announcements, and answers every
                 transaction <code>getdata</code> with <code>NOT_FOUND</code>. Toggles live with no restart.
@@ -155,7 +154,7 @@ export default function GhostModePage() {
                 borderRadius: "6px",
               }}
             >
-              <p style={{ color: "var(--fg)", fontSize: "13px", lineHeight: "1.6" }}>
+              <p className="t-label" style={{ color: "var(--fg)", lineHeight: "1.6" }}>
                 <span style={{ color: "var(--yellow)", fontWeight: 600 }}>Public Mining is active.</span>{" "}
                 Ghost Mode would make your node build empty blocks and forfeit all fee income, so the
                 two can&apos;t run together — disable Public Mining first on the{" "}
@@ -183,12 +182,12 @@ export default function GhostModePage() {
           >
             <div style={{ flex: 1, minWidth: 0 }}>
               <div className="flex items-center gap-2 mb-1">
-                <span style={{ color: "var(--fg)", fontWeight: 500, fontSize: "15px" }}>
+                <span className="t-lead" style={{ color: "var(--fg)", fontWeight: 500 }}>
                   Allow my own wallet broadcasts
                 </span>
                 {ghostMode && localEgress && <Badge variant="success">on</Badge>}
               </div>
-              <p style={{ color: "var(--dim)", fontSize: "13px", lineHeight: "1.5" }}>
+              <p className="t-label" style={{ color: "var(--dim)", lineHeight: "1.5" }}>
                 Keep transactions your own node submits (via <code>sendrawtransaction</code> or a connected
                 wallet) flowing to peers so they can reach a miner, while transactions received from other
                 peers stay fully suppressed. Only your <em>own</em> still-unbroadcast transactions are
@@ -252,7 +251,7 @@ export default function GhostModePage() {
                 borderRadius: "6px",
               }}
             >
-              <p style={{ color: "var(--fg)", fontSize: "13px", lineHeight: "1.6" }}>
+              <p className="t-label" style={{ color: "var(--fg)", lineHeight: "1.6" }}>
                 <span style={{ color: "var(--yellow)", fontWeight: 600 }}>Heads up:</span> broadcasting your
                 own transactions reveals them to the peers you announce to, which can tie a transaction to
                 your node&apos;s IP address. Enable{" "}
@@ -272,15 +271,15 @@ export default function GhostModePage() {
 
       {/* What it does */}
       <Card>
-        <h3 style={{ color: "var(--fg)", fontSize: "16px", fontWeight: 500, marginBottom: "4px" }}>
+        <h3 className="t-title" style={{ color: "var(--fg)", marginBottom: "4px" }}>
           What it does
         </h3>
-        <p style={{ color: "var(--dim)", fontSize: "13px", lineHeight: "1.6", marginBottom: "12px" }}>
+        <p className="t-label" style={{ color: "var(--dim)", lineHeight: "1.6", marginBottom: "12px" }}>
           Ghost Mode decides <em>whether</em> your node relays unconfirmed transactions at all — it is
           ghost-core&apos;s integrated take on Bitcoin Core&apos;s <code>-blocksonly</code>, wired into the runtime
           config with a friendly toggle. When <code>ghost_mode = true</code>:
         </p>
-        <ul style={{ color: "var(--dim)", fontSize: "13px", lineHeight: "1.7", paddingLeft: "18px", listStyle: "disc" }}>
+        <ul className="t-label" style={{ color: "var(--dim)", lineHeight: "1.7", paddingLeft: "18px", listStyle: "disc" }}>
           <li><strong style={{ color: "var(--fg)" }}>Relay is suppressed.</strong> <code>RelayTransaction()</code> returns early — your node never pushes unconfirmed transactions to peers.</li>
           <li><strong style={{ color: "var(--fg)" }}>getdata returns NOT_FOUND.</strong> A peer asking &quot;give me transaction X&quot; is answered <code>NOT_FOUND</code> regardless of whether X is in your mempool. Your mempool stops being a public lookup table.</li>
           <li><strong style={{ color: "var(--fg)" }}>No INV announcements.</strong> Your node doesn&apos;t tell peers about unconfirmed transactions it has seen.</li>
@@ -295,7 +294,7 @@ export default function GhostModePage() {
             borderRadius: "6px",
           }}
         >
-          <p style={{ color: "var(--fainter)", fontSize: "13px", lineHeight: "1.6" }}>
+          <p className="t-label" style={{ color: "var(--fainter)", lineHeight: "1.6" }}>
             <span style={{ color: "var(--accent)", fontWeight: 500 }}>Trade-off:</span> Ghost Mode is a
             suppression of the standard relay path, not a replacement transport. Without local egress, a
             wallet on a Ghost Mode node must find another route to reach miners — an out-of-band relay over
@@ -308,10 +307,10 @@ export default function GhostModePage() {
 
       {/* Rewards / capability shares */}
       <Card>
-        <h3 style={{ color: "var(--fg)", fontSize: "16px", fontWeight: 500, marginBottom: "4px" }}>
+        <h3 className="t-title" style={{ color: "var(--fg)", marginBottom: "4px" }}>
           Does this affect my capability shares?
         </h3>
-        <p style={{ color: "var(--dim)", fontSize: "13px", lineHeight: "1.6", marginBottom: "12px" }}>
+        <p className="t-label" style={{ color: "var(--dim)", lineHeight: "1.6", marginBottom: "12px" }}>
           <strong style={{ color: "var(--fg)" }}>Not for most of them.</strong> Archive, Ghost Pay, Reaper
           and Elder are each verified by an HTTP challenge–response to your node&apos;s API (block
           retrieval, L2-block lookup, policy classification, registration order) — none of which rides the
@@ -328,7 +327,7 @@ export default function GhostModePage() {
             borderRadius: "6px",
           }}
         >
-          <p style={{ color: "var(--fainter)", fontSize: "13px", lineHeight: "1.6" }}>
+          <p className="t-label" style={{ color: "var(--fainter)", lineHeight: "1.6" }}>
             <span style={{ color: "var(--yellow)", fontWeight: 500 }}>Public Mining is mutually exclusive.</span>{" "}
             Ghost Mode rejects transactions from peers, so your mempool never fills with fee-paying
             transactions and the blocks your node builds are near-empty — coinbase subsidy only. Since the
@@ -344,10 +343,10 @@ export default function GhostModePage() {
 
       {/* Threat model */}
       <Card>
-        <h3 style={{ color: "var(--fg)", fontSize: "16px", fontWeight: 500, marginBottom: "4px" }}>
+        <h3 className="t-title" style={{ color: "var(--fg)", marginBottom: "4px" }}>
           What it protects against
         </h3>
-        <p style={{ color: "var(--dim)", fontSize: "13px", marginBottom: "4px" }}>
+        <p className="t-label" style={{ color: "var(--dim)", marginBottom: "4px" }}>
           Ghost Mode is transaction-level silence at the gossip layer. It does not change consensus and
           does not make your node invisible.
         </p>
@@ -364,10 +363,10 @@ export default function GhostModePage() {
 
       {/* When to use */}
       <Card>
-        <h3 style={{ color: "var(--fg)", fontSize: "16px", fontWeight: 500, marginBottom: "4px" }}>
+        <h3 className="t-title" style={{ color: "var(--fg)", marginBottom: "4px" }}>
           When to enable it
         </h3>
-        <p style={{ color: "var(--dim)", fontSize: "13px", lineHeight: "1.6" }}>
+        <p className="t-label" style={{ color: "var(--dim)", lineHeight: "1.6" }}>
           Ghost Mode is for privacy-maximising operators who want zero P2P-layer transaction footprint and
           already have a separate broadcast path for their own payments (or use <em>Allow my own wallet
           broadcasts</em> above). Ghost Mode composes with Tor mode — running both gives a node
@@ -376,7 +375,7 @@ export default function GhostModePage() {
         </p>
       </Card>
 
-      <p style={{ color: "var(--fainter)", fontSize: "13px" }}>
+      <p className="t-label" style={{ color: "var(--fainter)" }}>
         For network-exposure controls (Tor mode, onion address) see{" "}
         <a href="/network" className="bare" style={{ color: "var(--dim)", textDecoration: "underline", textDecorationColor: "var(--rule-strong)" }}>
           Network

--- a/dashboard/src/app/(dashboard)/ghost-pay/page.tsx
+++ b/dashboard/src/app/(dashboard)/ghost-pay/page.tsx
@@ -53,20 +53,6 @@ function formatWhen(ts?: number | null): string {
   return d.toLocaleString();
 }
 
-const labelStyle: React.CSSProperties = {
-  color: "var(--dim)",
-  fontSize: "13px",
-  fontFamily: "var(--font-mono)",
-  textTransform: "uppercase",
-  letterSpacing: "0.06em",
-};
-
-const valueStyle: React.CSSProperties = {
-  color: "var(--fg)",
-  fontSize: "14px",
-  fontFamily: "var(--font-mono)",
-};
-
 function Field({ label, children }: { label: string; children: React.ReactNode }) {
   return (
     <div
@@ -79,8 +65,8 @@ function Field({ label, children }: { label: string; children: React.ReactNode }
         borderBottom: "1px solid var(--rule)",
       }}
     >
-      <span style={labelStyle}>{label}</span>
-      <span style={valueStyle}>{children}</span>
+      <span className="t-label-mono" style={{ color: "var(--dim)" }}>{label}</span>
+      <span className="t-body" style={{ color: "var(--fg)", fontFamily: "var(--font-mono)" }}>{children}</span>
     </div>
   );
 }
@@ -89,8 +75,8 @@ function SectionTitle({ title, subtitle, action }: { title: string; subtitle?: s
   return (
     <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: "16px", marginBottom: "16px" }}>
       <div>
-        <h2 style={{ color: "var(--fg)", fontSize: "16px", fontWeight: 500 }}>{title}</h2>
-        {subtitle && <p style={{ color: "var(--dim)", fontSize: "13px", marginTop: "4px", lineHeight: 1.5 }}>{subtitle}</p>}
+        <h2 className="t-title" style={{ color: "var(--fg)" }}>{title}</h2>
+        {subtitle && <p className="t-caption" style={{ color: "var(--dim)", marginTop: "4px" }}>{subtitle}</p>}
       </div>
       {action}
     </div>
@@ -127,7 +113,7 @@ export default function GhostPayPage() {
             title="Ghost Pay is not reachable"
             description="The ghost-pay service on this node isn't responding. Enable Ghost Pay in Settings, or check the ghost-pay daemon on port 8800."
             action={
-              <a href="/settings" className="bare" style={{ color: "var(--accent)", fontSize: "14px" }}>
+              <a href="/settings" className="bare t-body" style={{ color: "var(--accent)" }}>
                 Go to Settings →
               </a>
             }
@@ -177,8 +163,8 @@ export default function GhostPayPage() {
         <Card>
           <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: "16px" }}>
             <div>
-              <div style={{ color: "var(--fg)", fontSize: "15px", fontWeight: 500 }}>Ghost Pay L2</div>
-              <div style={{ color: "var(--dim)", fontSize: "13px", marginTop: "2px", lineHeight: 1.5 }}>
+              <div className="t-lead" style={{ color: "var(--fg)", fontWeight: 500 }}>Ghost Pay L2</div>
+              <div className="t-caption" style={{ color: "var(--dim)", marginTop: "2px" }}>
                 Run the L2 payments layer and earn the +4 capability share. L2 state pruning is mandatory and handled automatically.
               </div>
             </div>
@@ -190,7 +176,7 @@ export default function GhostPayPage() {
             />
           </div>
           {setGhostPay.isError && (
-            <p style={{ color: "var(--red)", fontSize: "13px", marginTop: "8px" }}>
+            <p className="t-caption" style={{ color: "var(--red)", marginTop: "8px" }}>
               Failed to update Ghost Pay setting. Try again.
             </p>
           )}
@@ -249,12 +235,12 @@ export default function GhostPayPage() {
             <Field label="Last batch amount">{last ? formatSats(last.total_amount_sats) : "—"}</Field>
             <Field label="Last L1 txid">{last?.l1_txid ? shortId(last.l1_txid) : "—"}</Field>
             <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: "16px", padding: "12px 0" }}>
-              <span style={labelStyle}>Last settled at</span>
-              <span style={valueStyle}>{formatWhen(last?.finalized_at)}</span>
+              <span className="t-label-mono" style={{ color: "var(--dim)" }}>Last settled at</span>
+              <span className="t-body" style={{ color: "var(--fg)", fontFamily: "var(--font-mono)" }}>{formatWhen(last?.finalized_at)}</span>
             </div>
           </div>
           {pendingSettlements === 0 && !last && (
-            <p style={{ color: "var(--fainter)", fontSize: "13px", marginTop: "4px", lineHeight: 1.5 }}>
+            <p className="t-caption" style={{ color: "var(--fainter)", marginTop: "4px" }}>
               No settlement batches yet. Batches appear here once L2 activity is reconciled to L1.
             </p>
           )}
@@ -282,7 +268,7 @@ export default function GhostPayPage() {
             <Field label="Nodes sharing L2 fees">{ghostPayNodeCount}</Field>
             <Field label="Your payout records">{payoutCount}</Field>
           </div>
-          <p style={{ color: "var(--fainter)", fontSize: "13px", marginTop: "12px", lineHeight: 1.5 }}>
+          <p className="t-caption" style={{ color: "var(--fainter)", marginTop: "12px" }}>
             {capabilityQualified
               ? "Your node is verified as Ghost Pay-capable and shares in L2 fee distribution. "
               : "The +4 share counts at payout only once peer challenges qualify the capability. "}

--- a/dashboard/src/app/(dashboard)/haze/page.tsx
+++ b/dashboard/src/app/(dashboard)/haze/page.tsx
@@ -315,7 +315,7 @@ export default function HazePage() {
                 <div className="text-2xl font-bold text-[color:var(--fg)]">
                   {savings.fullArchiveBytes > 0 ? formatBytes(savings.fullArchiveBytes) : "--"}
                 </div>
-                <div className="text-[11px] text-[color:var(--fainter)] mt-0.5">
+                <div className="t-caption text-[color:var(--fainter)] mt-0.5">
                   {(haze?.chain_tip ?? 0).toLocaleString()} blocks × ~1.6 MB
                 </div>
               </div>
@@ -856,7 +856,7 @@ export default function HazePage() {
                   </div>
                   <p className="text-[color:var(--dim)] text-xs leading-relaxed flex-1">{opt.desc}</p>
                   {opt.action && !selected && (
-                    <span className="mt-2 inline-block text-[11px] font-medium text-[color:var(--accent)]">
+                    <span className="mt-2 inline-block t-caption font-medium text-[color:var(--accent)]">
                       {opt.action} →
                     </span>
                   )}

--- a/dashboard/src/app/(dashboard)/network/page.tsx
+++ b/dashboard/src/app/(dashboard)/network/page.tsx
@@ -53,7 +53,7 @@ export default function NetworkPage() {
           subtitle="Live view of your node's outbound transport, onion address, and relay-suppression state."
         />
         <Card>
-          <p style={{ color: "var(--dim)", fontSize: "14px" }}>
+          <p className="t-body" style={{ color: "var(--dim)" }}>
             Could not reach the node status endpoint.{" "}
             {statusError instanceof Error ? statusError.message : "Ensure Ghost Core is running."}
           </p>
@@ -94,14 +94,13 @@ export default function NetworkPage() {
 
           {onion && (
             <div
-              className="flex items-center justify-between gap-3 mt-4"
+              className="flex items-center justify-between gap-3 mt-4 t-label"
               style={{
                 background: "var(--bg)",
                 border: "1px solid var(--rule)",
                 borderRadius: "4px",
                 padding: "12px 16px",
                 fontFamily: "var(--font-mono)",
-                fontSize: "13px",
                 overflow: "auto",
               }}
             >
@@ -114,10 +113,10 @@ export default function NetworkPage() {
 
       <SectionErrorBoundary section="Privacy modes">
         <Card>
-          <h3 style={{ color: "var(--fg)", fontSize: "16px", fontWeight: 500, marginBottom: "4px" }}>
+          <h3 className="t-title" style={{ color: "var(--fg)", marginBottom: "4px" }}>
             Privacy modes
           </h3>
-          <p style={{ color: "var(--dim)", fontSize: "13px", marginBottom: "8px" }}>
+          <p className="t-label" style={{ color: "var(--dim)", marginBottom: "8px" }}>
             Tor mode is a ghostd startup flag (<code>-tormode</code>): toggling it restarts ghostd, so it asks
             for confirmation. With Tor enabled, your node&rsquo;s real IP address is never leaked to peers.
           </p>
@@ -146,7 +145,7 @@ export default function NetworkPage() {
         </Card>
       </SectionErrorBoundary>
 
-      <p style={{ color: "var(--fainter)", fontSize: "13px" }}>
+      <p className="t-label" style={{ color: "var(--fainter)" }}>
         For the underlying config (ghostd flags, bridge configuration, etc.) see{" "}
         <a
           href="/settings/privacy"
@@ -183,10 +182,10 @@ function TorRow({
       <div className="flex items-start justify-between gap-6">
         <div style={{ flex: 1, minWidth: 0 }}>
           <div className="flex items-center gap-2 mb-1">
-            <span style={{ color: "var(--fg)", fontWeight: 500, fontSize: "15px" }}>Tor mode</span>
+            <span className="t-lead" style={{ color: "var(--fg)", fontWeight: 500 }}>Tor mode</span>
             {enabled && <Badge variant="success">+anonymity</Badge>}
           </div>
-          <p style={{ color: "var(--dim)", fontSize: "13px", lineHeight: "1.5", maxWidth: "60ch" }}>
+          <p className="t-label" style={{ color: "var(--dim)", lineHeight: "1.5", maxWidth: "60ch" }}>
             When enabled, ghostd routes all outbound P2P through Tor (<code>-tormode=1</code>) and publishes an
             onion service; clearnet address gossip is suppressed. This is a startup flag, so changing it
             restarts ghostd and briefly bounces the pool.
@@ -234,7 +233,7 @@ function TorRow({
             background: "var(--accent-weak)",
           }}
         >
-          <div style={{ color: "var(--fg)", fontSize: "13px", marginBottom: "10px" }}>
+          <div className="t-label" style={{ color: "var(--fg)", marginBottom: "10px" }}>
             {target ? "Enable" : "Disable"} <strong>Tor mode</strong>? This writes the config and{" "}
             <strong>restarts ghostd</strong> (then bounces the pool) to apply.
           </div>
@@ -264,24 +263,14 @@ function Stat({ label, value, accent }: { label: string; value: string; accent?:
   return (
     <div>
       <div
-        style={{
-          fontSize: "11px",
-          fontFamily: "var(--font-mono)",
-          textTransform: "uppercase",
-          letterSpacing: "0.06em",
-          color: "var(--dim)",
-          marginBottom: "4px",
-        }}
+        className="t-label-mono"
+        style={{ color: "var(--dim)", marginBottom: "4px" }}
       >
         {label}
       </div>
       <div
-        style={{
-          fontSize: "22px",
-          fontWeight: 500,
-          color: accent ?? "var(--fg)",
-          fontFamily: "var(--font-mono)",
-        }}
+        className="t-stat"
+        style={{ color: accent ?? "var(--fg)", fontFamily: "var(--font-mono)" }}
       >
         {value}
       </div>

--- a/dashboard/src/app/(dashboard)/shroud/page.tsx
+++ b/dashboard/src/app/(dashboard)/shroud/page.tsx
@@ -1,15 +1,18 @@
 "use client";
 
+import { useState } from "react";
 import { StatusRow } from "@/components/ui/StatusRow";
 import { FlowDiagram } from "@/components/ui/FlowDiagram";
 import { Card, CardHeader } from "@/components/ui/Card";
 import { PageHeader } from "@/components/ui/PageHeader";
 import { StatCard } from "@/components/ui/StatCard";
 import { Badge } from "@/components/ui/Badge";
+import { Button } from "@/components/ui/Button";
 import { StatusDot } from "@/components/ui/StatusDot";
 import { SectionErrorBoundary } from "@/components/ui/SectionErrorBoundary";
 import { SkeletonCard } from "@/components/ui/Skeleton";
 import { useShroudStatus } from "@/hooks/queries/useShroudQueries";
+import ShroudWizard from "../settings/wizards/ShroudWizard";
 
 const TOOLTIPS = {
   enabled: "Whether Ghost Shroud relay delay is currently active on your node.",
@@ -22,22 +25,29 @@ const TOOLTIPS = {
 
 export default function ShroudPage() {
   const { data: status, isLoading, error } = useShroudStatus({ refetchInterval: 10_000 });
+  const [wizardOpen, setWizardOpen] = useState(false);
 
   const showSkeleton = isLoading && !status;
 
   return (
     <div className="space-y-6">
-      {/* 1. PageHeader */}
+      {/* 1. PageHeader — Configure opens the ShroudWizard inline so operators
+           can enable/disable Shroud here rather than hunting for it in Settings. */}
       <PageHeader
         eyebrow="shroud"
         title="Relay-timing privacy."
         subtitle="Transaction relay privacy"
         actions={
-          status ? (
-            <Badge variant={status.enabled ? "success" : "default"}>
-              {status.enabled ? "Enabled" : "Disabled"}
-            </Badge>
-          ) : undefined
+          <div className="flex items-center gap-3">
+            {status && (
+              <Badge variant={status.enabled ? "success" : "default"}>
+                {status.enabled ? "Enabled" : "Disabled"}
+              </Badge>
+            )}
+            <Button variant="primary" size="sm" onClick={() => setWizardOpen(true)}>
+              Configure Shroud
+            </Button>
+          </div>
         }
       />
 
@@ -234,6 +244,8 @@ export default function ShroudPage() {
           </div>
         </div>
       </Card>
+
+      <ShroudWizard isOpen={wizardOpen} onClose={() => setWizardOpen(false)} />
     </div>
   );
 }

--- a/dashboard/src/app/(dashboard)/treasury/page.tsx
+++ b/dashboard/src/app/(dashboard)/treasury/page.tsx
@@ -114,7 +114,7 @@ function TreasuryDetails() {
                 <div className="flex flex-col items-center flex-1">
                   <div className={`w-3.5 h-3.5 rounded-full ${dotColor}`} />
                   <div className="text-xs text-[color:var(--fainter)] mt-1.5">{step.label}</div>
-                  <div className="text-[10px] text-[color:var(--fainter)] mt-0.5">
+                  <div className="t-caption text-[color:var(--fainter)] mt-0.5">
                     {(step.treasury * 100).toFixed(0)}% / {(step.nodePool * 100).toFixed(0)}%
                   </div>
                 </div>

--- a/dashboard/src/app/(dashboard)/wraith/page.tsx
+++ b/dashboard/src/app/(dashboard)/wraith/page.tsx
@@ -22,20 +22,6 @@ import { useGhostPayStatus, useWraithStats, useSetWraith } from "@/hooks/queries
  * genuinely empty data say so honestly rather than rendering a misleading zero.
  */
 
-const labelStyle: React.CSSProperties = {
-  color: "var(--dim)",
-  fontSize: "13px",
-  fontFamily: "var(--font-mono)",
-  textTransform: "uppercase",
-  letterSpacing: "0.06em",
-};
-
-const valueStyle: React.CSSProperties = {
-  color: "var(--fg)",
-  fontSize: "14px",
-  fontFamily: "var(--font-mono)",
-};
-
 function Field({ label, children }: { label: string; children: React.ReactNode }) {
   return (
     <div
@@ -48,8 +34,8 @@ function Field({ label, children }: { label: string; children: React.ReactNode }
         borderBottom: "1px solid var(--rule)",
       }}
     >
-      <span style={labelStyle}>{label}</span>
-      <span style={valueStyle}>{children}</span>
+      <span className="t-label-mono" style={{ color: "var(--dim)" }}>{label}</span>
+      <span className="t-body" style={{ color: "var(--fg)", fontFamily: "var(--font-mono)" }}>{children}</span>
     </div>
   );
 }
@@ -58,8 +44,8 @@ function SectionTitle({ title, subtitle, action }: { title: string; subtitle?: s
   return (
     <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: "16px", marginBottom: "16px" }}>
       <div>
-        <h2 style={{ color: "var(--fg)", fontSize: "16px", fontWeight: 500 }}>{title}</h2>
-        {subtitle && <p style={{ color: "var(--dim)", fontSize: "13px", marginTop: "4px", lineHeight: 1.5 }}>{subtitle}</p>}
+        <h2 className="t-title" style={{ color: "var(--fg)" }}>{title}</h2>
+        {subtitle && <p className="t-caption" style={{ color: "var(--dim)", marginTop: "4px" }}>{subtitle}</p>}
       </div>
       {action}
     </div>
@@ -100,7 +86,7 @@ export default function WraithPage() {
             title="Wraith status is not reachable"
             description="The ghost-pay service on this node isn't responding, so mixing status is unavailable. Enable Ghost Pay in Settings, or check the ghost-pay daemon on port 8800."
             action={
-              <a href="/settings" className="bare" style={{ color: "var(--accent)", fontSize: "14px" }}>
+              <a href="/settings" className="bare t-body" style={{ color: "var(--accent)" }}>
                 Go to Settings →
               </a>
             }
@@ -136,6 +122,31 @@ export default function WraithPage() {
           ) : undefined
         }
       />
+
+      {/* 1b. Primary control — enable Wraith mixing, up top (mirrors Ghost Pay).
+           The enable switch is the lead card; telemetry follows below. */}
+      <SectionErrorBoundary section="Wraith">
+        <Card>
+          {statusLoading ? (
+            <SkeletonCard />
+          ) : (
+            <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: "16px" }}>
+              <div>
+                <div className="t-lead" style={{ color: "var(--fg)", fontWeight: 500 }}>Wraith mixing</div>
+                <div className="t-caption" style={{ color: "var(--dim)", marginTop: "2px", maxWidth: "36rem" }}>
+                  When enabled, any L2 participant can initiate a CoinJoin session through this node. Off means the node won&apos;t coordinate mixing. A ghost-pool restart applies the change.
+                </div>
+              </div>
+              <Toggle
+                label="Wraith mixing"
+                enabled={wraithEnabled}
+                disabled={setWraith.isPending}
+                onChange={handleWraithToggle}
+              />
+            </div>
+          )}
+        </Card>
+      </SectionErrorBoundary>
 
       {/* 2. Status strip — is mixing enabled and busy on this node. */}
       <SectionErrorBoundary section="Wraith status">
@@ -184,44 +195,16 @@ export default function WraithPage() {
             <Field label="Completed">{sessionsCompleted.toLocaleString()}</Field>
             <Field label="Expired">{sessionsExpired.toLocaleString()}</Field>
             <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: "16px", padding: "12px 0" }}>
-              <span style={labelStyle}>Participants served</span>
-              <span style={valueStyle}>{totalParticipants.toLocaleString()}</span>
+              <span className="t-label-mono" style={{ color: "var(--dim)" }}>Participants served</span>
+              <span className="t-body" style={{ color: "var(--fg)", fontFamily: "var(--font-mono)" }}>{totalParticipants.toLocaleString()}</span>
             </div>
           </div>
           {noActivity && (
-            <p style={{ color: "var(--fainter)", fontSize: "13px", marginTop: "4px", lineHeight: 1.5 }}>
+            <p className="t-caption" style={{ color: "var(--fainter)", marginTop: "4px" }}>
               {wraithEnabled
                 ? "No mixing sessions yet. Sessions appear here once wallet participants begin mixing through this node."
-                : "Wraith mixing is disabled on this node, so it is not coordinating any sessions. Enable it below to participate."}
+                : "Wraith mixing is disabled on this node, so it is not coordinating any sessions. Enable it above to participate."}
             </p>
-          )}
-        </Card>
-      </SectionErrorBoundary>
-
-      {/* 4. Config — Wraith on/off. */}
-      <SectionErrorBoundary section="Configuration">
-        <Card>
-          <SectionTitle title="Configuration" subtitle="Whether this node participates in Wraith CoinJoin mixing for L2 wallet users." />
-          {statusLoading ? (
-            <SkeletonCard />
-          ) : (
-            <div>
-              <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: "16px", padding: "12px 0", borderBottom: "1px solid var(--rule)" }}>
-                <div>
-                  <div style={{ color: "var(--fg)", fontSize: "14px", fontWeight: 500 }}>Wraith mixing</div>
-                  <div style={{ color: "var(--dim)", fontSize: "13px", marginTop: "2px", maxWidth: "36rem" }}>
-                    When enabled, any L2 participant can initiate a CoinJoin session through this node. Off means the node won&apos;t coordinate mixing. A ghost-pool restart applies the change.
-                  </div>
-                </div>
-                <Toggle
-                  label="Wraith mixing"
-                  enabled={wraithEnabled}
-                  disabled={setWraith.isPending}
-                  onChange={handleWraithToggle}
-                />
-              </div>
-              <Field label="Currently hosting">{hostsMixing ? "yes" : "no"}</Field>
-            </div>
           )}
         </Card>
       </SectionErrorBoundary>


### PR DESCRIPTION
## Privacy + Pay dashboard fixes

Two P-fixes plus a targeted typography-scale pass across the Privacy and Pay pages. One PR.

### P-fixes
- **P1.2 — /wraith toggle to top.** The Wraith enable toggle lived in a `Configuration` card at the *bottom* of the page. Moved it into a prominent lead card at the *top*, directly under the header, mirroring the reworked `/ghost-pay` pattern (enable switch is the lead card; telemetry follows below). The restart-required note (in the control description) and the restart toast (`restart ghost-pool to apply`) are preserved. The redundant bottom `Configuration` card is removed — its `Currently hosting` state is already surfaced by the header badge and the `Wraith` stat card. The empty-state copy now reads "Enable it above" (was "below").
- **P1.4 — /shroud dead-end.** `/shroud` was a read-only status/reference page with no way to enable Shroud (config lived only in `ShroudWizard`, reachable from Settings). Added a prominent **Configure Shroud** button in the page header that opens the existing `ShroudWizard` inline (same launch pattern other pages use), so operators are no longer stranded looking for the switch.

### Type-scale normalisation
Targeted pass replacing inline `fontSize` px and off-scale sizes with the nearest semantic `.t-*` class by role; clean `text-xs/sm/lg/2xl` left untouched. Colours and spacing preserved.

- **/ghost-pay and /wraith:** removed the per-page `labelStyle` / `valueStyle` objects and the inline `SectionTitle` type styles, replacing with shared classes — `.t-label-mono` for the uppercase mono field labels, `.t-title` for section headings, `.t-lead` for control titles, `.t-body`/`.t-caption` for values and prose.
- **/network, /ghost-mode:** inline `fontSize` on headings, prose, stat labels/values and mono field labels mapped to `.t-title` / `.t-lead` / `.t-body` / `.t-label` / `.t-label-mono` / `.t-stat`.
- **/haze, /treasury:** off-scale arbitrary `text-[11px]` / `text-[10px]` caption text mapped to `.t-caption`.

`/payouts` needed no type changes (already on the scale).

### Verification
- `tsc --noEmit` clean.
- `eslint` clean on all changed files.