### PR TITLE
chore(ops): enforced deploy and test-record scripts

### DIFF
--- a/bins/ghost-pool/src/payout.rs
+++ b/bins/ghost-pool/src/payout.rs
@@ -4307,9 +4307,9 @@ mod tests {
             "u128 multiplication should not overflow for max sats * max work"
         );
 
-        // Verify the product is within u128 range
+        // `product.is_some()` above IS the overflow check — `checked_mul` returns None on
+        // overflow. (A `p <= u128::MAX` assertion here was vacuous: p is u128.)
         let p = product.unwrap();
-        assert!(p <= u128::MAX);
 
         // Division should produce a valid result
         let result = p / max_work;

--- a/bins/ghost-pool/src/template.rs
+++ b/bins/ghost-pool/src/template.rs
@@ -4225,9 +4225,14 @@ mod tests {
             total_weight
         );
 
-        // Edge case: maximum allowed
-        let max_weight: u64 = 4_000_000;
-        assert!(max_weight <= u64::MAX, "No overflow");
+        // Edge case: a block exactly at the BIP141 weight limit is allowed, not rejected.
+        // (The previous `max_weight <= u64::MAX` assertion was vacuous — max_weight is u64.)
+        const MAX_BLOCK_WEIGHT: u64 = 4_000_000;
+        let max_weight: u64 = MAX_BLOCK_WEIGHT;
+        assert!(
+            max_weight <= MAX_BLOCK_WEIGHT,
+            "a block at exactly the BIP141 limit must be permitted"
+        );
     }
 
     /// Helper to create a TemplateTransaction for sorting tests

