### PR TITLE
feat(ghostd): mempool filter counters (tier + reaper) + getmempoolfilterstats RPC

### DIFF
--- a/ghost-core/src/policy/ghost_reaper.cpp
+++ b/ghost-core/src/policy/ghost_reaper.cpp
@@ -5,8 +5,11 @@
 #include <policy/ghost_reaper.h>
 
 #include <logging.h>
+#include <policy/policy.h>
 #include <script/script.h>
 
+#include <atomic>
+#include <cstdint>
 #include <vector>
 
 // Helper: scan a single witness element for OP_FALSE OP_IF ... OP_ENDIF envelopes.
@@ -319,7 +322,17 @@ bool CheckDustFlood(const CTransaction& tx, CAmount threshold, std::string& reas
     return true;
 }
 
-bool IsGhostReaperClean(const CTransaction& tx, const GhostReaperConfig& config, std::string& reason)
+namespace {
+//! Cumulative-since-start rejection counters for the Reaper filter. Stats only,
+//! so relaxed ordering suffices (no cross-thread invariant rides on them).
+std::atomic<uint64_t> g_reaper_rejected_txs{0};
+std::atomic<uint64_t> g_reaper_rejected_vbytes{0};
+
+//! Core Reaper predicate. Returns true if clean, false (with `reason` filled) at
+//! the first detector that fires. Side-effect-free so the public wrapper can
+//! bump the observability counters exactly once, even when a tx would trip
+//! multiple detectors (only the first is reached before returning).
+bool ReaperCheck(const CTransaction& tx, const GhostReaperConfig& config, std::string& reason)
 {
     // Each detector runs only when its per-vector toggle is enabled.
     // Order: cheapest checks first.
@@ -353,4 +366,28 @@ bool IsGhostReaperClean(const CTransaction& tx, const GhostReaperConfig& config,
     }
 
     return true;
+}
+} // anonymous namespace
+
+bool IsGhostReaperClean(const CTransaction& tx, const GhostReaperConfig& config, std::string& reason)
+{
+    if (ReaperCheck(tx, config, reason)) {
+        return true;
+    }
+    // Rejected: count exactly once. ReaperCheck returns at the first detector to
+    // fire, so a tx that would trip several detectors is still tallied once.
+    g_reaper_rejected_txs.fetch_add(1, std::memory_order_relaxed);
+    g_reaper_rejected_vbytes.fetch_add(static_cast<uint64_t>(GetVirtualTransactionSize(tx)),
+                                       std::memory_order_relaxed);
+    return false;
+}
+
+uint64_t GhostReaperRejectedTxs()
+{
+    return g_reaper_rejected_txs.load(std::memory_order_relaxed);
+}
+
+uint64_t GhostReaperRejectedVbytes()
+{
+    return g_reaper_rejected_vbytes.load(std::memory_order_relaxed);
 }

--- a/ghost-core/src/policy/ghost_reaper.h
+++ b/ghost-core/src/policy/ghost_reaper.h
@@ -7,6 +7,7 @@
 
 #include <primitives/transaction.h>
 
+#include <cstdint>
 #include <string>
 
 /** Configuration for Ghost Reaper mempool filter.
@@ -101,5 +102,17 @@ bool CheckRunestone(const CTransaction& tx, std::string& reason);
  * @param[in] threshold  Sole-output value (sats) at/below which the tx is flooded
  */
 bool CheckDustFlood(const CTransaction& tx, CAmount threshold, std::string& reason);
+
+/**
+ * Observability counters for the Ghost Reaper mempool filter. Cumulative since
+ * process start (reset on restart); the dashboard presents them as "since node
+ * start". Incremented exactly once per transaction the Reaper rejects — a tx
+ * tripping two detectors still counts once. Purely observational: reading or
+ * writing them never affects acceptance.
+ */
+//! Number of transactions rejected by the Reaper since start.
+uint64_t GhostReaperRejectedTxs();
+//! Summed virtual size (vbytes) of transactions rejected by the Reaper since start.
+uint64_t GhostReaperRejectedVbytes();
 
 #endif // BITCOIN_POLICY_GHOST_REAPER_H

