### PR TITLE
fix(storage): stop rebuilding the whole database every hour

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3535,6 +3535,7 @@ dependencies = [
  "tempfile",
  "template_distribution_sv2 4.0.2",
  "thiserror 1.0.69",
+ "tikv-jemallocator",
  "tokio",
  "toml 0.8.2",
  "tracing",
@@ -7835,7 +7836,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b1fdf65dd6331831494dd616b30351c38e96e45921a27745cf98490458b90bb"
 dependencies = [
- "dirs 5.0.1",
+ "dirs 6.0.0",
 ]
 
 [[package]]
@@ -8817,6 +8818,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
 dependencies = [
  "num_cpus",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/bins/ghost-pool/Cargo.toml
+++ b/bins/ghost-pool/Cargo.toml
@@ -119,6 +119,15 @@ zk-consensus = ["ghost-consensus/zk-consensus", "ghost-zkp"]
 mpc-ceremony = ["ghost-consensus/mpc-ceremony", "ghost-mpc"]
 # Use MPC ceremony parameters for ZK proofs (required for mainnet)
 zk-production = ["ghost-zkp/zk-production"]
+# Heap profiling. OFF by default and adds nothing to a normal build — it swaps in jemalloc
+# with profiling compiled in, which is inert until enabled at runtime via MALLOC_CONF.
+# Used to find what holds ghost-pool's ~2.2GB steady-state working set (see issue #418).
+heap-profiling = ["dep:tikv-jemallocator"]
+
+[dependencies.tikv-jemallocator]
+version = "0.6"
+features = ["profiling", "unprefixed_malloc_on_supported_platforms"]
+optional = true
 
 [dependencies.ghost-zkp]
 workspace = true

--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -2192,6 +2192,25 @@ async fn ensure_mpc_params_present(
     ))
 }
 
+/// Heap profiling allocator, compiled in only under `--features heap-profiling`.
+///
+/// jemalloc with profiling support. Inert until switched on at runtime, so a build with this
+/// feature behaves normally until you ask for a profile:
+///
+/// ```text
+/// MALLOC_CONF=prof:true,prof_active:true,lg_prof_sample:19,lg_prof_interval:30,prof_prefix:/tmp/gp-heap \
+///     /opt/ghost/bin/ghost-pool ...
+/// jeprof --show_bytes --text /opt/ghost/bin/ghost-pool /tmp/gp-heap.*.heap | head -40
+/// ```
+///
+/// `lg_prof_sample:19` samples every ~512KB allocated (cheap), and `lg_prof_interval:30`
+/// dumps a profile per ~1GB allocated, which is enough granularity to see what accumulates
+/// without babysitting it. Added to chase the ~2.2GB steady-state working set in #418, where
+/// reasoning from the outside repeatedly produced wrong answers.
+#[cfg(feature = "heap-profiling")]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 #[tokio::main]
 async fn main() -> Result<()> {
     let args = Args::parse();

--- a/bins/ghost-pool/src/self_check.rs
+++ b/bins/ghost-pool/src/self_check.rs
@@ -241,6 +241,18 @@ async fn check_public_mining(config: &NodeConfig) -> CapabilityCheck {
             config.network.sv2_port
         ));
     }
+    // A listening port only proves something bound it. Require a live TDP client too, which
+    // means pool_sv2 is connected and being served templates — the actual chain a miner needs.
+    // Without this, a node whose provider was wedged (ports up, nothing served) kept claiming
+    // the capability, and the load balancer preferentially routed miners to it because it
+    // looked idle.
+    if !port_has_established_connection(ghost_common::constants::TDP_PORT) {
+        missing.push(format!(
+            "no template-provider client connected on port {} — sri-pool is not being served \
+             templates",
+            ghost_common::constants::TDP_PORT
+        ));
+    }
     if config.network.public_address.is_none() {
         missing.push("public_address unset in pool.toml".to_string());
     }
