### PR TITLE
ci: fix the Coverage command mangled by YAML scalar folding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,13 @@ jobs:
         with:
           components: rustfmt
       - run: cargo fmt --all -- --check
+      # Runs here rather than in Coverage: this job is fast, needs no build, and
+      # runs on pull requests, so a workflow that only breaks after merge (as the
+      # Coverage job did for six commits) gets caught before it lands.
+      - name: Check workflow line continuations
+        run: |
+          python3 -m pip install --quiet pyyaml
+          ./scripts/check-workflow-scalars.sh
 
   # Clippy lints
   clippy:
@@ -176,7 +183,12 @@ jobs:
         # external infrastructure (a real bitcoin-core/ghostd node, a running
         # stratum server, a live cluster) that isn't available in CI — those
         # are exercised separately, not in the coverage gate.
-        run: cargo llvm-cov $WORKSPACE_EXCLUDES --exclude integration_tests_sv2 \
+        # Block scalar (`|`), not a plain one: a plain multi-line scalar is folded
+        # onto a single line joined with a space, and YAML leaves the backslash
+        # alone, so the shell sees `\ ` — an escaped space — and `--lib` arrives as
+        # one token with a leading space rather than as a flag.
+        run: |
+          cargo llvm-cov $WORKSPACE_EXCLUDES --exclude integration_tests_sv2 \
             --lib --bins --lcov --output-path lcov.info
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/scripts/check-workflow-scalars.sh
+++ b/scripts/check-workflow-scalars.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+#
+# Catch shell line-continuations that YAML has silently eaten.
+#
+# A `run:` written as a plain (unquoted, non-block) scalar is folded onto a single
+# line, joined with a space. YAML does not treat `\` specially, so a trailing
+# backslash survives the fold and the shell then reads `\ ` as an escaped space —
+# the next word arrives as one token with a leading space instead of as a flag.
+#
+# This broke the Coverage job on main for six consecutive commits (#428):
+#
+#     run: cargo llvm-cov $EXCLUDES --exclude integration_tests_sv2 \
+#         --lib --bins --lcov --output-path lcov.info
+#
+#   => cargo llvm-cov ... integration_tests_sv2 \ --lib --bins ...
+#   => error: unrecognized subcommand  --lib      (note the doubled space)
+#
+# Written as a block scalar (`run: |`) the newline is preserved and the backslash
+# does its normal shell job. That is the fix; this script is the guard.
+#
+# We detect it after parsing rather than by grepping the source, because the
+# post-fold string is unambiguous: backslash-then-space is always wrong, and
+# backslash-then-newline is always fine.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+python3 - "$REPO_ROOT" <<'PY'
+import sys, os, re, glob
+
+try:
+    import yaml
+except ImportError:
+    print("check-workflow-scalars: PyYAML not available, skipping", file=sys.stderr)
+    sys.exit(0)
+
+root = sys.argv[1]
+bad = []
+
+# A backslash followed by a space/tab (not a newline) in a shell command is the
+# signature of a continuation that YAML folded away.
+FOLDED = re.compile(r"\\[ \t]")
+
+def walk(node, path, wf):
+    if isinstance(node, dict):
+        for k, v in node.items():
+            if k == "run" and isinstance(v, str):
+                if FOLDED.search(v):
+                    snippet = next(
+                        (ln.strip() for ln in v.splitlines() if FOLDED.search(ln)), v.strip()
+                    )
+                    bad.append((wf, path, snippet[:120]))
+            else:
+                walk(v, f"{path}.{k}", wf)
+    elif isinstance(node, list):
+        for i, v in enumerate(node):
+            walk(v, f"{path}[{i}]", wf)
+
+files = sorted(glob.glob(os.path.join(root, ".github/workflows/*.yml")) +
+               glob.glob(os.path.join(root, ".github/workflows/*.yaml")))
+for f in files:
+    with open(f) as fh:
+        try:
+            doc = yaml.safe_load(fh)
+        except yaml.YAMLError as e:
+            print(f"check-workflow-scalars: {os.path.relpath(f, root)} does not parse: {e}", file=sys.stderr)
+            sys.exit(1)
+    walk(doc, "", os.path.relpath(f, root))
+
+if bad:
+    print("Line continuation eaten by YAML folding — use a block scalar (`run: |`):\n", file=sys.stderr)
+    for wf, path, snippet in bad:
+        print(f"  {wf}{path}", file=sys.stderr)
+        print(f"    {snippet}", file=sys.stderr)
+    print("\nA plain `run:` scalar folds onto one line and keeps the backslash, so the", file=sys.stderr)
+    print("shell sees an escaped space and the next flag becomes part of that token.", file=sys.stderr)
+    sys.exit(1)
+
+print(f"check-workflow-scalars: {len(files)} workflow(s) clean")
+PY

