### PR TITLE
dashboard(filtering): simplify overview + mempool tile shows cumulative reaper total

### DIFF
--- a/dashboard/src/app/(dashboard)/filtering/page.tsx
+++ b/dashboard/src/app/(dashboard)/filtering/page.tsx
@@ -1,24 +1,14 @@
 "use client";
 
 import Link from "next/link";
-import { useQuery } from "@tanstack/react-query";
 import { PageHeader } from "@/components/ui/PageHeader";
 import { Card, CardHeader } from "@/components/ui/Card";
-import { StatCard } from "@/components/ui/StatCard";
 import { SectionErrorBoundary } from "@/components/ui/SectionErrorBoundary";
-import { fetchApi } from "@/lib/api/client";
 import { useConfig, useFullConfig } from "@/hooks/queries/useConfigQueries";
-import { useReaperStatus } from "@/hooks/queries";
 import { useAdvancedFilteringGate } from "@/hooks/useAdvancedFilteringGate";
 import type { FullNodeConfig } from "@/types/api";
 
 type TierKey = "T0" | "T1" | "T2" | "T3";
-
-interface BudsMempool {
-  by_tier?: { T0: number; T1: number; T2: number; T3: number };
-  sample_size?: number;
-  message?: string;
-}
 
 // Plain-English preset name for the stored [policy].profile, normalising the
 // legacy `bitcoin_pure` alias to Strict. Returns "Custom" for the custom policy.
@@ -35,31 +25,6 @@ function modeLabel(profile?: string): string {
       return "Custom";
     default:
       return profile ? profile : "—";
-  }
-}
-
-// Headline "what your node does" summary for the mode card: a short value plus a
-// one-line plain-English description of what it means for the blocks you build.
-// The description is driven by the tiers actually dropped, so a Custom policy
-// reads correctly too.
-function modeSummary(
-  profile: string | undefined,
-  dropped: TierKey[],
-): { value: string; sublabel: string } {
-  switch (profile) {
-    case "full_open":
-      return { value: "Open", sublabel: "Accepting every kind of transaction" };
-    case "permissive":
-      return { value: "Standard", sublabel: "T3 not accepted" };
-    case "bitcoin_pure":
-    case "strict":
-      return { value: "Strict", sublabel: "T2 + T3 not accepted" };
-    case "custom":
-      return dropped.length
-        ? { value: "Custom", sublabel: `Rejecting ${dropped.join(" + ")}` }
-        : { value: "Custom", sublabel: "Accepting every tier" };
-    default:
-      return { value: modeLabel(profile), sublabel: "The tier policy this node accepts under" };
   }
 }
 
