### PR TITLE
feat(policy): emit -ghostpolicy flags to ghostd + apply on profile change (default inert)

### DIFF
--- a/bins/ghost-setup/src/main.rs
+++ b/bins/ghost-setup/src/main.rs
@@ -137,6 +137,7 @@ fn apply_reaper_to_ghostd(
     let settings = &config.reaper;
     let launch = &config.node_launch;
     let storage = &config.storage;
+    let policy = &config.policy;
 
     println!(
         "Ghost-managed ghostd flags (from {}):",
@@ -147,12 +148,13 @@ fn apply_reaper_to_ghostd(
         .iter()
         .chain(launch.ghostd_flags().iter())
         .chain(storage.ghostd_flags().iter())
+        .chain(policy.ghostd_flags().iter())
     {
         println!("  {f}");
     }
 
     let exec_argv = read_ghostd_exec_argv()?;
-    let dropin = setup::ghostd_managed_dropin(&exec_argv, settings, launch, storage);
+    let dropin = setup::ghostd_managed_dropin(&exec_argv, settings, launch, storage, policy);
 
     if dry_run {
         println!("\n--- drop-in {DROPIN_PATH} (dry-run, not written) ---\n{dropin}");

--- a/crates/ghost-common/src/config.rs
+++ b/crates/ghost-common/src/config.rs
@@ -1472,6 +1472,74 @@ impl Default for PolicyConfig {
     }
 }
 
+impl PolicyConfig {
+    /// The ghostd (Bitcoin Core) CLI flags that carry this policy profile to the
+    /// node's mempool-acceptance path (`-ghostpolicy-*`, parsed in ghost-core).
+    /// This is the node-mempool twin of ghost-pool's block-template tier gate:
+    /// the same profile now enforces at BOTH layers.
+    ///
+    /// Only *restrictive* flags are emitted. ghostd's inert default is
+    /// all-tiers-allowed / all-content-allowed / no-limits, so a `full_open`
+    /// profile emits NOTHING and the node behaves exactly as it did before this
+    /// policy existed. The built-in tier presets emit only their tier set;
+    /// `custom` emits its tier set plus every per-field limit verbatim (a custom
+    /// profile is by definition an explicit, non-inert configuration).
+    ///
+    /// Emitted through the same managed drop-in as the reaper / node-launch /
+    /// storage flags (`ghostd_managed_dropin` in `setup.rs`); every prefix here
+    /// (`-ghostpolicy`) is listed in `MANAGED_GHOSTD_FLAG_PREFIXES` so stale
+    /// copies are stripped on each regeneration. Read by ghostd only at startup,
+    /// so a change needs a ghostd restart to take effect.
+    pub fn ghostd_flags(&self) -> Vec<String> {
+        // Render a tier set as the ascending, de-duplicated CSV ghostd expects
+        // (`-ghostpolicy-allowtiers=0,1,2`).
+        fn tier_csv(tiers: &[BudsTier]) -> String {
+            let mut idx: Vec<u8> = tiers.iter().map(|t| t.as_index()).collect();
+            idx.sort_unstable();
+            idx.dedup();
+            idx.iter()
+                .map(|n| n.to_string())
+                .collect::<Vec<_>>()
+                .join(",")
+        }
+
+        match self.profile {
+            // Inert: all tiers, all content, no size/fee limits. Emit nothing so
+            // a default/open node stays exactly as it was before this feature.
+            PolicyProfile::FullOpen => Vec::new(),
+            PolicyProfile::BitcoinPure => {
+                vec![format!(
+                    "-ghostpolicy-allowtiers={}",
+                    tier_csv(&[BudsTier::T0, BudsTier::T1])
+                )]
+            }
+            PolicyProfile::Permissive => {
+                vec![format!(
+                    "-ghostpolicy-allowtiers={}",
+                    tier_csv(&[BudsTier::T0, BudsTier::T1, BudsTier::T2])
+                )]
+            }
+            PolicyProfile::Custom => {
+                let c = self.custom.clone().unwrap_or_default();
+                vec![
+                    format!("-ghostpolicy-allowtiers={}", tier_csv(&c.allowed_tiers)),
+                    format!(
+                        "-ghostpolicy-allowinscriptions={}",
+                        u8::from(c.allow_inscriptions)
+                    ),
+                    format!("-ghostpolicy-allowrunes={}", u8::from(c.allow_runes)),
+                    format!("-ghostpolicy-allowbrc20={}", u8::from(c.allow_brc20)),
+                    format!("-ghostpolicy-maxopreturn={}", c.max_op_return_size),
+                    format!("-ghostpolicy-maxwitness={}", c.max_witness_per_input),
+                    format!("-ghostpolicy-maxtxoutputs={}", c.max_tx_outputs),
+                    format!("-ghostpolicy-maxtxsize={}", c.max_tx_size),
+                    format!("-ghostpolicy-minfeerate={}", c.min_fee_rate),
+                ]
+            }
+        }
+    }
+}
+
 /// Built-in policy profiles
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -1548,6 +1616,19 @@ pub enum BudsTier {
     T2,
     /// Heavy data (inscriptions, large witness)
     T3,
+}
+
+impl BudsTier {
+    /// The numeric tier index (T0..T3 → 0..3) used by the BUDS classifier and by
+    /// the `-ghostpolicy-allowtiers` CSV that carries the allowed set to ghostd.
+    pub fn as_index(self) -> u8 {
+        match self {
+            BudsTier::T0 => 0,
+            BudsTier::T1 => 1,
+            BudsTier::T2 => 2,
+            BudsTier::T3 => 3,
+        }
+    }
 }
 
 /// Ghost Haze storage mode
@@ -2847,6 +2928,118 @@ mod tests {
             custom: None,
         };
         assert_eq!(config.profile, PolicyProfile::BitcoinPure);
+    }
+
+    // --- PolicyConfig::ghostd_flags emission ------------------------------
+
+    #[test]
+    fn test_policy_ghostd_flags_full_open_is_inert() {
+        // The whole safety property: an open/default node emits ZERO
+        // `-ghostpolicy` flags, so deploying this feature changes nothing until
+        // an operator picks a stricter profile.
+        let cfg = PolicyConfig {
+            profile: PolicyProfile::FullOpen,
+            custom: None,
+        };
+        assert!(
+            cfg.ghostd_flags().is_empty(),
+            "full_open must be inert, got: {:?}",
+            cfg.ghostd_flags()
+        );
+    }
+
+    #[test]
+    fn test_policy_ghostd_flags_strict_tiers() {
+        let cfg = PolicyConfig {
+            profile: PolicyProfile::BitcoinPure,
+            custom: None,
+        };
+        assert_eq!(
+            cfg.ghostd_flags(),
+            vec!["-ghostpolicy-allowtiers=0,1".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_policy_ghostd_flags_permissive_tiers() {
+        let cfg = PolicyConfig {
+            profile: PolicyProfile::Permissive,
+            custom: None,
+        };
+        assert_eq!(
+            cfg.ghostd_flags(),
+            vec!["-ghostpolicy-allowtiers=0,1,2".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_policy_ghostd_flags_custom_emits_tiers_and_limits() {
+        let cfg = PolicyConfig {
+            profile: PolicyProfile::Custom,
+            custom: Some(CustomPolicyConfig {
+                allowed_tiers: vec![BudsTier::T0, BudsTier::T1, BudsTier::T2, BudsTier::T3],
+                max_op_return_size: 80,
+                max_witness_per_input: 400,
+                max_tx_outputs: 50,
+                max_tx_size: 100_000,
+                allow_inscriptions: false,
+                allow_runes: true,
+                allow_brc20: false,
+                min_fee_rate: 2.5,
+            }),
+        };
+        assert_eq!(
+            cfg.ghostd_flags(),
+            vec![
+                "-ghostpolicy-allowtiers=0,1,2,3".to_string(),
+                "-ghostpolicy-allowinscriptions=0".to_string(),
+                "-ghostpolicy-allowrunes=1".to_string(),
+                "-ghostpolicy-allowbrc20=0".to_string(),
+                "-ghostpolicy-maxopreturn=80".to_string(),
+                "-ghostpolicy-maxwitness=400".to_string(),
+                "-ghostpolicy-maxtxoutputs=50".to_string(),
+                "-ghostpolicy-maxtxsize=100000".to_string(),
+                "-ghostpolicy-minfeerate=2.5".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_policy_ghostd_flags_custom_tiers_sorted_and_deduped() {
+        // Out-of-order / duplicate tiers from a hand-edited config still produce
+        // a clean ascending CSV.
+        let cfg = PolicyConfig {
+            profile: PolicyProfile::Custom,
+            custom: Some(CustomPolicyConfig {
+                allowed_tiers: vec![BudsTier::T2, BudsTier::T0, BudsTier::T0, BudsTier::T1],
+                ..CustomPolicyConfig::default()
+            }),
+        };
+        assert_eq!(
+            cfg.ghostd_flags()[0],
+            "-ghostpolicy-allowtiers=0,1,2".to_string()
+        );
+    }
+
+    #[test]
+    fn test_policy_ghostd_flags_custom_missing_block_uses_defaults() {
+        // Profile says custom but no [policy.custom] block persisted: fall back
+        // to the safe defaults rather than panicking, and still emit a full set.
+        let cfg = PolicyConfig {
+            profile: PolicyProfile::Custom,
+            custom: None,
+        };
+        let flags = cfg.ghostd_flags();
+        assert!(flags[0].starts_with("-ghostpolicy-allowtiers="));
+        assert_eq!(flags.len(), 9);
+    }
+
+    #[test]
+    fn test_buds_tier_as_index() {
+        assert_eq!(BudsTier::T0.as_index(), 0);
+        assert_eq!(BudsTier::T1.as_index(), 1);
+        assert_eq!(BudsTier::T2.as_index(), 2);
+        assert_eq!(BudsTier::T3.as_index(), 3);
     }
 
     #[test]

--- a/crates/ghost-common/src/setup.rs
+++ b/crates/ghost-common/src/setup.rs
@@ -284,6 +284,8 @@ const MANAGED_GHOSTD_FLAG_PREFIXES: &[&str] = &[
     // Reaper (per-vector) + Tor.
     "-ghostreaper",
     "-tormode",
+    // Mempool tier/content policy (PolicyConfig): allowed tiers + custom limits.
+    "-ghostpolicy",
     // Daemon / node launch settings (NodeLaunchConfig).
     "-maxmempool",
     "-mempoolexpiry",
@@ -316,7 +318,8 @@ fn is_managed_ghostd_flag(tok: &str) -> bool {
 }
 
 /// Render a systemd drop-in for ghostd that applies the per-vector reaper
-/// settings AND the node launch flags (e.g. Tor mode) to the daemon.
+/// settings, the node launch flags (e.g. Tor mode), the storage-mode flags AND
+/// the mempool tier/content policy flags to the daemon.
 ///
 /// `exec_argv` is the daemon's resolved command line (e.g. the `argv[]` from
 /// `systemctl show ghostd -p ExecStart --value`). Any existing managed flags
@@ -331,6 +334,7 @@ pub fn ghostd_managed_dropin(
     reaper: &crate::config::ReaperSettings,
     launch: &crate::config::NodeLaunchConfig,
     storage: &crate::config::StorageConfig,
+    policy: &crate::config::PolicyConfig,
 ) -> String {
     let base: Vec<&str> = exec_argv
         .split_whitespace()
@@ -339,6 +343,7 @@ pub fn ghostd_managed_dropin(
     let mut flags = reaper.ghostd_flags();
     flags.extend(launch.ghostd_flags());
     flags.extend(storage.ghostd_flags());
+    flags.extend(policy.ghostd_flags());
     format!(
         "# Managed by `ghost-setup apply-reaper` — Ghost Reaper + node launch + storage flags.\n\
          # Do not edit by hand; regenerate from pool.toml [reaper]/[node_launch]/[storage].\n\
@@ -434,7 +439,18 @@ pub fn apply_mempool_policy(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{HazeMode, NodeLaunchConfig, ReaperSettings, StorageConfig};
+    use crate::config::{
+        HazeMode, NodeLaunchConfig, PolicyConfig, PolicyProfile, ReaperSettings, StorageConfig,
+    };
+
+    /// An inert (`full_open`) policy that emits no `-ghostpolicy` flags, so the
+    /// reaper/launch/storage-focused drop-in tests below stay uncluttered.
+    fn inert_policy() -> PolicyConfig {
+        PolicyConfig {
+            profile: PolicyProfile::FullOpen,
+            custom: None,
+        }
+    }
 
     #[test]
     fn test_ghostd_managed_dropin_strips_and_appends() {
@@ -445,7 +461,7 @@ mod tests {
         };
         let launch = NodeLaunchConfig::default();
         let storage = StorageConfig::default();
-        let dropin = ghostd_managed_dropin(exec, &s, &launch, &storage);
+        let dropin = ghostd_managed_dropin(exec, &s, &launch, &storage, &inert_policy());
 
         // resets ExecStart then re-emits the base (minus any managed flags)
         assert!(dropin.contains("[Service]\nExecStart=\nExecStart="));
@@ -482,6 +498,7 @@ mod tests {
             &reaper,
             &NodeLaunchConfig { tor_mode: true, ..Default::default() },
             &storage,
+            &inert_policy(),
         );
         assert_eq!(on.matches("-tormode=1").count(), 1);
 
@@ -490,6 +507,7 @@ mod tests {
             &reaper,
             &NodeLaunchConfig { tor_mode: false, ..Default::default() },
             &storage,
+            &inert_policy(),
         );
         assert!(!off.contains("-tormode"));
     }
@@ -519,7 +537,7 @@ mod tests {
         };
 
         let storage = StorageConfig::default();
-        let dropin = ghostd_managed_dropin(exec, &reaper, &launch, &storage);
+        let dropin = ghostd_managed_dropin(exec, &reaper, &launch, &storage, &inert_policy());
 
         // Base non-managed args survive.
         assert!(dropin.contains("/opt/ghost/bin/ghostd"));
@@ -560,7 +578,7 @@ mod tests {
             .find(|l| l.starts_with("ExecStart=/"))
             .unwrap()
             .trim_start_matches("ExecStart=");
-        let dropin2 = ghostd_managed_dropin(regen_exec, &reaper, &launch, &storage);
+        let dropin2 = ghostd_managed_dropin(regen_exec, &reaper, &launch, &storage, &inert_policy());
         assert_eq!(dropin2.matches("-maxmempool=").count(), 1);
         assert_eq!(dropin2.matches("-onlynet=").count(), 2);
         assert_eq!(dropin2.matches("-tormode=1").count(), 1);
@@ -579,12 +597,14 @@ mod tests {
             &reaper,
             &launch,
             &StorageConfig { archive_mode: true, ..Default::default() },
+            &inert_policy(),
         );
         assert!(on.contains("-prune=0"));
         // No reindex unless explicitly armed.
         assert!(!on.contains("-reindex"));
 
-        let off = ghostd_managed_dropin(exec, &reaper, &launch, &StorageConfig::default());
+        let off =
+            ghostd_managed_dropin(exec, &reaper, &launch, &StorageConfig::default(), &inert_policy());
         assert!(!off.contains("-prune"));
     }
 
@@ -602,6 +622,7 @@ mod tests {
             &reaper,
             &launch,
             &StorageConfig { archive_mode: true, reindex_pending: true, ..Default::default() },
+            &inert_policy(),
         );
         assert_eq!(armed.matches("-reindex").count(), 1);
         assert_eq!(armed.matches("-prune=0").count(), 1);
@@ -612,6 +633,7 @@ mod tests {
             &reaper,
             &launch,
             &StorageConfig { archive_mode: true, reindex_pending: false, ..Default::default() },
+            &inert_policy(),
         );
         assert!(!cleared.contains("-reindex"));
         assert_eq!(cleared.matches("-prune=0").count(), 1);
@@ -632,6 +654,7 @@ mod tests {
             &reaper,
             &launch,
             &StorageConfig { haze_mode: HazeMode::Hazed, exorcist_pending: true, ..Default::default() },
+            &inert_policy(),
         );
         assert_eq!(converting.matches("-exorcist").count(), 1);
         assert!(!converting.contains("-hazemode=hazed"));
@@ -641,8 +664,35 @@ mod tests {
             &reaper,
             &launch,
             &StorageConfig { haze_mode: HazeMode::Hazed, exorcist_pending: false, ..Default::default() },
+            &inert_policy(),
         );
         assert!(!converted.contains("-exorcist"));
         assert_eq!(converted.matches("-hazemode=hazed").count(), 1);
+    }
+
+    #[test]
+    fn test_ghostd_managed_dropin_policy_flags_present_and_idempotent() {
+        // A stricter profile threads its `-ghostpolicy-*` flags into the drop-in,
+        // and re-applying (with a stale copy in the inherited ExecStart) strips
+        // and re-emits them exactly once — the managed-prefix idempotence that
+        // keeps regeneration stable.
+        let exec =
+            "/opt/ghost/bin/ghostd -signet -ghostpolicy-allowtiers=0,1,2,3 -ghostreaper=enabled";
+        let reaper = ReaperSettings::default();
+        let launch = NodeLaunchConfig::default();
+        let storage = StorageConfig::default();
+        let strict = PolicyConfig {
+            profile: PolicyProfile::BitcoinPure,
+            custom: None,
+        };
+
+        let dropin = ghostd_managed_dropin(exec, &reaper, &launch, &storage, &strict);
+        assert_eq!(dropin.matches("-ghostpolicy-allowtiers=").count(), 1);
+        assert!(dropin.contains("-ghostpolicy-allowtiers=0,1"));
+        assert!(!dropin.contains("-ghostpolicy-allowtiers=0,1,2,3"));
+
+        // full_open leaves ExecStart free of any policy flag (inert).
+        let open = ghostd_managed_dropin(exec, &reaper, &launch, &storage, &inert_policy());
+        assert!(!open.contains("-ghostpolicy"));
     }
 }

--- a/crates/ghost-verification/src/routes.rs
+++ b/crates/ghost-verification/src/routes.rs
@@ -6722,8 +6722,13 @@ async fn api_config_policy_profile_post_handler(
         }
     }
 
-    // The profile is resolved at startup, so a graceful restart applies it.
-    state.request_restart();
+    // Apply the new profile at BOTH layers: ghost-pool (block template) and
+    // ghostd (mempool acceptance). `spawn_ghostd_reaper_apply` regenerates the
+    // combined managed drop-in — which now includes the `-ghostpolicy-*` flags
+    // from `PolicyConfig::ghostd_flags()` — restarts ghostd, then bounces the
+    // pool afterwards (it owns the ordering, so we must NOT also call
+    // `request_restart()` here or the pool would bounce before ghostd).
+    spawn_ghostd_reaper_apply(Arc::clone(&state));
 
     Json(serde_json::json!({
         "success": true,
@@ -6989,8 +6994,13 @@ async fn api_config_policy_custom_post_handler(
         }
     }
 
-    // The custom profile is resolved at startup, so a graceful restart applies it.
-    state.request_restart();
+    // Apply the custom policy at BOTH layers: ghost-pool (block template) and
+    // ghostd (mempool acceptance). `spawn_ghostd_reaper_apply` regenerates the
+    // combined managed drop-in — which now includes the `-ghostpolicy-*` flags
+    // (allowed tiers + per-field limits) from `PolicyConfig::ghostd_flags()` —
+    // restarts ghostd, then bounces the pool afterwards (it owns the ordering,
+    // so we must NOT also call `request_restart()` here).
+    spawn_ghostd_reaper_apply(Arc::clone(&state));
 
     Json(serde_json::json!({
         "success": true,


### PR DESCRIPTION
## Summary

Phase 2 of mempool tier-filtering (Rust side). Carries the pool's tier/content policy down to ghostd's mempool-acceptance path via managed launch flags, mirroring how the Reaper already threads its flags into the daemon. A profile change now applies at **both** layers: ghost-pool (block template) and ghostd (mempool).

Default stays **inert** — a `full_open` node emits zero `-ghostpolicy` flags, so deploying this changes nothing until an operator selects a stricter profile.

## Changes

- **`ghost-common/config.rs`** — new `PolicyConfig::ghostd_flags()` and a `BudsTier::as_index()` helper. Profile → flags:
  - `full_open` → **nothing** (inert)
  - `strict`/`bitcoin_pure` → `-ghostpolicy-allowtiers=0,1`
  - `permissive` → `-ghostpolicy-allowtiers=0,1,2`
  - `custom` → `allowtiers` from `custom.allowed_tiers` (sorted/deduped) plus every per-field limit (`allowinscriptions/allowrunes/allowbrc20/maxopreturn/maxwitness/maxtxoutputs/maxtxsize/minfeerate`)
- **`ghost-common/setup.rs`** — `-ghostpolicy` added to `MANAGED_GHOSTD_FLAG_PREFIXES`; `ghostd_managed_dropin()` now takes a `&PolicyConfig` and chains `policy.ghostd_flags()` alongside reaper/launch/storage.
- **`ghost-setup/main.rs`** — `apply-reaper` regenerates the combined drop-in including the policy flags.
- **`ghost-verification/routes.rs`** — the policy profile + custom POST handlers now call `spawn_ghostd_reaper_apply` (same path the Reaper uses: regenerate drop-in → restart ghostd → bounce pool) instead of a bare `request_restart()`.
- **`ghost-pool/template.rs`** — tier gate left in place as a redundant safety net during rollout (unchanged).

## Verification

- `cargo check` clean: `ghost-common`, `ghost-verification`, `ghost-pool`, `ghost-setup`
- `cargo test -p ghost-common`: 281 pass, 0 fail (incl. 7 new tests covering the mapping, inert `full_open`, custom limits, tier sort/dedup, and drop-in idempotence)