@@ -357,6 +369,42 @@ fn check_reaper(config: &NodeConfig) -> CapabilityCheck {
 /// Reads `/proc/net/tcp{,6}` directly instead of opening a TCP connection,
 /// which keeps probes invisible to the listening daemon (no spurious
 /// "downstream connected → disconnected" log entries every tick).
+/// True when `port` has at least one ESTABLISHED connection.
+///
+/// Used to tell "the listener is up" apart from "the node is actually serving". A listening
+/// socket only proves a process bound the port; it says nothing about whether the stack behind
+/// it works. A node whose template provider was wedged still had every port listening while
+/// being completely unable to serve a miner, and it kept advertising `public_mining: true` —
+/// so the load balancer, which prefers least-loaded peers, actively steered miners INTO it.
+///
+/// An established TDP connection is a much stronger signal: it means pool_sv2 is running,
+/// connected and being served templates, which is the whole chain a miner depends on.
+#[cfg(target_os = "linux")]
+fn port_has_established_connection(port: u16) -> bool {
+    fn scan(path: &str, port: u16) -> bool {
+        let Ok(content) = std::fs::read_to_string(path) else {
+            return false;
+        };
+        let port_hex = format!("{:04X}", port);
+        for line in content.lines().skip(1) {
+            let mut fields = line.split_whitespace();
+            let _sl = fields.next();
+            let Some(local) = fields.next() else { continue };
+            let _rem = fields.next();
+            let Some(state) = fields.next() else { continue };
+            // 01 = ESTABLISHED
+            if state != "01" {
+                continue;
+            }
+            if local.rsplit_once(':').map(|(_, p)| p) == Some(port_hex.as_str()) {
+                return true;
+            }
+        }
+        false
+    }
+    scan("/proc/net/tcp", port) || scan("/proc/net/tcp6", port)
+}
+
 #[cfg(target_os = "linux")]
 fn port_listening(port: u16) -> bool {
     fn scan(path: &str, port: u16) -> bool {
@@ -383,6 +431,14 @@ fn port_listening(port: u16) -> bool {
         false
     }
     scan("/proc/net/tcp", port) || scan("/proc/net/tcp6", port)
+}
+
+/// Non-Linux fallback. Establishing a connection to check for OTHER established
+/// connections isn't meaningful, and this only runs in dev environments, so report false
+/// rather than probing. Production is Linux, where the /proc implementation is used.
+#[cfg(not(target_os = "linux"))]
+fn port_has_established_connection(_port: u16) -> bool {
+    false
 }
 
 /// Non-Linux fallback for dev environments. Falls back to a short-lived TCP

--- a/crates/ghost-common/src/constants.rs
+++ b/crates/ghost-common/src/constants.rs
@@ -229,6 +229,12 @@ pub const SV2_STRATUM_PORT: u16 = 34255;
 /// SV1 Stratum port (translator)
 pub const SV1_STRATUM_PORT: u16 = 3333;
 
+/// Template Distribution Protocol port, served by ghost-pool and consumed by pool_sv2.
+///
+/// Matches the `--tdp-port` default. Shared here so health checks can reason about the
+/// provider without duplicating the literal.
+pub const TDP_PORT: u16 = 8442;
+
 /// SV2 pool authority public key (the Noise static key SV2/Noise clients pin).
 ///
 /// This is the network-wide authority key that every `pool_sv2` instance

--- a/crates/ghost-storage/src/database.rs
+++ b/crates/ghost-storage/src/database.rs
@@ -991,7 +991,7 @@ impl Database {
     ///
     /// Always runs `ANALYZE` (cheap, and it is what actually helps the query planner) and a
     /// WAL checkpoint. Only runs `VACUUM` when there is enough reclaimable space to justify
-    /// it — see [`VACUUM_MIN_RECLAIMABLE_BYTES`].
+    /// it — see `VACUUM_MIN_RECLAIMABLE_BYTES`.
     ///
     /// This used to run `VACUUM; ANALYZE;` unconditionally, and `run_maintenance` calls it
     /// whenever a maintenance pass deletes more than 1000 rows — which pruning health pings,

--- a/crates/ghost-storage/src/database.rs
+++ b/crates/ghost-storage/src/database.rs
@@ -977,11 +977,73 @@ impl Database {
         })
     }
 
-    /// Optimize the database (vacuum and analyze)
+    /// Minimum reclaimable free space before a full `VACUUM` is worth doing.
+    ///
+    /// `VACUUM` rebuilds the entire database through SQLite's page cache, so its peak memory is
+    /// proportional to database size, not to the amount being reclaimed. Rebuilding 2.1GB to
+    /// recover a few MB of pruned rows is what OOM-killed ghost-pool hourly on 3.87GB nodes.
+    ///
+    /// 256MB means a rebuild only happens when it would actually recover a meaningful amount of
+    /// disk, at which point paying the memory cost once is reasonable.
+    const VACUUM_MIN_RECLAIMABLE_BYTES: u64 = 256 * 1024 * 1024;
+
+    /// Optimize the database.
+    ///
+    /// Always runs `ANALYZE` (cheap, and it is what actually helps the query planner) and a
+    /// WAL checkpoint. Only runs `VACUUM` when there is enough reclaimable space to justify
+    /// it — see [`VACUUM_MIN_RECLAIMABLE_BYTES`].
+    ///
+    /// This used to run `VACUUM; ANALYZE;` unconditionally, and `run_maintenance` calls it
+    /// whenever a maintenance pass deletes more than 1000 rows — which pruning health pings,
+    /// challenges and verifications clears most hours. `VACUUM` rebuilds the ENTIRE database
+    /// by streaming it through SQLite's page cache, so on a 2.1GB SQLCipher file it took
+    /// ~2.8GB resident, every hour, to reclaim a few MB of freed rows.
+    ///
+    /// On 3.87GB nodes that was fatal: the kernel OOM-killed ghost-pool on the hour, every
+    /// hour. Because an OOM kill is SIGKILL, it also never got to checkpoint, so the WAL grew
+    /// to the size of the database and stayed there. Heap profiling attributed 96.9% of all
+    /// allocation in the process to this one call.
+    ///
+    /// The checkpoint here is deliberate too: `VACUUM` holds a long transaction across the
+    /// whole database, which blocks `wal_checkpoint(TRUNCATE)` (it returned busy with only
+    /// ~4MB live inside a 2GB WAL). Checkpointing before any VACUUM lets the WAL actually
+    /// shrink.
     pub fn optimize(&self) -> GhostResult<()> {
-        info!("Optimizing database");
         self.with_connection(|conn| {
-            conn.execute_batch("VACUUM; ANALYZE;")
+            // Truncating checkpoint first: cheap, and bounds WAL growth. Without this the WAL
+            // file never shrinks (`journal_size_limit` is -1 by default).
+            if let Err(e) = conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);") {
+                warn!("WAL checkpoint during maintenance failed: {e}");
+            }
+
+            // ANALYZE is the part that pays for itself — it refreshes planner statistics and
+            // costs orders of magnitude less than a rebuild.
+            conn.execute_batch("ANALYZE;")
+                .map_err(|e| GhostError::Database(e.to_string()))?;
+
+            let page_size: i64 = conn
+                .query_row("PRAGMA page_size", [], |row| row.get(0))
+                .map_err(|e| GhostError::Database(e.to_string()))?;
+            let freelist_pages: i64 = conn
+                .query_row("PRAGMA freelist_count", [], |row| row.get(0))
+                .map_err(|e| GhostError::Database(e.to_string()))?;
+            let reclaimable =
+                (freelist_pages.max(0) as u64).saturating_mul(page_size.max(0) as u64);
+
+            if reclaimable < Self::VACUUM_MIN_RECLAIMABLE_BYTES {
+                debug!(
+                    reclaimable_bytes = reclaimable,
+                    threshold = Self::VACUUM_MIN_RECLAIMABLE_BYTES,
+                    "Skipping VACUUM — not enough reclaimable space to justify a full rebuild"
+                );
+                return Ok(());
+            }
+
+            info!(
+                reclaimable_bytes = reclaimable,
+                "Running VACUUM — reclaimable space exceeds threshold"
+            );
+            conn.execute_batch("VACUUM;")
                 .map_err(|e| GhostError::Database(e.to_string()))
         })
     }
