### PR TITLE
dashboard(filtering/overview): live Reaper telemetry on advanced + type scale

### DIFF
--- a/dashboard/src/app/(dashboard)/filtering/advanced/page.tsx
+++ b/dashboard/src/app/(dashboard)/filtering/advanced/page.tsx
@@ -1,12 +1,117 @@
 "use client";
 
+import { useQuery } from "@tanstack/react-query";
 import { PageHeader } from "@/components/ui/PageHeader";
 import { Card, CardHeader } from "@/components/ui/Card";
 import { Toggle } from "@/components/ui/Toggle";
 import { SectionErrorBoundary } from "@/components/ui/SectionErrorBoundary";
 import { ReaperControls } from "@/components/filtering/ReaperControls";
 import { AdvancedPolicyPanel } from "@/components/filtering/AdvancedPolicyPanel";
+import { fetchApi } from "@/lib/api/client";
+import { useReaperStatus } from "@/hooks/queries";
 import { useAdvancedFilteringGate } from "@/hooks/useAdvancedFilteringGate";
+import { BUDS_TIER_COLORS, BUDS_TIER_KEYS } from "@/lib/budsTiers";
+
+interface BudsMempool {
+  by_tier?: { T0: number; T1: number; T2: number; T3: number };
+  sample_size?: number;
+  message?: string;
+}
+
+function bytes(n?: number): string {
+  if (n === undefined || n === null) return "—";
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  if (n < 1024 * 1024 * 1024) return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(n / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}
+
+// Live context strip for the controls below. These pages are otherwise
+// controls-only, so an operator tuning the Reaper's per-vector rejects and
+// thresholds has no readout of what's actually in the mempool or what the
+// Reaper is currently stripping. This reuses the exact same sources as the
+// /filtering overview: the sampled BUDS-tier histogram and the Reaper's
+// per-block counters. Compact by design — it's context, not the main content.
+function ReaperLiveContext() {
+  const { data: mempool } = useQuery({
+    queryKey: ["buds-mempool"],
+    queryFn: () => fetchApi<BudsMempool>("/api/v1/buds/mempool"),
+    refetchInterval: 15_000,
+  });
+  const { data: reaper } = useReaperStatus();
+
+  const byTier = mempool?.by_tier ?? { T0: 0, T1: 0, T2: 0, T3: 0 };
+  const sampled = mempool?.sample_size ?? (byTier.T0 + byTier.T1 + byTier.T2 + byTier.T3);
+  const hasSample = !mempool?.message && sampled > 0;
+
+  const blockBuilt = reaper?.last_block_unix != null;
+  const lastReaped = reaper?.last_block_reaped ?? 0;
+  const lastDeadBytes = reaper?.last_block_dead_bytes ?? 0;
+
+  return (
+    <Card>
+      <div className="flex items-center justify-between gap-3" style={{ marginBottom: "10px" }}>
+        <span className="t-eyebrow" style={{ color: "var(--dim)" }}>Live Reaper context</span>
+        <span className="t-caption" style={{ color: "var(--fainter)" }}>
+          the current picture your Reaper settings act on
+        </span>
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {/* Mempool make-up right now, by BUDS class */}
+        <div>
+          <div className="t-label" style={{ color: "var(--fg)", fontWeight: 600, marginBottom: "6px" }}>
+            Mempool by class
+          </div>
+          {hasSample ? (
+            <>
+              <div style={{ display: "flex", height: "12px", borderRadius: "4px", overflow: "hidden", background: "var(--bg)" }}>
+                {BUDS_TIER_KEYS.map((k) => {
+                  const count = byTier[k] ?? 0;
+                  const pct = sampled ? (count / sampled) * 100 : 0;
+                  if (pct === 0) return null;
+                  return <div key={k} title={`${k}: ${count}`} style={{ width: `${pct}%`, background: BUDS_TIER_COLORS[k] }} />;
+                })}
+              </div>
+              <div className="flex items-center gap-3" style={{ marginTop: "6px", flexWrap: "wrap" }}>
+                {BUDS_TIER_KEYS.map((k) => (
+                  <span key={k} className="t-caption flex items-center gap-1" style={{ color: "var(--dim)" }}>
+                    <span style={{ width: "8px", height: "8px", borderRadius: "2px", background: BUDS_TIER_COLORS[k], display: "inline-block" }} />
+                    {k} {(byTier[k] ?? 0).toLocaleString()}
+                  </span>
+                ))}
+                <span className="t-caption" style={{ color: "var(--fainter)" }}>· {sampled.toLocaleString()} sampled</span>
+              </div>
+            </>
+          ) : (
+            <div className="t-caption" style={{ color: "var(--dim)" }}>
+              {mempool?.message ? `Classification unavailable — ${mempool.message}` : "Waiting for a mempool sample…"}
+            </div>
+          )}
+        </div>
+
+        {/* What the Reaper has been stripping */}
+        <div>
+          <div className="t-label" style={{ color: "var(--fg)", fontWeight: 600, marginBottom: "6px" }}>
+            Recently reaped
+          </div>
+          <div className="flex items-baseline gap-2">
+            <span className="t-stat" style={{ color: "var(--fg)", fontFamily: "var(--font-mono)" }}>
+              {!blockBuilt ? "—" : bytes(lastDeadBytes)}
+            </span>
+            <span className="t-caption" style={{ color: "var(--dim)" }}>
+              {!blockBuilt ? "no block built yet" : `${lastReaped} junk tx from your last block`}
+            </span>
+          </div>
+          {reaper && (
+            <div className="t-caption" style={{ color: "var(--fainter)", marginTop: "4px" }}>
+              {reaper.txs_reaped.toLocaleString()} tx · {bytes(reaper.dead_bytes_total)} stripped since restart
+            </div>
+          )}
+        </div>
+      </div>
+    </Card>
+  );
+}
 
 export default function AdvancedFilteringPage() {
   const [enabled, setEnabled] = useAdvancedFilteringGate();
@@ -20,12 +125,18 @@ export default function AdvancedFilteringPage() {
         subtitleFullWidth
       />
 
+      {/* Live context for the Reaper controls below — mempool make-up and what
+          the Reaper is currently stripping, so the tuning below isn't blind. */}
+      <SectionErrorBoundary section="Live Reaper context">
+        <ReaperLiveContext />
+      </SectionErrorBoundary>
+
       {/* Enable gate — controls stay hidden until deliberately switched on */}
       <Card>
         <div className="flex items-start justify-between gap-4">
           <div>
-            <div style={{ color: "var(--fg)", fontSize: "15px", fontWeight: 600 }}>Enable advanced controls</div>
-            <div style={{ color: "var(--dim)", fontSize: "13px", lineHeight: "1.6", marginTop: "4px" }}>
+            <div className="t-lead" style={{ color: "var(--fg)", fontWeight: 600 }}>Enable advanced controls</div>
+            <div className="t-label" style={{ color: "var(--dim)", lineHeight: "1.6", marginTop: "4px" }}>
               Off by default. When on, the reaper vectors and custom mining policy below become editable.
               This switch is per-browser only — it does not change your node until you save a control below.
             </div>

--- a/dashboard/src/app/(dashboard)/filtering/basic/page.tsx
+++ b/dashboard/src/app/(dashboard)/filtering/basic/page.tsx
@@ -80,7 +80,7 @@ export default function BasicFilteringPage() {
       {/* The four classes, explained — lead with what BUDS is */}
       <SectionErrorBoundary section="Transaction classes">
         <Card>
-          <p style={{ color: "var(--dim)", fontSize: "14px", lineHeight: "1.6", marginBottom: "16px" }}>
+          <p className="t-body" style={{ color: "var(--dim)", lineHeight: "1.6", marginBottom: "16px" }}>
             <strong style={{ color: "var(--fg)" }}>BUDS — Bitcoin Universal Data Specification.</strong>{" "}
             We use BUDS to sort every transaction into a class (T0–T3), so filtering is one simple choice
             instead of dozens of settings.
@@ -103,11 +103,11 @@ export default function BasicFilteringPage() {
               >
                 <div className="flex items-center gap-2" style={{ marginBottom: "4px" }}>
                   <span style={{ width: "10px", height: "10px", borderRadius: "2px", background: t.color, display: "inline-block" }} />
-                  <span style={{ color: "var(--fg)", fontSize: "14px", fontWeight: 600 }}>{t.name}</span>
-                  <span style={{ color: "var(--dim)", fontSize: "12px" }}>· {t.short}</span>
+                  <span className="t-body" style={{ color: "var(--fg)", fontWeight: 600 }}>{t.name}</span>
+                  <span className="t-caption" style={{ color: "var(--dim)" }}>· {t.short}</span>
                 </div>
-                <div style={{ color: "var(--dim)", fontSize: "13px", lineHeight: "1.5" }}>{t.blurb}</div>
-                <div style={{ color: "var(--fainter)", fontSize: "12px", marginTop: "6px" }}>
+                <div className="t-label" style={{ color: "var(--dim)", lineHeight: "1.5" }}>{t.blurb}</div>
+                <div className="t-caption" style={{ color: "var(--fainter)", marginTop: "6px" }}>
                   e.g. {t.examples}
                 </div>
               </div>
@@ -136,7 +136,7 @@ export default function BasicFilteringPage() {
           />
           <div className="space-y-3">
             {mempool?.message ? (
-              <p style={{ color: "var(--dim)", fontSize: "13px" }}>
+              <p className="t-label" style={{ color: "var(--dim)" }}>
                 Mempool classification is unavailable — {mempool.message}
               </p>
             ) : (
@@ -159,10 +159,10 @@ export default function BasicFilteringPage() {
                       <div key={t.key} style={{ padding: "10px 12px", border: "1px solid var(--rule)", borderRadius: "4px", background: "var(--bg)" }}>
                         <div className="flex items-center gap-2" style={{ marginBottom: "4px" }}>
                           <span style={{ width: "10px", height: "10px", borderRadius: "2px", background: t.color, display: "inline-block" }} />
-                          <span style={{ color: "var(--fg)", fontSize: "13px", fontWeight: 500 }}>{t.name}</span>
+                          <span className="t-label" style={{ color: "var(--fg)", fontWeight: 500 }}>{t.name}</span>
                         </div>
-                        <div style={{ fontFamily: "var(--font-mono)", fontSize: "18px", color: "var(--fg)" }}>{pct.toFixed(0)}%</div>
-                        <div style={{ color: "var(--dim)", fontSize: "12px" }}>{count.toLocaleString()} sampled</div>
+                        <div className="t-title" style={{ fontFamily: "var(--font-mono)", color: "var(--fg)" }}>{pct.toFixed(0)}%</div>
+                        <div className="t-caption" style={{ color: "var(--dim)" }}>{count.toLocaleString()} sampled</div>
                       </div>
                     );
                   })}

--- a/dashboard/src/app/(dashboard)/filtering/page.tsx
+++ b/dashboard/src/app/(dashboard)/filtering/page.tsx
@@ -246,7 +246,7 @@ export default function FilteringOverviewPage() {
               }
             />
             {pctFiltered !== null && (
-              <div style={{ color: "var(--fainter)", fontSize: "12px", lineHeight: "1.5" }}>
+              <div className="t-caption" style={{ color: "var(--fainter)", lineHeight: "1.5" }}>
                 {dropped.length
                   ? `${droppedCount.toLocaleString()} of ${sampled.toLocaleString()} sampled mempool transactions sit in the tiers this node drops (${droppedLabel}).`
                   : `All ${sampled.toLocaleString()} sampled mempool transactions fall in tiers this node mines — nothing is dropped by tier policy.`}{" "}
@@ -289,10 +289,10 @@ function StatusRow({ label, value, desc }: { label: string; value: string; desc:
       }}
     >
       <div className="flex items-center gap-2">
-        <span style={{ color: "var(--fg)", fontSize: "14px", fontWeight: 600 }}>{label}</span>
-        <span style={{ color: "var(--accent)", fontSize: "13px", fontWeight: 600 }}>{value}</span>
+        <span className="t-body" style={{ color: "var(--fg)", fontWeight: 600 }}>{label}</span>
+        <span className="t-label" style={{ color: "var(--accent)", fontWeight: 600 }}>{value}</span>
       </div>
-      <div style={{ color: "var(--dim)", fontSize: "13px", marginTop: "2px" }}>{desc}</div>
+      <div className="t-label" style={{ color: "var(--dim)", marginTop: "2px" }}>{desc}</div>
     </div>
   );
 }
@@ -302,10 +302,10 @@ function NavCard({ href, title, desc }: { href: string; title: string; desc: str
     <Link href={href} className="bare">
       <Card>
         <div className="flex items-center justify-between gap-3" style={{ marginBottom: "4px" }}>
-          <span style={{ color: "var(--fg)", fontSize: "15px", fontWeight: 600 }}>{title}</span>
-          <span style={{ color: "var(--accent)", fontSize: "13px", whiteSpace: "nowrap" }}>Open →</span>
+          <span className="t-lead" style={{ color: "var(--fg)", fontWeight: 600 }}>{title}</span>
+          <span className="t-label" style={{ color: "var(--accent)", whiteSpace: "nowrap" }}>Open →</span>
         </div>
-        <div style={{ color: "var(--dim)", fontSize: "13px", lineHeight: "1.6" }}>{desc}</div>
+        <div className="t-label" style={{ color: "var(--dim)", lineHeight: "1.6" }}>{desc}</div>
       </Card>
     </Link>
   );

--- a/dashboard/src/app/(dashboard)/geo/page.tsx
+++ b/dashboard/src/app/(dashboard)/geo/page.tsx
@@ -117,8 +117,8 @@ export default function GeoPage() {
           {regionCounts.map((r) => (
             <span
               key={r.region}
+              className="t-caption"
               style={{
-                fontSize: "12px",
                 color: "var(--dim)",
                 background: "var(--surface)",
                 border: "1px solid var(--rule)",
@@ -139,7 +139,7 @@ export default function GeoPage() {
           <CardHeader title="World map" subtitle={`${points.length} of ${rows.length} nodes plotted`} />
           <WorldMap points={points} self={self} hoveredId={hoveredId} onHover={setHoveredId} />
           {/* Legend */}
-          <div className="flex flex-wrap items-center gap-x-5 gap-y-2 mt-4" style={{ fontSize: "12px", color: "var(--dim)" }}>
+          <div className="flex flex-wrap items-center gap-x-5 gap-y-2 mt-4 t-caption" style={{ color: "var(--dim)" }}>
             <span className="inline-flex items-center gap-2">
               <span style={{ width: 8, height: 8, borderRadius: "50%", background: "var(--green)", display: "inline-block" }} />
               Online node
@@ -167,7 +167,7 @@ export default function GeoPage() {
         }}
       >
         <Info size={16} strokeWidth={1.75} style={{ color: "var(--accent)", flexShrink: 0, marginTop: "1px" }} />
-        <p style={{ color: "var(--dim)", fontSize: "13px", lineHeight: 1.5 }}>
+        <p className="t-label" style={{ color: "var(--dim)", lineHeight: 1.5 }}>
           Locations are <strong style={{ color: "var(--fg)" }}>country-level</strong>, resolved entirely
           offline. The dashboard&apos;s CSP forbids external map tiles and geolocation lookups, so each node IP
           is matched against a small bundled IP&#8209;to&#8209;country table (DB&#8209;IP Lite, CC&#8209;BY 4.0)
@@ -189,12 +189,12 @@ export default function GeoPage() {
         <Card>
           <CardHeader title="Nodes" subtitle={`${rows.length} known`} />
           {rows.length === 0 ? (
-            <p style={{ color: "var(--dim)", fontSize: "14px", padding: "8px 0" }}>
+            <p className="t-body" style={{ color: "var(--dim)", padding: "8px 0" }}>
               {nodesLoading ? "Loading nodes…" : "No mesh nodes connected. Your node will discover peers automatically."}
             </p>
           ) : (
             <div style={{ overflowX: "auto" }}>
-              <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "13px", minWidth: "520px" }}>
+              <table className="t-label" style={{ width: "100%", borderCollapse: "collapse", minWidth: "520px" }}>
                 <thead>
                   <tr style={{ textAlign: "left", color: "var(--dim)" }}>
                     <th style={{ padding: "8px 10px", fontWeight: 500 }}>Address</th>
@@ -220,17 +220,17 @@ export default function GeoPage() {
                         <td style={{ padding: "8px 10px", fontFamily: "var(--font-mono)", color: "var(--fg)", whiteSpace: "nowrap" }}>
                           {r.host || "—"}
                           {r.isSelf && (
-                            <span style={{ marginLeft: 8, color: "var(--accent)", fontSize: "11px" }}>this node</span>
+                            <span className="t-caption" style={{ marginLeft: 8, color: "var(--accent)" }}>this node</span>
                           )}
                         </td>
                         <td style={{ padding: "8px 10px", color: r.geo.plottable ? "var(--fg)" : "var(--dim)" }}>
                           {flag && <span style={{ marginRight: 6 }}>{flag}</span>}
                           {r.geo.plottable ? r.geo.name : r.geo.label}
                           {r.geo.plottable && r.geo.code && (
-                            <span style={{ marginLeft: 6, color: "var(--fainter)", fontSize: "11px" }}>{r.geo.code}</span>
+                            <span className="t-caption" style={{ marginLeft: 6, color: "var(--fainter)" }}>{r.geo.code}</span>
                           )}
                           {!r.geo.plottable && (
-                            <span style={{ marginLeft: 8, color: "var(--fainter)", fontSize: "11px" }}>not plotted</span>
+                            <span className="t-caption" style={{ marginLeft: 8, color: "var(--fainter)" }}>not plotted</span>
                           )}
                         </td>
                         <td style={{ padding: "8px 10px", color: "var(--dim)" }}>

--- a/dashboard/src/app/(dashboard)/mempool/page.tsx
+++ b/dashboard/src/app/(dashboard)/mempool/page.tsx
@@ -161,10 +161,10 @@ export default function MempoolPage() {
       {rpcUnavailable ? (
         <Card>
           <div className="space-y-2">
-            <p style={{ color: "var(--fg)", fontSize: "15px" }}>
+            <p className="t-lead" style={{ color: "var(--fg)" }}>
               Couldn&apos;t read the mempool from <code>ghostd</code> RPC.
             </p>
-            <p style={{ color: "var(--dim)", fontSize: "13px" }}>
+            <p className="t-label" style={{ color: "var(--dim)" }}>
               {mempool?.message ??
                 "The node API returned an error for /api/v1/buds/mempool. Check that ghostd is running and RPC credentials are configured in pool.toml."}
             </p>
@@ -243,8 +243,8 @@ function NodeMempoolExplorer() {
       href={NODE_MEMPOOL_APP_URL}
       target="_blank"
       rel="noreferrer"
-      className="bare"
-      style={{ color: "var(--accent)", fontSize: "13px", textDecoration: "underline" }}
+      className="bare t-label"
+      style={{ color: "var(--accent)", textDecoration: "underline" }}
     >
       open in a new tab ↗
     </a>
@@ -267,10 +267,10 @@ function NodeMempoolExplorer() {
             padding: "16px 18px",
           }}
         >
-          <p style={{ color: "var(--fg)", fontSize: "14px" }}>
+          <p className="t-body" style={{ color: "var(--fg)" }}>
             The embedded explorer couldn&apos;t load here.
           </p>
-          <p style={{ color: "var(--dim)", fontSize: "13px" }}>
+          <p className="t-label" style={{ color: "var(--dim)" }}>
             The dashboard couldn&apos;t serve <code>/mempool-app/</code>, or the node&apos;s
             mempool backend on <code>127.0.0.1:8999</code> isn&apos;t responding. Check that the
             mempool service is running on this node, then reload. You can also open it
@@ -309,7 +309,7 @@ function NodeMempoolExplorer() {
         </div>
       )}
 
-      <p style={{ color: "var(--fainter)", fontSize: "12px", marginTop: "12px" }}>
+      <p className="t-caption" style={{ color: "var(--fainter)", marginTop: "12px" }}>
         Served same-origin from the dashboard at <code>/mempool-app/</code>, proxied to this
         node&apos;s own mempool backend. The lightweight RPC view and the Reaper strip
         breakdown are below.
@@ -419,7 +419,7 @@ function FeeDistribution({ mempool }: { mempool?: BudsMempool }) {
     return (
       <Card>
         <CardHeader title="Fee-rate distribution" subtitle="sat/vB across sampled transactions" />
-        <p style={{ color: "var(--dim)", fontSize: "14px" }}>
+        <p className="t-body" style={{ color: "var(--dim)" }}>
           No transactions in the sample to bucket right now.
         </p>
       </Card>
@@ -439,11 +439,11 @@ function FeeDistribution({ mempool }: { mempool?: BudsMempool }) {
           return (
             <div key={b.label} className="flex items-center gap-3">
               <span
+                className="t-caption"
                 style={{
                   width: "56px",
                   textAlign: "right",
                   fontFamily: "var(--font-mono)",
-                  fontSize: "12px",
                   color: "var(--dim)",
                 }}
               >
@@ -461,10 +461,10 @@ function FeeDistribution({ mempool }: { mempool?: BudsMempool }) {
                 />
               </div>
               <span
+                className="t-caption"
                 style={{
                   width: "44px",
                   fontFamily: "var(--font-mono)",
-                  fontSize: "12px",
                   color: c > 0 ? "var(--fg)" : "var(--fainter)",
                 }}
               >
@@ -474,7 +474,7 @@ function FeeDistribution({ mempool }: { mempool?: BudsMempool }) {
           );
         })}
       </div>
-      <p style={{ color: "var(--fainter)", fontSize: "12px", marginTop: "12px" }}>
+      <p className="t-caption" style={{ color: "var(--fainter)", marginTop: "12px" }}>
         Buckets are computed in your browser from the transaction sample (fee ÷ vsize). The node does
         not expose a full server-side fee histogram, so this is a representative snapshot, not the
         whole mempool.

--- a/dashboard/src/app/(dashboard)/page.tsx
+++ b/dashboard/src/app/(dashboard)/page.tsx
@@ -301,7 +301,7 @@ function HealthSection() {
         ))}
       </div>
       {/* Color legend */}
-      <div className="flex gap-4 text-[10px] text-[color:var(--fainter)] border-t border-[var(--rule)] pt-2">
+      <div className="flex gap-4 t-caption text-[color:var(--fainter)] border-t border-[var(--rule)] pt-2">
         <div className="flex items-center gap-1">
           <span className="w-2 h-2 rounded-full bg-green-500" />
           Running

--- a/dashboard/src/app/(dashboard)/pool/page.tsx
+++ b/dashboard/src/app/(dashboard)/pool/page.tsx
@@ -77,22 +77,22 @@ function BestShareCard({ title, entry }: { title: string; entry: BestHashEntry |
       className="rounded-lg p-3"
       style={{ background: "var(--surface)", border: "1px solid var(--rule)" }}
     >
-      <div style={{ color: "var(--dim)", fontSize: "12px", marginBottom: "4px" }}>{title}</div>
+      <div className="t-caption" style={{ color: "var(--dim)", marginBottom: "4px" }}>{title}</div>
       {hasData ? (
         <>
-          <div style={{ color: "var(--accent)", fontSize: "18px", fontWeight: 600 }}>{formatDifficulty(diff)}</div>
-          <div className="truncate" style={{ color: "var(--dim)", fontFamily: "var(--font-mono)", fontSize: "11px" }}>
+          <div className="t-title" style={{ color: "var(--accent)", fontWeight: 600 }}>{formatDifficulty(diff)}</div>
+          <div className="truncate t-caption" style={{ color: "var(--dim)", fontFamily: "var(--font-mono)" }}>
             {entry.hash}
           </div>
-          <div style={{ color: "var(--fainter)", fontSize: "11px", marginTop: "2px" }}>
+          <div className="t-caption" style={{ color: "var(--fainter)", marginTop: "2px" }}>
             {calculateLeadingZeros(diff)} leading zeros
           </div>
-          <div style={{ color: "var(--fainter)", fontSize: "11px", marginTop: "2px" }}>
+          <div className="t-caption" style={{ color: "var(--fainter)", marginTop: "2px" }}>
             {formatTimeAgo(entry.timestamp ?? 0)}
           </div>
         </>
       ) : (
-        <div style={{ color: "var(--fainter)", fontSize: "13px" }}>No data yet</div>
+        <div className="t-label" style={{ color: "var(--fainter)" }}>No data yet</div>
       )}
     </div>
   );
@@ -116,11 +116,11 @@ function ChartCard({
     <Card>
       <div className="mb-3 flex items-start justify-between gap-2">
         <div>
-          <h3 className="font-medium" style={{ color: "var(--fg)", fontSize: "15px" }}>
+          <h3 className="font-medium t-lead" style={{ color: "var(--fg)" }}>
             {title}
           </h3>
           {subtitle && (
-            <p style={{ color: "var(--dim)", fontSize: "12px", marginTop: "2px" }}>{subtitle}</p>
+            <p className="t-caption" style={{ color: "var(--dim)", marginTop: "2px" }}>{subtitle}</p>
           )}
         </div>
         <Badge variant="default">{serverBacked ? "history" : "live (session)"}</Badge>
@@ -183,7 +183,7 @@ export default function NodePoolPage() {
         header: "Miner / Worker",
         accessorFn: (m) => minerName(m),
         cell: ({ getValue }) => (
-          <span className="truncate" style={{ fontFamily: "var(--font-mono)", fontSize: "12px" }}>
+          <span className="truncate t-caption" style={{ fontFamily: "var(--font-mono)" }}>
             {String(getValue())}
           </span>
         ),
@@ -227,7 +227,7 @@ export default function NodePoolPage() {
         header: "Node",
         accessorFn: (n) => n.name || n.node_id.slice(0, 10),
         cell: ({ row }) => (
-          <span className="truncate" style={{ fontFamily: "var(--font-mono)", fontSize: "12px" }}>
+          <span className="truncate t-caption" style={{ fontFamily: "var(--font-mono)" }}>
             {row.original.name || row.original.node_id.slice(0, 10)}
             {row.original.is_self && (
               <Badge variant="default" className="ml-2">
@@ -419,20 +419,20 @@ export default function NodePoolPage() {
             <CardHeader title="Shares" subtitle="Accepted vs rejected this round" />
             <div className="mb-4 grid grid-cols-3 gap-4">
               <div>
-                <div style={{ color: "var(--dim)", fontSize: "12px" }}>Submitted</div>
-                <div style={{ color: "var(--fg)", fontSize: "20px", fontWeight: 600 }}>
+                <div className="t-caption" style={{ color: "var(--dim)" }}>Submitted</div>
+                <div className="t-title" style={{ color: "var(--fg)", fontWeight: 600 }}>
                   {submitted.toLocaleString()}
                 </div>
               </div>
               <div>
-                <div style={{ color: "var(--dim)", fontSize: "12px" }}>Accepted</div>
-                <div style={{ color: "var(--green)", fontSize: "20px", fontWeight: 600 }}>
+                <div className="t-caption" style={{ color: "var(--dim)" }}>Accepted</div>
+                <div className="t-title" style={{ color: "var(--green)", fontWeight: 600 }}>
                   {accepted.toLocaleString()}
                 </div>
               </div>
               <div>
-                <div style={{ color: "var(--dim)", fontSize: "12px" }}>Rejected</div>
-                <div style={{ color: "var(--red)", fontSize: "20px", fontWeight: 600 }}>
+                <div className="t-caption" style={{ color: "var(--dim)" }}>Rejected</div>
+                <div className="t-title" style={{ color: "var(--red)", fontWeight: 600 }}>
                   {rejected.toLocaleString()}
                 </div>
               </div>
@@ -454,30 +454,30 @@ export default function NodePoolPage() {
             />
             <div className="grid grid-cols-2 gap-4">
               <div>
-                <div style={{ color: "var(--dim)", fontSize: "12px" }}>Current round</div>
-                <div style={{ color: "var(--fg)", fontSize: "18px", fontWeight: 600 }}>
+                <div className="t-caption" style={{ color: "var(--dim)" }}>Current round</div>
+                <div className="t-title" style={{ color: "var(--fg)", fontWeight: 600 }}>
                   {formatDuration(roundElapsed)}
                 </div>
-                <div style={{ color: "var(--fainter)", fontSize: "11px" }}>time on the current template</div>
+                <div className="t-caption" style={{ color: "var(--fainter)" }}>time on the current template</div>
               </div>
               <div>
-                <div style={{ color: "var(--dim)", fontSize: "12px" }}>Est. time to block</div>
-                <div style={{ color: "var(--fg)", fontSize: "18px", fontWeight: 600 }}>
+                <div className="t-caption" style={{ color: "var(--dim)" }}>Est. time to block</div>
+                <div className="t-title" style={{ color: "var(--fg)", fontWeight: 600 }}>
                   {hasRoundEta ? formatDuration(roundEta) : "—"}
                 </div>
-                <div style={{ color: "var(--fainter)", fontSize: "11px" }}>at this pool&apos;s hashrate vs network difficulty</div>
+                <div className="t-caption" style={{ color: "var(--fainter)" }}>at this pool&apos;s hashrate vs network difficulty</div>
               </div>
             </div>
             <div className="mt-4 grid grid-cols-2 gap-4">
               <div>
-                <div style={{ color: "var(--dim)", fontSize: "12px" }}>Shares this round</div>
-                <div style={{ color: "var(--fg)", fontSize: "18px", fontWeight: 600 }}>
+                <div className="t-caption" style={{ color: "var(--dim)" }}>Shares this round</div>
+                <div className="t-title" style={{ color: "var(--fg)", fontWeight: 600 }}>
                   {sharesThisRound.toLocaleString()}
                 </div>
               </div>
               <div>
-                <div style={{ color: "var(--dim)", fontSize: "12px" }}>Pending rewards</div>
-                <div style={{ color: "var(--accent)", fontSize: "18px", fontWeight: 600 }}>
+                <div className="t-caption" style={{ color: "var(--dim)" }}>Pending rewards</div>
+                <div className="t-title" style={{ color: "var(--accent)", fontWeight: 600 }}>
                   {formatSats(rewards?.pending_rewards_sats ?? 0)}
                 </div>
               </div>
@@ -495,8 +495,8 @@ export default function NodePoolPage() {
             action={
               bestHash?.network_hashrate ? (
                 <div className="text-right">
-                  <div style={{ color: "var(--dim)", fontSize: "11px" }}>Network hashrate</div>
-                  <div style={{ color: "var(--fg)", fontSize: "14px", fontWeight: 600 }}>
+                  <div className="t-caption" style={{ color: "var(--dim)" }}>Network hashrate</div>
+                  <div className="t-body" style={{ color: "var(--fg)", fontWeight: 600 }}>
                     {formatHashrate(bestHash.network_hashrate, 0)}
                   </div>
                 </div>
@@ -530,19 +530,19 @@ export default function NodePoolPage() {
           />
           {meshRecords.length > 0 && (
             <div className="mt-5">
-              <div style={{ color: "var(--dim)", fontSize: "12px", marginBottom: "8px" }}>
+              <div className="t-caption" style={{ color: "var(--dim)", marginBottom: "8px" }}>
                 Mesh best-share records
               </div>
               <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
                 {meshRecords.map((r) => (
                   <div key={r.window}>
-                    <div style={{ color: "var(--dim)", fontSize: "11px", textTransform: "capitalize" }}>
+                    <div className="t-caption" style={{ color: "var(--dim)", textTransform: "capitalize" }}>
                       {r.window}
                     </div>
-                    <div style={{ color: "var(--fg)", fontSize: "16px", fontWeight: 600 }}>
+                    <div className="t-lead" style={{ color: "var(--fg)", fontWeight: 600 }}>
                       {formatDifficulty(r.difficulty)}
                     </div>
-                    <div style={{ color: "var(--fainter)", fontSize: "11px" }}>
+                    <div className="t-caption" style={{ color: "var(--fainter)" }}>
                       {r.leading_zero_bits} zero bits · {r.miner_id_redacted || "—"}
                     </div>
                   </div>
@@ -551,7 +551,7 @@ export default function NodePoolPage() {
             </div>
           )}
           {meshLeaderboard?.limit_note && (
-            <p style={{ color: "var(--fainter)", fontSize: "11px", marginTop: "12px" }}>
+            <p className="t-caption" style={{ color: "var(--fainter)", marginTop: "12px" }}>
               {meshLeaderboard.limit_note}
             </p>
           )}
@@ -568,7 +568,7 @@ export default function NodePoolPage() {
             subtitle="Miners connected to this node's stratum port, ranked by hashrate"
           />
           {minersRedacted ? (
-            <div style={{ color: "var(--dim)", fontSize: "13px" }}>
+            <div className="t-label" style={{ color: "var(--dim)" }}>
               Per-miner detail is not available on this node (the miner list is redacted for unauthenticated
               access). Aggregate:{" "}
               <span style={{ color: "var(--fg)" }}>

--- a/dashboard/src/app/(dashboard)/sync/page.tsx
+++ b/dashboard/src/app/(dashboard)/sync/page.tsx
@@ -144,7 +144,7 @@ export default function SyncPage() {
 
       {isError && (
         <Card>
-          <p style={{ color: "var(--dim)", fontSize: "14px" }}>
+          <p className="t-body" style={{ color: "var(--dim)" }}>
             Failed to load sync status: {error instanceof Error ? error.message : "unknown error"}
           </p>
         </Card>
@@ -152,7 +152,7 @@ export default function SyncPage() {
 
       {unavailable && !isLoading && (
         <Card>
-          <p style={{ color: "var(--dim)", fontSize: "14px" }}>
+          <p className="t-body" style={{ color: "var(--dim)" }}>
             The node&apos;s Bitcoin RPC is not reachable, so chain details are unavailable. Values
             below show <span className="font-mono">{DASH}</span> until the daemon responds.
           </p>
@@ -389,7 +389,7 @@ function ChainHealthSection({
       />
 
       {isError ? (
-        <p style={{ color: "var(--dim)", fontSize: "14px" }}>
+        <p className="t-body" style={{ color: "var(--dim)" }}>
           Chain-health data is unavailable right now.
         </p>
       ) : isLoading ? (
@@ -435,17 +435,17 @@ function ChainHealthSection({
           >
             <div className="flex items-center gap-2" style={{ marginBottom: "6px" }}>
               <GitBranch size={15} strokeWidth={1.75} style={{ color: "var(--dim)" }} />
-              <span style={{ color: "var(--fg)", fontSize: "14px", fontWeight: 500 }}>
+              <span className="t-body" style={{ color: "var(--fg)", fontWeight: 500 }}>
                 Reorgs (last 24h)
               </span>
               <Badge variant={stable ? "success" : "warning"}>{formatCount(count24h)}</Badge>
             </div>
             {stable ? (
-              <p style={{ color: "var(--dim)", fontSize: "13px" }}>
+              <p className="t-label" style={{ color: "var(--dim)" }}>
                 None in the last 24 hours — a stable, single chain is the normal, healthy state.
               </p>
             ) : (
-              <p style={{ color: "var(--dim)", fontSize: "13px" }}>
+              <p className="t-label" style={{ color: "var(--dim)" }}>
                 {formatCount(count24h)} chain reorganisation{count24h === 1 ? "" : "s"} recorded in
                 the last 24 hours.
               </p>
@@ -463,7 +463,8 @@ function ChainHealthSection({
           {reorgs.length > 0 && (
             <div>
               <div
-                style={{ color: "var(--dim)", fontSize: "12px", marginBottom: "6px" }}
+                className="t-caption"
+                style={{ color: "var(--dim)", marginBottom: "6px" }}
               >
                 Recent reorgs
               </div>
@@ -471,8 +472,8 @@ function ChainHealthSection({
                 {reorgs.map((ev, i) => (
                   <li
                     key={`${ev.unix_time}-${ev.old_tip_hash}-${i}`}
-                    className="flex items-center gap-2 font-mono"
-                    style={{ color: "var(--fg)", fontSize: "13px" }}
+                    className="flex items-center gap-2 font-mono t-label"
+                    style={{ color: "var(--fg)" }}
                   >
                     <GitBranch size={13} strokeWidth={1.75} style={{ color: "var(--fainter)" }} />
                     <span>{reorgSummary(ev, now)}</span>
@@ -547,21 +548,21 @@ function Field({
   return (
     <div>
       <div
-        className="flex items-center gap-1.5"
-        style={{ color: "var(--dim)", fontSize: "12px", marginBottom: "3px" }}
+        className="flex items-center gap-1.5 t-caption"
+        style={{ color: "var(--dim)", marginBottom: "3px" }}
       >
         {icon}
         <span>{label}</span>
       </div>
       <div
-        className={mono ? "font-mono break-all" : ""}
-        style={{ color: "var(--fg)", fontSize: "14px" }}
+        className={mono ? "font-mono break-all t-body" : "t-body"}
+        style={{ color: "var(--fg)" }}
         title={title}
       >
         {value}
       </div>
       {(sub || sublabel) && (
-        <div style={{ color: "var(--fainter)", fontSize: "12px", marginTop: "2px" }}>
+        <div className="t-caption" style={{ color: "var(--fainter)", marginTop: "2px" }}>
           {sub ?? sublabel}
         </div>
       )}

--- a/dashboard/src/components/filtering/AdvancedPolicyPanel.tsx
+++ b/dashboard/src/components/filtering/AdvancedPolicyPanel.tsx
@@ -101,12 +101,12 @@ export function AdvancedPolicyPanel() {
   return (
     <div>
       <div className="flex items-center gap-2" style={{ marginBottom: "2px" }}>
-        <span style={{ color: "var(--fg)", fontSize: "14px", fontWeight: 600 }}>Custom mining policy</span>
+        <span className="t-body" style={{ color: "var(--fg)", fontWeight: 600 }}>Custom mining policy</span>
         {isCustomActive && (
-          <span style={{ color: "var(--accent)", fontSize: "11px", fontWeight: 600 }}>· current</span>
+          <span className="t-caption" style={{ color: "var(--accent)", fontWeight: 600 }}>· current</span>
         )}
       </div>
-      <div style={{ color: "var(--dim)", fontSize: "13px", marginBottom: "12px" }}>
+      <div className="t-label" style={{ color: "var(--dim)", marginBottom: "12px" }}>
         Per-field control over which transaction classes, content and sizes this node mines. Saving writes{" "}
         <code>[policy].custom</code>, sets the profile to <code>custom</code>, and restarts the node.
       </div>
@@ -123,7 +123,7 @@ export function AdvancedPolicyPanel() {
           />
         ))}
         {noTiers && (
-          <div style={{ color: "var(--warn, #d29922)", fontSize: "12px", marginTop: "6px" }}>
+          <div className="t-caption" style={{ color: "var(--warn, #d29922)", marginTop: "6px" }}>
             No classes selected — the node would mine empty blocks (coinbase only).
           </div>
         )}
@@ -174,7 +174,7 @@ export function AdvancedPolicyPanel() {
             boxShadow: "0 -6px 20px -8px rgba(0, 0, 0, 0.35)",
           }}
         >
-          <div style={{ color: "var(--fg)", fontSize: "13px", marginBottom: "10px" }}>
+          <div className="t-label" style={{ color: "var(--fg)", marginBottom: "10px" }}>
             Apply this <strong>custom mining policy</strong>? This writes the config and{" "}
             <strong>restarts the node</strong> to apply.
           </div>
@@ -211,7 +211,7 @@ export function AdvancedPolicyPanel() {
 function PanelSection({ title, children }: { title: string; children: ReactNode }) {
   return (
     <div style={{ marginBottom: "14px" }}>
-      <div style={{ color: "var(--fg)", fontSize: "13px", fontWeight: 600, marginBottom: "8px" }}>{title}</div>
+      <div className="t-label" style={{ color: "var(--fg)", fontWeight: 600, marginBottom: "8px" }}>{title}</div>
       <div className="space-y-2">{children}</div>
     </div>
   );
@@ -237,8 +237,8 @@ function CheckboxRow({
         style={{ marginTop: "3px" }}
       />
       <span>
-        <span style={{ color: "var(--fg)", fontSize: "13px", fontWeight: 500 }}>{label}</span>
-        <div style={{ color: "var(--dim)", fontSize: "12px", lineHeight: "1.5" }}>{desc}</div>
+        <span className="t-label" style={{ color: "var(--fg)", fontWeight: 500 }}>{label}</span>
+        <div className="t-caption" style={{ color: "var(--dim)", lineHeight: "1.5" }}>{desc}</div>
       </span>
     </label>
   );
@@ -262,8 +262,8 @@ function NumberRow({
   return (
     <div style={{ display: "flex", gap: "12px", alignItems: "flex-start", justifyContent: "space-between", flexWrap: "wrap" }}>
       <span style={{ flex: "1 1 240px" }}>
-        <span style={{ color: "var(--fg)", fontSize: "13px", fontWeight: 500 }}>{label}</span>
-        <div style={{ color: "var(--dim)", fontSize: "12px", lineHeight: "1.5" }}>{desc}</div>
+        <span className="t-label" style={{ color: "var(--fg)", fontWeight: 500 }}>{label}</span>
+        <div className="t-caption" style={{ color: "var(--dim)", lineHeight: "1.5" }}>{desc}</div>
       </span>
       <span className="flex items-center gap-2" style={{ flex: "0 0 auto" }}>
         <input
@@ -275,6 +275,7 @@ function NumberRow({
             const n = Number(e.target.value);
             onChange(Number.isFinite(n) && n >= 0 ? n : 0);
           }}
+          className="t-label"
           style={{
             width: "110px",
             padding: "6px 8px",
@@ -283,10 +284,9 @@ function NumberRow({
             background: "var(--bg)",
             color: "var(--fg)",
             fontFamily: "var(--font-mono)",
-            fontSize: "13px",
           }}
         />
-        <span style={{ color: "var(--dim)", fontSize: "12px", minWidth: "48px" }}>{unit}</span>
+        <span className="t-caption" style={{ color: "var(--dim)", minWidth: "48px" }}>{unit}</span>
       </span>
     </div>
   );

--- a/dashboard/src/components/filtering/BlockPrioritySelector.tsx
+++ b/dashboard/src/components/filtering/BlockPrioritySelector.tsx
@@ -85,12 +85,12 @@ export function BlockPrioritySelector() {
               }}
             >
               <div className="flex items-center gap-2" style={{ marginBottom: "4px" }}>
-                <span style={{ color: "var(--fg)", fontSize: "14px", fontWeight: 600 }}>{opt.label}</span>
+                <span className="t-body" style={{ color: "var(--fg)", fontWeight: 600 }}>{opt.label}</span>
                 {isCurrent && (
-                  <span style={{ color: "var(--accent)", fontSize: "11px", fontWeight: 600 }}>· current</span>
+                  <span className="t-caption" style={{ color: "var(--accent)", fontWeight: 600 }}>· current</span>
                 )}
               </div>
-              <div style={{ color: "var(--dim)", fontSize: "12px", lineHeight: "1.5" }}>{opt.desc}</div>
+              <div className="t-caption" style={{ color: "var(--dim)", lineHeight: "1.5" }}>{opt.desc}</div>
             </button>
           );
         })}
@@ -109,7 +109,7 @@ export function BlockPrioritySelector() {
             background: "var(--accent-weak)",
           }}
         >
-          <div style={{ color: "var(--fg)", fontSize: "13px", marginBottom: "10px" }}>
+          <div className="t-label" style={{ color: "var(--fg)", marginBottom: "10px" }}>
             Switch block priority to{" "}
             <strong>{BLOCK_PRIORITY_OPTIONS.find((o) => o.value === pending)?.label}</strong>? This writes the
             config and <strong>restarts the node</strong> to apply.

--- a/dashboard/src/components/filtering/PolicyProfileSelector.tsx
+++ b/dashboard/src/components/filtering/PolicyProfileSelector.tsx
@@ -33,10 +33,9 @@ function TierPills({ mined }: { mined: BudsTierKey[] }) {
         return (
           <span
             key={key}
+            className="t-eyebrow"
             title={isMined ? `${key} mined` : `${key} dropped`}
             style={{
-              fontFamily: "var(--font-mono, ui-monospace, monospace)",
-              fontSize: "11px",
               fontWeight: 600,
               lineHeight: 1,
               letterSpacing: "0.02em",
@@ -113,13 +112,13 @@ export function PolicyProfileSelector() {
               }}
             >
               <div className="flex items-center gap-2" style={{ marginBottom: "4px" }}>
-                <span style={{ color: "var(--fg)", fontSize: "14px", fontWeight: 600 }}>{p.label}</span>
+                <span className="t-body" style={{ color: "var(--fg)", fontWeight: 600 }}>{p.label}</span>
                 {isCurrent && (
-                  <span style={{ color: "var(--accent)", fontSize: "11px", fontWeight: 600 }}>· current</span>
+                  <span className="t-caption" style={{ color: "var(--accent)", fontWeight: 600 }}>· current</span>
                 )}
               </div>
               <TierPills mined={p.tiers} />
-              <div style={{ color: "var(--dim)", fontSize: "12px", lineHeight: "1.5" }}>{p.desc}</div>
+              <div className="t-caption" style={{ color: "var(--dim)", lineHeight: "1.5" }}>{p.desc}</div>
             </button>
           );
         })}
@@ -134,7 +133,7 @@ export function PolicyProfileSelector() {
             background: "var(--accent-weak)",
           }}
         >
-          <div style={{ color: "var(--fg)", fontSize: "13px", marginBottom: "10px" }}>
+          <div className="t-label" style={{ color: "var(--fg)", marginBottom: "10px" }}>
             Switch mining policy to <strong>{POLICY_PRESETS.find((p) => p.value === pending)?.label}</strong>? This
             writes the config and <strong>restarts the node</strong> to apply.
           </div>

--- a/dashboard/src/components/filtering/ReaperControls.tsx
+++ b/dashboard/src/components/filtering/ReaperControls.tsx
@@ -70,15 +70,15 @@ function VectorGroup({
       }}
     >
       <div style={{ marginBottom: "10px" }}>
-        <div style={{ color: "var(--accent)", fontSize: "14px", fontWeight: 500 }}>{title}</div>
-        <div style={{ color: "var(--dim)", fontSize: "12px", marginTop: "2px" }}>{note}</div>
+        <div className="t-body" style={{ color: "var(--accent)", fontWeight: 500 }}>{title}</div>
+        <div className="t-caption" style={{ color: "var(--dim)", marginTop: "2px" }}>{note}</div>
       </div>
       <div className="space-y-3">
         {vectors.map((v) => (
           <div key={v.key} className="flex items-start justify-between gap-4">
             <div>
-              <div style={{ color: "var(--fg)", fontSize: "13px" }}>{v.label}</div>
-              <div style={{ color: "var(--dim)", fontSize: "12px", lineHeight: "1.5" }}>{v.desc}</div>
+              <div className="t-label" style={{ color: "var(--fg)" }}>{v.label}</div>
+              <div className="t-caption" style={{ color: "var(--dim)", lineHeight: "1.5" }}>{v.desc}</div>
             </div>
             <Toggle
               enabled={Boolean(data[v.key])}
@@ -118,7 +118,7 @@ export function ReaperControls() {
     return (
       <Card>
         <CardHeader title="Adjust reaper" subtitle="Per-vector controls" />
-        <p style={{ color: "var(--dim)", fontSize: "14px" }}>
+        <p className="t-body" style={{ color: "var(--dim)" }}>
           Could not load the reaper configuration from ghost-pool. The controls are unavailable until
           the node responds.
         </p>
@@ -130,7 +130,7 @@ export function ReaperControls() {
     return (
       <Card>
         <CardHeader title="Adjust reaper" subtitle="Per-vector controls" />
-        <p style={{ color: "var(--dim)", fontSize: "14px" }}>Loading current reaper configuration…</p>
+        <p className="t-body" style={{ color: "var(--dim)" }}>Loading current reaper configuration…</p>
       </Card>
     );
   }
@@ -202,8 +202,8 @@ export function ReaperControls() {
         >
           <div className="flex items-start justify-between gap-4">
             <div>
-              <div style={{ color: "var(--accent)", fontSize: "14px", fontWeight: 500 }}>Reaper master switch</div>
-              <div style={{ color: "var(--dim)", fontSize: "12px", lineHeight: "1.5", marginTop: "2px" }}>
+              <div className="t-body" style={{ color: "var(--accent)", fontWeight: 500 }}>Reaper master switch</div>
+              <div className="t-caption" style={{ color: "var(--dim)", lineHeight: "1.5", marginTop: "2px" }}>
                 When off, every detector is disabled on both the pool template reaper and the ghostd mempool
                 reaper. When on, the per-vector choices below apply. Running Reaper earns +2 capability shares.
               </div>
@@ -251,7 +251,7 @@ export function ReaperControls() {
             background: "var(--bg)",
           }}
         >
-          <div style={{ color: "var(--accent)", fontSize: "14px", fontWeight: 500, marginBottom: "10px" }}>
+          <div className="t-body" style={{ color: "var(--accent)", fontWeight: 500, marginBottom: "10px" }}>
             Thresholds
           </div>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
@@ -299,7 +299,7 @@ export function ReaperControls() {
         </div>
 
         {errorMsg && (
-          <p style={{ color: "var(--red)", fontSize: "13px" }}>{errorMsg}</p>
+          <p className="t-label" style={{ color: "var(--red)" }}>{errorMsg}</p>
         )}
 
         <div
@@ -310,7 +310,7 @@ export function ReaperControls() {
             borderRadius: "4px",
           }}
         >
-          <p style={{ color: "var(--fg)", fontSize: "13px", lineHeight: "1.6" }}>
+          <p className="t-label" style={{ color: "var(--fg)", lineHeight: "1.6" }}>
             Saving writes these settings to the node config (<code>pool.toml [reaper]</code>) and applies
             them to <strong>both</strong> reapers automatically. The pool template reaper picks them up when{" "}
             <strong style={{ color: "var(--accent)" }}>ghost-pool restarts</strong>, and the ghostd{" "}


### PR DESCRIPTION
## Summary

Filtering + Overview dashboard pages: adds live Reaper telemetry to the otherwise controls-only Advanced page, and normalises typography onto the semantic `.t-*` scale across the filtering and overview surfaces.

## P-fix — /filtering/advanced live context (P3.10)

The Advanced page was controls-only (Reaper per-vector toggles + thresholds + custom policy) with no live data, so operators tuned the Reaper blind. Added a compact **Live Reaper context** strip at the top, reusing the exact sources already used on `/filtering`:

- **Mempool by class** — the sampled BUDS-tier histogram from `/api/v1/buds/mempool` (mini stacked bar + per-tier counts).
- **Recently reaped** — the Reaper's per-block counters from `useReaperStatus` (`last_block_reaped`/`last_block_dead_bytes`, plus `txs_reaped`/`dead_bytes_total` since restart).

Clearly labelled as the live context for the Reaper controls below; degrades gracefully when there is no sample or no block built yet.

## Type scale (targeted pass)

Replaced inline `fontSize` px and off-scale sizes with the nearest semantic `.t-*` class by role across the filtering pages/components, plus `mempool`, `pool`, `sync`, `geo` and the overview root (`text-[10px]` → `t-caption`). Colours and spacing preserved (inline weight/line-height/letter-spacing retained where set). Clean `text-xs/sm/lg/2xl` left untouched; `mining` and `home` needed no change.

## Reaper naming

The **Reaper** name is preserved verbatim in every label, heading, copy string and component touched — nothing genericised.

## Verification

- `tsc --noEmit` clean
- `eslint` clean on all changed files