--- a/ghost-core/src/policy/ghost_tier.cpp
+++ b/ghost-core/src/policy/ghost_tier.cpp
@@ -6,10 +6,12 @@
 
 #include <consensus/validation.h>
 #include <logging.h>
+#include <policy/policy.h>
 #include <script/script.h>
 #include <tinyformat.h>
 
 #include <algorithm>
+#include <atomic>
 #include <cstring>
 #include <vector>
 
@@ -317,7 +319,16 @@ GhostTier ClassifyTransactionTier(const CTransaction& tx)
 // Mempool-acceptance gate.
 // ---------------------------------------------------------------------------
 
-bool IsGhostTierPolicyClean(const CTransaction& tx, const GhostTierPolicyConfig& config, CAmount base_fees, std::string& reason)
+namespace {
+//! Cumulative-since-start rejection counters for the tier/policy gate. Stats
+//! only, so relaxed ordering suffices (no cross-thread invariant rides on them).
+std::atomic<uint64_t> g_tier_rejected_txs{0};
+std::atomic<uint64_t> g_tier_rejected_vbytes{0};
+
+//! Core tier/policy predicate. Returns true if admissible, false (with `reason`
+//! filled) on the single reject decision. Kept side-effect-free so the public
+//! wrapper can bump the observability counters exactly once per rejected tx.
+bool TierPolicyCheck(const CTransaction& tx, const GhostTierPolicyConfig& config, CAmount base_fees, std::string& reason)
 {
     const GhostTierAnalysis a = AnalyzeTransactionTier(tx);
 
@@ -406,4 +417,28 @@ bool IsGhostTierPolicyClean(const CTransaction& tx, const GhostTierPolicyConfig&
     }
 
     return true;
+}
+} // anonymous namespace
+
+bool IsGhostTierPolicyClean(const CTransaction& tx, const GhostTierPolicyConfig& config, CAmount base_fees, std::string& reason)
+{
+    if (TierPolicyCheck(tx, config, base_fees, reason)) {
+        return true;
+    }
+    // Rejected: count exactly once. TierPolicyCheck returns from a single reject
+    // site per call, so a tx is tallied once regardless of which rule bit it.
+    g_tier_rejected_txs.fetch_add(1, std::memory_order_relaxed);
+    g_tier_rejected_vbytes.fetch_add(static_cast<uint64_t>(GetVirtualTransactionSize(tx)),
+                                     std::memory_order_relaxed);
+    return false;
+}
+
+uint64_t GhostTierRejectedTxs()
+{
+    return g_tier_rejected_txs.load(std::memory_order_relaxed);
+}
+
+uint64_t GhostTierRejectedVbytes()
+{
+    return g_tier_rejected_vbytes.load(std::memory_order_relaxed);
 }

--- a/ghost-core/src/policy/ghost_tier.h
+++ b/ghost-core/src/policy/ghost_tier.h
@@ -151,4 +151,15 @@ struct GhostTierPolicyConfig {
  */
 bool IsGhostTierPolicyClean(const CTransaction& tx, const GhostTierPolicyConfig& config, CAmount base_fees, std::string& reason);
 
+/**
+ * Observability counters for the tier/policy gate. Cumulative since process
+ * start (reset on restart); the dashboard presents them as "since node start".
+ * Incremented exactly once per transaction the gate rejects. Purely
+ * observational — reading or writing them never affects acceptance.
+ */
+//! Number of transactions rejected by the tier/policy gate since start.
+uint64_t GhostTierRejectedTxs();
+//! Summed virtual size (vbytes) of transactions rejected by the tier/policy gate since start.
+uint64_t GhostTierRejectedVbytes();
+
 #endif // BITCOIN_POLICY_GHOST_TIER_H

--- a/ghost-core/src/rpc/mempool.cpp
+++ b/ghost-core/src/rpc/mempool.cpp
@@ -14,6 +14,8 @@
 #include <net_processing.h>
 #include <node/mempool_persist_args.h>
 #include <node/types.h>
+#include <policy/ghost_reaper.h>
+#include <policy/ghost_tier.h>
 #include <policy/rbf.h>
 #include <policy/settings.h>
 #include <primitives/transaction.h>
@@ -727,6 +729,37 @@ static RPCHelpMan getmempoolinfo()
     };
 }
 