--- a/scripts/record-tests.sh
+++ b/scripts/record-tests.sh
@@ -25,6 +25,11 @@ EXCLUDES="--exclude wraith-wallet-gui --exclude ghost-tap-desktop"
 echo "==> fmt"
 cargo fmt --all -- --check || { echo "FAILED: formatting" >&2; exit 1; }
 
+# Cheap and first, because a broken workflow does not fail until after merge — the
+# Coverage job was red on main for six commits before anyone looked (#428).
+echo "==> workflow line continuations"
+./scripts/check-workflow-scalars.sh || { echo "FAILED: workflow scalars" >&2; exit 1; }
+
 # NB: do NOT write these as `cmd | grep ... && { fail }`. With `set -o pipefail` a failing
 # cargo makes the whole pipeline non-zero, the `&&` short-circuits, the failure branch never
 # runs — and the gate reports success while not gating. That exact bug let a commit with two


### PR DESCRIPTION
Fixes #428.

The Coverage job has failed on every push to `main` since #421 — 911496d7, 61cd542c, af657270, 0cd88e7e, c9af8b48, c5009886 — while every other job stayed green. Six red builds behind us.

It only runs on main (`if: github.ref == 'refs/heads/main'`), so it never ran on any of those PR branches. Each merged green and went red afterwards, where nobody was looking.

## What was wrong

#421 split the command across two lines with a shell backslash but left it as a plain YAML scalar:

```yaml
run: cargo llvm-cov $WORKSPACE_EXCLUDES --exclude integration_tests_sv2 \
    --lib --bins --lcov --output-path lcov.info
```

A plain multi-line scalar is folded onto one line joined with a space, and YAML has no opinion about backslashes, so the shell received:

```
cargo llvm-cov ... --exclude integration_tests_sv2 \ --lib --bins ...
```

Bash reads `\ ` as an escaped space. `--lib` was therefore not a separate word — it became one token with a leading space, no longer began with a dash, and cargo-llvm-cov took it for a subcommand:

```
error: unrecognized subcommand  --lib
```

The doubled space in that message is the argument's own leading space. That is what pins the diagnosis rather than leaving it a guess.

## The fix

Block scalar, so the newline survives and the backslash does its normal shell job. The same continuation style is already used correctly elsewhere in this file inside `run: |` blocks — the "Free disk space" step three lines above, for one.

## The guard

`scripts/check-workflow-scalars.sh` parses the workflows and flags a backslash followed by a space in any `run:`. Detecting it after parsing is what makes it reliable: post-fold, backslash-then-space is always a continuation YAML has eaten, and backslash-then-newline is always fine. Grepping the raw source cannot tell those apart.

Verified both directions:

```
$ ./scripts/check-workflow-scalars.sh              # fixed
check-workflow-scalars: 4 workflow(s) clean

$ git show c5009886:.github/workflows/ci.yml > .github/workflows/ci.yml
$ ./scripts/check-workflow-scalars.sh              # broken
Line continuation eaten by YAML folding — use a block scalar (`run: |`):

  .github/workflows/ci.yml.jobs.coverage.steps[6]
    cargo llvm-cov $WORKSPACE_EXCLUDES --exclude integration_tests_sv2 \ --lib --bins ...
exit=1
```

Wired into the Format job — fast, no build, and it runs on pull requests, so the next one gets caught before merge instead of six commits later. Also added to `record-tests.sh`.

## Still open

The wider half of #428 is that a job which can only fail after merge needs watching. Not addressed here; leaving #428 open for it once this lands.