### PR TITLE
dashboard(CardHeader): title/subtitle onto type scale

### DIFF
--- a/dashboard/src/components/ui/Card.tsx
+++ b/dashboard/src/components/ui/Card.tsx
@@ -66,14 +66,11 @@ export function CardHeader({ title, subtitle, action }: CardHeaderProps) {
   return (
     <div className="flex items-center justify-between mb-4">
       <div>
-        <h3
-          className="font-medium"
-          style={{ color: 'var(--fg)', fontSize: '16px' }}
-        >
+        <h3 className="t-title" style={{ color: 'var(--fg)' }}>
           {title}
         </h3>
         {subtitle && (
-          <p style={{ color: 'var(--dim)', fontSize: '13px', marginTop: '2px' }}>
+          <p className="t-lead" style={{ color: 'var(--dim)', marginTop: '4px' }}>
             {subtitle}
           </p>
         )}


### PR DESCRIPTION
Subtitle was 13px (smaller than 14px body); title 16px (off the 18px scale). Now t-title/t-lead — fixes inverted hierarchy everywhere.