### PR TITLE
style(financial/identity): calm-prose discipline + open reference sections

### DIFF
--- a/dashboard/src/app/(dashboard)/capacity/page.tsx
+++ b/dashboard/src/app/(dashboard)/capacity/page.tsx
@@ -203,7 +203,7 @@ export default function CapacityPage() {
             </h3>
             <p className="t-label" style={{ color: "var(--dim)" }}>
               {nodes.length} {nodes.length === 1 ? "node" : "nodes"} across the mesh ·{" "}
-              <strong style={{ color: "var(--fg)" }}>{distinctMiners}</strong> distinct active{" "}
+              {distinctMiners} distinct active{" "}
               {distinctMiners === 1 ? "miner" : "miners"} (deduplicated). Each miner is owned by
               exactly one node, so the per-node counts below sum to this total.
               {capacityUnknown > 0 && (

--- a/dashboard/src/app/(dashboard)/elders/page.tsx
+++ b/dashboard/src/app/(dashboard)/elders/page.tsx
@@ -283,11 +283,11 @@ export default function EldersPage() {
 
               {/* Downtime warning */}
               {elder?.downtime_warning && (
-                <div className="p-3 bg-[var(--surface)] border border-[color:var(--accent)] rounded-lg">
-                  <p className="text-[color:var(--accent)] text-sm font-medium">
+                <div className="p-3 bg-[var(--surface)] border border-[color:var(--yellow)] rounded-lg">
+                  <p className="text-[color:var(--yellow)] text-sm font-medium">
                     Downtime Warning
                   </p>
-                  <p className="text-[color:var(--accent)] text-sm mt-1">
+                  <p className="text-[color:var(--yellow)] text-sm mt-1">
                     {elder.consecutive_downtime_days} consecutive days of downtime detected.
                     Elder status requires 95% uptime over a trailing 7-day window.
                   </p>
@@ -327,14 +327,14 @@ export default function EldersPage() {
 
       {/* ZK Proof Info (Collapsible) */}
       <SectionErrorBoundary section="ZK Proof Info">
-        <Card collapsible defaultCollapsed>
+        <Card>
           <CardHeader
             title="Zero-Knowledge Proof Info"
             subtitle="How the MPC ceremony secures the network"
           />
           <div className="space-y-4 text-sm text-[color:var(--dim)] leading-relaxed">
             <div>
-              <h4 className="text-[color:var(--fg)] font-medium mb-1">What is the MPC Ceremony?</h4>
+              <h4 className="t-title mb-1" style={{ color: "var(--fg)" }}>What is the MPC Ceremony?</h4>
               <p>
                 The Multi-Party Computation (MPC) ceremony generates trusted setup parameters
                 for Groth16 zero-knowledge proofs. Each of the 101 contributors adds a layer of
@@ -343,7 +343,7 @@ export default function EldersPage() {
               </p>
             </div>
             <div>
-              <h4 className="text-[color:var(--fg)] font-medium mb-1">Why Groth16?</h4>
+              <h4 className="t-title mb-1" style={{ color: "var(--fg)" }}>Why Groth16?</h4>
               <p>
                 Groth16 produces the smallest proofs (just 3 group elements, ~128 bytes) with the
                 fastest verification time of any general-purpose ZK proof system. The tradeoff is
@@ -351,7 +351,7 @@ export default function EldersPage() {
               </p>
             </div>
             <div>
-              <h4 className="text-[color:var(--fg)] font-medium mb-1">Elder Status</h4>
+              <h4 className="t-title mb-1" style={{ color: "var(--fg)" }}>Elder Status</h4>
               <p>
                 Nodes that contribute to the MPC ceremony earn permanent Elder status, granting +1
                 share in the 5-4-3-2-1 capability system. The first 101 nodes to contribute claim
@@ -360,7 +360,7 @@ export default function EldersPage() {
               </p>
             </div>
             <div>
-              <h4 className="text-[color:var(--fg)] font-medium mb-1">Ossification</h4>
+              <h4 className="t-title mb-1" style={{ color: "var(--fg)" }}>Ossification</h4>
               <p>
                 Once all 101 slots are filled, the ceremony is ossified. No new contributions
                 can be accepted and the parameters are finalized. The ceremony cannot be restarted

--- a/dashboard/src/app/(dashboard)/page.tsx
+++ b/dashboard/src/app/(dashboard)/page.tsx
@@ -63,9 +63,9 @@ function L1Card() {
   const isSyncing = syncStatus === false && syncHeight > 0 && blockHeight > 0;
 
   return (
-    <Card className="border-[color:var(--accent)]">
+    <Card>
       <CardHeader
-        title={<span className="text-[color:var(--accent)]">L1 &middot; Bitcoin</span>}
+        title={<span>L1 &middot; Bitcoin</span>}
         action={
           syncStatus != null && (
             <StatusDot
@@ -82,12 +82,12 @@ function L1Card() {
             <div className="text-xs text-[color:var(--fainter)] mb-1 flex items-center gap-1"><InfoIcon /> Block Height</div>
             <div className="text-lg font-mono font-semibold text-[color:var(--fg)]">
               {isLoading ? "..." : isSyncing
-                ? <span>{syncHeight.toLocaleString()} <span className="text-xs text-[color:var(--accent)]">/ {blockHeight.toLocaleString()}</span></span>
+                ? <span>{syncHeight.toLocaleString()} <span className="text-xs text-[color:var(--fainter)]">/ {blockHeight.toLocaleString()}</span></span>
                 : syncHeight.toLocaleString()
               }
             </div>
             {isSyncing && (
-              <div className="text-xs text-[color:var(--accent)] mt-0.5">
+              <div className="text-xs text-[color:var(--dim)] mt-0.5">
                 IBD &middot; {blockHeight > 0 ? ((syncHeight / blockHeight) * 100).toFixed(1) : 0}%
               </div>
             )}
@@ -150,9 +150,9 @@ function L2Card() {
   const wraithLabel = isLoading ? "..." : wraithActive ? "Active" : isRunning ? "Not enabled" : "Offline";
 
   return (
-    <Card className="border-purple-600/30">
+    <Card>
       <CardHeader
-        title={<span className="text-purple-400">L2 &middot; Ghost Pay</span>}
+        title={<span>L2 &middot; Ghost Pay</span>}
         action={
           isRunning != null && (
             <StatusDot
@@ -165,20 +165,20 @@ function L2Card() {
       />
       <div className="grid grid-cols-2 gap-3">
         <Tooltip content={TOOLTIPS.l2_height}>
-          <div className="p-3 bg-purple-900/10 rounded-lg">
+          <div className="p-3 bg-[var(--surface)] rounded-lg">
             <div className="text-xs text-[color:var(--fainter)] mb-1 flex items-center gap-1"><InfoIcon /> L2 Height</div>
             <div className="text-lg font-mono font-semibold text-[color:var(--fg)]">
-              {isLoading ? "..." : isSyncing ? <span className="text-purple-400">Syncing...</span> : height}
+              {isLoading ? "..." : isSyncing ? <span className="text-[color:var(--dim)]">Syncing...</span> : height}
             </div>
             {isSyncing && (
-              <div className="text-xs text-purple-400 mt-0.5">
+              <div className="text-xs text-[color:var(--dim)] mt-0.5">
                 {height}
               </div>
             )}
           </div>
         </Tooltip>
         <Tooltip content={TOOLTIPS.l2_peers}>
-          <div className="p-3 bg-purple-900/10 rounded-lg">
+          <div className="p-3 bg-[var(--surface)] rounded-lg">
             <div className="text-xs text-[color:var(--fainter)] mb-1 flex items-center gap-1"><InfoIcon /> L2 Peers</div>
             <div className="text-lg font-mono font-semibold text-[color:var(--fg)]">
               {isLoading ? "..." : `${gp?.peer_count ?? 0} connected`}
@@ -186,14 +186,14 @@ function L2Card() {
           </div>
         </Tooltip>
         <Tooltip content={TOOLTIPS.l2_wraith}>
-          <div className="p-3 bg-purple-900/10 rounded-lg">
+          <div className="p-3 bg-[var(--surface)] rounded-lg">
             <div className="text-xs text-[color:var(--fainter)] mb-1 flex items-center gap-1"><InfoIcon /> Wraith</div>
             <div className="text-lg font-mono font-semibold text-[color:var(--fg)]">
               {isLoading ? "..." : wraithLabel}
             </div>
           </div>
         </Tooltip>
-        <div className="p-3 bg-purple-900/10 rounded-lg">
+        <div className="p-3 bg-[var(--surface)] rounded-lg">
           <div className="text-xs text-[color:var(--fainter)] mb-1">Status</div>
           <div className="text-lg font-mono font-semibold text-[color:var(--fg)]">
             {isLoading ? "..." : isRunning ? "Active" : "Not enabled"}
@@ -279,7 +279,7 @@ function HealthSection() {
   const statusColor = overallStatus === "healthy" ? "online" : overallStatus === "degraded" ? "warning" : "offline";
 
   return (
-    <Card className="border-[color:var(--green)]">
+    <Card>
       <CardHeader
         title="Health"
         action={
@@ -340,8 +340,8 @@ function PrivacySection() {
   const wraithActive = gpRunning && gp?.wraith_enabled;
 
   return (
-    <Card className="border-[color:var(--red)]">
-      <CardHeader title={<span className="text-[color:var(--red)]">Privacy Status</span>} />
+    <Card>
+      <CardHeader title="Privacy Status" />
       <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3">
         <Tooltip content={TOOLTIPS.ghost_mode}>
           <div className="p-3 bg-[var(--surface)] rounded-lg">

--- a/dashboard/src/app/(dashboard)/pool/page.tsx
+++ b/dashboard/src/app/(dashboard)/pool/page.tsx
@@ -116,7 +116,7 @@ function ChartCard({
     <Card>
       <div className="mb-3 flex items-start justify-between gap-2">
         <div>
-          <h3 className="font-medium t-lead" style={{ color: "var(--fg)" }}>
+          <h3 className="t-title" style={{ color: "var(--fg)" }}>
             {title}
           </h3>
           {subtitle && (
@@ -571,7 +571,7 @@ export default function NodePoolPage() {
             <div className="t-label" style={{ color: "var(--dim)" }}>
               Per-miner detail is not available on this node (the miner list is redacted for unauthenticated
               access). Aggregate:{" "}
-              <span style={{ color: "var(--fg)" }}>
+              <span>
                 {minersData?.total ?? minersData?.total_miners ?? minersNow} miner
                 {(minersData?.total ?? minersData?.total_miners ?? minersNow) === 1 ? "" : "s"}
               </span>
@@ -611,7 +611,7 @@ export default function NodePoolPage() {
           connected-miners chart is always a session buffer. */}
       <div
         className="rounded-lg p-3 text-sm"
-        style={{ background: "var(--accent-weak)", border: "1px solid var(--rule)", color: "var(--dim)" }}
+        style={{ background: "var(--surface)", border: "1px solid var(--rule)", color: "var(--dim)" }}
       >
         {series.serverBacked ? (
           <>


### PR DESCRIPTION
Presentation-only visual-discipline pass across the financial/identity dashboard pages. No facts, values, links, or controls changed; theme-aware CSS vars throughout.

## Scope
Pages touched: overview root (`/`), `/pool`, `/elders`, `/capacity`. Already-compliant (no change needed): `/treasury`, `/capabilities`, `/payouts`, `/sync`.

## What changed
- **Uniform prose:** removed the one `<strong>` mid-sentence emphasis on `/capacity` (distinct-miners count) and the `--fg` coloured count span in the `/pool` redacted-miners note — both now fold into single-weight `var(--dim)` body copy.
- **Two heading sizes only:** `/pool` `ChartCard` heading `t-lead` (mid-size) and the four `/elders` reference sub-headings (`font-medium`, off-scale) are now `.t-title` weight 500 `var(--fg)`.
- **Colour is semantic, not decorative:** neutralised the overview hero-card category colour system (L1 accent, L2 purple, Health green, Privacy red — decorative borders, heading text, purple tile tints, and orphaned accent/purple value fragments) to the neutral palette. Kept all genuine status colour (StatusDots, Badges, ProgressBars, accepted/rejected/uptime values), the red critical uptime box, and all charts/data. Recoloured the `/elders` downtime **warning** box from accent to `var(--yellow)` (warning semantics) and de-tinted the `/pool` chart-source info note from `accent-weak` to `surface`.
- **Reference drop-down forced open:** `/elders` Zero-Knowledge Proof Info card was `collapsible defaultCollapsed`; now rendered always-open inline. No other static explanatory collapsibles exist on these pages. Functional interactivity (DataTable search/sort/paginate, time-filter selects) untouched.

## Verification
- `tsc --noEmit` clean
- `eslint` clean on all changed files
- `npm run build` succeeds