### PR TITLE
dashboard(filtering): move mempool metrics to Overview, compact What's active, reorder

### DIFF
--- a/dashboard/src/app/(dashboard)/filtering/page.tsx
+++ b/dashboard/src/app/(dashboard)/filtering/page.tsx
@@ -4,13 +4,12 @@ import type { CSSProperties, ReactNode } from "react";
 import Link from "next/link";
 import { PageHeader } from "@/components/ui/PageHeader";
 import { Card, CardHeader } from "@/components/ui/Card";
+import { StatCard } from "@/components/ui/StatCard";
 import { SectionErrorBoundary } from "@/components/ui/SectionErrorBoundary";
+import { MempoolMetrics } from "@/components/filtering/MempoolMetrics";
 import { useConfig, useFullConfig } from "@/hooks/queries/useConfigQueries";
 import { useFilteringActivity } from "@/hooks/queries/useFilteringQueries";
 import { useAdvancedFilteringGate } from "@/hooks/useAdvancedFilteringGate";
-import type { FullNodeConfig } from "@/types/api";
-
-type TierKey = "T0" | "T1" | "T2" | "T3";
 
 // Plain-English preset name for the stored [policy].profile, normalising the
 // legacy `bitcoin_pure` alias to Strict. Returns "Custom" for the custom policy.
@@ -30,36 +29,6 @@ function modeLabel(profile?: string): string {
   }
 }
 
