### PR TITLE
dashboard(mempool): tx-count tiles + mempool-over-time graph

### DIFF
--- a/dashboard/src/app/(dashboard)/mempool/page.tsx
+++ b/dashboard/src/app/(dashboard)/mempool/page.tsx
@@ -8,8 +8,10 @@ import { Badge } from "@/components/ui/Badge";
 import { SkeletonCard } from "@/components/ui/Skeleton";
 import { StatCard } from "@/components/ui/StatCard";
 import { SectionErrorBoundary } from "@/components/ui/SectionErrorBoundary";
+import { TimeSeriesChart } from "@/components/ui/MiniChart";
 import { useConfig } from "@/hooks/queries/useConfigQueries";
 import { useReaperStatus } from "@/hooks/queries";
+import { useMempoolSeries } from "@/hooks/useMempoolSeries";
 import { type ReaperStats } from "@/lib/api/reaper";
 import { fetchApi } from "@/lib/api/client";
 
@@ -151,6 +153,12 @@ export default function MempoolPage() {
         actions={<Badge variant="success">rpc · lightweight</Badge>}
       />
 
+      {/* Tx-count tiles + the mempool-over-time graph. Sits above the embed so
+          the two headline counts and the trend are the first thing you see. */}
+      <SectionErrorBoundary section="Mempool metrics">
+        <MempoolMetrics mempool={mempool} />
+      </SectionErrorBoundary>
+
       {/* The real mempool.space UI of THIS node's own mempool, served
           same-origin through the dashboard, at the very top. The lightweight
           RPC cards and the Reaper filter breakdown follow below. */}
@@ -178,6 +186,72 @@ export default function MempoolPage() {
           </SectionErrorBoundary>
         </>
       )}
+    </div>
+  );
+}
+
+// ─── mempool tx-count tiles + over-time graph ────────────────────────────────
+
+/**
+ * Two headline tiles (current mempool tx count, current block-template tx count)
+ * plus a "mempool over time" line chart.
+ *
+ * Data comes from {@link useMempoolSeries}: the node's server-side `/pool/series`
+ * ring (30s samples, ~24h, survives reloads) when it carries the mempool fields,
+ * otherwise a live in-browser session buffer keyed on this page's own
+ * `/buds/mempool` poll. The "Mempool" tile prefers the live `total` already
+ * fetched on the page and only falls back to the latest series sample; the
+ * "This block" tile is server-ring only (the RPC view has no block-template
+ * count) and shows "—" until the ring has it.
+ */
+function MempoolMetrics({ mempool }: { mempool?: BudsMempool }) {
+  const series = useMempoolSeries();
+
+  // Live getmempoolinfo.size when we have it, else the newest series sample.
+  const mempoolNow = mempool?.total ?? series.latestMempoolTxs ?? undefined;
+  const blockNow = series.latestBlockTxs ?? undefined;
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <StatCard
+          label="Mempool"
+          value={formatCount(mempoolNow)}
+          sublabel="transactions right now"
+          tooltip="getmempoolinfo.size — transactions your node currently holds"
+        />
+        <StatCard
+          label="This block"
+          value={formatCount(blockNow)}
+          sublabel="in the block template"
+          tooltip="transactions in the block template your node is currently building"
+        />
+      </div>
+
+      <Card>
+        <div className="mb-3 flex items-start justify-between gap-2">
+          <div>
+            <h3 className="t-title" style={{ color: "var(--fg)" }}>
+              Mempool over time
+            </h3>
+            <p className="t-caption" style={{ color: "var(--dim)", marginTop: "2px" }}>
+              Transactions in your node&apos;s mempool, sampled over time
+            </p>
+          </div>
+          <Badge variant="default">{series.serverBacked ? "history" : "live (session)"}</Badge>
+        </div>
+        <TimeSeriesChart
+          data={series.mempoolTxs}
+          minZero
+          ariaLabel="Mempool transaction count over time"
+          formatValue={(v) => Math.round(v).toLocaleString()}
+        />
+        <p className="t-caption" style={{ color: "var(--fainter)", marginTop: "12px" }}>
+          {series.serverBacked
+            ? "Drawn from this node's server-side history (sampled every 30s, up to 24h) so it survives reloads."
+            : `Collecting live in-browser samples (${series.sampleCount} this session) — the node's server-side history will back this chart once it has accumulated a few. Resets on reload.`}
+        </p>
+      </Card>
     </div>
   );
 }

