### PR TITLE
dashboard(sysops): /system uses shared StoragePruningCard, ConfirmDialog + nickname-hook + watchdog label + type scale

### DIFF
--- a/dashboard/src/app/(dashboard)/capabilities/page.tsx
+++ b/dashboard/src/app/(dashboard)/capabilities/page.tsx
@@ -33,13 +33,13 @@ interface Row {
 function StatusCell({ ok }: { ok: boolean }) {
   return (
     <span
+      className="t-label"
       style={{
         display: "inline-flex",
         alignItems: "center",
         gap: "8px",
         color: ok ? "var(--green)" : "var(--dim)",
         fontFamily: "var(--font-mono)",
-        fontSize: "13px",
       }}
     >
       <span
@@ -152,11 +152,11 @@ export default function CapabilitiesPage() {
             <table style={{ width: "100%", borderCollapse: "collapse" }}>
               <thead>
                 <tr style={{ borderBottom: "1px solid var(--rule)" }}>
-                  <th style={thStyle}>Capability</th>
-                  <th style={thStyle}>Bonus</th>
-                  <th style={thStyle}>Claimed</th>
-                  <th style={thStyle}>Qualified</th>
-                  <th style={thStyle}>Configure</th>
+                  <th className="t-label-mono" style={thStyle}>Capability</th>
+                  <th className="t-label-mono" style={thStyle}>Bonus</th>
+                  <th className="t-label-mono" style={thStyle}>Claimed</th>
+                  <th className="t-label-mono" style={thStyle}>Qualified</th>
+                  <th className="t-label-mono" style={thStyle}>Configure</th>
                 </tr>
               </thead>
               <tbody>
@@ -178,10 +178,9 @@ export default function CapabilitiesPage() {
                       {row.configHref && (
                         <Link
                           href={row.configHref}
-                          className="bare"
+                          className="bare t-label"
                           style={{
                             color: "var(--dim)",
-                            fontSize: "13px",
                             textDecoration: "underline",
                             textDecorationColor: "var(--rule-strong)",
                           }}
@@ -201,7 +200,7 @@ export default function CapabilitiesPage() {
       {driftRows.length > 0 && (
         <SectionErrorBoundary section="Drift detail">
           <Card>
-            <h3 style={{ color: "var(--fg)", fontSize: "16px", fontWeight: 500, marginBottom: "12px" }}>
+            <h3 className="t-title" style={{ color: "var(--fg)", marginBottom: "12px" }}>
               {driftRows.length === 1 ? "1 capability not qualifying" : `${driftRows.length} capabilities not qualifying`}
             </h3>
             <div className="space-y-4">
@@ -210,7 +209,7 @@ export default function CapabilitiesPage() {
                   <div style={{ color: "var(--fg)", fontWeight: 500, marginBottom: "4px" }}>
                     {row.label} <span style={{ color: "var(--dim)", fontWeight: 400 }}>(+{row.bonus})</span>
                   </div>
-                  <p style={{ color: "var(--dim)", fontSize: "14px", lineHeight: "1.5" }}>{row.hint}</p>
+                  <p className="t-body" style={{ color: "var(--dim)" }}>{row.hint}</p>
                 </div>
               ))}
             </div>
@@ -218,7 +217,7 @@ export default function CapabilitiesPage() {
         </SectionErrorBoundary>
       )}
 
-      <p style={{ color: "var(--fainter)", fontSize: "13px" }}>
+      <p className="t-label" style={{ color: "var(--fainter)" }}>
         Qualification is calculated from peer-issued verification challenges over a 7-day rolling window. A capability counts at payout when ≥10 challenges have completed at ≥95% pass rate (≥90% for Ghost Pay) from at least 2 unique peers.
       </p>
     </div>
@@ -229,10 +228,7 @@ const thStyle: React.CSSProperties = {
   textAlign: "left",
   padding: "12px 16px",
   fontWeight: 500,
-  fontSize: "13px",
   color: "var(--dim)",
-  fontFamily: "var(--font-mono)",
-  textTransform: "uppercase",
   letterSpacing: "0.06em",
 };
 

--- a/dashboard/src/app/(dashboard)/capacity/page.tsx
+++ b/dashboard/src/app/(dashboard)/capacity/page.tsx
@@ -158,10 +158,10 @@ export default function CapacityPage() {
       <SectionErrorBoundary section="This node">
         <Card>
           <div style={{ marginBottom: "16px" }}>
-            <h3 style={{ color: "var(--fg)", fontSize: "16px", fontWeight: 500, marginBottom: "4px" }}>
+            <h3 className="t-title" style={{ color: "var(--fg)", marginBottom: "4px" }}>
               This node
             </h3>
-            <p style={{ color: "var(--dim)", fontSize: "13px" }}>
+            <p className="t-label" style={{ color: "var(--dim)" }}>
               Hardware-derived ceiling. Operator&apos;s <code>network.max_miners</code> can throttle this DOWN, never UP.
             </p>
           </div>
@@ -198,10 +198,10 @@ export default function CapacityPage() {
       <SectionErrorBoundary section="Peers">
         <Card>
           <div style={{ marginBottom: "16px" }}>
-            <h3 style={{ color: "var(--fg)", fontSize: "16px", fontWeight: 500, marginBottom: "4px" }}>
+            <h3 className="t-title" style={{ color: "var(--fg)", marginBottom: "4px" }}>
               Peer mesh
             </h3>
-            <p style={{ color: "var(--dim)", fontSize: "13px" }}>
+            <p className="t-label" style={{ color: "var(--dim)" }}>
               {nodes.length} {nodes.length === 1 ? "node" : "nodes"} across the mesh ·{" "}
               <strong style={{ color: "var(--fg)" }}>{distinctMiners}</strong> distinct active{" "}
               {distinctMiners === 1 ? "miner" : "miners"} (deduplicated). Each miner is owned by
@@ -237,7 +237,7 @@ export default function CapacityPage() {
         </Card>
       </SectionErrorBoundary>
 
-      <p style={{ color: "var(--fainter)", fontSize: "13px" }}>
+      <p className="t-label" style={{ color: "var(--fainter)" }}>
         Capacity is hardware-derived (
         <code>min(ram_mb / 3, cpu_cores * 500, fd_limit / 4)</code>) at startup. Operator&apos;s{" "}
         <code>network.max_miners</code> in <code>pool.toml</code> can throttle below the calculated value but cannot exceed
@@ -262,7 +262,7 @@ function MeshRow({ node }: { node: MeshNode }) {
       }}
     >
       <td style={tdStyle}>
-        <code style={{ color: "var(--fg)", fontSize: "13px" }}>{label}</code>
+        <code className="t-label" style={{ color: "var(--fg)" }}>{label}</code>
         {isSelf && (
           <Badge variant="info" className="ml-2">
             you
@@ -297,10 +297,8 @@ function Stat({ label, value, accent }: { label: string; value: string; accent?:
   return (
     <div>
       <div
+        className="t-eyebrow"
         style={{
-          fontSize: "11px",
-          fontFamily: "var(--font-mono)",
-          textTransform: "uppercase",
           letterSpacing: "0.06em",
           color: "var(--dim)",
           marginBottom: "4px",
@@ -309,8 +307,8 @@ function Stat({ label, value, accent }: { label: string; value: string; accent?:
         {label}
       </div>
       <div
+        className="t-stat"
         style={{
-          fontSize: "24px",
           fontWeight: 500,
           color: accent ?? "var(--fg)",
           fontFamily: "var(--font-mono)",

--- a/dashboard/src/app/(dashboard)/storage/page.tsx
+++ b/dashboard/src/app/(dashboard)/storage/page.tsx
@@ -11,16 +11,6 @@ import {
 } from "@/hooks/queries";
 import { StoragePruningCard } from "@/components/settings/StoragePruningCard";
 
-function formatDuration(blocks: number): string {
-  const days = Math.round(blocks / 144);
-  if (days === 1) return "1 day";
-  if (days < 7) return `${days} days`;
-  if (days === 7) return "1 week";
-  if (days < 30) return `${Math.round(days / 7)} weeks`;
-  if (days < 60) return "1 month";
-  return `${Math.round(days / 30)} months`;
-}
-
 function formatTimestamp(ts: number): string {
   if (!ts) return "Never";
   const date = new Date(ts * 1000);
@@ -38,7 +28,7 @@ function formatTimeAgo(ts: number): string {
 }
 
 export default function StoragePage() {
-  const { data: fullConfig, isLoading: configLoading } = useFullConfig();
+  const { isLoading: configLoading } = useFullConfig();
   const { data: status } = useNodeStatus();
   const { data: l2Pruning, isLoading: l2Loading } = useL2PruningStatus();
   const { data: ghostPayStatus } = useGhostPayStatus();
@@ -90,7 +80,7 @@ export default function StoragePage() {
                   <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
                     <div className="p-4 bg-[var(--surface)] rounded-lg">
                       <div className="text-sm text-[color:var(--dim)]">Retention Period</div>
-                      <div className="text-xl font-bold text-[color:var(--fg)] mt-1">
+                      <div className="t-stat font-bold text-[color:var(--fg)] mt-1">
                         {l2Pruning.retention_days ?? 90} days
                       </div>
                     </div>

--- a/dashboard/src/app/(dashboard)/swarm/page.tsx
+++ b/dashboard/src/app/(dashboard)/swarm/page.tsx
@@ -20,8 +20,8 @@ import {
   useUpdateSwarmNode,
   useRefreshSwarmNode,
   useNodeInfo,
+  useSetNickname,
 } from "@/hooks/queries";
-import { setNickname } from "@/lib/api/node";
 import { refreshSwarmNode, syncSwarm, restartSwarmNode, updateAllSwarmNodes } from "@/lib/api/swarm";
 import { useQueryClient } from "@tanstack/react-query";
 import { useToast } from "@/components/ui/Toast";
@@ -123,6 +123,7 @@ export default function SwarmPage() {
   const addNode = useAddSwarmNode();
   const removeNode = useRemoveSwarmNode();
   const updateNode = useUpdateSwarmNode();
+  const setNicknameMutation = useSetNickname();
   const refreshNode = useRefreshSwarmNode();
   const queryClient = useQueryClient();
   const { success, error } = useToast();
@@ -321,7 +322,10 @@ export default function SwarmPage() {
 
     const interval = setInterval(doRefresh, 30000);
     return () => clearInterval(interval);
-  }, [nodes.length, queryClient]); // Re-setup when node count changes
+    // Deliberately keyed on node COUNT (not the array identity) so the polling
+    // interval is only torn down/recreated when a node is added or removed.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [nodes.length, queryClient]);
 
   const handleEditClick = (node: SwarmNode) => {
     setSelectedNode(node);
@@ -336,7 +340,7 @@ export default function SwarmPage() {
     // For localhost, only update the nickname
     if (selectedNode.address === "localhost") {
       try {
-        await setNickname(editNodeName.trim());
+        await setNicknameMutation.mutateAsync(editNodeName.trim());
         queryClient.invalidateQueries({ queryKey: swarmKeys.all });
         success("Node Updated", `Local node renamed to ${editNodeName}`);
         setEditDialogOpen(false);
@@ -911,7 +915,7 @@ export default function SwarmPage() {
               variant="primary"
               className="flex-1"
               onClick={handleEditNode}
-              loading={updateNode.isPending}
+              loading={updateNode.isPending || setNicknameMutation.isPending}
               disabled={!editNodeName.trim() || (selectedNode?.address !== "localhost" && !editNodeAddress.trim())}
             >
               Save Changes

--- a/dashboard/src/app/(dashboard)/system/page.tsx
+++ b/dashboard/src/app/(dashboard)/system/page.tsx
@@ -17,11 +17,7 @@ import {
   useStartUpdate,
   useRollbackUpdate,
   // Storage & Pruning
-  useFullConfig,
-  useNodeStatus,
   useL2PruningStatus,
-  useSetOperatorWindow,
-  useSetArchiveMode,
   useGhostPayStatus,
   // Backup & Restore
   useBackupHistory,
@@ -34,6 +30,7 @@ import { getBackupDownloadUrl } from "@/lib/api/backup";
 import { useToast } from "@/components/ui/Toast";
 import { AutoUpdateSection } from "@/components/settings/AutoUpdateSection";
 import { ScheduledBackupsCard } from "@/components/settings/ScheduledBackupsCard";
+import { StoragePruningCard } from "@/components/settings/StoragePruningCard";
 import type { UpdateStatus } from "@/lib/api/system";
 import type { VerifyBackupResponse } from "@/types/api";
 
@@ -65,16 +62,6 @@ function formatDate(dateStr: string): string {
 function formatTimestampDate(timestamp: number): string {
   if (!timestamp) return "—";
   return new Date(timestamp * 1000).toLocaleString();
-}
-
-function formatDuration(blocks: number): string {
-  const days = Math.round(blocks / 144);
-  if (days === 1) return "1 day";
-  if (days < 7) return `${days} days`;
-  if (days === 7) return "1 week";
-  if (days < 30) return `${Math.round(days / 7)} weeks`;
-  if (days < 60) return "1 month";
-  return `${Math.round(days / 30)} months`;
 }
 
 function formatTimestamp(ts: number): string {
@@ -118,16 +105,6 @@ function getStatusBadge(status: UpdateStatus["status"]): {
 }
 
 // ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
-const OW_PRESETS = [
-  { blocks: 1008, label: "7 days", description: "Minimum recommended" },
-  { blocks: 2016, label: "14 days", description: "Default" },
-  { blocks: 4032, label: "30 days", description: "Extended retention" },
-];
-
-// ---------------------------------------------------------------------------
 // Page Component
 // ---------------------------------------------------------------------------
 
@@ -157,17 +134,13 @@ export default function SystemPage() {
   const updateInfo = updateCheck?.update_info;
   const hasUpdate = updateCheck?.update_available ?? false;
 
-  // -- Storage hooks --
-  const { data: fullConfig, isLoading: configLoading } = useFullConfig();
-  const { data: status } = useNodeStatus();
+  // -- Storage hooks (L1 pruning lives in the shared <StoragePruningCard/>) --
   const { data: l2Pruning, isLoading: l2Loading } = useL2PruningStatus();
   const { data: ghostPayStatus } = useGhostPayStatus();
 
-  const setOperatorWindow = useSetOperatorWindow();
-  const setArchiveMode = useSetArchiveMode();
-
-  const archiveMode = status?.archive_mode ?? false;
-  const ghostPayRunning = !!ghostPayStatus?.l2_height;
+  // Running-state from the explicit `sync_state` flag, not `l2_height` (0 is a
+  // valid running height and would wrongly show "Ghost Pay Not Running").
+  const ghostPayRunning = ghostPayStatus?.sync_state === "synced";
 
   // -- Backup hooks --
   const { data: historyData, isLoading: backupLoading } = useBackupHistory();
@@ -183,7 +156,8 @@ export default function SystemPage() {
   const [verifyResult, setVerifyResult] = useState<VerifyBackupResponse | null>(null);
   // Set after a successful import: the artifact is staged and a restart applies it.
   const [restartRequired, setRestartRequired] = useState(false);
-  const [confirmArchiveOpen, setConfirmArchiveOpen] = useState(false);
+  // Filename pending a delete confirmation (drives the shared <ConfirmDialog>).
+  const [deleteConfirmFile, setDeleteConfirmFile] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const backupHistory = historyData?.backups ?? [];
@@ -199,7 +173,6 @@ export default function SystemPage() {
     if (!updateStatus) return;
 
     if (updateStatus.status === "complete") {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
       setIsUpdating(false);
       success(
         "Update Complete",
@@ -257,43 +230,6 @@ export default function SystemPage() {
   };
 
   // -------------------------------------------------------------------------
-  // Storage handlers
-  // -------------------------------------------------------------------------
-
-  const handleOperatorWindowChange = async (blocks: number) => {
-    try {
-      await setOperatorWindow.mutateAsync(blocks);
-      success("Window Updated", `Operator window set to ${formatDuration(blocks)}`);
-    } catch (err) {
-      toastError("Failed", err instanceof Error ? err.message : "Unknown error");
-    }
-  };
-
-  const applyArchiveMode = async (enabled: boolean) => {
-    try {
-      await setArchiveMode.mutateAsync(enabled);
-      success(
-        "Mode Changed",
-        enabled
-          ? "Archive Mode enabled — ghostd is restarting to stop pruning."
-          : "Archive Mode disabled.",
-      );
-    } catch (err) {
-      toastError("Failed", err instanceof Error ? err.message : "Unknown error");
-    }
-  };
-
-  const handleArchiveModeToggle = async () => {
-    // Enabling restarts ghostd and, on a pruned node, kicks off a long reindex —
-    // confirm first. Disabling is safe, so apply directly.
-    if (!archiveMode) {
-      setConfirmArchiveOpen(true);
-    } else {
-      await applyArchiveMode(false);
-    }
-  };
-
-  // -------------------------------------------------------------------------
   // Backup handlers
   // -------------------------------------------------------------------------
 
@@ -307,8 +243,9 @@ export default function SystemPage() {
     document.body.removeChild(link);
   };
 
-  const handleDeleteBackup = async (filename: string) => {
-    if (!confirm(`Are you sure you want to delete ${filename}?`)) return;
+  const handleDeleteBackup = async () => {
+    const filename = deleteConfirmFile;
+    if (!filename) return;
 
     try {
       const result = await deleteBackupMutation.mutateAsync(filename);
@@ -320,6 +257,8 @@ export default function SystemPage() {
     } catch (err) {
       console.error("Delete error:", err);
       toastError("Delete Failed", err instanceof Error ? err.message : String(err));
+    } finally {
+      setDeleteConfirmFile(null);
     }
   };
 
@@ -407,7 +346,7 @@ export default function SystemPage() {
             <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
               <div className="p-4 bg-[var(--surface)] rounded-lg">
                 <div className="text-sm text-[color:var(--dim)] mb-1">Version</div>
-                <div className="text-xl font-bold text-[color:var(--accent)]">
+                <div className="t-stat font-bold text-[color:var(--accent)]">
                   {version?.version ?? version?.node_version ?? "Unknown"}
                 </div>
               </div>
@@ -576,240 +515,107 @@ export default function SystemPage() {
       </SectionErrorBoundary>
 
       {/* ----------------------------------------------------------------- */}
-      {/* Storage & Pruning                                                  */}
+      {/* Storage & Pruning — L1 via the shared card (identical to /storage  */}
+      {/* and /settings/storage), L2 status alongside it.                    */}
       {/* ----------------------------------------------------------------- */}
       <SectionErrorBoundary section="Storage">
-        <Card collapsible>
+        <StoragePruningCard />
+      </SectionErrorBoundary>
+
+      <SectionErrorBoundary section="L2 Pruning">
+        <Card>
           <CardHeader
-            title="Storage & Pruning"
-            subtitle="L1/L2 pruning, archive mode, and operator window"
-            action={archiveMode ? <Badge variant="success">+5 Shares (Archive)</Badge> : undefined}
+            title="L2 Pruning (Ghost Pay)"
+            subtitle="Automatic pruning of old payments, attestations, and closed locks"
           />
-
-          {configLoading ? (
-            <SkeletonCard />
-          ) : (
-            <div className="space-y-6">
-              {/* ---------- L1 Pruning ---------- */}
-              <div className="space-y-6">
-                <h4 className="text-sm font-medium text-[color:var(--dim)] uppercase tracking-wider">L1 Pruning</h4>
-
-                {/* Archive Mode Toggle */}
-                <div className="p-4 bg-[var(--surface)] rounded-lg">
-                  <div className="flex items-center justify-between">
-                    <div>
-                      <div className="flex items-center gap-2">
-                        <span className="text-[color:var(--fg)] font-medium">Archive Mode</span>
-                        {archiveMode && <Badge variant="success">+5 Shares</Badge>}
-                      </div>
-                      <p className="text-sm text-[color:var(--dim)] mt-1">
-                        Store complete blockchain history. Disables all pruning and earns bonus shares.
-                      </p>
-                    </div>
-                    <Button
-                      variant={archiveMode ? "primary" : "secondary"}
-                      onClick={handleArchiveModeToggle}
-                      loading={setArchiveMode.isPending}
-                    >
-                      {archiveMode ? "Enabled" : "Disabled"}
-                    </Button>
-                  </div>
-
-                  {fullConfig?.pruning?.reindex_pending && (
-                    <div className="mt-3 flex items-start gap-2 p-3 rounded-lg bg-[color-mix(in_srgb,var(--yellow)_12%,transparent)] border border-[color:var(--yellow)]">
-                      <span
-                        className="mt-0.5 inline-block w-2 h-2 rounded-full bg-[color:var(--yellow)] animate-pulse"
-                        aria-hidden
-                      />
-                      <p className="text-xs text-[color:var(--dim)] leading-relaxed">
-                        <span className="text-[color:var(--fg)] font-medium">Re-indexing.</span>{" "}
-                        This node was pruned, so ghostd is rebuilding and re-downloading the full
-                        chain (a one-time <code>-reindex</code>). This can take hours; the flag
-                        clears itself once the resync completes.
-                      </p>
-                    </div>
-                  )}
+          <div className="space-y-4">
+            {!ghostPayRunning ? (
+              <div className="p-4 bg-[var(--surface)] border border-[color:var(--accent)] rounded-lg">
+                <div className="flex items-center gap-2">
+                  <Badge variant="warning">Ghost Pay Not Running</Badge>
                 </div>
-
-                <ConfirmDialog
-                  isOpen={confirmArchiveOpen}
-                  onClose={() => setConfirmArchiveOpen(false)}
-                  onConfirm={async () => {
-                    setConfirmArchiveOpen(false);
-                    await applyArchiveMode(true);
-                  }}
-                  title="Enable Archive Mode?"
-                  message="This restarts ghostd with pruning disabled (-prune=0). If this node is currently pruned, it also triggers a one-time full reindex and re-download of the chain — a long resync that can take hours. The node keeps validating throughout. Continue?"
-                  confirmLabel="Enable & restart ghostd"
-                  loading={setArchiveMode.isPending}
-                />
-
-                {/* Window Visualization */}
-                <div className="grid grid-cols-3 gap-4">
-                  <div className="p-4 bg-[var(--surface)] border border-[color:var(--accent)] rounded-lg">
-                    <div className="text-[color:var(--accent)] font-medium mb-2">Validator Window (VW)</div>
-                    <div className="text-2xl font-bold text-[color:var(--fg)]">{fullConfig?.pruning?.vw_blocks ?? 288} blocks</div>
-                    <div className="text-sm text-[color:var(--dim)] mt-1">~{formatDuration(fullConfig?.pruning?.vw_blocks ?? 288)}</div>
-                    <div className="mt-3 text-xs text-[color:var(--accent)]">
-                      Fixed - Bitcoin Core minimum for reorg safety
+                <p className="text-sm text-[color:var(--accent)] mt-2">
+                  Start ghost-pay-node to enable L2 functionality and see pruning status.
+                </p>
+              </div>
+            ) : l2Loading ? (
+              <SkeletonCard />
+            ) : l2Pruning ? (
+              <>
+                <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+                  <div className="p-4 bg-[var(--surface)] rounded-lg">
+                    <div className="text-sm text-[color:var(--dim)]">Retention Period</div>
+                    <div className="t-stat font-bold text-[color:var(--fg)] mt-1">
+                      {l2Pruning.retention_days ?? 90} days
                     </div>
                   </div>
-
-                  <div className={`p-4 rounded-lg border ${archiveMode ? "bg-[var(--surface)] border-[var(--rule-strong)]" : "bg-[var(--surface)] border-[color:var(--accent)]"}`}>
-                    <div className={`font-medium mb-2 ${archiveMode ? "text-[color:var(--fainter)]" : "text-[color:var(--accent)]"}`}>
-                      Operator Window (OW)
+                  <div className="p-4 bg-[var(--surface)] rounded-lg">
+                    <div className="text-sm text-[color:var(--dim)]">Auto Prune</div>
+                    <div className="mt-1">
+                      <Badge variant="success">Always On</Badge>
                     </div>
-                    <div className={`text-2xl font-bold ${archiveMode ? "text-[color:var(--fainter)]" : "text-[color:var(--fg)]"}`}>
-                      {(fullConfig?.pruning?.ow_blocks ?? 0) > 0 ? `${fullConfig?.pruning?.ow_blocks} blocks` : "Keep all"}
-                    </div>
-                    <div className="text-sm text-[color:var(--dim)] mt-1">
-                      {(fullConfig?.pruning?.ow_blocks ?? 0) > 0 ? `~${formatDuration(fullConfig?.pruning?.ow_blocks ?? 0)}` : "No pruning depth set"}
-                    </div>
-                    <div className={`mt-3 text-xs ${archiveMode ? "text-[color:var(--fainter)]" : "text-[color:var(--accent)]"}`}>
-                      {archiveMode ? "Disabled (Archive Mode)" : "Prune depth (prune_height)"}
+                    <div className="text-xs text-[color:var(--fainter)] mt-1">
+                      Every {l2Pruning.prune_interval_hours ?? 24}h
                     </div>
                   </div>
-
-                  <div className={`p-4 rounded-lg border ${archiveMode ? "bg-[var(--surface)] border-[color:var(--green)]" : "bg-[var(--surface)] border-[var(--rule-strong)]"}`}>
-                    <div className={`font-medium mb-2 ${archiveMode ? "text-[color:var(--green)]" : "text-[color:var(--fainter)]"}`}>
-                      Archive Window (AW)
+                  <div className="p-4 bg-[var(--surface)] rounded-lg">
+                    <div className="text-sm text-[color:var(--dim)]">Last Prune</div>
+                    <div className="text-lg font-medium text-[color:var(--fg)] mt-1">
+                      {formatTimeAgo(l2Pruning.last_prune_timestamp ?? 0)}
                     </div>
-                    <div className={`text-2xl font-bold ${archiveMode ? "text-[color:var(--fg)]" : "text-[color:var(--fainter)]"}`}>
-                      {archiveMode ? "Infinite" : "Pruned"}
+                    <div className="text-xs text-[color:var(--fainter)] mt-1">
+                      {formatTimestamp(l2Pruning.last_prune_timestamp ?? 0)}
                     </div>
-                    <div className="text-sm text-[color:var(--dim)] mt-1">
-                      {archiveMode ? "All history retained" : "Data beyond OW is deleted"}
-                    </div>
-                    <div className={`mt-3 text-xs ${archiveMode ? "text-[color:var(--green)]" : "text-[color:var(--fainter)]"}`}>
-                      {archiveMode ? "Full chain storage enabled" : "Enable Archive Mode for +5 shares"}
+                  </div>
+                  <div className="p-4 bg-[var(--surface)] rounded-lg">
+                    <div className="text-sm text-[color:var(--dim)]">Last Run Stats</div>
+                    <div className="text-sm text-[color:var(--dim)] mt-2 space-y-1">
+                      <div>Payments: {l2Pruning.payments_pruned ?? 0}</div>
+                      <div>Attestations: {l2Pruning.attestations_pruned ?? 0}</div>
+                      <div>Locks: {l2Pruning.locks_pruned ?? 0}</div>
                     </div>
                   </div>
                 </div>
 
-                {/* Operator Window Selection */}
-                {!archiveMode && (
-                  <div className="space-y-3">
-                    <label className="text-sm font-medium text-[color:var(--dim)]">Operator Window Size</label>
-                    <p className="text-xs text-[color:var(--fainter)]">
-                      How many recent blocks to keep on disk (prune_height). Any non-zero depth is
-                      clamped up to the Validator Window floor.
-                    </p>
-                    <div className="grid grid-cols-3 gap-3">
-                      {OW_PRESETS.map((preset) => (
-                        <button
-                          key={preset.blocks}
-                          onClick={() => handleOperatorWindowChange(preset.blocks)}
-                          disabled={setOperatorWindow.isPending}
-                          className={`p-3 rounded-lg border transition-colors text-left ${
-                            fullConfig?.pruning?.ow_blocks === preset.blocks
-                              ? "bg-[var(--surface)] border-[color:var(--accent)] text-[color:var(--accent)]"
-                              : "bg-[var(--surface)] border-[var(--rule-strong)] text-[color:var(--dim)] hover:border-[var(--rule-strong)]"
-                          }`}
-                        >
-                          <div className="font-medium">{preset.label}</div>
-                          <div className="text-xs text-[color:var(--fainter)] mt-1">{preset.blocks} blocks</div>
-                          <div className="text-xs text-[color:var(--dim)] mt-1">{preset.description}</div>
-                        </button>
-                      ))}
-                    </div>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  <div className="p-4 bg-[var(--surface)] border border-[color:var(--red)] rounded-lg">
+                    <h4 className="text-[color:var(--red)] font-medium mb-3">What Gets Pruned</h4>
+                    <ul className="text-sm text-[color:var(--red)] space-y-2">
+                      <li className="flex items-start gap-2">
+                        <span className="text-[color:var(--red)] mt-0.5">&bull;</span>
+                        <span>Payments (with ZK proofs) older than {l2Pruning.retention_days ?? 90} days</span>
+                      </li>
+                      <li className="flex items-start gap-2">
+                        <span className="text-[color:var(--red)] mt-0.5">&bull;</span>
+                        <span>Attestations older than {l2Pruning.retention_days ?? 90} days</span>
+                      </li>
+                      <li className="flex items-start gap-2">
+                        <span className="text-[color:var(--red)] mt-0.5">&bull;</span>
+                        <span>Closed locks (reconciled or jumped) older than {l2Pruning.retention_days ?? 90} days</span>
+                      </li>
+                    </ul>
                   </div>
-                )}
+                  <div className="p-4 bg-[var(--surface)] border border-[color:var(--green)] rounded-lg">
+                    <h4 className="text-[color:var(--green)] font-medium mb-3">What is Never Pruned</h4>
+                    <ul className="text-sm text-[color:var(--green)] space-y-2">
+                      <li className="flex items-start gap-2">
+                        <span className="text-[color:var(--green)] mt-0.5">&bull;</span>
+                        <span>Active locks (regardless of age)</span>
+                      </li>
+                      <li className="flex items-start gap-2">
+                        <span className="text-[color:var(--green)] mt-0.5">&bull;</span>
+                        <span>L2 block headers (contain state_root commitments)</span>
+                      </li>
+                    </ul>
+                  </div>
+                </div>
+              </>
+            ) : (
+              <div className="p-4 bg-[var(--surface)] rounded-lg text-[color:var(--dim)]">
+                Unable to fetch L2 pruning status. Ensure ghost-pay-node API is accessible.
               </div>
-
-              {/* ---------- L2 Pruning ---------- */}
-              <div className="space-y-4 pt-4 border-t border-[var(--rule)]">
-                <h4 className="text-sm font-medium text-[color:var(--dim)] uppercase tracking-wider">L2 Pruning (Ghost Pay)</h4>
-
-                {!ghostPayRunning ? (
-                  <div className="p-4 bg-[var(--surface)] border border-[color:var(--accent)] rounded-lg">
-                    <div className="flex items-center gap-2">
-                      <Badge variant="warning">Ghost Pay Not Running</Badge>
-                    </div>
-                    <p className="text-sm text-[color:var(--accent)] mt-2">
-                      Start ghost-pay-node to enable L2 functionality and see pruning status.
-                    </p>
-                  </div>
-                ) : l2Loading ? (
-                  <SkeletonCard />
-                ) : l2Pruning ? (
-                  <>
-                    <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-                      <div className="p-4 bg-[var(--surface)] rounded-lg">
-                        <div className="text-sm text-[color:var(--dim)]">Retention Period</div>
-                        <div className="text-xl font-bold text-[color:var(--fg)] mt-1">
-                          {l2Pruning.retention_days} days
-                        </div>
-                      </div>
-                      <div className="p-4 bg-[var(--surface)] rounded-lg">
-                        <div className="text-sm text-[color:var(--dim)]">Auto Prune</div>
-                        <div className="mt-1">
-                          <Badge variant="success">Always On</Badge>
-                        </div>
-                        <div className="text-xs text-[color:var(--fainter)] mt-1">
-                          Every {l2Pruning.prune_interval_hours}h
-                        </div>
-                      </div>
-                      <div className="p-4 bg-[var(--surface)] rounded-lg">
-                        <div className="text-sm text-[color:var(--dim)]">Last Prune</div>
-                        <div className="text-lg font-medium text-[color:var(--fg)] mt-1">
-                          {formatTimeAgo(l2Pruning.last_prune_timestamp ?? 0)}
-                        </div>
-                        <div className="text-xs text-[color:var(--fainter)] mt-1">
-                          {formatTimestamp(l2Pruning.last_prune_timestamp ?? 0)}
-                        </div>
-                      </div>
-                      <div className="p-4 bg-[var(--surface)] rounded-lg">
-                        <div className="text-sm text-[color:var(--dim)]">Last Run Stats</div>
-                        <div className="text-sm text-[color:var(--dim)] mt-2 space-y-1">
-                          <div>Payments: {l2Pruning.payments_pruned}</div>
-                          <div>Attestations: {l2Pruning.attestations_pruned}</div>
-                          <div>Locks: {l2Pruning.locks_pruned}</div>
-                        </div>
-                      </div>
-                    </div>
-
-                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                      <div className="p-4 bg-[var(--surface)] border border-[color:var(--red)] rounded-lg">
-                        <h4 className="text-[color:var(--red)] font-medium mb-3">What Gets Pruned</h4>
-                        <ul className="text-sm text-[color:var(--red)] space-y-2">
-                          <li className="flex items-start gap-2">
-                            <span className="text-[color:var(--red)] mt-0.5">&bull;</span>
-                            <span>Payments (with ZK proofs) older than {l2Pruning.retention_days} days</span>
-                          </li>
-                          <li className="flex items-start gap-2">
-                            <span className="text-[color:var(--red)] mt-0.5">&bull;</span>
-                            <span>Attestations older than {l2Pruning.retention_days} days</span>
-                          </li>
-                          <li className="flex items-start gap-2">
-                            <span className="text-[color:var(--red)] mt-0.5">&bull;</span>
-                            <span>Closed locks (reconciled or jumped) older than {l2Pruning.retention_days} days</span>
-                          </li>
-                        </ul>
-                      </div>
-                      <div className="p-4 bg-[var(--surface)] border border-[color:var(--green)] rounded-lg">
-                        <h4 className="text-[color:var(--green)] font-medium mb-3">What is Never Pruned</h4>
-                        <ul className="text-sm text-[color:var(--green)] space-y-2">
-                          <li className="flex items-start gap-2">
-                            <span className="text-[color:var(--green)] mt-0.5">&bull;</span>
-                            <span>Active locks (regardless of age)</span>
-                          </li>
-                          <li className="flex items-start gap-2">
-                            <span className="text-[color:var(--green)] mt-0.5">&bull;</span>
-                            <span>L2 block headers (contain state_root commitments)</span>
-                          </li>
-                        </ul>
-                      </div>
-                    </div>
-                  </>
-                ) : (
-                  <div className="p-4 bg-[var(--surface)] rounded-lg text-[color:var(--dim)]">
-                    Unable to fetch L2 pruning status. Ensure ghost-pay-node API is accessible.
-                  </div>
-                )}
-              </div>
-
-            </div>
-          )}
+            )}
+          </div>
         </Card>
       </SectionErrorBoundary>
 
@@ -894,7 +700,7 @@ export default function SystemPage() {
                           <Button
                             variant="ghost"
                             size="sm"
-                            onClick={() => handleDeleteBackup(backup.filename)}
+                            onClick={() => setDeleteConfirmFile(backup.filename)}
                             disabled={deleteBackupMutation.isPending}
                           >
                             Delete
@@ -1186,6 +992,22 @@ export default function SystemPage() {
           </div>
         </div>
       </Dialog>
+
+      {/* Delete Backup Confirmation */}
+      <ConfirmDialog
+        isOpen={deleteConfirmFile !== null}
+        onClose={() => setDeleteConfirmFile(null)}
+        onConfirm={handleDeleteBackup}
+        title="Delete Backup"
+        message={
+          deleteConfirmFile
+            ? `Delete ${deleteConfirmFile}? This permanently removes the backup file from the node and cannot be undone.`
+            : ""
+        }
+        confirmLabel="Delete"
+        variant="danger"
+        loading={deleteBackupMutation.isPending}
+      />
     </div>
   );
 }

--- a/dashboard/src/app/(dashboard)/watchdog/page.tsx
+++ b/dashboard/src/app/(dashboard)/watchdog/page.tsx
@@ -178,8 +178,8 @@ export default function WatchdogPage() {
     <div className="space-y-6">
       <PageHeader
         eyebrow="watchdog"
-        title="Capability verification."
-        subtitle="Service health and resource monitoring"
+        title="Service health & resources."
+        subtitle="Live status of node services, components, and system resources."
         actions={
           status ? (
             <Badge variant={getHealthBadge(overallHealth).variant}>


### PR DESCRIPTION
Storage and System-ops dashboard normalisation. One PR, four P-fixes plus a targeted type-scale pass.

## P-fixes
- **P1.1 + P2.7 — `/system` uses the shared `<StoragePruningCard/>`.** Deleted the bespoke Archive-Mode button and the crude 3-preset Operator-Window UI on `/system` and rendered the same `<StoragePruningCard/>` used on `/storage` and `/settings/storage`, so the depth/archive controls are now identical everywhere. The L2-pruning block now mirrors `/storage` (own card, and the correct `sync_state === "synced"` running-check rather than the misleading `!!l2_height`). Version/updates/backups are untouched.
- **Delete-confirm consistency.** The backup **Delete** action used a raw browser `confirm()`; it now drives the shared `<ConfirmDialog>` (with the `danger` variant), matching every other destructive action in the dashboard.
- **P1.3 — `/watchdog` label.** The eyebrow/title said `Capability verification`, which was wrong for a page that monitors services and resources. Retitled to `Service health & resources.` with an accurate subtitle.
- **P2.6 — `/swarm` nickname.** Local-node rename called the raw `setNickname` API directly; it now uses the `useSetNickname` mutation hook (as `/settings/general` does), and the Save button reflects its pending state.

## Type scale
Targeted pass replacing inline `fontSize` px and off-scale sizes with the nearest semantic `.t-*` by role, preserving colours and spacing:
- `/system`, `/storage` — `text-xl` stat values (version, L2 retention) to `.t-stat`.
- `/capacity` — `16px` headings to `.t-title`, `13px` prose/`code` to `.t-label`, stat tile label to `.t-eyebrow`, stat value to `.t-stat`.
- `/capabilities` — `13px` cells/links/prose to `.t-label`, `16px` heading to `.t-title`, `14px` hint to `.t-body`, table headers (`13px` mono-uppercase) to `.t-label-mono`.

Pages with no off-scale sizes and no P-fix (`/peers`, `/connect`, `/logs`, `/elders`, and the settings components) were left untouched. `/logs` uses on-scale `12px` throughout and was deliberately not churned.

## Housekeeping
Removed dead code exposed by the refactor to keep the touched files lint-clean: unused `formatDuration`/`fullConfig` in `/storage`, and a now-redundant `eslint-disable` in `/system`. Added an explanatory `exhaustive-deps` disable to the pre-existing `/swarm` auto-refresh interval (keyed on node count by design).

## Verification
`tsc --noEmit` clean and `eslint` clean on all changed files.
