### PR TITLE
style(privacy/pay): calm-prose discipline + open reference sections

### DIFF
--- a/dashboard/src/app/(dashboard)/ghost-mode/page.tsx
+++ b/dashboard/src/app/(dashboard)/ghost-mode/page.tsx
@@ -156,8 +156,7 @@ export default function GhostModePage() {
               }}
             >
               <p className="t-body" style={{ color: "var(--dim)", lineHeight: "1.6" }}>
-                <span style={{ color: "var(--fg)", fontWeight: 600 }}>Public Mining is active.</span>{" "}
-                Ghost Mode would make your node build empty blocks and forfeit all fee income, so the
+                Public Mining is active. Ghost Mode would make your node build empty blocks and forfeit all fee income, so the
                 two can&apos;t run together — disable Public Mining first on the{" "}
                 <a
                   href="/settings/capabilities"
@@ -254,7 +253,7 @@ export default function GhostModePage() {
               }}
             >
               <p className="t-body" style={{ color: "var(--dim)", lineHeight: "1.6" }}>
-                <span style={{ color: "var(--fg)", fontWeight: 600 }}>Heads up:</span> broadcasting your
+                Heads up: broadcasting your
                 own transactions reveals them to the peers you announce to, which can tie a transaction to
                 your node&apos;s IP address. Enable{" "}
                 <a
