### PR TITLE
dashboard(filtering): rewrite narrative for mempool-acceptance filtering (mempool = blockpool)

### DIFF
--- a/dashboard/src/app/(dashboard)/filtering/basic/page.tsx
+++ b/dashboard/src/app/(dashboard)/filtering/basic/page.tsx
@@ -5,8 +5,7 @@ import { PageHeader } from "@/components/ui/PageHeader";
 import { Card, CardHeader } from "@/components/ui/Card";
 import { SectionErrorBoundary } from "@/components/ui/SectionErrorBoundary";
 import { fetchApi } from "@/lib/api/client";
-import { PolicyProfileSelector, normalizeProfile } from "@/components/filtering/PolicyProfileSelector";
-import { useFullConfig } from "@/hooks/queries/useConfigQueries";
+import { PolicyProfileSelector } from "@/components/filtering/PolicyProfileSelector";
 import { BUDS_TIER_COLORS, type BudsTierKey } from "@/lib/budsTiers";
 
 interface TierMeta {
@@ -69,40 +68,12 @@ export default function BasicFilteringPage() {
   const byTier = mempool?.by_tier ?? { T0: 0, T1: 0, T2: 0, T3: 0 };
   const sampled = mempool?.sample_size ?? TIERS.reduce((s, t) => s + (byTier[t.key] ?? 0), 0);
 
-  // Which BUDS tiers this node's blocks actually mine, under the active policy.
-  // The mempool holds every class you relay; the blockpool is that set filtered
-  // through the tier policy — the difference is your filter at work.
-  const { data: fullConfig } = useFullConfig();
-  const profile = fullConfig?.policy?.profile;
-  const custom = fullConfig?.policy?.custom;
-  const mined = new Set<BudsTierKey>();
-  if (profile === "custom" && custom) {
-    if (custom.allow_t0) mined.add("T0");
-    if (custom.allow_t1) mined.add("T1");
-    if (custom.allow_t2) mined.add("T2");
-    if (custom.allow_t3) mined.add("T3");
-  } else {
-    const norm = normalizeProfile(profile);
-    if (norm === "strict") {
-      mined.add("T0");
-      mined.add("T1");
-    } else if (norm === "permissive") {
-      mined.add("T0");
-      mined.add("T1");
-      mined.add("T2");
-    } else {
-      // full_open or unknown (config not loaded) — assume all mined, never
-      // show a class as "dropped" unless we're sure it is.
-      (["T0", "T1", "T2", "T3"] as BudsTierKey[]).forEach((k) => mined.add(k));
-    }
-  }
-
   return (
     <div className="space-y-6">
       <PageHeader
         eyebrow="filtering"
         title="Basic."
-        subtitle="Pick how much your node filters with one simple choice. Every transaction is sorted into a BUDS class (T0–T3), and your choice decides which classes get mined."
+        subtitle="Pick how much your node filters with one simple choice. Every transaction is sorted into a BUDS class (T0–T3), and your choice decides which classes your node accepts — filtered classes are rejected at your mempool, so they are never relayed or mined."
         subtitleFullWidth
       />
 
@@ -160,7 +131,7 @@ export default function BasicFilteringPage() {
         <Card>
           <CardHeader
             title="Your mempool by class"
-            subtitle="Every valid transaction class your node holds and relays, from a live mempool sample. What you actually mine is the blockpool below."
+            subtitle="The transaction classes your node accepts, relays, and mines — filtered classes never enter your mempool. From a live mempool sample."
           />
           <div className="space-y-3">
             {mempool?.message ? (
@@ -191,67 +162,6 @@ export default function BasicFilteringPage() {
                         </div>
                         <div className="t-title" style={{ fontFamily: "var(--font-mono)", color: "var(--fg)" }}>{pct.toFixed(0)}%</div>
                         <div className="t-caption" style={{ color: "var(--dim)" }}>{count.toLocaleString()} sampled</div>
-                      </div>
-                    );
-                  })}
-                </div>
-              </>
-            )}
-          </div>
-        </Card>
-      </SectionErrorBoundary>
-
-      {/* Blockpool — what your blocks actually mine (the mempool after tier policy) */}
-      <SectionErrorBoundary section="Your blockpool by class">
-        <Card>
-          <CardHeader
-            title="Your blockpool by class"
-            subtitle="What your blocks actually mine — the mempool above, after your tier policy. Dropped classes still sit in your mempool and get relayed; they just don't earn a place in your block."
-          />
-          <div className="space-y-3">
-            {mempool?.message ? (
-              <p className="t-label" style={{ color: "var(--dim)" }}>
-                Mempool classification is unavailable — {mempool.message}
-              </p>
-            ) : (
-              <>
-                <div style={{ display: "flex", height: "14px", borderRadius: "4px", overflow: "hidden", background: "var(--bg)" }}>
-                  {TIERS.map((t) => {
-                    const count = byTier[t.key] ?? 0;
-                    const pct = sampled ? (count / sampled) * 100 : 0;
-                    if (pct === 0) return null;
-                    const isMined = mined.has(t.key);
-                    return (
-                      <div
-                        key={t.key}
-                        title={isMined ? `${t.name}: mined — ${count} (${pct.toFixed(1)}%)` : `${t.name}: dropped by your tier policy`}
-                        style={{ width: `${pct}%`, background: isMined ? t.color : "var(--rule-strong)", opacity: isMined ? 1 : 0.35 }}
-                      />
-                    );
-                  })}
-                </div>
-                <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-                  {TIERS.map((t) => {
-                    const count = byTier[t.key] ?? 0;
-                    const pct = sampled ? (count / sampled) * 100 : 0;
-                    const isMined = mined.has(t.key);
-                    return (
-                      <div key={t.key} style={{ padding: "10px 12px", border: "1px solid var(--rule)", borderRadius: "4px", background: "var(--bg)", opacity: isMined ? 1 : 0.55 }}>
-                        <div className="flex items-center gap-2" style={{ marginBottom: "4px" }}>
-                          <span style={{ width: "10px", height: "10px", borderRadius: "2px", background: isMined ? t.color : "var(--fainter)", display: "inline-block" }} />
-                          <span className="t-label" style={{ color: "var(--fg)" }}>{t.name}</span>
-                        </div>
-                        {isMined ? (
-                          <>
-                            <div className="t-title" style={{ fontFamily: "var(--font-mono)", color: "var(--fg)" }}>{pct.toFixed(0)}%</div>
-                            <div className="t-caption" style={{ color: "var(--dim)" }}>{count.toLocaleString()} mined</div>
-                          </>
-                        ) : (
-                          <>
-                            <div className="t-title" style={{ color: "var(--dim)" }}>Dropped</div>
-                            <div className="t-caption" style={{ color: "var(--dim)" }}>not mined by you</div>
-                          </>
-                        )}
                       </div>
                     );
                   })}

--- a/dashboard/src/app/(dashboard)/filtering/page.tsx
+++ b/dashboard/src/app/(dashboard)/filtering/page.tsx
@@ -48,18 +48,18 @@ function modeSummary(
 ): { value: string; sublabel: string } {
   switch (profile) {
     case "full_open":
-      return { value: "Open", sublabel: "Mining every kind of transaction" };
+      return { value: "Open", sublabel: "Accepting every kind of transaction" };
     case "permissive":
-      return { value: "Standard", sublabel: "T3 not mined into your blocks" };
+      return { value: "Standard", sublabel: "T3 not accepted" };
     case "bitcoin_pure":
     case "strict":
-      return { value: "Strict", sublabel: "T2 + T3 not mined into your blocks" };
+      return { value: "Strict", sublabel: "T2 + T3 not accepted" };
     case "custom":
       return dropped.length
-        ? { value: "Custom", sublabel: `Dropping ${dropped.join(" + ")}` }
-        : { value: "Custom", sublabel: "Mining every tier" };
+        ? { value: "Custom", sublabel: `Rejecting ${dropped.join(" + ")}` }
+        : { value: "Custom", sublabel: "Accepting every tier" };
     default:
-      return { value: modeLabel(profile), sublabel: "The tier policy this node mines under" };
+      return { value: modeLabel(profile), sublabel: "The tier policy this node accepts under" };
   }
 }
 
@@ -147,7 +147,7 @@ export default function FilteringOverviewPage() {
       <PageHeader
         eyebrow="filtering"
         title="Filtering."
-        subtitle="Two layers keep your blocks clean — the Reaper filters spam, and a tier policy picks which transaction classes you mine. Set it in Basic; fine-tune both in Advanced."
+        subtitle="Two layers keep your mempool clean — the Reaper rejects spam, and a tier policy picks which transaction classes your node accepts. Filtered transactions never enter your mempool, so they are not relayed or mined. Set it in Basic; fine-tune both in Advanced."
         subtitleFullWidth
       />
 
@@ -158,7 +158,7 @@ export default function FilteringOverviewPage() {
           label="Mode"
           value={fullConfig ? mode.value : "—"}
           sublabel={fullConfig ? mode.sublabel : undefined}
-          tooltip="What your node mines, in plain English. This is the tier policy — which kinds of transaction end up in the blocks you build."
+          tooltip="What your node accepts, in plain English. This is the tier policy — which classes enter your mempool, and therefore the blocks you build."
         />
         <StatCard
           label="Mempool right now"
@@ -176,7 +176,7 @@ export default function FilteringOverviewPage() {
           sublabel={
             dropped.length
               ? `${droppedCount} of ${sampled} in ${droppedLabel}`
-              : "You mine every tier"
+              : "You accept every tier"
           }
           tooltip="Share of that same live sample sitting in the tiers your policy drops. 0% means your node currently mines everything in the mempool — that's expected on Open mode, not a fault. (This is tier policy only — the Reaper still strips dead-code spam on top of it.)"
         />
@@ -213,26 +213,29 @@ export default function FilteringOverviewPage() {
               The Reaper — your junk filter
             </div>
             <p className="t-body" style={{ color: "var(--dim)", lineHeight: 1.6 }}>
-              It recognises known spam patterns — inscription stuffing, dust floods, oversized data — and
-              throws them out of your mempool and your blocks entirely. Junk it catches is never relayed on.
-              The Reaper runs all the time on a sensible default; tune its individual detectors in Advanced.
+              It rejects specific spam patterns — inscription stuffing, dust floods, oversized data —
+              regardless of class, at your mempool. Transactions it catches are never accepted, relayed, or
+              mined. The Reaper runs all the time on a sensible default; tune its individual detectors in
+              Advanced.
             </p>
           </div>
           <div>
             <div className="t-lead" style={{ color: "var(--fg)", fontWeight: 500, marginBottom: "4px" }}>
-              Tier policy (BUDS) — what your blocks mine
+              Tier policy (BUDS) — which classes your node accepts
             </div>
             <p className="t-body" style={{ color: "var(--dim)", lineHeight: 1.6 }}>
               Legitimate transactions come in classes, from ordinary payments (T0) up to heavy data (T3).
-              This is your choice of which classes earn space in the blocks you mine. It does not block relay —
-              valid transactions still flow through your node to the network; you are only deciding what goes
-              in your block. Set it in Basic, customise it in Advanced.
+              This is your choice of which classes your node accepts — and therefore relays and mines.
+              Filtered classes are rejected at your mempool, exactly like Bitcoin Core or Knots: they never
+              enter it, so they are not relayed on and never appear in the blocks you build. Set it in Basic,
+              customise it in Advanced.
             </p>
           </div>
           <div style={{ borderTop: "1px solid var(--rule)", paddingTop: "12px" }}>
             <p className="t-body" style={{ color: "var(--dim)", lineHeight: 1.6 }}>
-              In one line: the Reaper is the bouncer that keeps junk out; the tier policy is the menu deciding
-              which of the legitimate rest you mine. Basic sets the menu; Advanced tunes both.
+              In one line: the Reaper is the bouncer that rejects junk at the door; the tier policy is the
+              menu deciding which classes your node accepts. Whatever gets in is what you relay and mine — your
+              mempool is your block-building set. Basic sets the menu; Advanced tunes both.
             </p>
           </div>
         </div>
@@ -251,10 +254,10 @@ export default function FilteringOverviewPage() {
               value={modeLabel(profile)}
               desc={
                 dropped.length
-                  ? `Drops ${droppedLabel} — mines everything else.`
+                  ? `Rejects ${droppedLabel} — accepts everything else.`
                   : profile === "full_open"
-                    ? "Mines every class, including heavy data (T3)."
-                    : "The tier policy this node mines under."
+                    ? "Accepts every class, including heavy data (T3)."
+                    : "The tier policy this node accepts under."
               }
             />
             <StatusRow

--- a/dashboard/src/app/(dashboard)/mempool/page.tsx
+++ b/dashboard/src/app/(dashboard)/mempool/page.tsx
@@ -257,6 +257,12 @@ function NodeMempoolExplorer() {
         {openLink}
       </div>
 
+      <p className="t-label" style={{ color: "var(--dim)", marginBottom: "12px", lineHeight: 1.6 }}>
+        Your node&apos;s own mempool — which now equals the set your blocks build from. Filtered classes
+        never enter it, so this one view is your block builder: what you see here is exactly what your
+        blocks mine.
+      </p>
+
       {state === "blocked" ? (
         <div
           className="space-y-2"

--- a/dashboard/src/components/filtering/AdvancedPolicyPanel.tsx
+++ b/dashboard/src/components/filtering/AdvancedPolicyPanel.tsx
@@ -24,17 +24,17 @@ const TIER_TOGGLES: { key: keyof PolicyCustomConfig; label: string; desc: string
 ];
 
 const CONTENT_TOGGLES: { key: keyof PolicyCustomConfig; label: string; desc: string }[] = [
-  { key: "allow_inscriptions", label: "Inscriptions", desc: "Mine Ordinals inscription transactions." },
-  { key: "allow_runes", label: "Runes", desc: "Mine Runes runestone transactions." },
-  { key: "allow_brc20", label: "BRC-20", desc: "Mine BRC-20 token-transfer transactions." },
+  { key: "allow_inscriptions", label: "Inscriptions", desc: "Accept Ordinals inscription transactions." },
+  { key: "allow_runes", label: "Runes", desc: "Accept Runes runestone transactions." },
+  { key: "allow_brc20", label: "BRC-20", desc: "Accept BRC-20 token-transfer transactions." },
 ];
 
 const NUMERIC_FIELDS: { key: keyof PolicyCustomConfig; label: string; unit: string; desc: string; step?: number }[] = [
-  { key: "max_op_return_size", label: "Max OP_RETURN size", unit: "bytes", desc: "Largest OP_RETURN payload to mine. 0 drops every OP_RETURN transaction." },
+  { key: "max_op_return_size", label: "Max OP_RETURN size", unit: "bytes", desc: "Largest OP_RETURN payload to accept. 0 drops every OP_RETURN transaction." },
   { key: "max_witness_per_input", label: "Max witness / input", unit: "bytes", desc: "Largest witness per input. Low values block inscription-style witness stuffing." },
-  { key: "max_tx_outputs", label: "Max tx outputs", unit: "outputs", desc: "Most outputs a transaction may have to be eligible for a block." },
-  { key: "max_tx_size", label: "Max tx size", unit: "vB", desc: "Largest transaction to mine, in virtual bytes." },
-  { key: "min_fee_rate", label: "Min fee rate", unit: "sat/vB", desc: "Lowest fee rate to mine. 0 means no minimum.", step: 0.1 },
+  { key: "max_tx_outputs", label: "Max tx outputs", unit: "outputs", desc: "Most outputs a transaction may have to be accepted." },
+  { key: "max_tx_size", label: "Max tx size", unit: "vB", desc: "Largest transaction to accept, in virtual bytes." },
+  { key: "min_fee_rate", label: "Min fee rate", unit: "sat/vB", desc: "Lowest fee rate to accept. 0 means no minimum.", step: 0.1 },
 ];
 
 export function AdvancedPolicyPanel() {
@@ -107,12 +107,12 @@ export function AdvancedPolicyPanel() {
         )}
       </div>
       <div className="t-label" style={{ color: "var(--dim)", marginBottom: "12px" }}>
-        Per-field control over which transaction classes, content and sizes this node mines. Saving writes{" "}
+        Per-field control over which transaction classes, content and sizes this node accepts. Saving writes{" "}
         <code>[policy].custom</code>, sets the profile to <code>custom</code>, and restarts the node.
       </div>
 
       {/* Tiers */}
-      <PanelSection title="Transaction classes to mine">
+      <PanelSection title="Transaction classes to accept">
         {TIER_TOGGLES.map((t) => (
           <CheckboxRow
             key={t.key}


### PR DESCRIPTION
## Summary

Phase 3 of mempool tier-filtering: rewrites the dashboard filtering narrative from the old *mine-only* model ("the tier policy only decides what you mine; it doesn't block relay; your mempool holds every class you relay") to the correct **mempool-acceptance** model, matching Bitcoin Core / Knots.

New framing: the tier policy filters at **mempool acceptance** — filtered classes are **not accepted, not relayed, and not mined**. So your mempool **is** your block-building set (mempool = blockpool). The Reaper is unchanged: it rejects specific spam patterns at your mempool, regardless of class.

Presentation/copy only — no backend, no `ghost-core`/Rust changes.

## Changes

- **`filtering/basic/page.tsx`** — removed the "Your blockpool by class" classifier card entirely, along with its `mined`-set computation and the now-unused `useFullConfig` / `normalizeProfile` imports. Retitled the remaining "Your mempool by class" card ("The transaction classes your node accepts, relays, and mines — filtered classes never enter your mempool"). Header subtitle updated to the acceptance model.
- **`filtering/page.tsx`** — rewrote the "How filtering works" two-layer explainer: tier policy = which classes your node accepts (and therefore relays + mines), rejected at your mempool like Core/Knots; Reaper = rejects specific spam patterns at your mempool, regardless of class. Dropped all "does not block relay / only decides what you mine" wording. Updated the header subtitle, mode summaries, status descriptions and the two affected tooltips (`mine` → `accept`).
- **`AdvancedPolicyPanel.tsx`** — relabelled "…to mine" → "…to accept" throughout (section title "Transaction classes to accept", numeric-field and content-toggle descriptions, panel subtitle "which transaction classes, content and sizes this node accepts").
- **`mempool/page.tsx`** — added copy describing the same-origin `mempool.space` embed as your node's mempool, which now equals the set your blocks build from (filtered classes never enter it). One embed = your block builder.

## Verification

- `tsc --noEmit` clean
- `eslint` clean on all changed files
- `npm run build` succeeds
- Reaper naming preserved verbatim
- Blockpool classifier removed