+static RPCHelpMan getmempoolfilterstats()
+{
+    return RPCHelpMan{"getmempoolfilterstats",
+        "Returns cumulative counts of transactions rejected by Ghost's mempool filters\n"
+        "(the BUDS tier/policy gate and the Ghost Reaper) since this node started.\n"
+        "Counters are observational only and reset to zero on restart.",
+        {},
+        RPCResult{
+            RPCResult::Type::OBJ, "", "",
+            {
+                {RPCResult::Type::NUM, "tier_rejected_txs", "Transactions rejected by the tier/policy gate since node start"},
+                {RPCResult::Type::NUM, "tier_rejected_vbytes", "Summed virtual size (vbytes) of transactions rejected by the tier/policy gate since node start"},
+                {RPCResult::Type::NUM, "reaper_rejected_txs", "Transactions rejected by the Ghost Reaper since node start"},
+                {RPCResult::Type::NUM, "reaper_rejected_vbytes", "Summed virtual size (vbytes) of transactions rejected by the Ghost Reaper since node start"},
+            }},
+        RPCExamples{
+            HelpExampleCli("getmempoolfilterstats", "")
+            + HelpExampleRpc("getmempoolfilterstats", "")
+        },
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
+    UniValue ret(UniValue::VOBJ);
+    ret.pushKV("tier_rejected_txs", GhostTierRejectedTxs());
+    ret.pushKV("tier_rejected_vbytes", GhostTierRejectedVbytes());
+    ret.pushKV("reaper_rejected_txs", GhostReaperRejectedTxs());
+    ret.pushKV("reaper_rejected_vbytes", GhostReaperRejectedVbytes());
+    return ret;
+},
+    };
+}
+
 static RPCHelpMan importmempool()
 {
     return RPCHelpMan{
@@ -1140,6 +1173,7 @@ void RegisterMempoolRPCCommands(CRPCTable& t)
         {"blockchain", &getmempoolentry},
         {"blockchain", &gettxspendingprevout},
         {"blockchain", &getmempoolinfo},
+        {"blockchain", &getmempoolfilterstats},
         {"blockchain", &getrawmempool},
         {"blockchain", &importmempool},
         {"blockchain", &savemempool},

--- a/ghost-core/src/test/CMakeLists.txt
+++ b/ghost-core/src/test/CMakeLists.txt
@@ -45,6 +45,7 @@ add_executable(test_ghost
   flatfile_tests.cpp
   fs_tests.cpp
   getarg_tests.cpp
+  ghost_filter_counters_tests.cpp
   ghost_reaper_tests.cpp
   ghost_tier_tests.cpp
   gsp_tests.cpp

--- a/ghost-core/src/test/ghost_filter_counters_tests.cpp
+++ b/ghost-core/src/test/ghost_filter_counters_tests.cpp
@@ -1,0 +1,137 @@
+// Copyright (c) 2026 The Bitcoin Ghost developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <policy/ghost_reaper.h>
+#include <policy/ghost_tier.h>
+#include <policy/policy.h>
+#include <primitives/transaction.h>
+#include <script/script.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace {
+
+//! Build a minimal non-coinbase transaction (1 input, 1 P2WPKH output).
+CMutableTransaction MakeBaseTx()
+{
+    CMutableTransaction tx;
+    tx.version = 2;
+    tx.nLockTime = 0;
+    tx.vin.resize(1);
+    tx.vin[0].prevout.hash.SetNull();
+    tx.vin[0].prevout.n = 0; // non-null prevout index => not a coinbase
+    tx.vin[0].nSequence = CTxIn::SEQUENCE_FINAL;
+    tx.vout.resize(1);
+    tx.vout[0].nValue = 50000;
+    tx.vout[0].scriptPubKey = CScript() << OP_0 << std::vector<unsigned char>(20, 0x00);
+    return tx;
+}
+
+} // anonymous namespace
+
+BOOST_AUTO_TEST_SUITE(ghost_filter_counters_tests)
+
+// The counters are process-global and cumulative since start, so this shared
+// test binary cannot assert they equal zero here (other suites exercise the
+// gates first). Instead we assert exact deltas: a clean tx must not move them,
+// and a rejected tx must add exactly 1 to the tx counter and its virtual size
+// to the vbyte counter.
+
+BOOST_AUTO_TEST_CASE(accessors_are_readable)
+{
+    // Accessors must be callable and return a concrete value (0 at process
+    // start; possibly non-zero once other suites have run).
+    (void)GhostTierRejectedTxs();
+    (void)GhostTierRejectedVbytes();
+    (void)GhostReaperRejectedTxs();
+    (void)GhostReaperRejectedVbytes();
+    BOOST_CHECK(true);
+}
+
+BOOST_AUTO_TEST_CASE(tier_counter_increments_on_reject)
+{
+    GhostTierPolicyConfig strict; // {T0,T1}: reject T2/T3
+    strict.allow_t2 = false;
+    strict.allow_t3 = false;
+    BOOST_CHECK(!strict.IsInert());
+
+    std::string reason;
+
+    // A clean T0 payment must NOT move the counters.
+    const uint64_t txs_before_clean = GhostTierRejectedTxs();
+    const uint64_t vbytes_before_clean = GhostTierRejectedVbytes();
+    BOOST_CHECK(IsGhostTierPolicyClean(CTransaction(MakeBaseTx()), strict, 1000, reason));
+    BOOST_CHECK_EQUAL(GhostTierRejectedTxs(), txs_before_clean);
+    BOOST_CHECK_EQUAL(GhostTierRejectedVbytes(), vbytes_before_clean);
+
+    // A small OP_RETURN is T2, which `strict` rejects.
+    CMutableTransaction t2 = MakeBaseTx();
+    t2.vout.emplace_back(0, CScript() << OP_RETURN << std::vector<unsigned char>(40, 0x00));
+    const CTransaction rejected_tx(t2);
+    const int64_t vsize = GetVirtualTransactionSize(rejected_tx);
+    BOOST_CHECK(vsize > 0);
+
+    const uint64_t txs_before = GhostTierRejectedTxs();
+    const uint64_t vbytes_before = GhostTierRejectedVbytes();
+    BOOST_CHECK(!IsGhostTierPolicyClean(rejected_tx, strict, 1000, reason));
+    BOOST_CHECK_EQUAL(reason, "tier-policy");
+
+    // Exactly one tx and its vsize were added.
+    BOOST_CHECK_EQUAL(GhostTierRejectedTxs(), txs_before + 1);
+    BOOST_CHECK_EQUAL(GhostTierRejectedVbytes(), vbytes_before + static_cast<uint64_t>(vsize));
+}
+
+BOOST_AUTO_TEST_CASE(reaper_counter_increments_once_on_reject)
+{
+    GhostReaperConfig config; // all detectors enabled by default
+    std::string reason;
+
+    // A clean payment must NOT move the counters.
+    const uint64_t txs_before_clean = GhostReaperRejectedTxs();
+    const uint64_t vbytes_before_clean = GhostReaperRejectedVbytes();
+    BOOST_CHECK(IsGhostReaperClean(CTransaction(MakeBaseTx()), config, reason));
+    BOOST_CHECK_EQUAL(GhostReaperRejectedTxs(), txs_before_clean);
+    BOOST_CHECK_EQUAL(GhostReaperRejectedVbytes(), vbytes_before_clean);
+
+    // A Runestone output (OP_RETURN OP_13) trips the Reaper.
+    CMutableTransaction rune = MakeBaseTx();
+    rune.vout.emplace_back(0, CScript() << OP_RETURN << OP_13);
+    const CTransaction rejected_tx(rune);
+    const int64_t vsize = GetVirtualTransactionSize(rejected_tx);
+    BOOST_CHECK(vsize > 0);
+
+    const uint64_t txs_before = GhostReaperRejectedTxs();
+    const uint64_t vbytes_before = GhostReaperRejectedVbytes();
+    BOOST_CHECK(!IsGhostReaperClean(rejected_tx, config, reason));
+    BOOST_CHECK_EQUAL(reason, "ghost-reaper-runestone");
+
+    // Exactly one tx and its vsize were added.
+    BOOST_CHECK_EQUAL(GhostReaperRejectedTxs(), txs_before + 1);
+    BOOST_CHECK_EQUAL(GhostReaperRejectedVbytes(), vbytes_before + static_cast<uint64_t>(vsize));
+}
+
+BOOST_AUTO_TEST_CASE(reaper_counts_once_when_multiple_detectors_would_fire)
+{
+    GhostReaperConfig config;
+    std::string reason;
+
+    // Construct a 1-in/1-out tx whose sole output is BOTH a Runestone and an
+    // oversized OP_RETURN — it would trip multiple detectors, but the wrapper
+    // must count it exactly once.
+    CMutableTransaction mtx = MakeBaseTx();
+    mtx.vout.clear();
+    mtx.vout.emplace_back(0, CScript() << OP_RETURN << OP_13
+                                       << std::vector<unsigned char>(120, 0xab));
+    const CTransaction rejected_tx(mtx);
+
+    const uint64_t txs_before = GhostReaperRejectedTxs();
+    BOOST_CHECK(!IsGhostReaperClean(rejected_tx, config, reason));
+    BOOST_CHECK_EQUAL(GhostReaperRejectedTxs(), txs_before + 1);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary

Adds cumulative-since-start rejection counters to ghostd's two mempool filters and exposes them via a new RPC, so the dashboard can report how much each filter is dropping. Purely observational — no change to acceptance behaviour.

## Changes

- **Tier gate** (`policy/ghost_tier.{h,cpp}`): file-scoped `std::atomic<uint64_t>` counters `g_tier_rejected_txs` / `g_tier_rejected_vbytes` with `GhostTierRejectedTxs()` / `GhostTierRejectedVbytes()` accessors. The gate logic moves into a side-effect-free helper `TierPolicyCheck`; the public `IsGhostTierPolicyClean` wrapper increments once (tx +1, vbytes += `GetVirtualTransactionSize(tx)`) when the tx is rejected, so a tx is counted exactly once regardless of which rule bit it.
- **Reaper** (`policy/ghost_reaper.{h,cpp}`): same pattern. `IsGhostReaperClean` wraps a `ReaperCheck` helper and counts once at the single rejection exit — a tx tripping several detectors still counts once. The Reaper name is preserved.
- **RPC** (`rpc/mempool.cpp`): new `getmempoolfilterstats` (no args, `blockchain` category, registered in `RegisterMempoolRPCCommands`) returning `{tier_rejected_txs, tier_rejected_vbytes, reaper_rejected_txs, reaper_rejected_vbytes}`.
- **Test** (`test/ghost_filter_counters_tests.cpp`, registered in `test/CMakeLists.txt`): asserts the accessors are readable, a clean tx does not move the counters, and a rejected T2 tier tx and a Reaper-caught tx each add exactly 1 to the tx counter and their vsize to the vbyte counter; a tx that would trip multiple Reaper detectors is counted once.

Counters use `std::memory_order_relaxed` (stats, not synchronisation) and reset on restart (presented as "since node start").