### PR TITLE
dashboard: header consistency, Haze redesign, Zero-Sync tooling, session-keepalive fix

### DIFF
--- a/dashboard/src/app/(dashboard)/connect/page.tsx
+++ b/dashboard/src/app/(dashboard)/connect/page.tsx
@@ -97,9 +97,9 @@ export default function ConnectPage() {
   return (
     <div>
       <PageHeader
-        eyebrow="pairing"
-        title="Connect Wallet"
-        subtitle="Connection strings and QR codes for pairing wallets and other nodes to this node. Scan a code or copy a string into your wallet. QR codes are generated locally in your browser — nothing leaves this page."
+        eyebrow="connect wallet"
+        title="Pair wallets & nodes"
+        subtitle="Connection strings and QR codes to pair wallets and other nodes to this one. Scan a code or copy a string into your wallet — QR codes are generated locally in your browser, nothing leaves this page."
       />
 
       {!hostKnown && (

--- a/dashboard/src/app/(dashboard)/haze/page.tsx
+++ b/dashboard/src/app/(dashboard)/haze/page.tsx
@@ -7,6 +7,7 @@ import { ConfirmDialog } from "@/components/ui/Dialog";
 import { PageHeader } from "@/components/ui/PageHeader";
 import { Badge } from "@/components/ui/Badge";
 import { Button } from "@/components/ui/Button";
+import { Toggle } from "@/components/ui/Toggle";
 import { StatusDot } from "@/components/ui/StatusDot";
 import { SectionErrorBoundary } from "@/components/ui/SectionErrorBoundary";
 import { SkeletonCard } from "@/components/ui/Skeleton";
@@ -214,12 +215,14 @@ export default function HazePage() {
     return { strippedBytes, structuralBytes, fullArchiveBytes, percentSmaller };
   }, [haze?.bytes_stripped, haze?.structural_archive_size_gb, haze?.chain_tip]);
 
-  // Selecting Hazed from a node that already holds blocks (standard / full
-  // archive) is a one-time, long, irreversible retroactive conversion — gate it
-  // behind an explicit confirmation.
-  const [confirmConvert, setConfirmConvert] = useState(false);
+  // Every mode change restarts ghostd, so each one is gated behind an explicit
+  // confirmation. The dialog copy adapts to the target. Switching to Hazed from a
+  // node that already holds blocks is a one-time, long, IRREVERSIBLE retroactive
+  // conversion — flagged as danger.
+  type HazeMode = "hazed" | "full_archive" | "standard";
+  const [pendingMode, setPendingMode] = useState<HazeMode | null>(null);
 
-  const doSetMode = async (target: "hazed" | "full_archive" | "standard") => {
+  const doSetMode = async (target: HazeMode) => {
     try {
       await configureHaze.mutateAsync(target);
       toast.success("Ghost Haze updated", `Storage mode set to ${getModeLabel(target)}`);
@@ -231,24 +234,62 @@ export default function HazePage() {
     }
   };
 
-  const handleSetMode = async (target: "hazed" | "full_archive" | "standard") => {
+  // Open the confirmation for any real change; the dialog copy is derived below.
+  const handleSetMode = (target: HazeMode) => {
     if (target === mode) return;
-    const retroactive =
-      target === "hazed" && (mode === "standard" || mode === "full_archive");
-    if (retroactive) {
-      setConfirmConvert(true);
-      return;
-    }
-    await doSetMode(target);
+    setPendingMode(target);
   };
+
+  const pendingIsRetroactive =
+    pendingMode === "hazed" && (mode === "standard" || mode === "full_archive");
+
+  const confirmCopy: {
+    title: string;
+    message: string;
+    confirmLabel: string;
+    variant: "default" | "danger";
+  } | null =
+    pendingMode === "hazed"
+      ? pendingIsRetroactive
+        ? {
+            title: "Convert existing blocks to Hazed?",
+            message:
+              "This restarts ghostd to run the one-time Ghost Exorcist conversion of your existing block archive to stripped GSB format. It is a long, resumable batch job and is IRREVERSIBLE — witness, scriptSig, OP_RETURN and coinbase data are permanently stripped from local storage. The node comes back up hazed automatically once it finishes. Continue?",
+            confirmLabel: "Convert & restart ghostd",
+            variant: "danger",
+          }
+        : {
+            title: "Enable Hazed mode?",
+            message:
+              "This restarts ghostd. From now on every block is stripped of non-consensus data before it is written to disk — no embedded content is ever persisted — while full validation and UTXO integrity are preserved.",
+            confirmLabel: "Enable & restart ghostd",
+            variant: "default",
+          }
+      : pendingMode === "full_archive"
+        ? {
+            title: "Switch to Full Archive?",
+            message:
+              "This restarts ghostd. The node will keep complete, unstripped blocks going forward for maximum data availability — no haze stripping is applied.",
+            confirmLabel: "Switch & restart ghostd",
+            variant: "default",
+          }
+        : pendingMode === "standard"
+          ? {
+              title: "Switch to Standard?",
+              message:
+                "This restarts ghostd and turns off haze stripping. The node behaves as a normal Bitcoin Core node — full blocks, no haze metadata. Any blocks already stripped are not restored.",
+              confirmLabel: "Switch & restart ghostd",
+              variant: "danger",
+            }
+          : null;
 
   return (
     <div className="space-y-6">
       {/* Page Header */}
       <PageHeader
         eyebrow="haze"
-        title="Storage privacy layer."
-        subtitle="Strip arbitrary embedded content before it ever touches your disk — while keeping full validation and UTXO integrity."
+        title="Block content protection"
+        subtitle="Strip arbitrary embedded content out of blocks before it's written to disk — so your node never stores or hosts it, with full validation and UTXO integrity intact."
         actions={
           haze && (
             <div className="flex items-center gap-2">
@@ -262,6 +303,152 @@ export default function HazePage() {
           )
         }
       />
+
+      {/* Storage mode — primary control, at the top. Every change restarts ghostd. */}
+      <Card>
+        <CardHeader
+          title="Storage mode"
+          subtitle="Choose how this node stores block data"
+          action={
+            haze && <Badge variant={getModeBadgeVariant(mode)}>{getModeLabel(mode)}</Badge>
+          }
+        />
+
+        {/* Explain the two ways to become hazed */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3 mb-5">
+          <div className="p-3 rounded-lg bg-[var(--bg)] border border-[color:var(--rule-strong)]">
+            <div className="text-[color:var(--fg)] text-sm font-medium mb-1">
+              Forward — haze from genesis
+            </div>
+            <p className="text-[color:var(--dim)] text-xs leading-relaxed">
+              A fresh node can start hazed and strip
+              every block as it syncs. Nothing arbitrary is ever written — no conversion needed.
+            </p>
+          </div>
+          <div className="p-3 rounded-lg bg-[var(--bg)] border border-[color:var(--rule-strong)]">
+            <div className="text-[color:var(--fg)] text-sm font-medium mb-1">
+              Retroactive — convert existing blocks
+            </div>
+            <p className="text-[color:var(--dim)] text-xs leading-relaxed">
+              An already-synced full or pruned node
+              cannot simply flip to hazed — it must run a one-time, resumable conversion that strips
+              the blocks it already holds. This is the only path to haze later.
+            </p>
+          </div>
+        </div>
+
+        {/* Mode options */}
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+          {(() => {
+            // From a non-hazed node with blocks already on disk, selecting Hazed
+            // means a retroactive conversion — not an instant flip.
+            const retroactive = mode === "standard" || mode === "full_archive";
+            const options = [
+              {
+                key: "hazed" as const,
+                label: "Hazed",
+                action: retroactive ? "Convert existing blocks (retroactive)" : undefined,
+                desc: retroactive
+                  ? "Run the one-time Exorcist conversion to strip existing blocks. Smallest footprint; resumable; no embedded content left on disk."
+                  : "Strip non-consensus fields before storage. Smallest footprint, no embedded content on disk.",
+              },
+              {
+                key: "full_archive" as const,
+                label: "Full Archive",
+                action: undefined,
+                desc: "Keep the full archive — complete, unstripped blocks. Maximum data availability for archival serving.",
+              },
+              {
+                key: "standard" as const,
+                label: "Standard",
+                action: undefined,
+                desc: "A normal Bitcoin Core node — full blocks, no stripping and no haze metadata.",
+              },
+            ];
+            return options.map((opt) => {
+              const selected = mode === opt.key;
+              return (
+                <button
+                  key={opt.key}
+                  type="button"
+                  role="radio"
+                  aria-checked={selected}
+                  disabled={configureHaze.isPending}
+                  onClick={() => handleSetMode(opt.key)}
+                  className={`group flex flex-col text-left rounded-lg p-4 border-2 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent)] ${
+                    selected
+                      ? "border-[color:var(--accent)] cursor-default"
+                      : "border-[color:var(--rule-strong)] cursor-pointer hover:border-[color:var(--accent)]"
+                  } ${configureHaze.isPending ? "opacity-60 cursor-wait" : ""}`}
+                  style={{
+                    background: selected
+                      ? "color-mix(in srgb, var(--accent) 12%, var(--surface))"
+                      : "var(--surface)",
+                  }}
+                >
+                  <div className="flex items-center justify-between mb-1">
+                    <span className="text-[color:var(--fg)] text-sm font-medium">{opt.label}</span>
+                    {selected ? (
+                      <Badge variant={getModeBadgeVariant(opt.key)}>Active</Badge>
+                    ) : (
+                      <span
+                        aria-hidden
+                        className="h-4 w-4 shrink-0 rounded-full border-2 border-[color:var(--rule-strong)] transition-colors group-hover:border-[color:var(--accent)]"
+                      />
+                    )}
+                  </div>
+                  <p className="text-[color:var(--dim)] text-xs leading-relaxed flex-1">{opt.desc}</p>
+                  {opt.action && !selected && (
+                    <span className="mt-2 inline-block t-caption font-medium text-[color:var(--accent)]">
+                      {opt.action} →
+                    </span>
+                  )}
+                </button>
+              );
+            });
+          })()}
+        </div>
+        <p className="text-[color:var(--fainter)] text-xs mt-3">
+          Every mode change restarts ghostd to take effect. A retroactive conversion then runs
+          as a background batch job and reports its progress below.
+        </p>
+      </Card>
+
+      {/* Retroactive conversion progress — shows under the control while running */}
+      {conversionInProgress && (
+        <Card>
+          <CardHeader
+            title="Retroactive conversion in progress"
+            subtitle="The Exorcist is stripping the blocks this node already holds"
+            action={<Badge variant="warning">IN_PROGRESS</Badge>}
+          />
+          <div className="space-y-3">
+            <div className="flex items-baseline justify-between">
+              <span className="text-2xl font-bold text-[color:var(--fg)]">
+                {convPercent != null ? `${convPercent.toFixed(1)}%` : "--"}
+              </span>
+              <span className="font-mono text-sm text-[color:var(--dim)]">
+                {convBlocks.toLocaleString()} / {convTip.toLocaleString()} blocks
+              </span>
+            </div>
+            <div className="h-2.5 w-full rounded-full bg-[var(--rule-strong)] overflow-hidden">
+              <div
+                className="h-full rounded-full transition-[width] duration-500"
+                style={{
+                  width: `${convPercent ?? 0}%`,
+                  background: "var(--accent)",
+                }}
+              />
+            </div>
+            <p className="text-[color:var(--dim)] text-xs leading-relaxed">
+              This is a one-time batch job that rewrites existing block files into stripped
+              structural blocks. It is resumable —
+              if the node restarts, conversion continues from where it left off. Your Legal Pack
+              is finalised once it reads <code>COMPLETE</code>.
+            </p>
+          </div>
+        </Card>
+      )}
 
       {/* 1. HERO — Storage saved */}
       <SectionErrorBoundary section="Storage Savings">
@@ -277,14 +464,7 @@ export default function HazePage() {
             </div>
           </Card>
         ) : active ? (
-          <div
-            className="rounded-lg p-8 border"
-            style={{
-              borderColor: "color-mix(in srgb, var(--green) 40%, transparent)",
-              background:
-                "linear-gradient(135deg, color-mix(in srgb, var(--green) 12%, var(--surface)) 0%, var(--surface) 70%)",
-            }}
-          >
+          <Card>
             <div className="text-xs uppercase tracking-wider text-[color:var(--green)] font-semibold mb-2">
               Arbitrary data kept off your disk
             </div>
@@ -297,13 +477,13 @@ export default function HazePage() {
               spam and data-carrier payloads that never reached your disk.
             </p>
             <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mt-6">
-              <div className="rounded-lg p-4 bg-[var(--surface)] border border-[color:var(--rule)]">
+              <div className="rounded-lg p-4 bg-[var(--bg)] border border-[color:var(--rule)]">
                 <div className="text-xs text-[color:var(--dim)] mb-1">Structural archive on disk</div>
                 <div className="text-2xl font-bold text-[color:var(--fg)]">
                   {formatBytes(savings.structuralBytes)}
                 </div>
               </div>
-              <div className="rounded-lg p-4 bg-[var(--surface)] border border-[color:var(--rule)]">
+              <div className="rounded-lg p-4 bg-[var(--bg)] border border-[color:var(--rule)]">
                 <div className="text-xs text-[color:var(--dim)] mb-1">Full-archive estimate</div>
                 <div className="text-2xl font-bold text-[color:var(--fg)]">
                   {savings.fullArchiveBytes > 0 ? formatBytes(savings.fullArchiveBytes) : "--"}
@@ -312,7 +492,7 @@ export default function HazePage() {
                   {(haze?.chain_tip ?? 0).toLocaleString()} blocks × ~1.6 MB
                 </div>
               </div>
-              <div className="rounded-lg p-4 bg-[var(--surface)] border border-[color:var(--rule)]">
+              <div className="rounded-lg p-4 bg-[var(--bg)] border border-[color:var(--rule)]">
                 <div className="text-xs text-[color:var(--dim)] mb-1">Chain footprint</div>
                 <div className="text-2xl font-bold text-[color:var(--green)]">
                   {savings.percentSmaller != null
@@ -321,39 +501,30 @@ export default function HazePage() {
                 </div>
               </div>
             </div>
-          </div>
+          </Card>
         ) : (
-          // Inactive: value proposition + enable path (no fabricated numbers).
-          <div
-            className="rounded-lg p-8 border"
-            style={{
-              borderColor: "color-mix(in srgb, var(--accent) 35%, transparent)",
-              background:
-                "linear-gradient(135deg, color-mix(in srgb, var(--accent) 10%, var(--surface)) 0%, var(--surface) 70%)",
-            }}
-          >
-            <div className="text-xs uppercase tracking-wider text-[color:var(--accent)] font-semibold mb-2">
-              Haze is not active on this node
+          // Inactive: calm, full-width enable row — same typography as the rest of the app.
+          <Card>
+            <div className="flex items-center justify-between gap-6">
+              <div className="flex-1">
+                <div className="text-[color:var(--fg)] font-medium">
+                  Keep inscriptions, spam and arbitrary payloads off your disk
+                </div>
+                <p className="text-sm text-[color:var(--dim)] mt-1 leading-relaxed">
+                  In Hazed mode, Ghost Exorcism strips non-consensus fields from every block
+                  before it is written — you keep full validation and UTXO integrity while
+                  shrinking your on-disk footprint and never persisting embedded content.
+                  Enabling it starts measuring your savings and generates a court-ready Legal Pack.
+                </p>
+              </div>
+              <Toggle
+                enabled={active}
+                onChange={() => handleSetMode("hazed")}
+                label="Enable Haze"
+                disabled={configureHaze.isPending}
+              />
             </div>
-            <div className="text-3xl md:text-4xl font-bold text-[color:var(--fg)] leading-tight max-w-3xl">
-              Keep inscriptions, spam and arbitrary payloads off your disk.
-            </div>
-            <p className="text-[color:var(--dim)] text-sm mt-3 max-w-2xl leading-relaxed">
-              In Hazed mode, Ghost Exorcism strips non-consensus fields from every block
-              before it is written — you keep full validation and UTXO integrity while
-              shrinking your on-disk footprint and never persisting embedded content. Enable
-              it to start measuring your savings and generate a court-ready Legal Pack.
-            </p>
-            <div className="mt-6">
-              <Button
-                variant="primary"
-                onClick={() => handleSetMode("hazed")}
-                loading={configureHaze.isPending}
-              >
-                Enable Haze
-              </Button>
-            </div>
-          </div>
+          </Card>
         )}
       </SectionErrorBoundary>
 
@@ -729,151 +900,18 @@ export default function HazePage() {
         </div>
       </Card>
 
-      {/* 6a. Retroactive conversion progress — prominent while running */}
-      {conversionInProgress && (
-        <Card>
-          <CardHeader
-            title="Retroactive conversion in progress"
-            subtitle="The Exorcist is stripping the blocks this node already holds"
-            action={<Badge variant="warning">IN_PROGRESS</Badge>}
-          />
-          <div className="space-y-3">
-            <div className="flex items-baseline justify-between">
-              <span className="text-2xl font-bold text-[color:var(--fg)]">
-                {convPercent != null ? `${convPercent.toFixed(1)}%` : "--"}
-              </span>
-              <span className="font-mono text-sm text-[color:var(--dim)]">
-                {convBlocks.toLocaleString()} / {convTip.toLocaleString()} blocks
-              </span>
-            </div>
-            <div className="h-2.5 w-full rounded-full bg-[var(--rule-strong)] overflow-hidden">
-              <div
-                className="h-full rounded-full transition-[width] duration-500"
-                style={{
-                  width: `${convPercent ?? 0}%`,
-                  background: "var(--accent)",
-                }}
-              />
-            </div>
-            <p className="text-[color:var(--dim)] text-xs leading-relaxed">
-              This is a one-time batch job that rewrites existing block files into stripped
-              structural blocks. It is resumable —
-              if the node restarts, conversion continues from where it left off. Your Legal Pack
-              is finalised once it reads <code>COMPLETE</code>.
-            </p>
-          </div>
-        </Card>
-      )}
-
-      {/* 6b. Mode control — two programmes: forward vs retroactive */}
-      <Card>
-        <CardHeader
-          title="Storage mode"
-          subtitle="Choose how this node stores block data"
-          action={
-            haze && <Badge variant={getModeBadgeVariant(mode)}>{getModeLabel(mode)}</Badge>
-          }
-        />
-
-        {/* Explain the two ways to become hazed */}
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-3 mb-5">
-          <div className="p-3 rounded-lg bg-[var(--surface)] border border-[color:var(--rule-strong)]">
-            <div className="text-[color:var(--fg)] text-sm font-medium mb-1">
-              Forward — haze from genesis
-            </div>
-            <p className="text-[color:var(--dim)] text-xs leading-relaxed">
-              A fresh node can start hazed and strip
-              every block as it syncs. Nothing arbitrary is ever written — no conversion needed.
-            </p>
-          </div>
-          <div className="p-3 rounded-lg bg-[var(--surface)] border border-[color:var(--rule-strong)]">
-            <div className="text-[color:var(--fg)] text-sm font-medium mb-1">
-              Retroactive — convert existing blocks
-            </div>
-            <p className="text-[color:var(--dim)] text-xs leading-relaxed">
-              An already-synced full or pruned node
-              cannot simply flip to hazed — it must run a one-time, resumable conversion that strips
-              the blocks it already holds. This is the only path to haze later.
-            </p>
-          </div>
-        </div>
-
-        {/* Mode options */}
-        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-          {(() => {
-            // From a non-hazed node with blocks already on disk, selecting Hazed
-            // means a retroactive conversion — not an instant flip.
-            const retroactive = mode === "standard" || mode === "full_archive";
-            const options = [
-              {
-                key: "hazed" as const,
-                label: "Hazed",
-                action: retroactive ? "Convert existing blocks (retroactive)" : undefined,
-                desc: retroactive
-                  ? "Run the one-time Exorcist conversion to strip existing blocks. Smallest footprint; resumable; no embedded content left on disk."
-                  : "Strip non-consensus fields before storage. Smallest footprint, no embedded content on disk.",
-              },
-              {
-                key: "full_archive" as const,
-                label: "Full Archive",
-                action: undefined,
-                desc: "Keep the full archive — complete, unstripped blocks. Maximum data availability for archival serving.",
-              },
-              {
-                key: "standard" as const,
-                label: "Standard",
-                action: undefined,
-                desc: "A normal Bitcoin Core node — full blocks, no stripping and no haze metadata.",
-              },
-            ];
-            return options.map((opt) => {
-              const selected = mode === opt.key;
-              return (
-                <button
-                  key={opt.key}
-                  type="button"
-                  disabled={configureHaze.isPending || selected}
-                  onClick={() => handleSetMode(opt.key)}
-                  className="text-left rounded-lg p-4 border transition-colors disabled:cursor-default flex flex-col"
-                  style={{
-                    background: selected
-                      ? "color-mix(in srgb, var(--accent) 12%, var(--surface))"
-                      : "var(--surface)",
-                    borderColor: selected ? "var(--accent)" : "var(--rule-strong)",
-                  }}
-                >
-                  <div className="flex items-center justify-between mb-1">
-                    <span className="text-[color:var(--fg)] text-sm font-medium">{opt.label}</span>
-                    {selected && <Badge variant={getModeBadgeVariant(opt.key)}>Active</Badge>}
-                  </div>
-                  <p className="text-[color:var(--dim)] text-xs leading-relaxed flex-1">{opt.desc}</p>
-                  {opt.action && !selected && (
-                    <span className="mt-2 inline-block t-caption font-medium text-[color:var(--accent)]">
-                      {opt.action} →
-                    </span>
-                  )}
-                </button>
-              );
-            });
-          })()}
-        </div>
-        <p className="text-[color:var(--fainter)] text-xs mt-3">
-          Forward hazing and Full Archive take effect on the next node start. A retroactive
-          conversion runs as a background batch job and reports its progress above.
-        </p>
-      </Card>
-
       <ConfirmDialog
-        isOpen={confirmConvert}
-        onClose={() => setConfirmConvert(false)}
+        isOpen={pendingMode !== null}
+        onClose={() => setPendingMode(null)}
         onConfirm={async () => {
-          setConfirmConvert(false);
-          await doSetMode("hazed");
+          const target = pendingMode;
+          setPendingMode(null);
+          if (target) await doSetMode(target);
         }}
-        title="Convert existing blocks to Hazed?"
-        message="This restarts ghostd to run the one-time Ghost Exorcist conversion of your existing block archive to stripped GSB format. It is a long, resumable batch job and is IRREVERSIBLE — witness, scriptSig, OP_RETURN and coinbase data are permanently stripped from local storage. The node comes back up hazed automatically once it finishes. Continue?"
-        confirmLabel="Convert & restart ghostd"
-        variant="danger"
+        title={confirmCopy?.title ?? ""}
+        message={confirmCopy?.message ?? ""}
+        confirmLabel={confirmCopy?.confirmLabel ?? "Confirm"}
+        variant={confirmCopy?.variant ?? "default"}
         loading={configureHaze.isPending}
       />
     </div>

--- a/dashboard/src/app/(dashboard)/logs/page.tsx
+++ b/dashboard/src/app/(dashboard)/logs/page.tsx
@@ -60,11 +60,6 @@ export default function LogsPage() {
   // denied) — returned with HTTP 200 so the selector stays usable.
   const structuredError = data?.error ?? null;
 
-  const activeUnit = units.find((u) => u.key === unit);
-  const subtitle = activeUnit
-    ? `Recent logs for ${activeUnit.label}. ${activeUnit.description}.`
-    : "Recent node logs. Select a binary to inspect its output.";
-
   const copyAll = () => {
     const text = entries
       .map((e) => `${formatTs(e.timestamp)} ${e.level.toUpperCase().padEnd(5)} ${e.target}  ${e.message}`)
@@ -74,7 +69,12 @@ export default function LogsPage() {
 
   return (
     <div className="space-y-6">
-      <PageHeader eyebrow="system" title="Logs." subtitle={subtitle} subtitleFullWidth />
+      <PageHeader
+        eyebrow="logs"
+        title="Node logs"
+        subtitle="Live output from this node's services — select a binary to inspect its recent logs."
+        subtitleFullWidth
+      />
 
       <SectionErrorBoundary section="Logs">
         <Card>

--- a/dashboard/src/app/(dashboard)/mempool/page.tsx
+++ b/dashboard/src/app/(dashboard)/mempool/page.tsx
@@ -8,9 +8,6 @@ import { Badge } from "@/components/ui/Badge";
 import { SkeletonCard } from "@/components/ui/Skeleton";
 import { StatCard } from "@/components/ui/StatCard";
 import { SectionErrorBoundary } from "@/components/ui/SectionErrorBoundary";
-import { useConfig } from "@/hooks/queries/useConfigQueries";
-import { useReaperStatus } from "@/hooks/queries";
-import { type ReaperStats } from "@/lib/api/reaper";
 import { fetchApi } from "@/lib/api/client";
 
 /**
@@ -114,7 +111,6 @@ const FEE_BUCKETS = [
 // ─── page ───────────────────────────────────────────────────────────────────
 
 export default function MempoolPage() {
-  const { data: config } = useConfig();
   const {
     data: mempool,
     isLoading,
@@ -124,10 +120,6 @@ export default function MempoolPage() {
     queryFn: fetchBudsMempool,
     refetchInterval: 15_000,
   });
-
-  const { data: reaperStats } = useReaperStatus();
-
-  const reaperEnabled = config?.reaper ?? false;
 
   if (isLoading) {
     return (
@@ -172,7 +164,7 @@ export default function MempoolPage() {
         </Card>
       ) : (
         <>
-          <LiveStats mempool={mempool} reaperStats={reaperStats} reaperEnabled={reaperEnabled} />
+          <LiveStats mempool={mempool} />
           <SectionErrorBoundary section="Fee distribution">
             <FeeDistribution mempool={mempool} />
           </SectionErrorBoundary>
@@ -317,7 +309,7 @@ function NodeMempoolExplorer() {
 
       <p className="t-caption" style={{ color: "var(--fainter)", marginTop: "12px" }}>
         Served same-origin from the dashboard at <code>/mempool-app/</code>, proxied to this
-        node&apos;s own mempool backend. The lightweight RPC view and the Reaper strip
+        node&apos;s own mempool backend. The lightweight RPC view and fee-rate
         breakdown are below.
       </p>
     </Card>
@@ -326,15 +318,7 @@ function NodeMempoolExplorer() {
 
 // ─── live RPC stats row ─────────────────────────────────────────────────────
 
-function LiveStats({
-  mempool,
-  reaperStats,
-  reaperEnabled,
-}: {
-  mempool?: BudsMempool;
-  reaperStats?: ReaperStats | null;
-  reaperEnabled: boolean;
-}) {
+function LiveStats({ mempool }: { mempool?: BudsMempool }) {
   // maxmempool caps memory USAGE, not the summed vsize (`bytes`), so the "how
   // full" ratio must be usage/maxmempool — matching mempool.space's Memory
   // Usage / 300 MB. Dividing bytes by maxmempool understated it ~4x.
@@ -344,37 +328,14 @@ function LiveStats({
       : "—";
   const minFee = btcPerKvbToSatVb(mempool?.min_fee);
 
-  // The "Reaper — kept out" tile only appears when this node runs the reaper
-  // (opt-in +2 capability). It reports the Reaper's cumulative total — how much
-  // junk this node has kept out over time — not a per-block snapshot. Note this
-  // counts the Reaper only; BUDS tier-policy rejections aren't tallied here yet.
-  const showReaped = reaperEnabled;
-  const hasReaperData = !!reaperStats;
-  // Five tiles need a wider track; four keep the original layout.
-  const gridCols = showReaped
-    ? "grid-cols-2 md:grid-cols-3 xl:grid-cols-5"
-    : "grid-cols-2 md:grid-cols-4";
-
   return (
-    <div className={`grid ${gridCols} gap-4`}>
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
       <StatCard
         label="Transactions"
         value={formatCount(mempool?.total)}
         sublabel="in your mempool now"
         tooltip="getmempoolinfo.size — count of transactions your node currently holds in its mempool."
       />
-      {showReaped && (
-        <StatCard
-          label="Reaper — kept out"
-          value={hasReaperData ? reaperStats!.txs_reaped.toLocaleString() : "—"}
-          sublabel={
-            hasReaperData
-              ? `${formatBytes(reaperStats!.dead_bytes_total)} dead weight · cumulative`
-              : "no data yet"
-          }
-          tooltip="The Reaper's cumulative total — every dead-code / spam transaction this node has kept out of its mempool and blocks over time. Reaper only for now: BUDS tier-policy rejections aren't included here yet (a node-level tier-rejection counter is coming). Per-vector detail is on the Reaper page."
-        />
-      )}
       <StatCard
         label="Mempool size"
         value={formatBytes(mempool?.bytes)}

--- a/dashboard/src/app/(dashboard)/payouts/page.tsx
+++ b/dashboard/src/app/(dashboard)/payouts/page.tsx
@@ -147,7 +147,7 @@ export default function PayoutsPage() {
   if (payoutLoading && !payoutHistory) {
     return (
       <div className="space-y-6">
-        <PageHeader eyebrow="payouts" title="Block reward distributions." subtitle="Transparent record of all block reward distributions" />
+        <PageHeader eyebrow="payouts" title="Network Payouts" subtitle="Transparent record of all block reward distributions" />
         <PageLoader message="Loading payout data..." />
       </div>
     );
@@ -156,6 +156,7 @@ export default function PayoutsPage() {
   return (
     <div className="space-y-6">
       <PageHeader
+        eyebrow="payouts"
         title="Network Payouts"
         subtitle="Transparent record of all block reward distributions"
       />

--- a/dashboard/src/app/(dashboard)/pool/page.tsx
+++ b/dashboard/src/app/(dashboard)/pool/page.tsx
@@ -309,8 +309,8 @@ export default function NodePoolPage() {
   return (
     <div className="space-y-6">
       <PageHeader
-        eyebrow="ghost pool"
-        title="Node Pool"
+        eyebrow="node pool"
+        title="Pool statistics"
         subtitle="Live pool stats and graphs for this node and the Ghost mesh — hashrate, miners, shares, best shares, round progress and payouts."
       />
 

--- a/dashboard/src/app/(dashboard)/settings/layout.tsx
+++ b/dashboard/src/app/(dashboard)/settings/layout.tsx
@@ -113,7 +113,11 @@ export default function SettingsLayout({ children }: { children: ReactNode }) {
 
   return (
     <div className="space-y-6">
-      <PageHeader title="Settings" subtitle="Node configuration and preferences" />
+      <PageHeader
+        eyebrow="settings"
+        title="Node Settings"
+        subtitle="Your node's settings in one place"
+      />
 
       <div className="flex flex-col lg:flex-row gap-6">
         {/* Sidebar */}

--- a/dashboard/src/app/(dashboard)/zero-sync/page.tsx
+++ b/dashboard/src/app/(dashboard)/zero-sync/page.tsx
@@ -1,0 +1,208 @@
+"use client";
+
+import { Card, CardHeader } from "@/components/ui/Card";
+import { Badge } from "@/components/ui/Badge";
+import { StatCard } from "@/components/ui/StatCard";
+import { StatusDot } from "@/components/ui/StatusDot";
+import { SectionErrorBoundary } from "@/components/ui/SectionErrorBoundary";
+import { SkeletonCard } from "@/components/ui/Skeleton";
+import { PageHeader } from "@/components/ui/PageHeader";
+import { useHazeStatus, useCheckpointStatus } from "@/hooks/queries/useHazeQueries";
+
+const BYTES_PER_GB = 1024 * 1024 * 1024;
+
+function formatBytes(bytes: number | undefined | null): string {
+  if (bytes == null || !Number.isFinite(bytes)) return "--";
+  const gb = bytes / BYTES_PER_GB;
+  if (gb >= 1000) return `${(gb / 1024).toFixed(2)} TB`;
+  if (gb >= 1) return `${gb.toFixed(2)} GB`;
+  const mb = bytes / (1024 * 1024);
+  if (mb >= 1) return `${mb.toFixed(1)} MB`;
+  const kb = bytes / 1024;
+  if (kb >= 1) return `${kb.toFixed(0)} KB`;
+  return `${bytes} B`;
+}
+
+function shortHash(hash: string | undefined | null): string {
+  if (!hash) return "--";
+  if (hash.length <= 20) return hash;
+  return `${hash.slice(0, 10)}…${hash.slice(-8)}`;
+}
+
+/** Human-readable storage role from the node's own flags. */
+function roleOf(mode: string, pruned: boolean): { label: string; variant: "success" | "info" | "warning" | "default"; blurb: string } {
+  switch (mode) {
+    case "hazed":
+      return {
+        label: pruned ? "Hazed · pruned" : "Hazed",
+        variant: "success",
+        blurb: "Validates fully; arbitrary content stripped in RAM before disk. Serves stripped blocks and answers wallet queries — hosts no embedded data.",
+      };
+    case "full_archive":
+      return {
+        label: "Full Archive",
+        variant: "info",
+        blurb: "Keeps complete, unstripped blocks and the full witness. Can serve any historical block and build signed UTXO snapshots — accepts the storage and legal cost of doing so.",
+      };
+    case "standard":
+      return {
+        label: pruned ? "Standard · pruned" : "Standard",
+        variant: "warning",
+        blurb: "A normal Bitcoin node — full blocks, no haze stripping and no haze metadata.",
+      };
+    default:
+      return { label: "Unknown", variant: "default", blurb: "Ghost Core did not report a storage mode." };
+  }
+}
+
+export default function ZeroSyncPage() {
+  const { data: haze, isLoading: hazeLoading, error: hazeError } = useHazeStatus();
+  const { data: ckpt, isLoading: ckptLoading } = useCheckpointStatus();
+
+  const mode = haze?.mode ?? "unknown";
+  const pruned = haze?.pruned ?? false;
+  const role = roleOf(mode, pruned);
+
+  const downloading = ckpt?.downloading ?? false;
+  const serving = (ckpt?.serving ?? false) && (ckpt?.available ?? false);
+  const hasSnapshot = serving && (ckpt?.height ?? 0) > 0;
+  const pct =
+    ckpt?.percent_complete != null
+      ? ckpt.percent_complete
+      : ckpt?.chunks_total
+        ? ((ckpt.chunks_received ?? 0) / ckpt.chunks_total) * 100
+        : null;
+
+  const canServe: { label: string; on: boolean; note: string }[] = [
+    { label: "Full blocks", on: mode !== "hazed" && !pruned, note: "Complete historical blocks to any peer" },
+    { label: "Stripped blocks", on: mode === "hazed", note: "Structural blocks to hazed peers" },
+    { label: "Signed UTXO snapshot", on: hasSnapshot && (ckpt?.signed ?? false), note: "Fast bootstrap for new nodes" },
+    { label: "Light-client filters", on: false, note: "BIP158 + merkle proofs — planned (GSP serving layer)" },
+  ];
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        eyebrow="zero-sync"
+        title="Fast sync & serve"
+        subtitle="Bootstrap a node in minutes from a signed UTXO snapshot, and see what this node can serve to peers and wallets — witness-free."
+        actions={
+          haze && (
+            <div className="flex items-center gap-2">
+              <StatusDot
+                status={downloading ? "warning" : hasSnapshot ? "online" : "warning"}
+                label={downloading ? "Bootstrapping" : hasSnapshot ? "Serving snapshot" : "No snapshot"}
+                pulse={downloading}
+              />
+              <Badge variant={role.variant}>{role.label}</Badge>
+            </div>
+          )
+        }
+      />
+
+      {/* Snapshot bootstrap — the zero-sync core */}
+      <SectionErrorBoundary section="Snapshot bootstrap">
+        {ckptLoading || hazeLoading ? (
+          <SkeletonCard />
+        ) : hazeError ? (
+          <Card>
+            <div className="p-4 bg-[var(--surface)] border border-[color:var(--red)] rounded-lg">
+              <p className="text-[color:var(--red)] text-sm">
+                Unable to reach Ghost Core. Ensure <code>ghostd</code> is running and the Haze RPCs are available.
+              </p>
+            </div>
+          </Card>
+        ) : downloading ? (
+          <Card>
+            <CardHeader
+              title="Bootstrapping from a signed UTXO snapshot"
+              subtitle="This node is syncing the current UTXO set in chunks, then it validates forward"
+              action={<Badge variant="warning">In progress</Badge>}
+            />
+            <div className="space-y-3">
+              <div className="flex items-baseline justify-between">
+                <span className="text-2xl font-bold text-[color:var(--fg)]">
+                  {pct != null ? `${pct.toFixed(1)}%` : "--"}
+                </span>
+                <span className="font-mono text-sm text-[color:var(--dim)]">
+                  {(ckpt?.chunks_received ?? 0).toLocaleString()} / {(ckpt?.chunks_total ?? 0).toLocaleString()} chunks
+                </span>
+              </div>
+              <div className="h-2.5 w-full rounded-full bg-[var(--rule-strong)] overflow-hidden">
+                <div
+                  className="h-full rounded-full transition-[width] duration-500"
+                  style={{ width: `${pct ?? 0}%`, background: "var(--accent)" }}
+                />
+              </div>
+            </div>
+          </Card>
+        ) : hasSnapshot ? (
+          <Card>
+            <CardHeader
+              title="Serving a signed UTXO snapshot"
+              subtitle="A fresh node can adopt this snapshot and validate forward — sync in minutes, not hours"
+              action={ckpt?.signed ? <Badge variant="success">Signed</Badge> : <Badge variant="warning">Unsigned</Badge>}
+            />
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+              <StatCard label="Snapshot height" value={(ckpt?.height ?? 0).toLocaleString()} sublabel="block of the UTXO set" tooltip="The block height the served UTXO snapshot commits to." />
+              <StatCard label="UTXOs" value={(ckpt?.utxo_count ?? 0).toLocaleString()} sublabel="entries in the set" tooltip="Number of unspent outputs in the served snapshot." />
+              <StatCard label="Chunks" value={(ckpt?.total_chunks ?? 0).toLocaleString()} sublabel="2 MB each, hashed" tooltip="The snapshot is served as content-hashed chunks over P2P." />
+              <StatCard label="Snapshot block" value={shortHash(ckpt?.block_hash)} sublabel="commitment hash" tooltip={ckpt?.block_hash ?? "—"} />
+            </div>
+          </Card>
+        ) : (
+          <Card>
+            <div className="text-xs uppercase tracking-wider text-[color:var(--accent)] font-semibold mb-2">
+              No snapshot on this node
+            </div>
+            <div className="text-2xl md:text-3xl font-bold text-[color:var(--fg)] leading-tight max-w-3xl">
+              Fast bootstrap needs a signed UTXO snapshot.
+            </div>
+            <p className="text-[color:var(--dim)] text-sm mt-3 max-w-2xl leading-relaxed">
+              A signed UTXO snapshot lets a new node adopt the current ledger and validate forward — syncing in
+              minutes instead of hours, without downloading the whole chain. Full Archive nodes build these; hazed
+              nodes fetch and re-serve them. None is present on this node right now.
+            </p>
+          </Card>
+        )}
+      </SectionErrorBoundary>
+
+      {/* Storage role */}
+      <Card>
+        <CardHeader title="This node's storage role" subtitle="Derived from the node's own storage mode" action={<Badge variant={role.variant}>{role.label}</Badge>} />
+        <p className="text-[color:var(--dim)] text-sm leading-relaxed max-w-2xl">{role.blurb}</p>
+        {mode === "hazed" && (
+          <div className="grid grid-cols-2 md:grid-cols-3 gap-4 mt-4">
+            <StatCard label="Content kept off disk" value={formatBytes(haze?.bytes_stripped)} sublabel="cumulative, arbitrary data" tooltip="Non-consensus bytes stripped before ever touching disk." />
+            <StatCard label="Structural archive" value={formatBytes((haze?.structural_archive_size_gb ?? 0) * BYTES_PER_GB)} sublabel="stripped blocks on disk" tooltip="On-disk size of the .gsb (Ghost Stripped Block) archive." />
+            <StatCard label="Blocks stripped" value={(haze?.blocks_stripped ?? 0).toLocaleString()} sublabel="processed by Exorcism" tooltip="Blocks run through the Exorcism strip pipeline." />
+          </div>
+        )}
+      </Card>
+
+      {/* What this node can serve */}
+      <Card>
+        <CardHeader title="What this node can serve" subtitle="Capabilities available to peers and wallets, from the current role" />
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          {canServe.map((c) => (
+            <div key={c.label} className="flex items-start gap-3 p-3 rounded-lg bg-[var(--surface)] border border-[color:var(--rule-strong)]">
+              <StatusDot status={c.on ? "online" : "unknown"} />
+              <div>
+                <div className="text-[color:var(--fg)] text-sm font-medium flex items-center gap-2">
+                  {c.label}
+                  {c.on ? <Badge variant="success">Available</Badge> : <Badge variant="default">Off</Badge>}
+                </div>
+                <div className="text-xs text-[color:var(--dim)] mt-0.5">{c.note}</div>
+              </div>
+            </div>
+          ))}
+        </div>
+        <p className="t-caption text-[color:var(--fainter)] mt-3">
+          Filters + merkle-proof serving (the light-client backbone) is the next serving-layer build — it runs on the
+          economic graph a hazed node already keeps. Trustless bootstrap today rests on the signed checkpoint; recursive
+          validity proofs are the planned trust anchor beyond it.
+        </p>
+      </Card>
+    </div>
+  );
+}

--- a/dashboard/src/components/SessionRefresh.tsx
+++ b/dashboard/src/components/SessionRefresh.tsx
@@ -7,8 +7,17 @@ import { useEffect } from "react";
  *
  * The server issues tokens with a fixed TTL (DASHBOARD_TOKEN_TTL_SECS, default
  * 1 hour). Without refresh, an operator gets redirected to /login on the first
- * action after expiry. With refresh, the cookie is rotated every 20 minutes so
- * the TTL window is always well ahead of the current time.
+ * action after expiry — and because the Home (overview) and Sync screens run an
+ * always-on socket, they surface that expiry *immediately* as a bounce to
+ * /login, while plain REST pages only throw. So a lapsed session looks like
+ * "overview and sync force a re-login."
+ *
+ * A bare 20-minute `setInterval` is not enough on its own: browsers throttle or
+ * pause timers in a backgrounded tab, so the interval can silently lapse past
+ * the 1-hour TTL while the tab is hidden. We therefore also renew immediately on
+ * mount and whenever the tab returns to the foreground (visibility / focus), so
+ * a session that was merely idle (not yet expired) is slid the moment the
+ * operator comes back, before any socket reconnects and probes it.
  *
  * If the refresh returns 401 the token has already been invalidated — we let
  * the next route navigation trigger the middleware-driven redirect rather than
@@ -18,27 +27,43 @@ const REFRESH_INTERVAL_MS = 20 * 60 * 1000; // 20 minutes
 
 export function SessionRefresh() {
   useEffect(() => {
-    // Skip for the login page and when running on localhost (middleware
-    // skips auth there too).
     if (typeof window === "undefined") return;
     if (window.location.pathname.startsWith("/login")) return;
 
     let cancelled = false;
     const refresh = async () => {
       try {
-        await fetch("/api/auth/refresh", { method: "POST", credentials: "same-origin" });
+        await fetch("/api/auth/refresh", {
+          method: "POST",
+          credentials: "same-origin",
+          cache: "no-store",
+        });
       } catch {
-        // Ignore — network blip. Next cycle or next navigation will recover.
+        // Ignore — network blip. Next cycle, focus, or navigation recovers it.
       }
     };
+
+    // Slide once on mount so a session that sat idle in a backgrounded tab is
+    // renewed the moment the operator returns to the dashboard.
+    void refresh();
 
     const handle = window.setInterval(() => {
       if (!cancelled) void refresh();
     }, REFRESH_INTERVAL_MS);
 
+    // Timers are throttled/paused in hidden tabs, so renew on return-to-front.
+    const onForeground = () => {
+      if (cancelled) return;
+      if (document.visibilityState === "visible") void refresh();
+    };
+    document.addEventListener("visibilitychange", onForeground);
+    window.addEventListener("focus", onForeground);
+
     return () => {
       cancelled = true;
       window.clearInterval(handle);
+      document.removeEventListener("visibilitychange", onForeground);
+      window.removeEventListener("focus", onForeground);
     };
   }, []);
 

--- a/dashboard/src/components/layout/Sidebar.tsx
+++ b/dashboard/src/components/layout/Sidebar.tsx
@@ -102,6 +102,7 @@ const GROUPS: NavGroup[] = [
     items: [
       { href: "/storage", label: "Storage", icon: <HardDrive {...ICON} /> },
       { href: "/haze", label: "Haze", icon: <Cloud {...ICON} /> },
+      { href: "/zero-sync", label: "Zero-Sync", icon: <Gauge {...ICON} /> },
     ],
   },
   {


### PR DESCRIPTION
Brings `main` up to the dashboard state already running on the VM1 canary (deployed this session, not yet committed). Prerequisite for cutting v1.10.22 so the release reflects what the canary actually serves.

## Changes
- **Header consistency** — page eyebrows match the nav item; titles are descriptive (Connect Wallet → "Pair wallets & nodes", Logs → "Node logs", Payouts, Node Pool → "Pool statistics", Settings → "Node Settings").
- **Haze page redesign** — reframed from "Storage privacy layer" to **"Block content protection"** (it's block-content/storage protection, not privacy). Storage-mode selector moved to the top as clickable radio-cards; **confirmation on every mode change**; the marketing hero replaced by a calm full-width toggle. Big "N bytes kept off disk" stat kept when active.
- **Mempool** — removed the Reaper "kept out" tile and its dead wiring; caption corrected.
- **Zero-Sync tooling page** (new, under NODE STORAGE) — storage role, signed-UTXO-snapshot bootstrap status, and what the node can serve; grounded in `gethazestatus` + `getcheckpointstatus`.
- **Session keepalive fix** — renew the session on mount + tab focus/visibility, not just a 20-min timer (browsers throttle timers in backgrounded tabs). Fixes overview/sync bouncing a returning operator to /login.

## Testing
All changes deployed to and verified on the VM1 canary this session.