--- a/dashboard/src/hooks/useMempoolSeries.ts
+++ b/dashboard/src/hooks/useMempoolSeries.ts
@@ -1,0 +1,128 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { usePoolSeriesHistory } from '@/hooks/queries';
+import type { SeriesPoint } from '@/hooks/usePoolSeries';
+
+/**
+ * Rolling time-series of this node's mempool transaction count, for the Mempool
+ * page graph + tiles.
+ *
+ * It mirrors {@link usePoolSeries}: the preferred source is the backend
+ * `GET /api/v1/pool/series` ring (sampled every 30s, up to 24h, survives
+ * reloads), which now carries a per-sample `mempool_txs` (getmempoolinfo.size)
+ * and `block_txs` (block-template tx count). When that ring is empty — or is an
+ * older node whose samples predate those fields — the hook falls back to a
+ * client-side session buffer keyed on the mempool page's own `/buds/mempool`
+ * query (`total` = getmempoolinfo.size): every time that query refetches we
+ * append the latest reading. Session accumulation is driven by subscribing to
+ * the react-query cache (an external system), the same idiomatic pattern
+ * usePoolSeries uses.
+ *
+ * There is no session source for the block-template tx count (the buds/mempool
+ * RPC view doesn't expose it), so `blockTxs` / `latestBlockTxs` are populated
+ * only from the server ring and stay `[]` / `null` until it has samples.
+ */
+
+export interface MempoolSeries {
+  /** Mempool transaction count over time (server ring, else session buffer). */
+  mempoolTxs: SeriesPoint[];
+  /** Block-template transaction count over time (server ring only). */
+  blockTxs: SeriesPoint[];
+  /** Most recent mempool tx count from the series (null until any sample). */
+  latestMempoolTxs: number | null;
+  /** Most recent block-template tx count from the server ring (null until any). */
+  latestBlockTxs: number | null;
+  /** Number of samples collected this session (session buffer). */
+  sampleCount: number;
+  /** True when the mempool-txs chart is backed by server-side history. */
+  serverBacked: boolean;
+}
+
+// The mempool page's buds/mempool query key + the field the graph tracks.
+const BUDS_MEMPOOL_KEY = ['buds-mempool'] as const;
+const MAX_POINTS = 240; // ~1h at the 15s buds/mempool poll
+
+interface BudsMempoolSample {
+  total?: number; // getmempoolinfo.size
+}
+
+interface SessionSeries {
+  mempoolTxs: SeriesPoint[];
+  sampleCount: number;
+}
+
+export function useMempoolSeries(): MempoolSeries {
+  // Server-side history (1h window). Falls back silently to the session buffer
+  // when the endpoint is empty, unavailable, or predates the mempool fields.
+  const { data: history } = usePoolSeriesHistory('1h');
+
+  const queryClient = useQueryClient();
+  const [session, setSession] = useState<SessionSeries>({ mempoolTxs: [], sampleCount: 0 });
+
+  // Dedupe: only append once per distinct refetch tick.
+  const lastTickRef = useRef<number>(0);
+
+  useEffect(() => {
+    const cache = queryClient.getQueryCache();
+
+    const sample = () => {
+      const state = queryClient.getQueryState<BudsMempoolSample>(BUDS_MEMPOOL_KEY);
+      const data = state?.data;
+      const updatedAt = state?.dataUpdatedAt ?? 0;
+      if (!data || updatedAt === 0 || updatedAt === lastTickRef.current) return;
+      const total = data.total;
+      if (total === undefined || total === null) return;
+      lastTickRef.current = updatedAt;
+
+      const t = Math.floor(updatedAt / 1000);
+      setSession((prev) => {
+        const next = [...prev.mempoolTxs, { t, v: total }];
+        return {
+          mempoolTxs: next.length > MAX_POINTS ? next.slice(next.length - MAX_POINTS) : next,
+          sampleCount: prev.sampleCount + 1,
+        };
+      });
+    };
+
+    // Seed with whatever is already cached, then follow cache updates.
+    sample();
+    const unsubscribe = cache.subscribe(sample);
+    return unsubscribe;
+  }, [queryClient]);
+
+  return useMemo<MempoolSeries>(() => {
+    const samples = history?.samples ?? [];
+    // The mempool/block fields are optional; only samples that carry them count.
+    const withMempool = samples.filter((s) => s.mempool_txs != null);
+    const withBlock = samples.filter((s) => s.block_txs != null);
+    const latestBlockTxs = withBlock.length ? withBlock[withBlock.length - 1].block_txs! : null;
+    const blockTxs = withBlock.map((s) => ({ t: s.t, v: s.block_txs! }));
+
+    // Prefer the server ring once it has ≥2 mempool points to draw a line.
+    const serverBacked = withMempool.length >= 2;
+    if (serverBacked) {
+      const mempoolTxs = withMempool.map((s) => ({ t: s.t, v: s.mempool_txs! }));
+      return {
+        mempoolTxs,
+        blockTxs,
+        latestMempoolTxs: mempoolTxs[mempoolTxs.length - 1].v,
+        latestBlockTxs,
+        sampleCount: session.sampleCount,
+        serverBacked: true,
+      };
+    }
+
+    return {
+      mempoolTxs: session.mempoolTxs,
+      blockTxs,
+      latestMempoolTxs: session.mempoolTxs.length
+        ? session.mempoolTxs[session.mempoolTxs.length - 1].v
+        : null,
+      latestBlockTxs,
+      sampleCount: session.sampleCount,
+      serverBacked: false,
+    };
+  }, [history, session]);
+}

