### PR TITLE
web: sync repo nav to live — add site-wide hazync nav link

### DIFF
--- a/ghost-web/404.html
+++ b/ghost-web/404.html
@@ -75,6 +75,7 @@
       <a href="/pool.html">pool</a>
       <a href="/pay.html">pay</a>
       <a href="/nodes.html">nodes</a>
+      <a href="/hazync.html">hazync</a>
       <a href="/miners.html">miners</a>
       <a href="/downloads.html">downloads</a>
       <a href="/docs/">docs</a>

--- a/ghost-web/core.html
+++ b/ghost-web/core.html
@@ -48,6 +48,7 @@
       <a href="/pool.html">pool</a>
       <a href="/pay.html">pay</a>
       <a href="/nodes.html">nodes</a>
+      <a href="/hazync.html">hazync</a>
       <a href="/miners.html">miners</a>
       <a href="/downloads.html">downloads</a>
       <a href="/docs/">docs</a>

--- a/ghost-web/downloads.html
+++ b/ghost-web/downloads.html
@@ -49,6 +49,7 @@
       <a href="/pool.html">pool</a>
       <a href="/pay.html">pay</a>
       <a href="/nodes.html">nodes</a>
+      <a href="/hazync.html">hazync</a>
       <a href="/miners.html">miners</a>
       <a href="/downloads.html" class="current">downloads</a>
       <a href="/docs/">docs</a>

--- a/ghost-web/index.html
+++ b/ghost-web/index.html
@@ -50,6 +50,7 @@
       <a href="/pool.html">pool</a>
       <a href="/pay.html">pay</a>
       <a href="/nodes.html">nodes</a>
+      <a href="/hazync.html">hazync</a>
       <a href="/miners.html">miners</a>
       <a href="/downloads.html">downloads</a>
       <a href="/docs/">docs</a>

--- a/ghost-web/miner.html
+++ b/ghost-web/miner.html
@@ -48,6 +48,7 @@
       <a href="/pool.html" class="current">pool</a>
       <a href="/pay.html">pay</a>
       <a href="/nodes.html">nodes</a>
+      <a href="/hazync.html">hazync</a>
       <a href="/miners.html">miners</a>
       <a href="/downloads.html">downloads</a>
       <a href="/docs/">docs</a>

--- a/ghost-web/miners.html
+++ b/ghost-web/miners.html
@@ -48,6 +48,7 @@
       <a href="/pool.html">pool</a>
       <a href="/pay.html">pay</a>
       <a href="/nodes.html">nodes</a>
+      <a href="/hazync.html">hazync</a>
       <a href="/miners.html" class="current">miners</a>
       <a href="/downloads.html">downloads</a>
       <a href="/docs/">docs</a>

--- a/ghost-web/nodes.html
+++ b/ghost-web/nodes.html
@@ -48,6 +48,7 @@
       <a href="/pool.html">pool</a>
       <a href="/pay.html">pay</a>
       <a href="/nodes.html" class="current">nodes</a>
+      <a href="/hazync.html">hazync</a>
       <a href="/miners.html">miners</a>
       <a href="/downloads.html">downloads</a>
       <a href="/docs/">docs</a>

--- a/ghost-web/pay.html
+++ b/ghost-web/pay.html
@@ -48,6 +48,7 @@
       <a href="/pool.html">pool</a>
       <a href="/pay.html" class="current">pay</a>
       <a href="/nodes.html">nodes</a>
+      <a href="/hazync.html">hazync</a>
       <a href="/miners.html">miners</a>
       <a href="/downloads.html">downloads</a>
       <a href="/docs/">docs</a>

--- a/ghost-web/pool.html
+++ b/ghost-web/pool.html
@@ -56,6 +56,7 @@
       <a href="/pool.html" class="current">pool</a>
       <a href="/pay.html">pay</a>
       <a href="/nodes.html">nodes</a>
+      <a href="/hazync.html">hazync</a>
       <a href="/miners.html">miners</a>
       <a href="/downloads.html">downloads</a>
       <a href="/docs/">docs</a>

--- a/ghost-web/security.html
+++ b/ghost-web/security.html
@@ -48,6 +48,7 @@
       <a href="/pool.html">pool</a>
       <a href="/pay.html">pay</a>
       <a href="/nodes.html">nodes</a>
+      <a href="/hazync.html">hazync</a>
       <a href="/miners.html">miners</a>
       <a href="/downloads.html">downloads</a>
       <a href="/docs/">docs</a>


### PR DESCRIPTION
## What

Adds the site-wide `hazync` nav link (`<a href="/hazync.html">hazync</a>`) to the shared top navigation across all ten `ghost-web` pages, placed between `nodes` and `miners`.

## Why

The hazync landing page was added to the live shared nav on `bitcoinghost.org` (every page), but the change was only ever made on the server and never captured in the repo. As a result `ghost-web/*.html` in `main` was missing the link on every page while the served site had it everywhere. This imports that one line back so the repo matches what is served.

## Scope

- **10 insertions, 0 removals** — one identical nav link per page.
- `hazync.html` (v0.3.0) and `style.css` already matched live; untouched here.
- Verified: every `ghost-web` file now byte-matches the live server.