### PR TITLE
fix(tdp): run the Noise handshake off the accept loop; reconnect instead of exiting

### DIFF
--- a/bins/ghost-pool/src/template_provider.rs
+++ b/bins/ghost-pool/src/template_provider.rs
@@ -345,45 +345,61 @@ impl TemplateDistributionServer {
                         .next_client_id
                         .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
 
-                    // Create Noise responder for this connection
-                    let responder = match Responder::from_authority_kp(
-                        &self.config.authority_public_key,
-                        &self.config.authority_secret_key,
-                        Duration::from_secs(self.config.cert_validity_secs),
-                    ) {
-                        Ok(r) => r,
-                        Err(e) => {
-                            error!("Failed to create Noise responder: {:?}", e);
-                            continue;
-                        }
-                    };
-
-                    // Perform Noise handshake. The 10s per-read timeout matches
-                    // stratum-apps' NOISE_HANDSHAKE_TIMEOUT default (used by
-                    // accept_noise_connection), so a stalled peer handshake can't
-                    // hang the TDP responder.
-                    let noise_stream = match NoiseTcpStream::<Message>::new(
-                        socket,
-                        HandshakeRole::Responder(responder),
-                        Duration::from_secs(10),
-                    )
-                    .await
-                    {
-                        Ok(ns) => {
-                            info!("Noise handshake completed with {}", peer_addr);
-                            ns
-                        }
-                        Err(e) => {
-                            error!("Noise handshake failed with {}: {:?}", peer_addr, e);
-                            continue;
-                        }
-                    };
-
                     let clients = Arc::clone(&self.clients);
                     let template_processor = Arc::clone(&self.template_processor);
                     let template_id_counter = Arc::clone(&self.template_id_counter);
+                    let authority_public_key = self.config.authority_public_key.clone();
+                    let authority_secret_key = self.config.authority_secret_key.clone();
+                    let cert_validity_secs = self.config.cert_validity_secs;
 
+                    // The Noise handshake runs INSIDE the spawned task, never on the accept
+                    // loop.
+                    //
+                    // It used to run inline here, and a handshake can take up to its 10s
+                    // timeout. For that whole time `listener.accept()` could not run, so further
+                    // connections sat unaccepted in the kernel backlog. That is not merely slow,
+                    // it is self-sustaining: the client's handshake timeout is also ~10s, so once
+                    // the loop falls one connection behind, every queued client has already given
+                    // up by the time the server reaches it — and the server then spends another
+                    // full timeout handshaking against a socket nobody is listening on. The
+                    // backlog never drains.
+                    //
+                    // Observed in production as a wedged template provider: `ss` showing
+                    // `LISTEN 2` with 64 unread bytes on accepted sockets while the pool was
+                    // otherwise healthy and still building blocks, and every pool_sv2 client
+                    // timing out and exiting, which systemd then restarted in a loop. Spawning
+                    // first keeps accept() free at all times, so a slow or dead peer costs one
+                    // task rather than the whole listener.
                     tokio::spawn(async move {
+                        let responder = match Responder::from_authority_kp(
+                            &authority_public_key,
+                            &authority_secret_key,
+                            Duration::from_secs(cert_validity_secs),
+                        ) {
+                            Ok(r) => r,
+                            Err(e) => {
+                                error!("Failed to create Noise responder: {:?}", e);
+                                return;
+                            }
+                        };
+
+                        let noise_stream = match NoiseTcpStream::<Message>::new(
+                            socket,
+                            HandshakeRole::Responder(responder),
+                            Duration::from_secs(10),
+                        )
+                        .await
+                        {
+                            Ok(ns) => {
+                                info!("Noise handshake completed with {}", peer_addr);
+                                ns
+                            }
+                            Err(e) => {
+                                error!("Noise handshake failed with {}: {:?}", peer_addr, e);
+                                return;
+                            }
+                        };
+
                         if let Err(e) = handle_tdp_client(
                             noise_stream,
                             peer_addr,

--- a/bins/pool-sv2/src/lib/template_receiver/sv2_tp/mod.rs
+++ b/bins/pool-sv2/src/lib/template_receiver/sv2_tp/mod.rs
@@ -36,6 +36,17 @@ pub struct Sv2TpChannel {
 #[derive(Clone)]
 pub struct Sv2Tp {
     sv2_tp_channel: Sv2TpChannel,
+    /// Retained so the session can be re-established without tearing down the pool.
+    tp_address: String,
+    public_key: Option<Secp256k1PublicKey>,
+    task_manager: Arc<TaskManager>,
+    /// Last `CoinbaseOutputConstraints` sent upstream, replayed after a reconnect.
+    ///
+    /// The channel manager sends this exactly once, at its own startup, and the template
+    /// provider will not emit templates until it has it. A reconnected session is a fresh
+    /// session from the TP's point of view, so without replaying this the pool would come
+    /// back up and then sit silent, receiving no work.
+    last_coinbase_constraints: Arc<std::sync::Mutex<Option<TemplateDistribution<'static>>>>,
 }
 
 #[cfg_attr(not(test), hotpath::measure_all)]
@@ -100,6 +111,12 @@ impl Sv2Tp {
                                     info!(attempt, "TemplateReceiver initialized successfully");
                                     return Ok(Sv2Tp {
                                         sv2_tp_channel: template_receiver_channel,
+                                        tp_address: tp_address.clone(),
+                                        public_key,
+                                        task_manager: task_manager.clone(),
+                                        last_coinbase_constraints: Arc::new(
+                                            std::sync::Mutex::new(None),
+                                        ),
                                     });
                                 }
                                 Err(network_helpers::Error::InvalidKey) => {
@@ -128,6 +145,106 @@ impl Sv2Tp {
         }
 
         error!("Exhausted all connection attempts, shutting down TemplateReceiver");
+        Err(PoolError::shutdown(PoolErrorKind::CouldNotInitiateSystem))
+    }
+
+    /// Re-establish the template-provider session in place, without tearing down the pool.
+    ///
+    /// A dropped TP connection used to be fatal: the reader task closed the inbound channel,
+    /// the message loop saw `Action::Shutdown` and cancelled the global token, the process
+    /// exited and systemd restarted it — roughly 15s during which every miner on the node was
+    /// disconnected. Three nodes were doing this hourly, on the hour, because the TDP
+    /// connection has a fixed lifetime. Losing the TP is a transient upstream condition and
+    /// belongs in a reconnect loop, not a process exit.
+    ///
+    /// Restores the full session: new TCP + Noise, fresh IO tasks, `SetupConnection`, then a
+    /// replay of the cached `CoinbaseOutputConstraints` — without which the TP accepts the
+    /// connection but never sends a template, leaving the pool up and idle.
+    async fn reconnect(
+        &mut self,
+        cancellation_token: &CancellationToken,
+    ) -> PoolResult<(), error::TemplateProvider> {
+        const MAX_RECONNECT_ATTEMPTS: usize = 10;
+
+        for attempt in 1..=MAX_RECONNECT_ATTEMPTS {
+            if cancellation_token.is_cancelled() {
+                return Err(PoolError::shutdown(PoolErrorKind::CouldNotInitiateSystem));
+            }
+            info!(
+                attempt,
+                MAX_RECONNECT_ATTEMPTS, "Reconnecting to template provider"
+            );
+
+            match TcpStream::connect(self.tp_address.as_str()).await {
+                Ok(stream) => match connect_with_noise(stream, self.public_key).await {
+                    Ok(noise_stream) => {
+                        let (reader, writer) = noise_stream.into_split();
+                        let (inbound_tx, inbound_rx) = unbounded::<Sv2Frame>();
+                        let (outbound_tx, outbound_rx) = unbounded::<Sv2Frame>();
+                        spawn_io_tasks(
+                            self.task_manager.clone(),
+                            reader,
+                            writer,
+                            outbound_rx,
+                            inbound_tx,
+                            cancellation_token.clone(),
+                        );
+                        self.sv2_tp_channel.tp_receiver = inbound_rx;
+                        self.sv2_tp_channel.tp_sender = outbound_tx;
+
+                        let addr = self.tp_address.clone();
+                        if let Err(e) = self.setup_connection(addr).await {
+                            warn!(attempt, error = ?e, "Handshake failed on reconnect");
+                        } else {
+                            // Re-prime the TP, or it will never send us a template.
+                            let cached = self
+                                .last_coinbase_constraints
+                                .lock()
+                                .ok()
+                                .and_then(|slot| slot.clone());
+                            if let Some(constraints) = cached {
+                                let message =
+                                    AnyMessage::TemplateDistribution(constraints).into_static();
+                                match Sv2Frame::try_from(message) {
+                                    Ok(frame) => {
+                                        if let Err(e) =
+                                            self.sv2_tp_channel.tp_sender.send(frame).await
+                                        {
+                                            warn!(error = ?e, "Failed to replay coinbase constraints");
+                                            continue;
+                                        }
+                                        info!("Replayed CoinbaseOutputConstraints after reconnect");
+                                    }
+                                    Err(e) => {
+                                        warn!(error = ?e, "Failed to encode cached coinbase constraints")
+                                    }
+                                }
+                            } else {
+                                warn!(
+                                    "No cached CoinbaseOutputConstraints to replay — the template \
+                                     provider may not send templates until the channel manager \
+                                     resends them"
+                                );
+                            }
+                            info!(attempt, "Template provider session re-established");
+                            return Ok(());
+                        }
+                    }
+                    Err(network_helpers::Error::InvalidKey) => {
+                        error!("Template provider key invalid — not retrying");
+                        return Err(PoolError::shutdown(PoolErrorKind::InvalidKey));
+                    }
+                    Err(e) => warn!(attempt, error = ?e, "Noise handshake failed on reconnect"),
+                },
+                Err(e) => warn!(attempt, error = ?e, "TCP connect failed on reconnect"),
+            }
+
+            // Linear backoff, capped — the TP is usually back within a few seconds.
+            let delay = std::cmp::min(attempt as u64, 5);
+            tokio::time::sleep(std::time::Duration::from_secs(delay)).await;
+        }
+
+        error!("Exhausted template-provider reconnect attempts");
         Err(PoolError::shutdown(PoolErrorKind::CouldNotInitiateSystem))
     }
 
@@ -163,8 +280,25 @@ impl Sv2Tp {
                             error!("TemplateReceiver template provider handler failed: {e:?}");
                             match e.action {
                                 Action::Shutdown => {
-                                    cancellation_token.cancel();
-                                    break;
+                                    // Losing the TP is transient — reconnect in place rather
+                                    // than cancelling the global token and taking the whole
+                                    // pool (and every miner on it) down with us. Only if
+                                    // reconnection is genuinely exhausted do we fall through to
+                                    // the old fatal behaviour.
+                                    warn!("Template provider connection lost — attempting to reconnect");
+                                    match self.reconnect(&cancellation_token).await {
+                                        Ok(()) => {
+                                            info!("Template provider reconnected; resuming");
+                                            continue;
+                                        }
+                                        Err(reconnect_err) => {
+                                            error!(
+                                                "Template provider reconnect failed: {reconnect_err:?} — shutting down"
+                                            );
+                                            cancellation_token.cancel();
+                                            break;
+                                        }
+                                    }
                                 }
                                 Action::Log => {
                                     warn!("Log-only error from Template Provider: {:?}", e.kind);
@@ -263,6 +397,12 @@ impl Sv2Tp {
             .recv()
             .await
             .map_err(PoolError::shutdown)?;
+        // Remember the coinbase constraints so a reconnected session can be primed with them.
+        if matches!(msg, TemplateDistribution::CoinbaseOutputConstraints(_)) {
+            if let Ok(mut slot) = self.last_coinbase_constraints.lock() {
+                *slot = Some(msg.clone().into_static());
+            }
+        }
         let message = AnyMessage::TemplateDistribution(msg).into_static();
         let frame: Sv2Frame = message.try_into().map_err(PoolError::shutdown)?;
 


### PR DESCRIPTION
Fixes #420

The template provider ran the Noise handshake inside its accept loop, blocking `accept()` for up to its 10s timeout. Since the client's timeout is also ~10s, falling one connection behind meant every queued client had already given up by the time the server reached it — a self-sustaining livelock that only a process restart cleared.

Spawn first, handshake inside the task, so a slow or dead peer costs one task rather than the listener.

Also: pool_sv2 reconnects to the template provider instead of cancelling the global token and exiting, replaying the cached `CoinbaseOutputConstraints` so templates resume (the channel manager only sends those once at startup).

Verified by holding 5 peers open without completing a handshake: a fresh connection was accepted in 0.11s (previously it would queue behind 5x10s), all 7 accepted, the 6 doomed handshakes failed concurrently, backlog drained to zero, live client kept receiving templates.

Note this is a real livelock but was NOT the cause of the hourly restarts — that was #418.