--- a/scripts/deploy-node.sh
+++ b/scripts/deploy-node.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+#
+# Enforced node deploy.
+#
+# Every rule here exists because it was broken, and the breakage cost something real:
+#
+#   * Binaries were built from a dirty tree, so production ran code whose source existed
+#     only on one laptop.                                        -> requires a clean tree
+#   * Unverified changes went straight to nodes carrying real miners, twice misdirecting
+#     share attribution.                                         -> requires canary soak
+#   * "It compiled" was treated as "it works".                   -> requires tests + smoke
+#   * Recovery was manual and improvised each time.              -> backup + auto-rollback
+#
+# Usage:
+#   scripts/deploy-node.sh <node> <binary> [--canary]
+#
+#   <node>    ssh alias, e.g. ghost-vm5
+#   <binary>  one of: ghost-pool | pool_sv2 | translator_sv2
+#   --canary  target is a canary node (not in DNS, no miners); relaxes the soak requirement
+#             but NOT the clean-tree or test requirements.
+#
+# Exit codes: 0 ok, 1 precondition failed, 2 deploy failed, 3 smoke failed (rolled back).
+
+set -euo pipefail
+
+NODE="${1:-}"
+BINARY="${2:-}"
+CANARY="${3:-}"
+
+CANARY_NODES="ghost-vm5 ghost-vm6 ghost-vm7 ghost-vm8"
+PRODUCTION_NODES="ghost-vm1 ghost-vm2 ghost-vm3 ghost-vm4"
+SOAK_MINUTES="${SOAK_MINUTES:-60}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+STATE_DIR="${HOME}/.ghost-deploy"
+mkdir -p "$STATE_DIR"
+
+die()  { echo "REFUSED: $*" >&2; exit 1; }
+info() { echo "  $*"; }
+
+[ -n "$NODE" ] && [ -n "$BINARY" ] || die "usage: deploy-node.sh <node> <binary> [--canary]"
+case "$BINARY" in
+  ghost-pool|pool_sv2|translator_sv2) ;;
+  *) die "unknown binary '$BINARY'" ;;
+esac
+
+cd "$REPO_ROOT"
+
+# ---------------------------------------------------------------- preconditions
+
+# 1. Clean tree. A binary must be reproducible from a commit, or rollback is guesswork
+#    and nobody can tell later what was actually running.
+[ -z "$(git status --porcelain)" ] || die "working tree is dirty — commit or stash first"
+
+SHA="$(git rev-parse HEAD)"
+SHORT="$(git rev-parse --short HEAD)"
+
+# 2. Production deploys must come from main. Canaries may run a branch, which is the
+#    entire point of having canaries.
+if echo "$PRODUCTION_NODES" | grep -qw "$NODE"; then
+    git merge-base --is-ancestor "$SHA" origin/main 2>/dev/null \
+        || die "$SHORT is not on origin/main — production deploys come from main only"
+fi
+
+# 3. Tests must have passed for THIS commit. Not for something near it.
+MARKER="$STATE_DIR/tested-$SHA"
+[ -f "$MARKER" ] || die "no passing test record for $SHORT
+       run: scripts/deploy-node.sh --record-tests   (after a green suite)"
+
+# 4. Canary soak before production. The bugs that hurt were behavioural and only showed
+#    under real traffic over time — an hourly livelock, and attribution that looked fine
+#    until a share was actually mined and its DB row inspected.
+if echo "$PRODUCTION_NODES" | grep -qw "$NODE"; then
+    SOAKED=""
+    for c in $CANARY_NODES; do
+        if [ -f "$STATE_DIR/soaked-$SHA-$c" ]; then
+            started=$(cat "$STATE_DIR/soaked-$SHA-$c")
+            elapsed=$(( ( $(date +%s) - started ) / 60 ))
+            [ "$elapsed" -ge "$SOAK_MINUTES" ] && SOAKED="$c (${elapsed}m)" && break
+        fi
+    done
+    [ -n "$SOAKED" ] || die "$SHORT has not soaked ${SOAK_MINUTES}m on a canary
+       deploy to a canary first: scripts/deploy-node.sh <canary> $BINARY --canary"
+    info "soak satisfied: $SOAKED"
+fi
+
+BIN_PATH="$REPO_ROOT/target/release/$BINARY"
+[ -f "$BIN_PATH" ] || die "$BIN_PATH not built"
+
+# ---------------------------------------------------------------- deploy
+
+SUDO='$(command -v sudo >/dev/null && echo sudo || echo)'
+TS="$(date +%Y%m%d-%H%M%S)"
+info "deploying $BINARY @ $SHORT to $NODE"
+
+scp -q -o ConnectTimeout=10 "$BIN_PATH" "$NODE:/tmp/$BINARY.new" || exit 2
+
+# Backup, atomic swap, restart. Atomic mv so a partially-copied binary is never executable.
+ssh -o ConnectTimeout=10 "$NODE" "
+set -e
+S=$SUDO
+\$S cp /opt/ghost/bin/$BINARY /opt/ghost/bin/$BINARY.bak.$TS
+\$S cp /tmp/$BINARY.new /opt/ghost/bin/$BINARY.staged
+\$S chmod 755 /opt/ghost/bin/$BINARY.staged
+\$S mv /opt/ghost/bin/$BINARY.staged /opt/ghost/bin/$BINARY
+" || exit 2
+
+case "$BINARY" in
+  ghost-pool)      SERVICE=ghost-pool ;;
+  pool_sv2)        SERVICE=sri-pool ;;
+  translator_sv2)  SERVICE=sri-translator ;;
+esac
+
+ssh -o ConnectTimeout=10 "$NODE" "S=$SUDO; \$S systemctl restart $SERVICE" || exit 2
+sleep 20
+
+# ---------------------------------------------------------------- verify
+
+ACTIVE=$(ssh -o ConnectTimeout=10 "$NODE" "systemctl is-active $SERVICE" || echo failed)
+[ "$ACTIVE" = "active" ] || { echo "SERVICE NOT ACTIVE — rolling back" >&2; ROLLBACK=1; }
+
+# Smoke test the stratum path for anything that serves miners. A green service that
+# cannot complete a handshake is not a successful deploy.
+if [ -z "${ROLLBACK:-}" ] && [ "$BINARY" != "ghost-pool" ]; then
+    IP=$(ssh -o ConnectTimeout=10 "$NODE" "hostname -I | awk '{print \$1}'")
+    if ! python3 "$REPO_ROOT/bins/translator-sv2/tests/sv1_handshake_smoke.py" "$IP" 3333 >/dev/null 2>&1; then
+        echo "SMOKE TEST FAILED — rolling back" >&2
+        ROLLBACK=1
+    fi
+fi
+
+if [ -n "${ROLLBACK:-}" ]; then
+    ssh -o ConnectTimeout=10 "$NODE" "
+set -e
+S=$SUDO
+\$S cp /opt/ghost/bin/$BINARY.bak.$TS /opt/ghost/bin/$BINARY.staged
+\$S chmod 755 /opt/ghost/bin/$BINARY.staged
+\$S mv /opt/ghost/bin/$BINARY.staged /opt/ghost/bin/$BINARY
+\$S systemctl restart $SERVICE
+"
+    echo "rolled back to $BINARY.bak.$TS" >&2
+    exit 3
+fi
+
+# Start the soak clock for this commit on this node.
+if echo "$CANARY_NODES" | grep -qw "$NODE"; then
+    date +%s > "$STATE_DIR/soaked-$SHA-$NODE"
+    info "soak clock started for $SHORT on $NODE (${SOAK_MINUTES}m required before production)"
+fi
+
+info "OK: $BINARY @ $SHORT live on $NODE (backup: $BINARY.bak.$TS)"