@@ -282,10 +281,10 @@ export default function GhostModePage() {
           config with a friendly toggle. When <code>ghost_mode = true</code>:
         </p>
         <ul className="t-body" style={{ color: "var(--dim)", lineHeight: "1.7", paddingLeft: "18px", listStyle: "disc" }}>
-          <li><strong style={{ color: "var(--fg)" }}>Relay is suppressed.</strong> <code>RelayTransaction()</code> returns early — your node never pushes unconfirmed transactions to peers.</li>
-          <li><strong style={{ color: "var(--fg)" }}>getdata returns NOT_FOUND.</strong> A peer asking &quot;give me transaction X&quot; is answered <code>NOT_FOUND</code> regardless of whether X is in your mempool. Your mempool stops being a public lookup table.</li>
-          <li><strong style={{ color: "var(--fg)" }}>No INV announcements.</strong> Your node doesn&apos;t tell peers about unconfirmed transactions it has seen.</li>
-          <li><strong style={{ color: "var(--fg)" }}>Blocks are unaffected.</strong> You still receive, validate and forward blocks; the chain propagates through your node normally.</li>
+          <li>Relay is suppressed. <code>RelayTransaction()</code> returns early — your node never pushes unconfirmed transactions to peers.</li>
+          <li><code>getdata</code> returns <code>NOT_FOUND</code>. A peer asking &quot;give me transaction X&quot; is answered <code>NOT_FOUND</code> regardless of whether X is in your mempool. Your mempool stops being a public lookup table.</li>
+          <li>No <code>INV</code> announcements. Your node doesn&apos;t tell peers about unconfirmed transactions it has seen.</li>
+          <li>Blocks are unaffected. You still receive, validate and forward blocks; the chain propagates through your node normally.</li>
         </ul>
         <div
           style={{
@@ -297,7 +296,7 @@ export default function GhostModePage() {
           }}
         >
           <p className="t-body" style={{ color: "var(--dim)", lineHeight: "1.6" }}>
-            <span style={{ color: "var(--fg)", fontWeight: 600 }}>Trade-off:</span> Ghost Mode is a
+            Trade-off: Ghost Mode is a
             suppression of the standard relay path, not a replacement transport. Without local egress, a
             wallet on a Ghost Mode node must find another route to reach miners — an out-of-band relay over
             Tor, a separate broadcasting node, or a paid broadcast service — otherwise its transactions
@@ -313,7 +312,7 @@ export default function GhostModePage() {
           Does this affect my capability shares?
         </h3>
         <p className="t-body" style={{ color: "var(--dim)", lineHeight: "1.6", marginBottom: "12px" }}>
-          <strong style={{ color: "var(--fg)", fontWeight: 600 }}>Not for most of them.</strong> Archive, Ghost Pay, Reaper
+          Not for most of them. Archive, Ghost Pay, Reaper
           and Elder are each verified by an HTTP challenge–response to your node&apos;s API (block
           retrieval, L2-block lookup, policy classification, registration order) — none of which rides the
           P2P transaction-relay path Ghost Mode suppresses, so those +5 / +4 / +2 / +1 shares are
@@ -331,8 +330,7 @@ export default function GhostModePage() {
           }}
         >
           <p className="t-body" style={{ color: "var(--dim)", lineHeight: "1.6" }}>
-            <span style={{ color: "var(--fg)", fontWeight: 600 }}>Public Mining is mutually exclusive.</span>{" "}
-            Ghost Mode rejects transactions from peers, so your mempool never fills with fee-paying
+            Public Mining is mutually exclusive. Ghost Mode rejects transactions from peers, so your mempool never fills with fee-paying
             transactions and the blocks your node builds are near-empty — coinbase subsidy only. Since the
             node operator keeps the transaction fees (miners are paid from the subsidy, less the pool fee),
             an empty block means zero fee income. So you

--- a/dashboard/src/app/(dashboard)/ghost-pay/page.tsx
+++ b/dashboard/src/app/(dashboard)/ghost-pay/page.tsx
@@ -163,7 +163,7 @@ export default function GhostPayPage() {
         <Card>
           <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: "16px" }}>
             <div>
-              <div className="t-lead" style={{ color: "var(--fg)", fontWeight: 500 }}>Ghost Pay L2</div>
+              <div className="t-title" style={{ color: "var(--fg)" }}>Ghost Pay L2</div>
               <div className="t-caption" style={{ color: "var(--dim)", marginTop: "2px" }}>
                 Run the L2 payments layer and earn the +4 capability share. L2 state pruning is mandatory and handled automatically.
               </div>

--- a/dashboard/src/app/(dashboard)/haze/page.tsx
+++ b/dashboard/src/app/(dashboard)/haze/page.tsx
@@ -292,16 +292,9 @@ export default function HazePage() {
               {formatBytes(savings.strippedBytes)}
             </div>
             <p className="text-[color:var(--dim)] text-sm mt-3 max-w-2xl leading-relaxed">
-              Ghost Exorcism has removed{" "}
-              <span className="text-[color:var(--fg)] font-medium">
-                {formatBytes(savings.strippedBytes)}
-              </span>{" "}
-              of non-consensus content across{" "}
-              <span className="text-[color:var(--fg)] font-medium">
-                {(haze?.blocks_stripped ?? 0).toLocaleString()}
-              </span>{" "}
-              blocks — inscriptions, spam and data-carrier payloads that never reached your
-              disk.
+              Ghost Exorcism has removed {formatBytes(savings.strippedBytes)} of non-consensus
+              content across {(haze?.blocks_stripped ?? 0).toLocaleString()} blocks — inscriptions,
+              spam and data-carrier payloads that never reached your disk.
             </p>
             <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mt-6">
               <div className="rounded-lg p-4 bg-[var(--surface)] border border-[color:var(--rule)]">
@@ -519,8 +512,7 @@ export default function HazePage() {
             <div className="p-4 rounded-lg bg-[var(--surface)] border border-[color:var(--rule-strong)]">
               <p className="text-[color:var(--dim)] text-sm leading-relaxed">
                 The Legal Compliance Pack is a signed, court-ready proof that your node does
-                not persist arbitrary embedded content. It is generated once{" "}
-                <span className="text-[color:var(--fg)] font-medium">Haze is enabled</span> and
+                not persist arbitrary embedded content. It is generated once Haze is enabled and
                 the Exorcist is stripping blocks.
                 {legal?.reason && (
                   <span className="block mt-2 text-xs text-[color:var(--fainter)]">
@@ -540,7 +532,7 @@ export default function HazePage() {
           subtitle="Non-consensus fields removed by Ghost Haze's own field classifier"
         />
         <p className="text-[color:var(--dim)] text-sm leading-relaxed mb-4">
-          Ghost Haze uses its own <code className="text-[color:var(--accent)]">field_classifier</code>{" "}
+          Ghost Haze uses its own <code>field_classifier</code>{" "}
           — distinct from the BUDS policy system — to identify the non-consensus bytes where
           inscriptions and spam live. These are stripped after full validation, so consensus and
           the UTXO set are untouched while the arbitrary payloads never reach disk.
@@ -552,7 +544,7 @@ export default function HazePage() {
               className="p-3 bg-[var(--surface)] rounded-lg border border-[color:var(--rule-strong)]"
             >
               <div className="flex items-center gap-2 mb-1.5">
-                <span className="text-[color:var(--accent)] font-mono text-xs font-bold">✕</span>
+                <span className="text-[color:var(--dim)] font-mono text-xs">✕</span>
                 <span className="text-[color:var(--fg)] text-sm font-medium">{f.title}</span>
               </div>
               <p className="text-[color:var(--dim)] text-xs leading-relaxed">{f.body}</p>
@@ -660,8 +652,8 @@ export default function HazePage() {
         </Card>
       </SectionErrorBoundary>
 
-      {/* 5. The Exorcism pipeline */}
-      <Card collapsible defaultCollapsed>
+      {/* 5. The Exorcism pipeline — always-open reference section */}
+      <Card>
         <CardHeader
           title="The Exorcism pipeline"
           subtitle="How Ghost Haze strips blocks before they hit disk"
@@ -676,18 +668,18 @@ export default function HazePage() {
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
             <div className="p-3 bg-[var(--surface)] rounded-lg border border-[color:var(--rule-strong)]">
               <div className="flex items-center gap-2 mb-1.5">
-                <span className="text-[color:var(--accent)] font-mono text-xs font-bold">1</span>
+                <span className="text-[color:var(--dim)] font-mono text-xs">1</span>
                 <span className="text-[color:var(--fg)] text-sm font-medium">Field Classification</span>
               </div>
               <p className="text-[color:var(--dim)] text-xs leading-relaxed">
-                Ghost Haze&apos;s own <code className="text-[color:var(--accent)]">field_classifier</code>{" "}
+                Ghost Haze&apos;s own <code>field_classifier</code>{" "}
                 (not BUDS) marks each non-consensus field — witness data, scriptSig, OP_RETURN
                 payloads and coinbase scriptSig — as strippable once validated.
               </p>
             </div>
             <div className="p-3 bg-[var(--surface)] rounded-lg border border-[color:var(--rule-strong)]">
               <div className="flex items-center gap-2 mb-1.5">
-                <span className="text-[color:var(--accent)] font-mono text-xs font-bold">2</span>
+                <span className="text-[color:var(--dim)] font-mono text-xs">2</span>
                 <span className="text-[color:var(--fg)] text-sm font-medium">Block Stripping</span>
               </div>
               <p className="text-[color:var(--dim)] text-xs leading-relaxed">
@@ -697,18 +689,18 @@ export default function HazePage() {
             </div>
             <div className="p-3 bg-[var(--surface)] rounded-lg border border-[color:var(--rule-strong)]">
               <div className="flex items-center gap-2 mb-1.5">
-                <span className="text-[color:var(--accent)] font-mono text-xs font-bold">3</span>
+                <span className="text-[color:var(--dim)] font-mono text-xs">3</span>
                 <span className="text-[color:var(--fg)] text-sm font-medium">GSB Storage</span>
               </div>
               <p className="text-[color:var(--dim)] text-xs leading-relaxed">
                 Stripped blocks are stored in Ghost Stripped Block (
-                <code className="text-[color:var(--accent)]">.gsb</code>) format — a compact
+                <code>.gsb</code>) format — a compact
                 representation that preserves everything needed for chain validation.
               </p>
             </div>
             <div className="p-3 bg-[var(--surface)] rounded-lg border border-[color:var(--rule-strong)]">
               <div className="flex items-center gap-2 mb-1.5">
-                <span className="text-[color:var(--accent)] font-mono text-xs font-bold">4</span>
+                <span className="text-[color:var(--dim)] font-mono text-xs">4</span>
                 <span className="text-[color:var(--fg)] text-sm font-medium">UTXO Preservation</span>
               </div>
               <p className="text-[color:var(--dim)] text-xs leading-relaxed">
@@ -723,12 +715,12 @@ export default function HazePage() {
             <h4 className="text-[color:var(--fg)] font-medium text-sm mb-1">The Exorcist</h4>
             <p className="text-[color:var(--dim)] text-xs leading-relaxed">
               The Exorcist is the component that performs the actual stripping. It runs inside
-              Ghost Core (<code className="text-[color:var(--accent)]">ghostd</code>) at the block
+              Ghost Core (<code>ghostd</code>) at the block
               acceptance layer, intercepting blocks before they are serialized to disk.
             </p>
             <div className="mt-2 p-2 bg-[var(--surface)] rounded border border-[color:var(--rule-strong)]">
               <div className="text-xs text-[color:var(--dim)] leading-relaxed">
-                <span className="text-[color:var(--accent)] font-medium">Mode A (Active Stripping):</span>{" "}
+                Mode A (Active Stripping):{" "}
                 the Exorcist strips classified content before the block is written. Blocks arrive
                 from the network, get stripped in memory, and only the clean version is persisted.
               </div>
@@ -765,9 +757,9 @@ export default function HazePage() {
             </div>
             <p className="text-[color:var(--dim)] text-xs leading-relaxed">
               This is a one-time batch job that rewrites existing block files into stripped
-              structural blocks. It is <span className="text-[color:var(--fg)]">resumable</span> —
+              structural blocks. It is resumable —
               if the node restarts, conversion continues from where it left off. Your Legal Pack
-              is finalised once it reads <span className="font-mono">COMPLETE</span>.
+              is finalised once it reads <code>COMPLETE</code>.
             </p>
           </div>
         </Card>
@@ -790,7 +782,7 @@ export default function HazePage() {
               Forward — haze from genesis
             </div>
             <p className="text-[color:var(--dim)] text-xs leading-relaxed">
-              A <span className="text-[color:var(--fg)]">fresh</span> node can start hazed and strip
+              A fresh node can start hazed and strip
               every block as it syncs. Nothing arbitrary is ever written — no conversion needed.
             </p>
           </div>
@@ -799,7 +791,7 @@ export default function HazePage() {
               Retroactive — convert existing blocks
             </div>
             <p className="text-[color:var(--dim)] text-xs leading-relaxed">
-              An <span className="text-[color:var(--fg)]">already-synced</span> full or pruned node
+              An already-synced full or pruned node
               cannot simply flip to hazed — it must run a one-time, resumable conversion that strips
               the blocks it already holds. This is the only path to haze later.
             </p>

--- a/dashboard/src/app/(dashboard)/network/page.tsx
+++ b/dashboard/src/app/(dashboard)/network/page.tsx
@@ -182,7 +182,7 @@ function TorRow({
       <div className="flex items-start justify-between gap-6">
         <div style={{ flex: 1, minWidth: 0 }}>
           <div className="flex items-center gap-2 mb-1">
-            <span className="t-lead" style={{ color: "var(--fg)", fontWeight: 500 }}>Tor mode</span>
+            <span className="t-title" style={{ color: "var(--fg)" }}>Tor mode</span>
             {enabled && <Badge variant="success">+anonymity</Badge>}
           </div>
           <p className="t-label" style={{ color: "var(--dim)", lineHeight: "1.5", maxWidth: "60ch" }}>
@@ -234,8 +234,7 @@ function TorRow({
           }}
         >
           <div className="t-label" style={{ color: "var(--fg)", marginBottom: "10px" }}>
-            {target ? "Enable" : "Disable"} <strong>Tor mode</strong>? This writes the config and{" "}
-            <strong>restarts ghostd</strong> (then bounces the pool) to apply.
+            {target ? "Enable" : "Disable"} Tor mode? This writes the config and restarts ghostd (then bounces the pool) to apply.
           </div>
           <div className="flex items-center gap-2">
             <Button

--- a/dashboard/src/app/(dashboard)/shroud/page.tsx
+++ b/dashboard/src/app/(dashboard)/shroud/page.tsx
@@ -79,8 +79,8 @@ export default function ShroudPage() {
         />
       </div>
 
-      {/* 3. How It Works — collapsible */}
-      <Card collapsible defaultCollapsed>
+      {/* 3. How It Works — always-open reference section */}
+      <Card>
         <CardHeader
           title="How It Works"
           subtitle="Transaction relay flow with Shroud enabled"
@@ -103,9 +103,9 @@ export default function ShroudPage() {
         />
         <div className="mt-4 p-3 bg-[var(--surface)] rounded-lg border border-[var(--rule-strong)]">
           <p className="text-xs text-[color:var(--dim)] leading-relaxed">
-            <span className="text-[color:var(--blue)] font-medium">Note:</span> The mempool addition is
+            Note: The mempool addition is
             instant — your node can mine and validate the transaction immediately. Shroud only
-            affects the <span className="text-[color:var(--blue)]">outbound relay</span> timing, ensuring
+            affects the outbound relay timing, ensuring
             adversaries cannot correlate relay order with transaction origin.
           </p>
         </div>
@@ -151,7 +151,7 @@ export default function ShroudPage() {
                 </span>
               </StatusRow>
               <StatusRow label="Avg Delay" tooltip={TOOLTIPS.avg_delay}>
-                <span className="text-[color:var(--blue)] font-mono text-sm">
+                <span className="text-[color:var(--fg)] font-mono text-sm">
                   {(status.avg_delay_ms ?? 0).toLocaleString()} ms
                 </span>
               </StatusRow>
@@ -160,16 +160,16 @@ export default function ShroudPage() {
         ) : null}
       </SectionErrorBoundary>
 
-      {/* 5. Technical Details — collapsible */}
-      <Card collapsible defaultCollapsed>
+      {/* 5. Technical Details — always-open reference section */}
+      <Card>
         <CardHeader
           title="Privacy Properties"
           subtitle="What Shroud does and does not protect against"
         />
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           {/* Protects Against */}
-          <div className="p-4 bg-[color-mix(in_srgb,var(--blue)_10%,transparent)] rounded-lg border border-[color-mix(in_srgb,var(--blue)_30%,transparent)]">
-            <h4 className="text-sm font-medium text-[color:var(--blue)] mb-3 flex items-center gap-2">
+          <div className="p-4 bg-[var(--surface)] rounded-lg border border-[var(--rule-strong)]">
+            <h4 className="text-sm font-medium text-[color:var(--fg)] mb-3 flex items-center gap-2">
               <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                 <path strokeLinecap="round" strokeLinejoin="round" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
               </svg>

--- a/dashboard/src/app/(dashboard)/wraith/page.tsx
+++ b/dashboard/src/app/(dashboard)/wraith/page.tsx
@@ -132,7 +132,7 @@ export default function WraithPage() {
           ) : (
             <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: "16px" }}>
               <div>
-                <div className="t-lead" style={{ color: "var(--fg)", fontWeight: 500 }}>Wraith mixing</div>
+                <div className="t-title" style={{ color: "var(--fg)" }}>Wraith mixing</div>
                 <div className="t-caption" style={{ color: "var(--dim)", marginTop: "2px", maxWidth: "36rem" }}>
                   When enabled, any L2 participant can initiate a CoinJoin session through this node. Off means the node won&apos;t coordinate mixing. A ghost-pool restart applies the change.
                 </div>


### PR DESCRIPTION
Presentation-only visual-discipline pass across the privacy and payments dashboard pages. No facts, warnings, links, or controls changed — only how the copy is styled.

## Scope (edited only these pages)
`ghost-mode`, `shroud`, `haze`, `network`, `wraith`, `ghost-pay`. No shared components, `globals.css`, settings, or filtering files touched — only imported.

## The discipline applied
- **Uniform prose** — stripped all inline word/term emphasis from running copy: `<strong>`, `fontWeight` 600/700, mid-sentence coloured/`--fg`/accent/blue spans, and mono on non-literal phrases. Body copy is now one weight, one colour (`var(--dim)`).
- **Two heading sizes only** — page title stays `.t-display`; section/card headings that were rendered with `.t-lead` are now `.t-title` (weight 500, `var(--fg)`).
- **Semantic colour** — accent reserved for links/active toggles; green/red kept only as status values (Ghost-Mode's Strong/None column, online/offline dots, Present/None attestation, % savings); yellow kept only as warning-box tint with `var(--dim)` text inside. Removed decorative blue (Shroud) and decorative accent list markers (Haze).
- **Code spans** — mono/`<code>` kept only for literal identifiers (`getdata`, `NOT_FOUND`, `INV`, `field_classifier`, `.gsb`, `ghostd`, `COMPLETE`); dropped the accent colour on code so literals read uncoloured.
- **Reference drop-downs always open** — force-opened the static explanatory sections (Shroud "How It Works" + "Privacy Properties"; Haze "The Exorcism pipeline") by removing `collapsible defaultCollapsed`. All functional interactivity (Configure Shroud wizard, Haze mode controls, toggles, confirm dialogs) untouched.

## Verification
`tsc --noEmit` clean, `eslint` clean on all six files, `npm run build` succeeds.