### PR TITLE
ops: make the journal persistent

### DIFF
--- a/scripts/install-node.sh
+++ b/scripts/install-node.sh
@@ -490,6 +490,38 @@ if [ -n "${SUDO_USER:-}" ] && [ "$SUDO_USER" != "root" ] && id "$SUDO_USER" >/de
     && log "Granted ${SUDO_USER} journal read access (takes effect on next login; use 'sudo journalctl' until then)"
 fi
 
+# Persistent journal. Without /var/log/journal, `Storage=auto` keeps the journal in
+# /run/log/journal — tmpfs — which means it is capped at 10% of RAM and, more to the
+# point, is DESTROYED on every reboot and on any journald restart.
+#
+# That is not a theoretical loss. While diagnosing an hourly OOM kill, each kill wiped
+# the run-up to the previous one, and the cause took four wrong guesses to find because
+# the evidence was being deleted by the thing under investigation. Measured retention on
+# the fleet was ~3-4.5 hours, which cannot show a daily pattern at all.
+#
+# Limits are set explicitly rather than inherited: the SystemMaxUse default is 10% of the
+# filesystem, which on a large disk would let the journal grow into space the node needs.
+log "Enabling persistent journald storage"
+mkdir -p /var/log/journal
+systemd-tmpfiles --create --prefix /var/log/journal >/dev/null 2>&1 || true
+mkdir -p /etc/systemd/journald.conf.d
+cat > /etc/systemd/journald.conf.d/10-ghost.conf <<'EOF'
+# Bitcoin Ghost — journal retention. Written by install-node.sh.
+#
+# Persistent so the journal survives the restart of whatever is being diagnosed,
+# and long enough to see a daily pattern rather than only the last few hours.
+[Journal]
+Storage=persistent
+SystemMaxUse=2G
+SystemKeepFree=1G
+MaxRetentionSec=2week
+EOF
+if systemctl restart systemd-journald >/dev/null 2>&1; then
+  log "Journal is now persistent (2G cap, 2 week retention)"
+else
+  log "WARNING: could not restart systemd-journald; journal may still be volatile"
+fi
+
 # ─────────────────────── 3. download + verify binaries ───────────────────────
 log "Downloading and verifying binaries (${GHOST_VERSION})"
 TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT

