### PR TITLE
fix: share attribution credited the operator address instead of the miner

### DIFF
--- a/bins/pool-sv2/src/lib/channel_manager/mining_message_handler.rs
+++ b/bins/pool-sv2/src/lib/channel_manager/mining_message_handler.rs
@@ -21,7 +21,7 @@ use stratum_apps::stratum_core::{
     parsers_sv2::{Mining, TemplateDistribution, Tlv, TlvField},
     template_distribution_sv2::SubmitSolution,
 };
-use tracing::{error, info};
+use tracing::{debug, error, info};
 
 use jd_server_sv2::job_declarator::SetCustomMiningJobResponse;
 
@@ -853,6 +853,15 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
                 // sharing one aggregated channel.
                 let tlv_worker: Option<&str> =
                     user_identity.as_ref().and_then(|ui| ui.as_str());
+                debug!(
+                    "share attribution: channel_uid={:?} tlv_worker={:?} -> {:?}",
+                    extended_channel.get_user_identity(),
+                    tlv_worker,
+                    build_webhook_user_identity(
+                        extended_channel.get_user_identity().to_string(),
+                        tlv_worker
+                    )
+                );
 
                 match res {
                     Ok(ShareValidationResult::Valid(share_hash, header80)) => {

--- a/bins/pool-sv2/src/lib/channel_manager/mining_message_handler.rs
+++ b/bins/pool-sv2/src/lib/channel_manager/mining_message_handler.rs
@@ -853,20 +853,39 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
                 // sharing one aggregated channel.
                 let tlv_worker: Option<&str> =
                     user_identity.as_ref().and_then(|ui| ui.as_str());
-                debug!(
-                    "share attribution: channel_uid={:?} tlv_worker={:?} -> {:?}",
-                    extended_channel.get_user_identity(),
-                    tlv_worker,
-                    build_webhook_user_identity(
-                        extended_channel.get_user_identity().to_string(),
-                        tlv_worker
-                    )
-                );
+
+                // FAIL CLOSED on a missing worker TLV when the extension IS negotiated.
+                //
+                // A client that negotiated Worker-Specific Hashrate Tracking is telling us its
+                // channel identity is not the payout target — it is a translator or proxy
+                // fronting other miners, and the per-miner identity travels in the TLV. If the
+                // TLV is then absent, we do NOT know who earned this share, and crediting the
+                // channel identity means silently paying the fronting operator's own address.
+                // That is exactly how a duplicated length constant quietly misdirected shares:
+                // encoding failed, the TLV vanished, and the fallback looked like normal
+                // operation. Dropping the share is visible and costs one share; guessing is
+                // invisible and costs someone their earnings.
+                //
+                // Clients that never negotiate the extension (direct SV2 miners) are unaffected
+                // — their channel identity IS the payout target.
+                let extension_negotiated = negotiated_extensions
+                    .as_ref()
+                    .is_ok_and(|exts| exts.contains(&EXTENSION_TYPE_WORKER_HASHRATE_TRACKING));
+                let attributable = !(extension_negotiated && tlv_worker.is_none());
+                if !attributable {
+                    error!(
+                        "share attribution FAILED: channel {} (identity {:?}) negotiated the \
+                         worker-identity extension but submitted a share with no TLV — share \
+                         accepted for the miner but NOT credited, as the payout target is unknown",
+                        channel_id,
+                        extended_channel.get_user_identity()
+                    );
+                }
 
                 match res {
                     Ok(ShareValidationResult::Valid(share_hash, header80)) => {
                         let share_work = extended_channel.get_target().difficulty_float();
-                        if let Some(ref sender) = self.share_webhook_sender {
+                        if let (Some(ref sender), true) = (&self.share_webhook_sender, attributable) {
                             sender.send(ShareData {
                                 timestamp_ms: now_ms(),
                                 share_hash: share_hash.to_string(),
@@ -902,6 +921,17 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
                     }
                     Ok(ShareValidationResult::BlockFound(share_hash, template_id, coinbase, header80)) => {
                         info!("SubmitSharesExtended: 💰 Block Found!!! 💰{share_hash}");
+                        // Deliberately NOT gated on `attributable`: a block is always reported,
+                        // even if we cannot identify who found it. Losing a block to an
+                        // attribution problem would be far worse than recording one whose finder
+                        // needs resolving by hand afterwards.
+                        if !attributable {
+                            error!(
+                                "BLOCK FOUND on channel {} but the worker TLV is missing — block \
+                                 IS being reported; finder attribution needs manual resolution",
+                                channel_id
+                            );
+                        }
                         let share_work = extended_channel.get_target().difficulty_float();
                         if let Some(ref sender) = self.share_webhook_sender {
                             sender.send(ShareData {

--- a/bins/translator-sv2/src/lib/sv1/sv1_server/mod.rs
+++ b/bins/translator-sv2/src/lib/sv1/sv1_server/mod.rs
@@ -335,3 +335,37 @@ mod username_difficulty_tests {
         assert_eq!(extract_worker_name(name), "braiins");
     }
 }
+
+#[cfg(test)]
+mod worker_tlv_length_tests {
+    use stratum_apps::stratum_core::{extensions_sv2::UserIdentity, parsers_sv2::TlvField};
+
+    /// A full `<address>.<worker>` must survive TLV encode AND decode.
+    ///
+    /// Lives here rather than in `parsers-sv2` because that crate is not a workspace member,
+    /// so tests written there never run.
+    ///
+    /// Regression guard for a two-layer bug: `MAX_USER_IDENTITY_LENGTH` was declared
+    /// independently in BOTH `extensions_sv2` (gating `UserIdentity::new`) and
+    /// `parsers_sv2::tlv_extensions` (gating `to_tlv`/`from_tlv`). Raising only the first left
+    /// encoding still rejecting at 32 bytes; the caller discarded that error with `.ok()`, so
+    /// the share went upstream with NO identity TLV and the pool credited it to the channel's
+    /// provisional identity — i.e. the operator's address instead of the miner's. Verified
+    /// end-to-end on an isolated node: before, a share from `<addr>.attrtest` landed on
+    /// `<config-addr>.miner2`; after, it lands on `<addr>.attrtest`.
+    #[test]
+    fn full_address_and_worker_round_trips_through_tlv() {
+        for identity in [
+            "bc1q7zvdh3uza6u52uemd3c60g0h0eu9g9yvm2y492.attrtest",
+            "bc1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr.worker1",
+        ] {
+            assert!(identity.len() > 32, "must exceed the old 32-byte cap");
+            let ui = UserIdentity::new(identity).expect("construct");
+            let tlv = ui
+                .to_tlv()
+                .unwrap_or_else(|e| panic!("encode rejected {identity:?}: {e:?}"));
+            let decoded = UserIdentity::from_tlv(&tlv).expect("decode");
+            assert_eq!(decoded.as_str().unwrap(), identity);
+        }
+    }
+}

--- a/bins/translator-sv2/src/lib/sv1/sv1_server/sv1_server.rs
+++ b/bins/translator-sv2/src/lib/sv1/sv1_server/sv1_server.rs
@@ -973,12 +973,40 @@ impl Sv1Server {
             // bytes. If it somehow isn't (empty downstream pre-authorize), skip the TLV
             // gracefully rather than disconnecting the miner.
             if user_identity.is_empty() {
+                warn!(
+                    "Down: downstream {} has no user_identity at share submit — TLV omitted, \
+                     pool will attribute this share to the CHANNEL identity",
+                    message.downstream_id
+                );
                 None
             } else {
-                UserIdentity::new(&user_identity)
-                    .ok()
-                    .and_then(|ui| ui.to_tlv().ok())
-                    .map(|tlv| vec![tlv])
+                match UserIdentity::new(&user_identity)
+                    .map_err(|e| e.to_string())
+                    .and_then(|ui| ui.to_tlv().map_err(|e| format!("{e:?}")))
+                {
+                    Ok(tlv) => {
+                        debug!(
+                            "Down: attaching worker TLV for downstream {}: {:?} ({} bytes)",
+                            message.downstream_id,
+                            user_identity,
+                            user_identity.len()
+                        );
+                        Some(vec![tlv])
+                    }
+                    Err(e) => {
+                        // Previously `.ok()` — an error here silently dropped the TLV and sent
+                        // the share with no identity at all, so the pool credited the channel's
+                        // (possibly provisional) identity instead of the miner.
+                        warn!(
+                            "Down: FAILED to build worker TLV for downstream {} from {:?} \
+                             ({} bytes): {e} — share will be misattributed",
+                            message.downstream_id,
+                            user_identity,
+                            user_identity.len()
+                        );
+                        None
+                    }
+                }
             }
         };
 

--- a/vendor/stratum/sv2/extensions-sv2/src/worker_specific_hashrate_tracking.rs
+++ b/vendor/stratum/sv2/extensions-sv2/src/worker_specific_hashrate_tracking.rs
@@ -9,8 +9,19 @@ use alloc::{
     vec::Vec,
 };
 
-/// Maximum length for user identity in bytes as per the spec.
-pub const MAX_USER_IDENTITY_LENGTH: usize = 32;
+/// Maximum length for user identity in bytes.
+///
+/// The TLV `length` field is a `u16`, so the encoding permits far more than this; 255 matches
+/// the `Str0255` limit used for identity strings elsewhere in SV2.
+///
+/// This was 32, which fits a bare worker name but not a full `<address>.<worker>` — a bech32
+/// address is 42 bytes by itself. That mattered once the TLV became the authoritative source of
+/// a miner's payout address: `UserIdentity::new` returns `Err` past the cap and the caller
+/// discards it with `.ok()`, so an over-long identity did not truncate, it silently sent NO TLV
+/// at all, and the pool fell back to the channel's identity. For a channel opened before
+/// `mining.authorize` that identity is the translator's provisional config value, so shares
+/// were credited to the operator's configured address instead of the miner's.
+pub const MAX_USER_IDENTITY_LENGTH: usize = 255;
 
 /// Extension type for Worker-Specific Hashrate Tracking
 pub const EXTENSION_TYPE: u16 = 0x0002;
@@ -24,11 +35,11 @@ pub const FIELD_TYPE_USER_IDENTITY: u8 = 0x01;
 /// `SubmitSharesExtended` messages via TLV encoding when the Worker-Specific Hashrate Tracking
 /// extension (0x0002) is negotiated.
 ///
-/// The UserIdentity is stored as raw UTF-8 bytes (max 32 bytes) to
+/// The UserIdentity is stored as raw UTF-8 bytes (max [`MAX_USER_IDENTITY_LENGTH`]) to
 /// match the TLV specification exactly.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UserIdentity {
-    /// UserIdentity as raw UTF-8 bytes (max 32 bytes).
+    /// UserIdentity as raw UTF-8 bytes (max [`MAX_USER_IDENTITY_LENGTH`]).
     ///
     /// The TLV Value field contains these raw bytes directly.
     pub(crate) user_identity: Vec<u8>,
@@ -43,7 +54,7 @@ impl UserIdentity {
     /// Creates a UserIdentity directly from raw bytes.
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, &'static str> {
         if bytes.len() > MAX_USER_IDENTITY_LENGTH {
-            return Err("UserIdentity exceeds 32 bytes");
+            return Err("UserIdentity exceeds MAX_USER_IDENTITY_LENGTH");
         }
         Ok(Self {
             user_identity: bytes.to_vec(),
@@ -110,12 +121,28 @@ mod tests {
 
     #[test]
     fn test_user_identity_max_length() {
-        let worker_name = "Worker_1234567890123456789012345";
-        assert_eq!(worker_name.len(), MAX_USER_IDENTITY_LENGTH);
-
-        let msg = UserIdentity::new(worker_name).unwrap();
+        let worker_name = "W".repeat(MAX_USER_IDENTITY_LENGTH);
+        let msg = UserIdentity::new(&worker_name).unwrap();
         assert_eq!(msg.as_str().unwrap(), worker_name);
-        assert_eq!(msg.len(), 32);
+        assert_eq!(msg.len(), MAX_USER_IDENTITY_LENGTH);
+    }
+
+    #[test]
+    fn test_user_identity_fits_full_address_and_worker() {
+        // The TLV must carry a full `<address>.<worker>`, because for a channel opened before
+        // `mining.authorize` it is the only place the miner's payout address travels. A bech32
+        // address alone is 42 bytes, so the old 32-byte cap rejected these outright — and the
+        // caller discards the error, so the TLV vanished and shares were credited to the
+        // channel's provisional identity instead of the miner.
+        for identity in [
+            "bc1q7zvdh3uza6u52uemd3c60g0h0eu9g9yvm2y492.braiins",
+            "bc1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr.worker1",
+            "148WRjKfSSo911CYRLzeyYm1QKhy7kCXTN.SKBitaxe",
+        ] {
+            let msg = UserIdentity::new(identity)
+                .unwrap_or_else(|e| panic!("{identity} ({} bytes) rejected: {e}", identity.len()));
+            assert_eq!(msg.as_str().unwrap(), identity);
+        }
     }
 
     #[test]
@@ -135,7 +162,7 @@ mod tests {
 
     #[test]
     fn test_user_identity_too_long() {
-        let too_long = "x".repeat(33);
+        let too_long = "x".repeat(MAX_USER_IDENTITY_LENGTH + 1);
         let result = UserIdentity::new(&too_long);
         assert!(result.is_err());
     }

--- a/vendor/stratum/sv2/parsers-sv2/src/tlv_extensions/mod.rs
+++ b/vendor/stratum/sv2/parsers-sv2/src/tlv_extensions/mod.rs
@@ -10,14 +10,23 @@ pub use error::{ExtensionError, UserIdentityError};
 use super::{Tlv, TlvField};
 use crate::ParserError;
 use extensions_sv2::{
-    UserIdentity, EXTENSION_TYPE_WORKER_HASHRATE_TRACKING, TLV_FIELD_TYPE_USER_IDENTITY,
+    UserIdentity, EXTENSION_TYPE_WORKER_HASHRATE_TRACKING, MAX_USER_IDENTITY_LENGTH,
+    TLV_FIELD_TYPE_USER_IDENTITY,
 };
 
 extern crate alloc;
 use alloc::vec::Vec;
 
-/// Maximum length for worker identifiers in bytes as per the spec.
-const MAX_USER_IDENTITY_LENGTH: usize = 32;
+// NOTE: `MAX_USER_IDENTITY_LENGTH` is imported from `extensions_sv2`, which owns
+// `UserIdentity`, rather than redeclared here.
+//
+// This module previously kept its own `const MAX_USER_IDENTITY_LENGTH: usize = 32`. Two
+// constants of the same name in different crates silently diverged: raising the one in
+// `extensions_sv2` fixed `UserIdentity::new` but left this copy gating `to_tlv`/`from_tlv`,
+// so an over-long identity still failed to encode — and because the caller discarded the
+// error, the share went out with NO identity TLV and was credited to the channel's
+// (possibly provisional) identity instead of the miner. Keeping a single owner of the limit
+// makes that class of drift impossible.
 
 /// Implementation of TlvField trait for UserIdentity.
 ///
@@ -77,3 +86,4 @@ impl TlvField for UserIdentity {
         ))
     }
 }
+

--- a/vendor/stratum/sv2/parsers-sv2/src/tlv_extensions/mod.rs
+++ b/vendor/stratum/sv2/parsers-sv2/src/tlv_extensions/mod.rs
@@ -86,4 +86,3 @@ impl TlvField for UserIdentity {
         ))
     }
 }
-


### PR DESCRIPTION
Fixes #419

`MAX_USER_IDENTITY_LENGTH` was declared independently in `extensions_sv2` (gating `UserIdentity::new`) and `parsers_sv2::tlv_extensions` (gating `to_tlv`/`from_tlv`). Raising one left the other rejecting at 32 bytes, and a full `<address>.<worker>` is ~50. The caller used `.ok()`, so the TLV was silently dropped and the pool credited the channel's provisional identity — the operator's address.

- `parsers_sv2` now imports the constant rather than keeping a copy, so they cannot drift again
- cap raised to 255 (matches `Str0255`; TLV length field is a u16)
- `.ok()` replaced with an explicit warning naming the identity, length and error
- attribution **fails closed**: negotiated extension but no TLV means the share is accepted for the miner but not credited, and logged. Blocks are exempt and always reported.

Verified by mining real shares against an isolated node: before, a share from `bc1q7zvdh3….attrtest` landed on `bc1q9z23a6….miner2`; after, four consecutive shares credited correctly with zero provisional attributions. Since confirmed with live rented hashrate — 5000+ shares credited correctly.

Regression test asserts a full `<addr>.<worker>` survives TLV encode and decode. It lives in `translator_sv2` because `parsers-sv2` is not a workspace member and tests written there never run.