### PR TITLE
feat(series): sample mempool_txs + block_txs into the pool ring

### DIFF
--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -7039,6 +7039,8 @@ async fn main() -> Result<()> {
     // serve real server-side history instead of a client-side session buffer.
     {
         let state_for_series = Arc::clone(&verification_state);
+        let rpc_for_series = Arc::clone(&rpc);
+        let tp_for_series = Arc::clone(&template_processor);
         let mut series_shutdown = shutdown_tx.subscribe();
         tokio::spawn(async move {
             let mut interval = tokio::time::interval(std::time::Duration::from_secs(30));
@@ -7049,11 +7051,26 @@ async fn main() -> Result<()> {
                             .mesh_total_hashrate()
                             .or_else(|| state_for_series.local_hashrate())
                             .unwrap_or(0.0);
+                        // Local ghostd mempool tx count via the shared RPC client
+                        // (0 if the RPC is briefly unavailable).
+                        let mempool_txs = rpc_for_series
+                            .get_mempool_info()
+                            .await
+                            .map(|i| i.size)
+                            .unwrap_or(0);
+                        // Current block template tx count (incl. coinbase); 0 before
+                        // the first template is built.
+                        let block_txs = tp_for_series
+                            .current_work()
+                            .map(|w| w.tx_count as u64)
+                            .unwrap_or(0);
                         let sample = ghost_verification::pool_series::PoolSample {
                             t: chrono::Utc::now().timestamp(),
                             mesh_hashrate_th,
                             local_hashrate_th: state_for_series.local_hashrate().unwrap_or(0.0),
                             miners: state_for_series.mesh_active_miners().unwrap_or(0),
+                            mempool_txs,
+                            block_txs,
                         };
                         state_for_series.pool_series.push(sample);
                     }

--- a/crates/ghost-verification/src/pool_series.rs
+++ b/crates/ghost-verification/src/pool_series.rs
@@ -12,11 +12,11 @@
 //! sampler task and the route handler share one instance.
 
 use parking_lot::RwLock;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::collections::VecDeque;
 
 /// One periodic sample of pool-wide metrics.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PoolSample {
     /// Unix timestamp (seconds) the sample was taken.
     pub t: i64,
@@ -26,6 +26,14 @@ pub struct PoolSample {
     pub local_hashrate_th: f64,
     /// Mesh-wide deduplicated connected-miner count.
     pub miners: u32,
+    /// Local ghostd mempool transaction count at sample time (`getmempoolinfo.size`).
+    /// `#[serde(default)]` so samples serialised before this field deserialise as 0.
+    #[serde(default)]
+    pub mempool_txs: u64,
+    /// Transaction count of the current block template (including coinbase).
+    /// `#[serde(default)]` so samples serialised before this field deserialise as 0.
+    #[serde(default)]
+    pub block_txs: u64,
 }
 
 /// Bounded FIFO ring of [`PoolSample`], shared between the sampler task and the
@@ -87,6 +95,8 @@ mod tests {
             mesh_hashrate_th: t as f64,
             local_hashrate_th: 0.0,
             miners: 1,
+            mempool_txs: t as u64,
+            block_txs: (t as u64) + 1,
         }
     }
 
@@ -117,5 +127,35 @@ mod tests {
         let s = PoolSeries::new(10);
         assert!(s.is_empty());
         assert!(s.since(0).is_empty());
+    }
+
+    #[test]
+    fn mempool_and_block_txs_survive_push_and_since() {
+        let s = PoolSeries::new(10);
+        s.push(sample(5));
+        let out = s.since(i64::MIN);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].mempool_txs, 5);
+        assert_eq!(out[0].block_txs, 6);
+    }
+
+    #[test]
+    fn serde_round_trip_preserves_new_fields() {
+        let json = serde_json::to_string(&sample(42)).unwrap();
+        let back: PoolSample = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.t, 42);
+        assert_eq!(back.mempool_txs, 42);
+        assert_eq!(back.block_txs, 43);
+    }
+
+    #[test]
+    fn old_samples_without_new_fields_default_to_zero() {
+        // A payload serialised before mempool_txs/block_txs existed.
+        let legacy = r#"{"t":100,"mesh_hashrate_th":1.5,"local_hashrate_th":0.5,"miners":3}"#;
+        let s: PoolSample = serde_json::from_str(legacy).unwrap();
+        assert_eq!(s.t, 100);
+        assert_eq!(s.miners, 3);
+        assert_eq!(s.mempool_txs, 0);
+        assert_eq!(s.block_txs, 0);
     }
 }


### PR DESCRIPTION
## What

Extends the pool-metrics time-series ring so the dashboard can graph "mempool over time" and show tiles.

Adds two fields to `PoolSample` (`crates/ghost-verification/src/pool_series.rs`):

- `mempool_txs: u64` — local ghostd mempool transaction count.
- `block_txs: u64` — current block template transaction count (including coinbase).

Both are `#[serde(default)]` so samples serialised before these fields existed deserialise cleanly (default `0`).

## Wiring

- **Sampler** (`bins/ghost-pool/src/main.rs`, 30s pool time-series task): now clones the pool's shared `rpc` client and the `template_processor` into the sampler task.
  - `mempool_txs` ← `rpc.get_mempool_info().await.map(|i| i.size).unwrap_or(0)`.
  - `block_txs` ← `template_processor.current_work().map(|w| w.tx_count as u64).unwrap_or(0)` — sourced from the current `WorkState.tx_count` (`template.rs`, `filtered_template.transactions.len() + 1`, i.e. includes coinbase). Not stubbed to 0; wired to the live template.
- **Route** (`GET /api/v1/pool/series`): the handler serialises the `Vec<PoolSample>` directly, so the new fields flow through automatically — no handler change.

## Tests

`pool_series.rs` gains coverage for the new fields:
- `mempool_and_block_txs_survive_push_and_since` — fields carry through ring push/`since`.
- `serde_round_trip_preserves_new_fields` — JSON round-trip.
- `old_samples_without_new_fields_default_to_zero` — legacy payload (no new keys) deserialises with both fields `0`.

## Verification

- `cargo test -p ghost-verification` (pool_series) — 6 passed, 0 failed.
- `cargo check -p ghost-common -p ghost-verification -p ghost-pool` — clean (only pre-existing unrelated warnings in `ghost-locks`/`wraith-protocol`).

No changes to `dashboard/**` or `ghost-core/**`.