### PR TITLE
dashboard(filtering): Filtering Activity on Overview — funnel + table + tiles

### DIFF
--- a/dashboard/src/app/(dashboard)/filtering/page.tsx
+++ b/dashboard/src/app/(dashboard)/filtering/page.tsx
@@ -1,10 +1,12 @@
 "use client";
 
+import type { CSSProperties, ReactNode } from "react";
 import Link from "next/link";
 import { PageHeader } from "@/components/ui/PageHeader";
 import { Card, CardHeader } from "@/components/ui/Card";
 import { SectionErrorBoundary } from "@/components/ui/SectionErrorBoundary";
 import { useConfig, useFullConfig } from "@/hooks/queries/useConfigQueries";
+import { useFilteringActivity } from "@/hooks/queries/useFilteringQueries";
 import { useAdvancedFilteringGate } from "@/hooks/useAdvancedFilteringGate";
 import type { FullNodeConfig } from "@/types/api";
 
@@ -132,6 +134,11 @@ export default function FilteringOverviewPage() {
         </div>
       </Card>
 
+      {/* What the node has actually rejected, and where */}
+      <SectionErrorBoundary section="Filtering activity">
+        <FilteringActivityCard />
+      </SectionErrorBoundary>
+
       {/* Where to go next */}
       <SectionErrorBoundary section="Configure filtering">
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -181,5 +188,292 @@ function NavCard({ href, title, desc }: { href: string; title: string; desc: str
         <div className="t-label" style={{ color: "var(--dim)", lineHeight: "1.6" }}>{desc}</div>
       </Card>
     </Link>
+  );
+}
+
+// A count that renders "—" when we have no data (endpoint 404 during rollout).
+const dash = "—";
+
+// Human byte size — B / KB / MB. Bytes here are virtual bytes (vbytes).
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+// "Filtering activity" — what this node has rejected, and where, since it
+// started. Reads the cumulative per-stage counters and lays them out as
+// summary tiles (the glance) → a two-stage funnel (teaches the shape) → a
+// detail table (the exact numbers). Degrades to a calm "no rejections yet"
+// state when the endpoint is absent (older nodes 404) or all counts are zero.
+function FilteringActivityCard() {
+  const { data, isLoading } = useFilteringActivity();
+
+  // No payload: still loading, or the endpoint isn't wired on this node yet.
+  const haveData = !!data;
+
+  const s1Reaper = data?.stage1_mempool.reaper ?? { txs: 0, vbytes: 0 };
+  const s1Tier = data?.stage1_mempool.tier ?? { txs: 0, vbytes: 0 };
+  const s2Reaper = data?.stage2_block.reaper ?? { txs: 0, vbytes: 0 };
+
+  const keptOut = s1Reaper.txs + s1Tier.txs;
+  const stripped = s2Reaper.txs;
+  const totalRejected = data?.totals.rejected_txs ?? 0;
+  const totalBytes = s1Reaper.vbytes + s1Tier.vbytes + s2Reaper.vbytes;
+
+  // Nothing to show: either no data, or the node has rejected nothing so far.
+  const nothingYet = haveData && totalRejected === 0 && keptOut === 0 && stripped === 0;
+
+  // Render a count, or "—" when we have no data to stand behind it.
+  const count = (n: number) => (haveData ? n.toLocaleString() : dash);
+  const bytes = (n: number) => (haveData ? formatBytes(n) : dash);
+
+  return (
+    <Card>
+      <CardHeader
+        title="Filtering activity"
+        subtitle="What your node has rejected, and where — since it started."
+      />
+
+      {isLoading && !haveData ? (
+        <p className="t-body" style={{ color: "var(--dim)" }}>Loading…</p>
+      ) : (
+        <div className="space-y-6">
+          {/* Summary tiles — the glance */}
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            <SummaryTile label="Kept out of your mempool" value={count(keptOut)} />
+            <SummaryTile label="Stripped from your block" value={count(stripped)} />
+            <SummaryTile label="Total rejected" value={count(totalRejected)} />
+          </div>
+
+          {(nothingYet || !haveData) && (
+            <p className="t-label" style={{ color: "var(--dim)" }}>
+              {haveData
+                ? "No rejections yet — nothing junk has reached this node so far."
+                : "No rejections recorded yet — this node hasn't reported filtering activity."}
+            </p>
+          )}
+
+          {/* Funnel — teaches the two stages, top to bottom */}
+          <div>
+            <FunnelEndcap label="Transactions in" />
+            <FunnelConnector />
+            <StagePanel
+              stage="Stage 1 · Your mempool"
+              note="Not kept, relayed, or mined."
+              filters={[
+                { label: "Reaper rejected", value: count(s1Reaper.txs) },
+                { label: "Tier policy rejected", value: count(s1Tier.txs) },
+              ]}
+            />
+            <FunnelConnector caption="accepted" />
+            <StagePanel
+              stage="Stage 2 · Your block"
+              note="Stripped when building the block."
+              filters={[{ label: "Reaper stripped", value: count(s2Reaper.txs) }]}
+            />
+            <FunnelConnector />
+            <FunnelEndcap label="Your block" />
+          </div>
+
+          {/* Detail table — the exact numbers. Open by default; we don't hide reference. */}
+          <details open>
+            <summary
+              className="t-label"
+              style={{ color: "var(--dim)", cursor: "pointer", marginBottom: "8px" }}
+            >
+              Details
+            </summary>
+            <div style={{ overflowX: "auto" }}>
+              <table className="t-label" style={{ width: "100%", borderCollapse: "collapse" }}>
+                <thead>
+                  <tr style={{ borderBottom: "1px solid var(--rule)" }}>
+                    <ActivityTh>Stage</ActivityTh>
+                    <ActivityTh>Filter</ActivityTh>
+                    <ActivityTh align="right">Rejected txs</ActivityTh>
+                    <ActivityTh align="right">Bytes</ActivityTh>
+                  </tr>
+                </thead>
+                <tbody>
+                  <ActivityRow
+                    stage="Stage 1 · Your mempool"
+                    filter="Reaper"
+                    txs={count(s1Reaper.txs)}
+                    bytes={bytes(s1Reaper.vbytes)}
+                  />
+                  <ActivityRow
+                    stage="Stage 1 · Your mempool"
+                    filter="Tier policy"
+                    txs={count(s1Tier.txs)}
+                    bytes={bytes(s1Tier.vbytes)}
+                  />
+                  <ActivityRow
+                    stage="Stage 2 · Your block"
+                    filter="Reaper"
+                    txs={count(s2Reaper.txs)}
+                    bytes={bytes(s2Reaper.vbytes)}
+                  />
+                  <tr style={{ borderTop: "1px solid var(--rule-strong)" }}>
+                    <ActivityTd style={{ color: "var(--fg)" }}>Total</ActivityTd>
+                    <ActivityTd />
+                    <ActivityTd align="right" style={{ color: "var(--fg)" }}>
+                      {count(totalRejected)}
+                    </ActivityTd>
+                    <ActivityTd align="right" style={{ color: "var(--fg)" }}>
+                      {bytes(totalBytes)}
+                    </ActivityTd>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </details>
+        </div>
+      )}
+    </Card>
+  );
+}
+
+function SummaryTile({ label, value }: { label: string; value: string }) {
+  return (
+    <div
+      style={{
+        padding: "12px 14px",
+        border: "1px solid var(--rule)",
+        borderRadius: "6px",
+        background: "var(--bg)",
+      }}
+    >
+      <div className="t-caption" style={{ color: "var(--dim)" }}>{label}</div>
+      <div
+        className="t-stat"
+        style={{ color: "var(--fg)", marginTop: "4px", fontVariantNumeric: "tabular-nums" }}
+      >
+        {value}
+      </div>
+    </div>
+  );
+}
+
+// A labelled endpoint of the funnel (top = junk in, bottom = clean block out).
+function FunnelEndcap({ label }: { label: string }) {
+  return (
+    <div className="t-label" style={{ color: "var(--dim)", textAlign: "center" }}>
+      {label}
+    </div>
+  );
+}
+
+// The vertical rule + arrow that connects two funnel stages, with an optional
+// caption (e.g. "accepted") describing what flows through.
+function FunnelConnector({ caption }: { caption?: string }) {
+  return (
+    <div
+      className="flex flex-col items-center"
+      style={{ color: "var(--dim)", padding: "6px 0" }}
+    >
+      <div style={{ width: "1px", height: "10px", background: "var(--rule-strong)" }} />
+      <div className="t-caption" style={{ lineHeight: 1 }} aria-hidden>↓</div>
+      {caption && <div className="t-caption" style={{ marginTop: "2px" }}>{caption}</div>}
+    </div>
+  );
+}
+
+// One stage of the funnel: a bordered panel listing its filters and counts.
+function StagePanel({
+  stage,
+  note,
+  filters,
+}: {
+  stage: string;
+  note: string;
+  filters: { label: string; value: string }[];
+}) {
+  return (
+    <div
+      style={{
+        padding: "14px 16px",
+        border: "1px solid var(--rule)",
+        borderRadius: "6px",
+        background: "var(--bg)",
+      }}
+    >
+      <div className="t-body" style={{ color: "var(--fg)" }}>{stage}</div>
+      <div className="t-caption" style={{ color: "var(--dim)", marginTop: "1px" }}>{note}</div>
+      <div className="space-y-1" style={{ marginTop: "10px" }}>
+        {filters.map((f) => (
+          <div key={f.label} className="flex items-baseline justify-between gap-3">
+            <span className="t-label" style={{ color: "var(--dim)" }}>{f.label}</span>
+            <span
+              className="t-body"
+              style={{ color: "var(--accent)", fontVariantNumeric: "tabular-nums" }}
+            >
+              {f.value}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ActivityTh({
+  children,
+  align = "left",
+}: {
+  children?: ReactNode;
+  align?: "left" | "right";
+}) {
+  return (
+    <th
+      className="t-caption"
+      style={{ color: "var(--dim)", fontWeight: 400, textAlign: align, padding: "6px 8px" }}
+    >
+      {children}
+    </th>
+  );
+}
+
+function ActivityTd({
+  children,
+  align = "left",
+  style,
+}: {
+  children?: ReactNode;
+  align?: "left" | "right";
+  style?: CSSProperties;
+}) {
+  return (
+    <td
+      style={{
+        color: "var(--dim)",
+        textAlign: align,
+        padding: "6px 8px",
+        fontVariantNumeric: "tabular-nums",
+        ...style,
+      }}
+    >
+      {children}
+    </td>
+  );
+}
+
+function ActivityRow({
+  stage,
+  filter,
+  txs,
+  bytes,
+}: {
+  stage: string;
+  filter: string;
+  txs: string;
+  bytes: string;
+}) {
+  return (
+    <tr style={{ borderBottom: "1px solid var(--rule)" }}>
+      <ActivityTd>{stage}</ActivityTd>
+      <ActivityTd style={{ color: "var(--fg)" }}>{filter}</ActivityTd>
+      <ActivityTd align="right">{txs}</ActivityTd>
+      <ActivityTd align="right">{bytes}</ActivityTd>
+    </tr>
   );
 }

--- a/dashboard/src/hooks/queries/index.ts
+++ b/dashboard/src/hooks/queries/index.ts
@@ -55,6 +55,9 @@ export * from './useShroudQueries';
 // Reaper queries
 export * from './useReaperQueries';
 
+// Filtering-activity queries
+export * from './useFilteringQueries';
+
 // Capability self-check queries
 export * from './useSelfCheckQueries';
 

--- a/dashboard/src/hooks/queries/useFilteringQueries.ts
+++ b/dashboard/src/hooks/queries/useFilteringQueries.ts
@@ -1,0 +1,14 @@
+import { useQuery } from "@tanstack/react-query";
+import { getFilteringActivity } from "@/lib/api/filtering";
+
+export const filteringKeys = {
+  all: ["filtering-activity"] as const,
+};
+
+export function useFilteringActivity(options?: { refetchInterval?: number }) {
+  return useQuery({
+    queryKey: filteringKeys.all,
+    queryFn: getFilteringActivity,
+    refetchInterval: options?.refetchInterval ?? 15_000,
+  });
+}

--- a/dashboard/src/lib/api/filtering.ts
+++ b/dashboard/src/lib/api/filtering.ts
@@ -1,0 +1,24 @@
+// Filtering activity — cumulative per-stage rejection counts, read from the node
+// via `/api/v1/filtering/activity`.
+import { fetchApi } from "./client";
+import type { FilteringActivity } from "@/types/api";
+
+/**
+ * Fetch the cumulative filtering-activity counters. Returns `null` (rather than
+ * throwing) when the endpoint is absent — it is added in a separate rollout, so
+ * older nodes 404 — or on any transport error, so callers can degrade to a
+ * "no rejections yet" state instead of crashing.
+ *
+ * Routed through `fetchApi` so the HMAC-signed internal request actually reaches
+ * the node; a bare `fetch` hits the Next server and 404s.
+ */
+export async function getFilteringActivity(): Promise<FilteringActivity | null> {
+  try {
+    const data = await fetchApi<unknown>("/api/v1/filtering/activity");
+    return data && typeof data === "object" && "stage1_mempool" in data
+      ? (data as FilteringActivity)
+      : null;
+  } catch {
+    return null;
+  }
+}

--- a/dashboard/src/types/api.ts
+++ b/dashboard/src/types/api.ts
@@ -1210,6 +1210,34 @@ export interface ShroudStatus {
   avg_delay_ms: number;
 }
 
+// Filtering activity (GET /api/v1/filtering/activity) — per-stage counts of the
+// transactions this node has rejected since it started. Two stages: Stage 1 is
+// the mempool (Reaper spam-strip + the tier/BUDS policy), Stage 2 is the block
+// template (the Reaper strips dead weight when the block is built). All counts
+// are cumulative since node start. The endpoint may 404 during rollout, so the
+// hook degrades to null and the UI shows a "no rejections yet" state.
+export interface FilteringStageCount {
+  /** Transactions rejected by this filter at this stage. */
+  txs: number;
+  /** Virtual bytes those rejected transactions accounted for. */
+  vbytes: number;
+}
+
+export interface FilteringActivity {
+  // Stage 1 — your mempool: never kept, relayed, or mined.
+  stage1_mempool: {
+    reaper: FilteringStageCount;
+    tier: FilteringStageCount;
+  };
+  // Stage 2 — your block: stripped when the block template is built.
+  stage2_block: {
+    reaper: FilteringStageCount;
+  };
+  totals: {
+    rejected_txs: number;
+  };
+}
+
 // Tor mode status from gettormode RPC
 export interface TorModeStatus {
   enabled: boolean;


### PR DESCRIPTION
## What

Adds a **Filtering activity** card to the TX-Filtering Overview page — a glance-first view of what the node has rejected, and where, since it started.

Three tiers of detail, ordered glance → teach → reference:

1. **Summary tiles** — Kept out of your mempool, Stripped from your block, Total rejected.
2. **Funnel (hero)** — a two-stage vertical flow the eye follows top→bottom: `Transactions in → Stage 1 · Your mempool (Reaper rejected · Tier policy rejected) → accepted → Stage 2 · Your block (Reaper stripped) → your block`. Stage 1 is framed as "not kept, relayed, or mined"; Stage 2 as "stripped when building the block".
3. **Detail table** (open by default) — rows for Stage 1·Reaper, Stage 1·Tier policy, Stage 2·Reaper with rejected txs + bytes, plus a totals row.

## Data

New `useFilteringActivity` hook (react-query, ~15s refetch, `queryKey ["filtering-activity"]`) calling `fetchApi("/api/v1/filtering/activity")`, plus a `FilteringActivity` type in `types/api.ts`. The endpoint is added under a separate change; this UI degrades gracefully.

## Graceful degradation

- **Endpoint 404 during rollout** (older nodes): the fetch helper returns \`null\`, counts render \`—\`, and a calm note explains no activity was reported.
- **All-zero counts**: shows a "no rejections yet" note.
- Wrapped in a \`SectionErrorBoundary\` — never crashes the page.

## Notes

- Calm-prose copy, \`.t-*\` type scale, theme-aware (light/dark via CSS vars), accent used only on the counts.
- The **Reaper** name is preserved throughout.
- \`tsc --noEmit\`, \`eslint\` on changed files, and \`npm run build\` all clean.