@@ -93,153 +58,23 @@ function droppedTiers(
 
 type FullPolicyCustom = NonNullable<FullNodeConfig["policy"]>["custom"];
 
-function bytes(n?: number): string {
-  if (n === undefined || n === null) return "—";
-  if (n < 1024) return `${n} B`;
-  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
-  if (n < 1024 * 1024 * 1024) return `${(n / (1024 * 1024)).toFixed(1)} MB`;
-  return `${(n / (1024 * 1024 * 1024)).toFixed(2)} GB`;
-}
-
 export default function FilteringOverviewPage() {
   const { data: config } = useConfig();
   const { data: fullConfig } = useFullConfig();
-  const { data: reaperStats } = useReaperStatus();
-  const { data: mempool } = useQuery({
-    queryKey: ["buds-mempool"],
-    queryFn: () => fetchApi<BudsMempool>("/api/v1/buds/mempool"),
-    refetchInterval: 15_000,
-  });
-
   const [advancedEnabled] = useAdvancedFilteringGate();
 
   const reaperOn = config?.reaper ?? false;
   const profile = fullConfig?.policy?.profile;
   const dropped = droppedTiers(profile, fullConfig?.policy?.custom);
-  const mode = modeSummary(profile, dropped);
-
-  // Live mempool composition from the sampled tier histogram. T0/T1 are ordinary
-  // payments; T2/T3 carry data (OP_RETURN, inscriptions, runes). These are the
-  // real, per-request counts — not a since-restart artefact.
-  const byTier = mempool?.by_tier ?? { T0: 0, T1: 0, T2: 0, T3: 0 };
-  const sampled = mempool?.sample_size ?? (byTier.T0 + byTier.T1 + byTier.T2 + byTier.T3);
-  const hasSample = !mempool?.message && sampled > 0;
-  const paymentsCount = byTier.T0 + byTier.T1;
-  const dataCount = byTier.T2 + byTier.T3;
-  const paymentsPct = hasSample ? Math.round((paymentsCount / sampled) * 100) : null;
-  const dataPct = hasSample ? Math.round((dataCount / sampled) * 100) : null;
-
-  // What THIS node would drop: the share of the current sample sitting in the
-  // tiers its policy drops. 0% on Open mode — that's correct, not broken.
-  const droppedCount = dropped.reduce((s, t) => s + (byTier[t] ?? 0), 0);
-  const pctFiltered = hasSample ? Math.round((droppedCount / sampled) * 100) : null;
   const droppedLabel = dropped.length ? dropped.join(" + ") : "none";
-
-  // Per-block reaper impact — the junk stripped from the block this node most
-  // recently built. Uses the per-template snapshot (last_block_*), NOT the
-  // cumulative since-restart counters, so it stays honest and current.
-  const blockBuilt = reaperStats?.last_block_unix != null;
-  const lastBlockDeadBytes = reaperStats?.last_block_dead_bytes ?? 0;
-  const lastBlockReaped = reaperStats?.last_block_reaped ?? 0;
 
   return (
     <div className="space-y-6">
       <PageHeader
         eyebrow="filtering"
         title="Filtering."
-        subtitle="Two layers keep your mempool clean — the Reaper rejects spam, and a tier policy picks which transaction classes your node accepts. Filtered transactions never enter your mempool, so they are not relayed or mined. Set it in Basic; fine-tune both in Advanced."
-        subtitleFullWidth
+        subtitle="What your node filters. Set it in Basic, fine-tune in Advanced."
       />
-
-      {/* Live, comparative snapshot — what your node does, what's in the
-          mempool right now, and what your policy actually removes. */}
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-        <StatCard
-          label="Mode"
-          value={fullConfig ? mode.value : "—"}
-          sublabel={fullConfig ? mode.sublabel : undefined}
-          tooltip="What your node accepts, in plain English. This is the tier policy — which classes enter your mempool, and therefore the blocks you build."
-        />
-        <StatCard
-          label="Mempool right now"
-          value={paymentsPct === null ? "—" : `${paymentsPct}% payments`}
-          sublabel={
-            dataPct === null
-              ? "waiting for a sample"
-              : `${dataPct}% carry data · of ${sampled} sampled`
-          }
-          tooltip="Live make-up of the current mempool from a sample of up to 100 transactions. Payments are simple sends and financial scripts (T0/T1); data-carrying are OP_RETURN, inscriptions and runes (T2/T3)."
-        />
-        <StatCard
-          label="What you'd drop"
-          value={pctFiltered === null ? "—" : `${pctFiltered}%`}
-          sublabel={
-            dropped.length
-              ? `${droppedCount} of ${sampled} in ${droppedLabel}`
-              : "You accept every tier"
-          }
-          tooltip="Share of that same live sample sitting in the tiers your policy drops. 0% means your node currently mines everything in the mempool — that's expected on Open mode, not a fault. (This is tier policy only — the Reaper still strips dead-code spam on top of it.)"
-        />
-        <StatCard
-          label="Kept out of your blocks"
-          value={
-            !reaperOn
-              ? "Reaper off"
-              : !blockBuilt
-                ? "—"
-                : lastBlockReaped === 0
-                  ? "0"
-                  : bytes(lastBlockDeadBytes)
-          }
-          sublabel={
-            !reaperOn
-              ? "Not stripping junk"
-              : !blockBuilt
-                ? "No block built yet"
-                : lastBlockReaped === 0
-                  ? "Nothing to strip last block"
-                  : `${lastBlockReaped} junk tx from your last block`
-          }
-          tooltip="Dead-code and malformed data the reaper stripped from the last block template this node built. This is per-block, not a running total — it reflects your most recent block only."
-        />
-      </div>
-
-      {/* How filtering works — plain-English teaching block for newcomers */}
-      <Card>
-        <CardHeader title="How filtering works" subtitle="Two layers, in plain terms." />
-        <div className="space-y-4">
-          <div>
-            <div className="t-lead" style={{ color: "var(--fg)", fontWeight: 500, marginBottom: "4px" }}>
-              The Reaper — your junk filter
-            </div>
-            <p className="t-body" style={{ color: "var(--dim)", lineHeight: 1.6 }}>
-              It rejects specific spam patterns — inscription stuffing, dust floods, oversized data —
-              regardless of class, at your mempool. Transactions it catches are never accepted, relayed, or
-              mined. The Reaper runs all the time on a sensible default; tune its individual detectors in
-              Advanced.
-            </p>
-          </div>
-          <div>
-            <div className="t-lead" style={{ color: "var(--fg)", fontWeight: 500, marginBottom: "4px" }}>
-              Tier policy (BUDS) — which classes your node accepts
-            </div>
-            <p className="t-body" style={{ color: "var(--dim)", lineHeight: 1.6 }}>
-              Legitimate transactions come in classes, from ordinary payments (T0) up to heavy data (T3).
-              This is your choice of which classes your node accepts — and therefore relays and mines.
-              Filtered classes are rejected at your mempool, exactly like Bitcoin Core or Knots: they never
-              enter it, so they are not relayed on and never appear in the blocks you build. Set it in Basic,
-              customise it in Advanced.
-            </p>
-          </div>
-          <div style={{ borderTop: "1px solid var(--rule)", paddingTop: "12px" }}>
-            <p className="t-body" style={{ color: "var(--dim)", lineHeight: 1.6 }}>
-              In one line: the Reaper is the bouncer that rejects junk at the door; the tier policy is the
-              menu deciding which classes your node accepts. Whatever gets in is what you relay and mine — your
-              mempool is your block-building set. Basic sets the menu; Advanced tunes both.
-            </p>
-          </div>
-        </div>
-      </Card>
 
       {/* Status readout — which settings are active */}
       <SectionErrorBoundary section="Active settings">
@@ -264,13 +99,9 @@ export default function FilteringOverviewPage() {
               label="Reaper"
               value={reaperOn ? "On" : "Off"}
               desc={
-                !reaperOn
-                  ? "Not removing dead-code transactions."
-                  : !blockBuilt
-                    ? "Strips dead-code spam from your mempool relay and block templates — no block built yet this run."
-                    : lastBlockReaped === 0
-                      ? "Strips dead-code spam from your mempool relay and blocks. Nothing matched in your last block."
-                      : `Strips dead-code spam from your mempool relay and blocks — removed ${lastBlockReaped} junk tx (${bytes(lastBlockDeadBytes)}) from your last block.`
+                reaperOn
+                  ? "Strips dead-code spam from your mempool relay and block templates."
+                  : "Not removing dead-code spam."
               }
             />
             <StatusRow
@@ -282,19 +113,24 @@ export default function FilteringOverviewPage() {
                   : "Basic presets only. Unlock per-vector controls in Advanced."
               }
             />
-            {pctFiltered !== null && (
-              <div className="t-caption" style={{ color: "var(--fainter)", lineHeight: "1.5" }}>
-                {dropped.length
-                  ? `${droppedCount.toLocaleString()} of ${sampled.toLocaleString()} sampled mempool transactions sit in the tiers this node drops (${droppedLabel}).`
-                  : `All ${sampled.toLocaleString()} sampled mempool transactions fall in tiers this node mines — nothing is dropped by tier policy.`}{" "}
-                A live single-node reading of your current mempool sample — not a standard-vs-reaper-vs-Knots comparison.
-                {reaperOn &&
-                  " The Reaper is a separate layer on top: it targets specific dead-code/spam patterns (inscription envelopes, drop-stuffing, dust-flood, oversized OP_RETURN…) in both your mempool relay and blocks — so it only removes the handful of transactions that match those patterns, never whole classes. That's why a wide-open tier policy can still show a small reaped count."}
-              </div>
-            )}
           </div>
         </Card>
       </SectionErrorBoundary>
+
+      {/* How filtering works — short two-line explainer for newcomers */}
+      <Card>
+        <CardHeader title="How filtering works" subtitle="Two layers, in plain terms." />
+        <div className="space-y-2">
+          <p className="t-body" style={{ color: "var(--dim)", lineHeight: 1.6 }}>
+            The Reaper rejects spam — inscription stuffing, dust floods, oversized data — at your
+            mempool, so it is never relayed or mined.
+          </p>
+          <p className="t-body" style={{ color: "var(--dim)", lineHeight: 1.6 }}>
+            The tier policy (BUDS) picks which transaction classes your node accepts — and your
+            mempool is exactly the set your blocks build from.
+          </p>
+        </div>
+      </Card>
 
       {/* Where to go next */}
       <SectionErrorBoundary section="Configure filtering">

--- a/dashboard/src/app/(dashboard)/mempool/page.tsx
+++ b/dashboard/src/app/(dashboard)/mempool/page.tsx
@@ -344,12 +344,12 @@ function LiveStats({
       : "—";
   const minFee = btcPerKvbToSatVb(mempool?.min_fee);
 
-  // The "Reaped this block" tile only appears when this node runs the reaper
-  // (opt-in +2 capability). It reports the block currently being built — the
-  // most recent template snapshot — not cumulative history; lifetime totals
-  // live on the Reaper page.
+  // The "Reaper — kept out" tile only appears when this node runs the reaper
+  // (opt-in +2 capability). It reports the Reaper's cumulative total — how much
+  // junk this node has kept out over time — not a per-block snapshot. Note this
+  // counts the Reaper only; BUDS tier-policy rejections aren't tallied here yet.
   const showReaped = reaperEnabled;
-  const hasBlock = !!reaperStats && reaperStats.last_block_unix != null;
+  const hasReaperData = !!reaperStats;
   // Five tiles need a wider track; four keep the original layout.
   const gridCols = showReaped
     ? "grid-cols-2 md:grid-cols-3 xl:grid-cols-5"
@@ -365,14 +365,14 @@ function LiveStats({
       />
       {showReaped && (
         <StatCard
-          label="Reaped this block"
-          value={hasBlock ? reaperStats!.last_block_reaped.toLocaleString() : "—"}
+          label="Reaper — kept out"
+          value={hasReaperData ? reaperStats!.txs_reaped.toLocaleString() : "—"}
           sublabel={
-            hasBlock
-              ? `${formatBytes(reaperStats!.last_block_dead_bytes)} dead weight · ${formatRelative(reaperStats!.last_block_unix)}`
-              : "no block built yet"
+            hasReaperData
+              ? `${formatBytes(reaperStats!.dead_bytes_total)} dead weight · cumulative`
+              : "no data yet"
           }
-          tooltip="Transactions the pool template-builder reaper dropped from the block currently being built (dead code detected). A per-block snapshot, not cumulative — lifetime totals and per-vector detail are on the Reaper page."
+          tooltip="The Reaper's cumulative total — every dead-code / spam transaction this node has kept out of its mempool and blocks over time. Reaper only for now: BUDS tier-policy rejections aren't included here yet (a node-level tier-rejection counter is coming). Per-vector detail is on the Reaper page."
         />
       )}
       <StatCard
@@ -395,17 +395,6 @@ function LiveStats({
       />
     </div>
   );
-}
-
-// ─── reaper helpers (feed the "Reaped this block" stat tile) ─────────────────
-
-function formatRelative(unixSecs: number | null): string {
-  if (!unixSecs) return "never";
-  const secs = Math.max(0, Math.floor(Date.now() / 1000) - unixSecs);
-  if (secs < 60) return `${secs}s ago`;
-  if (secs < 3600) return `${Math.floor(secs / 60)}m ago`;
-  if (secs < 86400) return `${Math.floor(secs / 3600)}h ago`;
-  return `${Math.floor(secs / 86400)}d ago`;
 }
 
 // ─── fee-rate distribution (computed client-side from the tx sample) ─────────


### PR DESCRIPTION
## Two frontend cleanups in the Ghost node dashboard

### 1. Simplify the Filtering overview (`filtering/page.tsx`)
The overview was over-built (349 lines). Trimmed it to a tight landing page that matches the calm simplicity of the sibling Basic page.

**Removed:**
- The entire 4-tile `StatCard` grid (Mode / Mempool right now / What you'd drop / Kept out of your blocks). "What you'd drop" reads ~0% and is misleading under mempool-acceptance filtering, and the per-block reaper tile was noise.
- The long caption paragraph inside "What's active" (the live mempool-sample readout).
- Condensed "How filtering works" from three paragraphs + a summary down to a short two-line explainer.
- Shortened the PageHeader subtitle to one clean line and the surviving StatusRow descriptions to one line each.
- Cleaned up every now-unused import / hook / computed value the removed tiles relied on: `StatCard`, `useQuery`, `fetchApi`, `useReaperStatus`, the `buds-mempool` query and all the sample math (`paymentsPct` / `dataPct` / `pctFiltered` / `droppedCount` / `sampled` / `last_block_*` reads), plus the `modeSummary` and `bytes` helpers and the `BudsMempool` interface.

**Kept:** the PageHeader, a compact "What's active" card with the three StatusRows (Mode / Reaper / Advanced controls), the short explainer, and the Basic / Advanced NavCards.

Net: **349 → 185 lines.**

### 2. Fix the reaper tile on the Mempool page (`mempool/page.tsx`)
The tile showed `last_block_reaped` ("Reaped this block") — a per-block number that is small by nature. Changed it to the cumulative total so it reads as how much junk this node has kept out over time.

- Value is now `txs_reaped` (cumulative); sublabel is `dead_bytes_total` formatted as bytes/KB/MB.
- Relabelled to **"Reaper — kept out"**.
- Kept the existing show/hide logic (only when the reaper is enabled); empty state now shows `—` until there's data.
- Added an honest tooltip: this is the **Reaper's** cumulative total only, and BUDS tier-policy rejections aren't included yet (a node-level tier-rejection counter is coming).
- Removed the now-unused `formatRelative` helper.

### Verification
- `tsc --noEmit` clean
- `eslint` clean on both changed files
- `npm run build` succeeds
- "Reaper" name preserved verbatim; theme-aware CSS vars only; calm-prose discipline retained.