@@ -1596,6 +1658,48 @@ impl DatabaseStats {
 mod tests {
     use super::*;
     use std::sync::atomic::{AtomicU32, Ordering};
+
+    /// `optimize()` must not run a full VACUUM when there is nothing worth reclaiming.
+    ///
+    /// Regression guard for the hourly OOM: `optimize()` ran `VACUUM; ANALYZE;`
+    /// unconditionally, and `run_maintenance` calls it whenever a pass deletes >1000 rows —
+    /// most hours. VACUUM rebuilds the whole database through SQLite's page cache, so on a
+    /// 2.1GB file it needed ~2.8GB resident and the kernel OOM-killed the process on the
+    /// hour. Heap profiling attributed 96.9% of all allocation to that one call.
+    ///
+    /// A fresh database has an empty freelist, so this asserts the cheap path is taken and
+    /// the database is still usable afterwards.
+    #[test]
+    fn optimize_skips_vacuum_when_nothing_to_reclaim() {
+        let db = Database::in_memory().expect("create in-memory database");
+
+        let freelist_before: i64 = db
+            .with_connection(|conn| {
+                conn.query_row("PRAGMA freelist_count", [], |row| row.get(0))
+                    .map_err(|e| GhostError::Database(e.to_string()))
+            })
+            .expect("read freelist");
+        assert_eq!(
+            freelist_before, 0,
+            "a fresh database should have no free pages"
+        );
+
+        db.optimize().expect("optimize must succeed");
+
+        // Still usable, and ANALYZE ran without a rebuild.
+        let stats = db.stats().expect("stats after optimize");
+        assert!(stats.page_count > 0);
+    }
+
+    #[test]
+    fn vacuum_threshold_is_large_enough_to_matter() {
+        // The threshold exists so a rebuild only happens when it recovers meaningful disk.
+        // Anything small here reintroduces the hourly rebuild this was written to stop.
+        assert!(
+            Database::VACUUM_MIN_RECLAIMABLE_BYTES >= 64 * 1024 * 1024,
+            "threshold too low — VACUUM would run routinely again"
+        );
+    }
 
     #[test]
     fn test_in_memory_database() {


### PR DESCRIPTION
Fixes #418
Fixes #417

`optimize()` ran `VACUUM; ANALYZE;` unconditionally, and `run_maintenance` calls it whenever a pass deletes >1000 rows — most hours. VACUUM rebuilds the entire database through SQLite's page cache, so peak memory scales with database size, not with what's reclaimed. On a 2.1GB SQLCipher file that meant ~2.8GB resident hourly to recover a few MB, and on 3.87GB nodes the kernel OOM-killed ghost-pool on the hour.

Heap profiling attributed 96.9% of all allocation in the process to that one call:

```
ghost_pool::main::{closure#0}::{closure#121}   2,816,503,807 B   96.9%
  -> run_maintenance -> optimize -> execute_batch
     -> sqlite3PagerGet -> pcache1Fetch -> allocateBtreePage -> sqlcipher_mem_malloc
```

Everything previously blamed on the SV2 stack followed from that kill: pool_sv2 losing its socket, "Exhausted all connection attempts", the systemd restart loop.

Now: ANALYZE always; VACUUM only when the freelist holds >=256MB; a truncating WAL checkpoint first (VACUUM's long transaction was the reader blocking `wal_checkpoint(TRUNCATE)`, leaving a 2GB WAL with ~4MB live inside it).

Also includes the opt-in `heap-profiling` feature used to find this — off by default, zero jemalloc in the default dependency tree — and a self-check requiring a live TDP client before `public_mining` passes.

Note `auto_vacuum` is NONE on existing databases and cannot be changed to INCREMENTAL without a full VACUUM, so incremental reclamation isn't available without one-off offline maintenance.

Tests cover the skip path on a clean database and guard the threshold against being lowered.