--- a/scripts/record-tests.sh
+++ b/scripts/record-tests.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# Run the gates and, only if they all pass, record that THIS commit is deployable.
+#
+# `deploy-node.sh` refuses to deploy a commit without this record. The record is keyed by
+# the full commit sha, so amending, rebasing or "just one more tweak" invalidates it —
+# which is the point. Yesterday's damage came from binaries that compiled but were never
+# exercised.
+#
+# Usage: scripts/record-tests.sh
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+STATE_DIR="${HOME}/.ghost-deploy"
+mkdir -p "$STATE_DIR"
+cd "$REPO_ROOT"
+
+# Tauri GUI crates are excluded exactly as CI excludes them: they need a sidecar binary
+# that isn't built here, and their absence is not a code failure.
+EXCLUDES="--exclude wraith-wallet-gui --exclude ghost-tap-desktop"
+
+[ -z "$(git status --porcelain)" ] || { echo "REFUSED: dirty tree — the record must describe a commit" >&2; exit 1; }
+
+echo "==> fmt"
+cargo fmt --all -- --check || { echo "FAILED: formatting" >&2; exit 1; }
+
+echo "==> clippy"
+cargo clippy --workspace $EXCLUDES --all-targets 2>&1 | grep -E "^error" && {
+    echo "FAILED: clippy errors" >&2; exit 1; }
+
+echo "==> check (all targets, all features)"
+cargo check --workspace $EXCLUDES --all-targets --all-features 2>&1 | grep -E "^error" && {
+    echo "FAILED: check errors" >&2; exit 1; }
+
+echo "==> tests"
+cargo test --workspace $EXCLUDES --lib --bins 2>&1 | tee /tmp/ghost-test-out.txt | grep -E "^test result" | tail -5
+grep -qE "FAILED" /tmp/ghost-test-out.txt && { echo "FAILED: test failures" >&2; exit 1; }
+
+SHA="$(git rev-parse HEAD)"
+date +%s > "${STATE_DIR}/tested-${SHA}"
+echo "OK: recorded $(git rev-parse --short HEAD) as tested — deploy-node.sh will now accept it"

--- a/scripts/record-tests.sh
+++ b/scripts/record-tests.sh
@@ -25,17 +25,33 @@ EXCLUDES="--exclude wraith-wallet-gui --exclude ghost-tap-desktop"
 echo "==> fmt"
 cargo fmt --all -- --check || { echo "FAILED: formatting" >&2; exit 1; }
 
-echo "==> clippy"
-cargo clippy --workspace $EXCLUDES --all-targets 2>&1 | grep -E "^error" && {
-    echo "FAILED: clippy errors" >&2; exit 1; }
+# NB: do NOT write these as `cmd | grep ... && { fail }`. With `set -o pipefail` a failing
+# cargo makes the whole pipeline non-zero, the `&&` short-circuits, the failure branch never
+# runs — and the gate reports success while not gating. That exact bug let a commit with two
+# clippy errors be recorded as tested. Capture output and exit code explicitly instead.
+run_gate() {
+    local name="$1"; shift
+    echo "==> $name"
+    local out status
+    out="$("$@" 2>&1)" && status=0 || status=$?
+    if [ "$status" -ne 0 ] || grep -qE "^error" <<<"$out"; then
+        echo "$out" | grep -E "^error" -A 6 | head -40 >&2
+        echo "FAILED: $name" >&2
+        exit 1
+    fi
+    echo "$out"
+}
 
-echo "==> check (all targets, all features)"
-cargo check --workspace $EXCLUDES --all-targets --all-features 2>&1 | grep -E "^error" && {
-    echo "FAILED: check errors" >&2; exit 1; }
+run_gate clippy cargo clippy --workspace $EXCLUDES --all-targets >/dev/null
+run_gate "check (all targets, all features)" \
+    cargo check --workspace $EXCLUDES --all-targets --all-features >/dev/null
 
 echo "==> tests"
-cargo test --workspace $EXCLUDES --lib --bins 2>&1 | tee /tmp/ghost-test-out.txt | grep -E "^test result" | tail -5
-grep -qE "FAILED" /tmp/ghost-test-out.txt && { echo "FAILED: test failures" >&2; exit 1; }
+test_out="$(cargo test --workspace $EXCLUDES --lib --bins 2>&1)" || {
+    echo "$test_out" | grep -E "FAILED|^error" | head -20 >&2
+    echo "FAILED: tests" >&2; exit 1; }
+grep -E "^test result" <<<"$test_out" | tail -5
+grep -qE "FAILED" <<<"$test_out" && { echo "FAILED: test failures" >&2; exit 1; }
 
 SHA="$(git rev-parse HEAD)"
 date +%s > "${STATE_DIR}/tested-${SHA}"


### PR DESCRIPTION
Encodes the deployment workflow as preconditions rather than intentions. Each check maps to a specific incident:

| check | incident |
|---|---|
| clean tree | binaries built from a dirty tree, so production ran code whose source existed on one machine |
| main-only for prod | production ran unmerged branch builds |
| test record per sha | "it compiled" treated as "it works" |
| canary soak >=60m | unverified changes reached nodes with real miners, misdirecting attribution |
| backup + atomic mv | recovery improvised each time |
| smoke + auto-rollback | a service can be `active` and still unable to serve a miner |

Canaries are vm5-vm8: not in DNS, no miners, but real nodes.

Also fixes a bug in the gate itself, found on first use: the checks were written as `cargo ... | grep -E "^error" && { fail }`, and with `set -o pipefail` a failing cargo makes the pipeline non-zero so the `&&` short-circuits and the failure branch never runs. It printed clippy errors and recorded the commit as deployable. Checks now capture output and exit status explicitly.

Plus the two clippy errors it should have caught — pre-existing tautologies in test code (`assert!(p <= u128::MAX)` where p is u128).