### PR TITLE
dashboard: ProgressBar outline + sidebar active-item fix

### DIFF
--- a/dashboard/src/components/layout/Sidebar.tsx
+++ b/dashboard/src/components/layout/Sidebar.tsx
@@ -40,6 +40,7 @@ import { SidebarItem } from "./SidebarItem";
 import { GhostBrand } from "@/components/ui/GhostBrand";
 import { StatusDot } from "@/components/ui/StatusDot";
 import { ThemeToggle } from "@/components/ui/ThemeToggle";
+import { usePathname } from "next/navigation";
 
 interface NavItem {
   href: string;
@@ -168,6 +169,16 @@ export function Sidebar() {
   const nickname = useConfigStore((s) => s.nickname);
   const isConnected = useNodeStore((s) => s.isConnected);
 
+  // Single active route = the nav item whose href is the LONGEST prefix (exact
+  // or `href/…`) of the current path. This stops a parent like `/filtering`
+  // lighting up when you're on `/filtering/advanced`, while still keeping e.g.
+  // `/settings` active across `/settings/*`. `/` matches only itself.
+  const pathname = usePathname();
+  const activeHref =
+    GROUPS.flatMap((g) => g.items.map((i) => i.href))
+      .filter((h) => pathname === h || pathname.startsWith(h + "/"))
+      .sort((a, b) => b.length - a.length)[0] ?? null;
+
   return (
     <>
       {/* Mobile hamburger button */}
@@ -277,6 +288,7 @@ export function Sidebar() {
                     icon={item.icon}
                     label={item.label}
                     collapsed={collapsed}
+                    isActive={item.href === activeHref}
                   />
                 ))}
               </div>

--- a/dashboard/src/components/layout/SidebarItem.tsx
+++ b/dashboard/src/components/layout/SidebarItem.tsx
@@ -9,6 +9,10 @@ interface SidebarItemProps {
   icon: ReactNode;
   label: string;
   collapsed?: boolean;
+  /** When provided, the parent (Sidebar) has computed the single active item
+   *  via longest-prefix match, so nested routes highlight only their deepest
+   *  match (e.g. /filtering/advanced does NOT also light up /filtering). */
+  isActive?: boolean;
 }
 
 /**
@@ -19,9 +23,9 @@ interface SidebarItemProps {
  * Borders carry the meaning — matches the website's "no card chrome,
  * borders only where they signal something" rule.
  */
-export function SidebarItem({ href, icon, label, collapsed = false }: SidebarItemProps) {
+export function SidebarItem({ href, icon, label, collapsed = false, isActive: isActiveProp }: SidebarItemProps) {
   const pathname = usePathname();
-  const isActive = pathname === href || (href !== "/" && pathname.startsWith(href));
+  const isActive = isActiveProp ?? (pathname === href || (href !== "/" && pathname.startsWith(href)));
 
   return (
     <Link

--- a/dashboard/src/components/ui/ProgressBar.tsx
+++ b/dashboard/src/components/ui/ProgressBar.tsx
@@ -42,7 +42,7 @@ export function ProgressBar({
           {sublabel && <span className="text-sm text-[color:var(--dim)] font-mono">{sublabel}</span>}
         </div>
       )}
-      <div className={`bg-[var(--surface)] rounded-full overflow-hidden ${sizeClasses[size]}`}>
+      <div className={`bg-[var(--surface)] border border-[color:var(--rule-strong)] rounded-full overflow-hidden ${sizeClasses[size]}`}>
         <div
           className={`${colorClasses[color]} rounded-full transition-all duration-500 h-full`}
           style={{ width: `${percent}%` }}


### PR DESCRIPTION
Track outline so empty progress bars show (treasury/elders); sidebar longest-prefix active so nested routes don't double-highlight.