--- a/dashboard/src/types/api.ts
+++ b/dashboard/src/types/api.ts
@@ -347,6 +347,12 @@ export interface PoolSeriesSample {
   local_hashrate_th: number;
   /** Mesh-wide deduplicated connected-miner count. */
   miners: number;
+  /** Transactions in this node's mempool at sample time (getmempoolinfo.size).
+   *  Optional: absent on nodes whose `/pool/series` ring predates this field. */
+  mempool_txs?: number;
+  /** Transactions in the block template this node was building at sample time.
+   *  Optional: absent on nodes whose `/pool/series` ring predates this field. */
+  block_txs?: number;
 }
 
 export interface PoolSeriesResponse {


### PR DESCRIPTION
## What

Adds mempool metrics to the dashboard **Mempool** page: two headline tiles and a mempool-over-time line graph, reusing the existing pool-page pattern (no new charting library).

### Tiles (near the top, existing `StatCard` styling)
- **Mempool** — current tx count. Prefers the live `mempool.total` (`getmempoolinfo.size`) already fetched on the page, falls back to the latest series sample's `mempool_txs`. Tooltip: *getmempoolinfo.size — transactions your node currently holds*.
- **This block** — current block-template tx count from the latest series sample's `block_txs`; shows `—` until the ring has it. Tooltip: *transactions in the block template your node is currently building*.

### Graph
- A `TimeSeriesChart` (the same inline-SVG component the pool page uses) of `mempool_txs` over time, in a card titled **Mempool over time** with the same `history` / `live (session)` badge treatment as the pool `ChartCard`.

### Data source — mirrors `usePoolSeries`
New thin hook `useMempoolSeries`:
- Preferred source is the server-side `GET /api/v1/pool/series` ring (30s samples, ~24h, survives reloads), reading the new per-sample `mempool_txs` / `block_txs` fields.
- **Session-buffer fallback** keyed on the page's own `/buds/mempool` poll (`total`) via a react-query cache subscription — empty ring builds a live in-browser series and the chart shows a friendly *collecting samples…* until there are ≥2 points.
- `serverBacked` flips the badge to `history` once the ring has ≥2 mempool points.

`PoolSeriesSample` gains **optional** `mempool_txs?` / `block_txs?` so older nodes (whose ring predates the fields) degrade gracefully to the session buffer / `—`.

The existing mempool.space embed, live RPC stat row, and reaper tile are untouched — the new section slots in above them.

## Verification
- `tsc --noEmit` clean
- `eslint` clean on changed files
- `npm run build` compiles successfully (`/mempool` renders)