--- a/scripts/ops/enable-persistent-journal.sh
+++ b/scripts/ops/enable-persistent-journal.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+#
+# Switch a node's journal from volatile to persistent.
+#
+# Without /var/log/journal, `Storage=auto` keeps the journal in /run/log/journal —
+# tmpfs. Two consequences:
+#
+#   * capped at 10% of RAM (~386 MB of 3867 MB on our nodes), and
+#   * DESTROYED on every reboot and on any journald restart.
+#
+# The second one is what actually costs. Diagnosing an hourly OOM kill, each kill
+# wiped the run-up to the previous one — the evidence was being deleted by the thing
+# under investigation, and the cause took four wrong guesses to find. Measured
+# retention across the fleet was ~3-4.5 hours, too short to show a daily pattern.
+#
+# Idempotent: safe to re-run. It does NOT touch /etc/ghost/*.toml, so unlike
+# re-running install-node.sh it cannot revert a node's stratum config (see #431).
+#
+# Usage:
+#   scripts/ops/enable-persistent-journal.sh <node> [<node> ...]
+#   scripts/ops/enable-persistent-journal.sh --check <node> [<node> ...]
+#
+#   <node>    ssh alias, e.g. ghost-vm5
+#   --check   report only, change nothing
+
+set -uo pipefail
+
+CHECK_ONLY=false
+if [ "${1:-}" = "--check" ]; then CHECK_ONLY=true; shift; fi
+
+[ $# -gt 0 ] || { echo "usage: $0 [--check] <node> [<node> ...]" >&2; exit 1; }
+
+# Sized to hold well over a week at the observed ~35 MB per 4h (~210 MB/day), while
+# leaving the node room: SystemMaxUse is an explicit cap because the default is 10%
+# of the filesystem, which on a large disk would let the journal grow into space the
+# node needs. SystemKeepFree is the floor journald will not eat into.
+read -r -d '' DROPIN <<'EOF' || true
+# Bitcoin Ghost — journal retention. Managed by scripts/ops/enable-persistent-journal.sh.
+#
+# Persistent so the journal survives the restart of whatever is being diagnosed,
+# and long enough to see a daily pattern rather than only the last few hours.
+[Journal]
+Storage=persistent
+SystemMaxUse=2G
+SystemKeepFree=1G
+MaxRetentionSec=2week
+EOF
+
+rc=0
+for NODE in "$@"; do
+    echo "=== $NODE ==="
+
+    before="$(ssh -o ConnectTimeout=10 -o BatchMode=yes "$NODE" '
+        printf "%s|%s|%s|%s" \
+          "$([ -d /var/log/journal ] && echo persistent || echo volatile)" \
+          "$(journalctl --disk-usage 2>/dev/null | grep -oE "[0-9.]+[KMG]" | head -1)" \
+          "$(journalctl -o short-iso --no-pager 2>/dev/null | head -1 | cut -d" " -f1)" \
+          "$(df -BG --output=avail /var 2>/dev/null | tail -1 | tr -d " G")"
+    ' 2>/dev/null)" || { echo "  UNREACHABLE"; rc=1; continue; }
+
+    IFS='|' read -r mode usage earliest avail <<<"$before"
+    echo "  storage=${mode} usage=${usage:-?} earliest=${earliest:-?} /var free=${avail:-?}G"
+
+    if [ "$mode" = "persistent" ]; then
+        echo "  already persistent — nothing to do"
+        continue
+    fi
+
+    if $CHECK_ONLY; then
+        echo "  WOULD switch to persistent (--check given, no change made)"
+        rc=1
+        continue
+    fi
+
+    # 3G is SystemMaxUse + SystemKeepFree. Refuse rather than configure a node into a
+    # disk-full condition; a full /var takes the node down, which is worse than short logs.
+    if [ -n "$avail" ] && [ "$avail" -lt 4 ]; then
+        echo "  REFUSED: only ${avail}G free on /var, need >4G for a 2G cap plus 1G floor"
+        rc=1
+        continue
+    fi
+
+    if ! printf '%s\n' "$DROPIN" | ssh -o ConnectTimeout=10 "$NODE" '
+        set -e
+        S=$(command -v sudo >/dev/null && echo sudo || echo)
+        $S mkdir -p /etc/systemd/journald.conf.d /var/log/journal
+        $S tee /etc/systemd/journald.conf.d/10-ghost.conf >/dev/null
+        $S systemd-tmpfiles --create --prefix /var/log/journal >/dev/null 2>&1 || true
+        $S systemctl restart systemd-journald
+    ' 2>&1 | sed 's/^/    /'; then
+        echo "  FAILED to apply"
+        rc=1
+        continue
+    fi
+
+    after="$(ssh -o ConnectTimeout=10 "$NODE" '
+        printf "%s|%s" \
+          "$([ -d /var/log/journal ] && echo persistent || echo volatile)" \
+          "$(journalctl --no-pager -n1 >/dev/null 2>&1 && echo readable || echo UNREADABLE)"
+    ' 2>/dev/null)"
+    IFS='|' read -r mode2 readable <<<"$after"
+    echo "  now: storage=${mode2} journal=${readable}"
+
+    # Verify rather than assume: a drop-in that does not parse leaves journald running
+    # on the old settings and reports active either way.
+    if [ "$mode2" != "persistent" ] || [ "$readable" != "readable" ]; then
+        echo "  VERIFY FAILED"
+        rc=1
+    fi
+done
+
+exit $rc


### PR DESCRIPTION
Fixes #414.

The problem is not that retention was tuned too short — nothing was tuned at all. `/var/log/journal` does not exist on any node, so `Storage=auto` falls back to `/run/log/journal`, which is tmpfs.

```
/var/log/journal exists: NO
/run/log/journal exists: YES
effective Storage:        (unset -> auto)
```

Two consequences:

1. **Capped at 10% of RAM** (~386M of 3867M). In practice we were holding 34-36M, about 3-4.5 hours:

   | node | on disk | earliest held | span |
   |---|---|---|---|
   | vm1 | 34.1M | 19:16 | ~4.6h |
   | vm3 | 35.9M | 20:46 | ~3.1h |
   | vm5 | 34.2M | 20:00 | ~3.9h |

2. **Wiped on every reboot and on any journald restart.** This is the one that actually cost. While `ghost-pool` was being OOM-killed hourly, each kill destroyed the run-up to the previous one. It is a large part of why those restarts took four wrong diagnoses before a heap profile settled it — the evidence was being deleted by the thing under investigation.

Not a disk problem: /var had 5.9G free on the tightest node, 29G on vm3.

## Changes

**`scripts/install-node.sh`** — creates `/var/log/journal` and writes `/etc/systemd/journald.conf.d/10-ghost.conf`:

```
Storage=persistent
SystemMaxUse=2G
SystemKeepFree=1G
MaxRetentionSec=2week
```

Limits are explicit rather than inherited: the `SystemMaxUse` default is 10% of the filesystem, which on a large disk would let the journal grow into space the node needs. At the observed ~35M per 4h (~210M/day) a 2G cap holds well over the two weeks.

**`scripts/ops/enable-persistent-journal.sh`** — for nodes that already exist. Re-running the installer is not an option: it rewrites `/etc/ghost/*.toml` and would revert a node stratum config (#431). This script does only this one change.

- Idempotent; reports "already persistent" and exits clean.
- `--check` reports without changing anything.
- Refuses a node with under 4G free on `/var` rather than configuring it into a disk-full condition — a full `/var` takes the node down, which is worse than short logs.
- Verifies afterwards rather than trusting the restart. A drop-in that fails to parse leaves journald running on the old settings and `active` either way, so "restarted OK" proves nothing.

## Canary

`ghost-vm6`:

```
before  storage=volatile  usage=34.1M  earliest=2026-07-25T19:55  /var free=7G
after   storage=persistent  SystemMaxUse=2G  MaxRetentionSec=2week
        journald=active ghost-pool=active sri-pool=active tr=active
        journal writing: 2026-07-26T00:03:53
```

Rest of the fleet after this lands.

## Note

The `--check` mode exits non-zero when a node would be changed, so it can be used as a drift gate. That overlaps with #413 and is the natural place to wire it in.