-// Which BUDS tiers this node's policy drops (does not mine). Presets map to a
-// fixed set; a custom policy drops any tier whose allow flag is false.
-function droppedTiers(
-  profile: string | undefined,
-  custom?: FullPolicyCustom,
-): TierKey[] {
-  switch (profile) {
-    case "bitcoin_pure":
-    case "strict":
-      return ["T2", "T3"];
-    case "permissive":
-      return ["T3"];
-    case "full_open":
-      return [];
-    case "custom": {
-      if (!custom) return [];
-      const dropped: TierKey[] = [];
-      if (!custom.allow_t0) dropped.push("T0");
-      if (!custom.allow_t1) dropped.push("T1");
-      if (!custom.allow_t2) dropped.push("T2");
-      if (!custom.allow_t3) dropped.push("T3");
-      return dropped;
-    }
-    default:
-      return [];
-  }
-}
-
-type FullPolicyCustom = NonNullable<FullNodeConfig["policy"]>["custom"];
-
 export default function FilteringOverviewPage() {
   const { data: config } = useConfig();
   const { data: fullConfig } = useFullConfig();
@@ -67,8 +36,6 @@ export default function FilteringOverviewPage() {
 
   const reaperOn = config?.reaper ?? false;
   const profile = fullConfig?.policy?.profile;
-  const dropped = droppedTiers(profile, fullConfig?.policy?.custom);
-  const droppedLabel = dropped.length ? dropped.join(" + ") : "none";
 
   return (
     <div className="space-y-6">
@@ -77,47 +44,6 @@ export default function FilteringOverviewPage() {
         title="Filtering."
         subtitle="What your node filters. Set it in Basic, fine-tune in Advanced."
       />
-
-      {/* Status readout — which settings are active */}
-      <SectionErrorBoundary section="Active settings">
-        <Card>
-          <CardHeader
-            title="What's active"
-            subtitle="The filtering your node is running right now."
-          />
-          <div className="space-y-3">
-            <StatusRow
-              label="Mode"
-              value={modeLabel(profile)}
-              desc={
-                dropped.length
-                  ? `Rejects ${droppedLabel} — accepts everything else.`
-                  : profile === "full_open"
-                    ? "Accepts every class, including heavy data (T3)."
-                    : "The tier policy this node accepts under."
-              }
-            />
-            <StatusRow
-              label="Reaper"
-              value={reaperOn ? "On" : "Off"}
-              desc={
-                reaperOn
-                  ? "Strips dead-code spam from your mempool relay and block templates."
-                  : "Not removing dead-code spam."
-              }
-            />
-            <StatusRow
-              label="Advanced controls"
-              value={advancedEnabled ? "Enabled" : "Disabled"}
-              desc={
-                advancedEnabled
-                  ? "Per-vector reaper + custom policy controls are unlocked in Advanced."
-                  : "Basic presets only. Unlock per-vector controls in Advanced."
-              }
-            />
-          </div>
-        </Card>
-      </SectionErrorBoundary>
 
       {/* How filtering works — short two-line explainer for newcomers */}
       <Card>
@@ -133,6 +59,26 @@ export default function FilteringOverviewPage() {
           </p>
         </div>
       </Card>
+
+      {/* Status readout — which settings are active. Compact tiles: label + value. */}
+      <SectionErrorBoundary section="Active settings">
+        <Card>
+          <CardHeader
+            title="What's active"
+            subtitle="The filtering your node is running right now."
+          />
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            <StatCard label="Mode" value={modeLabel(profile)} />
+            <StatCard label="Reaper" value={reaperOn ? "On" : "Off"} />
+            <StatCard label="Advanced controls" value={advancedEnabled ? "Enabled" : "Disabled"} />
+          </div>
+        </Card>
+      </SectionErrorBoundary>
+
+      {/* Mempool tx-count tiles + over-time graph */}
+      <SectionErrorBoundary section="Mempool metrics">
+        <MempoolMetrics />
+      </SectionErrorBoundary>
 
       {/* What the node has actually rejected, and where */}
       <SectionErrorBoundary section="Filtering activity">
@@ -154,25 +100,6 @@ export default function FilteringOverviewPage() {
           />
         </div>
       </SectionErrorBoundary>
-    </div>
-  );
-}
-
-function StatusRow({ label, value, desc }: { label: string; value: string; desc: string }) {
-  return (
-    <div
-      style={{
-        padding: "12px 14px",
-        border: "1px solid var(--rule)",
-        borderRadius: "6px",
-        background: "var(--bg)",
-      }}
-    >
-      <div className="flex items-center gap-2">
-        <span className="t-body" style={{ color: "var(--dim)" }}>{label}</span>
-        <span className="t-body" style={{ color: "var(--fg)" }}>{value}</span>
-      </div>
-      <div className="t-label" style={{ color: "var(--dim)", marginTop: "2px" }}>{desc}</div>
     </div>
   );
 }
@@ -232,7 +159,7 @@ function FilteringActivityCard() {
     <Card>
       <CardHeader
         title="Filtering activity"
-        subtitle="What your node has rejected, and where — since it started."
+        subtitle="Transactions your node has rejected, by stage — cumulative since your node last started."
       />
 
       {isLoading && !haveData ? (
@@ -245,6 +172,10 @@ function FilteringActivityCard() {
             <SummaryTile label="Stripped from your block" value={count(stripped)} />
             <SummaryTile label="Total rejected" value={count(totalRejected)} />
           </div>
+
+          <p className="t-caption" style={{ color: "var(--fainter)" }}>
+            Running totals since your node last started — they reset to zero on a node restart.
+          </p>
 
           {(nothingYet || !haveData) && (
             <p className="t-label" style={{ color: "var(--dim)" }}>

--- a/dashboard/src/app/(dashboard)/mempool/page.tsx
+++ b/dashboard/src/app/(dashboard)/mempool/page.tsx
@@ -8,10 +8,8 @@ import { Badge } from "@/components/ui/Badge";
 import { SkeletonCard } from "@/components/ui/Skeleton";
 import { StatCard } from "@/components/ui/StatCard";
 import { SectionErrorBoundary } from "@/components/ui/SectionErrorBoundary";
-import { TimeSeriesChart } from "@/components/ui/MiniChart";
 import { useConfig } from "@/hooks/queries/useConfigQueries";
 import { useReaperStatus } from "@/hooks/queries";
-import { useMempoolSeries } from "@/hooks/useMempoolSeries";
 import { type ReaperStats } from "@/lib/api/reaper";
 import { fetchApi } from "@/lib/api/client";
 
@@ -153,12 +151,6 @@ export default function MempoolPage() {
         actions={<Badge variant="success">rpc · lightweight</Badge>}
       />
 
-      {/* Tx-count tiles + the mempool-over-time graph. Sits above the embed so
-          the two headline counts and the trend are the first thing you see. */}
-      <SectionErrorBoundary section="Mempool metrics">
-        <MempoolMetrics mempool={mempool} />
-      </SectionErrorBoundary>
-
       {/* The real mempool.space UI of THIS node's own mempool, served
           same-origin through the dashboard, at the very top. The lightweight
           RPC cards and the Reaper filter breakdown follow below. */}
@@ -186,72 +178,6 @@ export default function MempoolPage() {
           </SectionErrorBoundary>
         </>
       )}
-    </div>
-  );
-}
-
-// ─── mempool tx-count tiles + over-time graph ────────────────────────────────
-
-/**
- * Two headline tiles (current mempool tx count, current block-template tx count)
- * plus a "mempool over time" line chart.
- *
- * Data comes from {@link useMempoolSeries}: the node's server-side `/pool/series`
- * ring (30s samples, ~24h, survives reloads) when it carries the mempool fields,
- * otherwise a live in-browser session buffer keyed on this page's own
- * `/buds/mempool` poll. The "Mempool" tile prefers the live `total` already
- * fetched on the page and only falls back to the latest series sample; the
- * "This block" tile is server-ring only (the RPC view has no block-template
- * count) and shows "—" until the ring has it.
- */
-function MempoolMetrics({ mempool }: { mempool?: BudsMempool }) {
-  const series = useMempoolSeries();
-
-  // Live getmempoolinfo.size when we have it, else the newest series sample.
-  const mempoolNow = mempool?.total ?? series.latestMempoolTxs ?? undefined;
-  const blockNow = series.latestBlockTxs ?? undefined;
-
-  return (
-    <div className="space-y-4">
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-        <StatCard
-          label="Mempool"
-          value={formatCount(mempoolNow)}
-          sublabel="transactions right now"
-          tooltip="getmempoolinfo.size — transactions your node currently holds"
-        />
-        <StatCard
-          label="This block"
-          value={formatCount(blockNow)}
-          sublabel="in the block template"
-          tooltip="transactions in the block template your node is currently building"
-        />
-      </div>
-
-      <Card>
-        <div className="mb-3 flex items-start justify-between gap-2">
-          <div>
-            <h3 className="t-title" style={{ color: "var(--fg)" }}>
-              Mempool over time
-            </h3>
-            <p className="t-caption" style={{ color: "var(--dim)", marginTop: "2px" }}>
-              Transactions in your node&apos;s mempool, sampled over time
-            </p>
-          </div>
-          <Badge variant="default">{series.serverBacked ? "history" : "live (session)"}</Badge>
-        </div>
-        <TimeSeriesChart
-          data={series.mempoolTxs}
-          minZero
-          ariaLabel="Mempool transaction count over time"
-          formatValue={(v) => Math.round(v).toLocaleString()}
-        />
-        <p className="t-caption" style={{ color: "var(--fainter)", marginTop: "12px" }}>
-          {series.serverBacked
-            ? "Drawn from this node's server-side history (sampled every 30s, up to 24h) so it survives reloads."
-            : `Collecting live in-browser samples (${series.sampleCount} this session) — the node's server-side history will back this chart once it has accumulated a few. Resets on reload.`}
-        </p>
-      </Card>
     </div>
   );
 }

--- a/dashboard/src/components/filtering/MempoolMetrics.tsx
+++ b/dashboard/src/components/filtering/MempoolMetrics.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { Card } from "@/components/ui/Card";
+import { Badge } from "@/components/ui/Badge";
+import { StatCard } from "@/components/ui/StatCard";
+import { TimeSeriesChart } from "@/components/ui/MiniChart";
+import { useMempoolSeries } from "@/hooks/useMempoolSeries";
+import { fetchApi } from "@/lib/api/client";
+
+/**
+ * Mempool tx-count tiles + over-time graph.
+ *
+ * Two headline tiles (current mempool tx count, current block-template tx count)
+ * plus a "mempool over time" line chart. Self-contained: it runs its own
+ * lightweight `/buds/mempool` poll (getmempoolinfo.size) under the shared
+ * `["buds-mempool"]` query key so {@link useMempoolSeries} can accumulate a live
+ * session buffer from it, and reads the node's server-side `/pool/series` ring
+ * when that carries the mempool fields.
+ *
+ * Data comes from {@link useMempoolSeries}: the node's server-side `/pool/series`
+ * ring (30s samples, ~24h, survives reloads) when it carries the mempool fields,
+ * otherwise a live in-browser session buffer keyed on this component's own
+ * `/buds/mempool` poll. The "Mempool" tile prefers the live `total` already
+ * fetched here and only falls back to the latest series sample; the "This block"
+ * tile is server-ring only (the RPC view has no block-template count) and shows
+ * "—" until the ring has it.
+ */
+
+interface BudsMempoolSummary {
+  total?: number; // getmempoolinfo.size
+  message?: string; // present when RPC unavailable
+}
+
+async function fetchBudsMempool(): Promise<BudsMempoolSummary> {
+  return fetchApi<BudsMempoolSummary>("/api/v1/buds/mempool");
+}
+
+function formatCount(n: number | undefined): string {
+  return n === undefined || n === null ? "—" : n.toLocaleString();
+}
+
+export function MempoolMetrics() {
+  // Own the buds/mempool poll (shared query key so useMempoolSeries can sample
+  // it for the live session buffer). The full mempool page uses the same key.
+  const { data: mempool } = useQuery<BudsMempoolSummary>({
+    queryKey: ["buds-mempool"],
+    queryFn: fetchBudsMempool,
+    refetchInterval: 15_000,
+  });
+
+  const series = useMempoolSeries();
+
+  // Live getmempoolinfo.size when we have it, else the newest series sample.
+  const mempoolNow = mempool?.total ?? series.latestMempoolTxs ?? undefined;
+  const blockNow = series.latestBlockTxs ?? undefined;
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <StatCard
+          label="Mempool"
+          value={formatCount(mempoolNow)}
+          sublabel="transactions right now"
+          tooltip="getmempoolinfo.size — transactions your node currently holds"
+        />
+        <StatCard
+          label="This block"
+          value={formatCount(blockNow)}
+          sublabel="in the block template"
+          tooltip="transactions in the block template your node is currently building"
+        />
+      </div>
+
+      <Card>
+        <div className="mb-3 flex items-start justify-between gap-2">
+          <div>
+            <h3 className="t-title" style={{ color: "var(--fg)" }}>
+              Mempool over time
+            </h3>
+            <p className="t-caption" style={{ color: "var(--dim)", marginTop: "2px" }}>
+              Transactions in your node&apos;s mempool, sampled over time
+            </p>
+          </div>
+          <Badge variant="default">{series.serverBacked ? "history" : "live (session)"}</Badge>
+        </div>
+        <TimeSeriesChart
+          data={series.mempoolTxs}
+          minZero
+          ariaLabel="Mempool transaction count over time"
+          formatValue={(v) => Math.round(v).toLocaleString()}
+        />
+        <p className="t-caption" style={{ color: "var(--fainter)", marginTop: "12px" }}>
+          {series.serverBacked
+            ? "Drawn from this node's server-side history (sampled every 30s, up to 24h) so it survives reloads."
+            : `Collecting live in-browser samples (${series.sampleCount} this session) — the node's server-side history will back this chart once it has accumulated a few. Resets on reload.`}
+        </p>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Moves the mempool-metrics block off the **Mempool** page and onto the **Filtering Overview**, reorders the Overview, and compacts the "What's active" element.

## Changes

- **Extract** the `MempoolMetrics` block (two tiles — "Mempool" tx count + "This block" template tx count — plus the "Mempool over time" chart) out of `mempool/page.tsx` into a self-contained, reusable component `dashboard/src/components/filtering/MempoolMetrics.tsx`. It owns its own lightweight `/buds/mempool` poll under the shared `["buds-mempool"]` query key so `useMempoolSeries` keeps its server-ring / live-session-buffer behaviour and the `history` vs `live (session)` badge. Behaviour is unchanged.
- **Mempool page** returns to its prior content (mempool.space embed + Reaper tile + RPC stats). Removed the now-unused `useMempoolSeries` / `TimeSeriesChart` imports. `useMempoolSeries.ts` stays in place, now consumed by the new component.
- **Filtering Overview** reordered to: `PageHeader` → **How filtering works** → **What's active** → `<MempoolMetrics />` → **Filtering activity** → **Basic / Advanced** nav cards.
- **What's active** compacted to a small grid of `StatCard` tiles (Mode / Reaper / Advanced controls) showing just label + value. Dropped the per-row descriptions, the `StatusRow` helper, and the now-unused `droppedTiers` / `TierKey` / `FullPolicyCustom` / `dropped` / `droppedLabel` plumbing.
- **Filtering activity** timeframe made explicit and honest — subtitle now reads "Transactions your node has rejected, by stage — cumulative since your node last started", plus a muted note under the totals: "Running totals since your node last started — they reset to zero on a node restart." (The ghostd counters are process-lived and reset on restart.)

Theme-aware throughout, `.t-*` scale preserved, "Reaper" name preserved.

## Verification

- `tsc --noEmit` — clean
- `eslint` on all three changed files — clean
- `npm run build` — succeeds; `/filtering` and `/mempool` both compile