### PR TITLE
ops: restart-loop watchdog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,11 @@ jobs:
         run: |
           python3 -m pip install --quiet pyyaml
           ./scripts/check-workflow-scalars.sh
+      # install-node.sh embeds copies of scripts it installs (it is fetched standalone
+      # and has no repo to read). Nothing checked they stayed in step, which is how the
+      # vardiff floor was fixed in one copy and not the other (#431).
+      - name: Check inlined installer copies
+        run: ./scripts/check-inlined-copies.sh
 
   # Clippy lints
   clippy:

--- a/scripts/check-inlined-copies.sh
+++ b/scripts/check-inlined-copies.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+#
+# Catch drift between a file and the copy of it inlined in install-node.sh.
+#
+# install-node.sh is fetched standalone over curl and has no repo to read from, so
+# scripts and units it installs are embedded as heredocs. Each embedded copy names a
+# "canonical source" in the repo — and nothing has ever checked that the two still
+# agree.
+#
+# That is not hypothetical. The vardiff floor was corrected in
+# config/sri/translator-config.toml and not in the installer heredoc, so a fresh node
+# would have been provisioned with the old value and re-broken the thing the change
+# fixed (#431). The same shape of bug is available for every inlined script.
+#
+# This compares each pair byte-for-byte and fails on any difference. It cannot remove
+# the duplication — the delivery model forces it — but it makes divergence loud
+# instead of silent.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+python3 - <<'PY'
+import re, sys, os
+
+INSTALLER = "scripts/install-node.sh"
+
+# heredoc marker -> canonical source in the repo
+PAIRS = {
+    "GHOST_RESTART_WATCH_SH_EOF":      "scripts/ghost-restart-watch.sh",
+    "GHOST_RESTART_WATCH_SERVICE_EOF": "scripts/systemd/ghost-restart-watch.service",
+    "GHOST_RESTART_WATCH_TIMER_EOF":   "scripts/systemd/ghost-restart-watch.timer",
+}
+
+src = open(INSTALLER).read()
+bad = []
+
+for marker, path in PAIRS.items():
+    m = re.search(r"<<'" + re.escape(marker) + r"'\n(.*?)" + re.escape(marker) + r"\n", src, re.S)
+    if not m:
+        bad.append((path, f"heredoc {marker} not found in {INSTALLER}"))
+        continue
+    if not os.path.exists(path):
+        bad.append((path, "canonical source missing"))
+        continue
+    inlined, canonical = m.group(1), open(path).read()
+    if inlined != canonical:
+        # Show the first differing line rather than a wall of diff.
+        il, cl = inlined.splitlines(), canonical.splitlines()
+        detail = f"{len(il)} inlined lines vs {len(cl)} canonical"
+        for i, (a, b) in enumerate(zip(il, cl), 1):
+            if a != b:
+                detail = f"first difference at line {i}:\n      installer: {a.strip()[:90]}\n      canonical: {b.strip()[:90]}"
+                break
+        bad.append((path, detail))
+
+if bad:
+    print(f"Inlined copies in {INSTALLER} have drifted from their canonical sources:\n", file=sys.stderr)
+    for path, detail in bad:
+        print(f"  {path}", file=sys.stderr)
+        print(f"    {detail}", file=sys.stderr)
+    print("\nUpdate both, or the next fresh node is provisioned from the stale copy.", file=sys.stderr)
+    sys.exit(1)
+
+print(f"check-inlined-copies: {len(PAIRS)} inlined copies match their sources")
+PY

--- a/scripts/ghost-restart-watch.sh
+++ b/scripts/ghost-restart-watch.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+#
+# Restart-loop watchdog.
+#
+# sri-pool reached 84-88 restarts on three nodes and nothing surfaced it — it was found
+# by accident, long after the fact. systemd restarts a crashing service forever and
+# reports it `active` between crashes, so every dashboard and every `is-active` check
+# says the node is fine while it is in fact dying on a loop.
+#
+# This watches the RATE, not the total. NRestarts is cumulative since the last
+# daemon-reload, so a node that crash-looped last week and has been stable since still
+# shows a large number; and a `systemctl daemon-reload` silently resets it to zero. What
+# matters is "how many restarts in the last N minutes", which is the delta between runs.
+#
+# Alerting: a webhook if one is configured, and always a journal entry at error priority.
+# The journal is only useful because it is now persistent (#414) — before that, a restart
+# loop erased its own evidence roughly every four hours.
+#
+# Config, all optional, /etc/ghost/alerting.conf:
+#   ALERT_WEBHOOK=https://...     POST {"text": "..."} on alert. No default: without it
+#                                 this logs and nothing else. See the note in #412.
+#   RESTART_THRESHOLD=3           restarts within one window before alerting
+#   RESTART_RENOTIFY_SECS=3600    minimum gap between repeat alerts for the same unit
+#
+# Usage:
+#   ghost-restart-watch.sh          # normal run, intended for the timer
+#   ghost-restart-watch.sh --check  # report current state, never alert, never persist
+
+set -uo pipefail
+
+CONF=/etc/ghost/alerting.conf
+STATE_DIR=/var/lib/ghost/restart-watch
+UNITS="ghost-pool sri-pool sri-translator ghostd"
+
+ALERT_WEBHOOK=""
+RESTART_THRESHOLD=3
+RESTART_RENOTIFY_SECS=3600
+# shellcheck source=/dev/null
+[ -r "$CONF" ] && . "$CONF"
+
+CHECK_ONLY=false
+[ "${1:-}" = "--check" ] && CHECK_ONLY=true
+
+$CHECK_ONLY || mkdir -p "$STATE_DIR"
+now=$(date +%s)
+problems=()
+
+for unit in $UNITS; do
+    systemctl list-unit-files "${unit}.service" >/dev/null 2>&1 || continue
+    systemctl cat "$unit" >/dev/null 2>&1 || continue
+
+    n=$(systemctl show -p NRestarts --value "$unit" 2>/dev/null)
+    [ -n "$n" ] || continue
+
+    f="$STATE_DIR/$unit"
+    prev_n=""; prev_t=""; last_alert=0
+    [ -r "$f" ] && read -r prev_n prev_t last_alert < "$f" 2>/dev/null
+    : "${last_alert:=0}"
+
+    if $CHECK_ONLY; then
+        printf "  %-16s NRestarts=%s active=%s\n" "$unit" "$n" "$(systemctl is-active "$unit")"
+        continue
+    fi
+
+    # First run for this unit, or the counter went backwards because something ran
+    # daemon-reload. Either way there is no meaningful delta — record and move on
+    # rather than inventing one.
+    if [ -z "$prev_n" ] || [ "$n" -lt "$prev_n" ]; then
+        printf '%s %s %s\n' "$n" "$now" "$last_alert" > "$f"
+        continue
+    fi
+
+    delta=$(( n - prev_n ))
+    elapsed=$(( now - ${prev_t:-$now} ))
+
+    if [ "$delta" -ge "$RESTART_THRESHOLD" ]; then
+        mins=$(( elapsed / 60 )); [ "$mins" -lt 1 ] && mins=1
+        msg="$(hostname -s): ${unit} restarted ${delta} times in ${mins}m (total ${n})"
+
+        if [ $(( now - last_alert )) -ge "$RESTART_RENOTIFY_SECS" ]; then
+            logger -t ghost-restart-watch -p daemon.err -- "$msg" 2>/dev/null || true
+            echo "ALERT: $msg" >&2
+            if [ -n "$ALERT_WEBHOOK" ]; then
+                payload=$(printf '{"text":"Ghost alert: %s"}' "$msg")
+                curl -fsS -m 10 -X POST -H 'Content-Type: application/json' \
+                     -d "$payload" "$ALERT_WEBHOOK" >/dev/null 2>&1 \
+                  || logger -t ghost-restart-watch -p daemon.warning -- \
+                       "webhook POST failed for: $msg" 2>/dev/null || true
+            fi
+            last_alert=$now
+        fi
+        problems+=("$msg")
+    fi
+
+    printf '%s %s %s\n' "$n" "$now" "$last_alert" > "$f"
+done
+
+# Non-zero when something is looping, so this is usable as a check from elsewhere
+# (a fleet script, a CI job, a human) and not only as a timer that mails itself.
+[ ${#problems[@]} -eq 0 ]

--- a/scripts/install-node.sh
+++ b/scripts/install-node.sh
@@ -1695,6 +1695,163 @@ GHOST_AUTOUPDATE_SH_EOF
 chmod 755 /opt/ghost/bin/ghost-auto-update.sh
 chown root:root /opt/ghost/bin/ghost-auto-update.sh
 
+# ── restart-loop watchdog ────────────────────────────────────────────────────
+# systemd restarts a crashing service forever and reports it `active` between
+# crashes, so `is-active` and every dashboard say the node is healthy while it is
+# dying on a loop. sri-pool reached 84-88 restarts on three nodes and nothing
+# surfaced it (#412). This watches the restart RATE and complains.
+#
+# Canonical source: scripts/ghost-restart-watch.sh — kept in step by hand, same as
+# ghost-auto-update.sh above. The installer is fetched standalone over curl and has
+# no repo to read from, which is why these are duplicated; see #431.
+cat > /opt/ghost/bin/ghost-restart-watch.sh <<'GHOST_RESTART_WATCH_SH_EOF'
+#!/usr/bin/env bash
+#
+# Restart-loop watchdog.
+#
+# sri-pool reached 84-88 restarts on three nodes and nothing surfaced it — it was found
+# by accident, long after the fact. systemd restarts a crashing service forever and
+# reports it `active` between crashes, so every dashboard and every `is-active` check
+# says the node is fine while it is in fact dying on a loop.
+#
+# This watches the RATE, not the total. NRestarts is cumulative since the last
+# daemon-reload, so a node that crash-looped last week and has been stable since still
+# shows a large number; and a `systemctl daemon-reload` silently resets it to zero. What
+# matters is "how many restarts in the last N minutes", which is the delta between runs.
+#
+# Alerting: a webhook if one is configured, and always a journal entry at error priority.
+# The journal is only useful because it is now persistent (#414) — before that, a restart
+# loop erased its own evidence roughly every four hours.
+#
+# Config, all optional, /etc/ghost/alerting.conf:
+#   ALERT_WEBHOOK=https://...     POST {"text": "..."} on alert. No default: without it
+#                                 this logs and nothing else. See the note in #412.
+#   RESTART_THRESHOLD=3           restarts within one window before alerting
+#   RESTART_RENOTIFY_SECS=3600    minimum gap between repeat alerts for the same unit
+#
+# Usage:
+#   ghost-restart-watch.sh          # normal run, intended for the timer
+#   ghost-restart-watch.sh --check  # report current state, never alert, never persist
+
+set -uo pipefail
+
+CONF=/etc/ghost/alerting.conf
+STATE_DIR=/var/lib/ghost/restart-watch
+UNITS="ghost-pool sri-pool sri-translator ghostd"
+
+ALERT_WEBHOOK=""
+RESTART_THRESHOLD=3
+RESTART_RENOTIFY_SECS=3600
+# shellcheck source=/dev/null
+[ -r "$CONF" ] && . "$CONF"
+
+CHECK_ONLY=false
+[ "${1:-}" = "--check" ] && CHECK_ONLY=true
+
+$CHECK_ONLY || mkdir -p "$STATE_DIR"
+now=$(date +%s)
+problems=()
+
+for unit in $UNITS; do
+    systemctl list-unit-files "${unit}.service" >/dev/null 2>&1 || continue
+    systemctl cat "$unit" >/dev/null 2>&1 || continue
+
+    n=$(systemctl show -p NRestarts --value "$unit" 2>/dev/null)
+    [ -n "$n" ] || continue
+
+    f="$STATE_DIR/$unit"
+    prev_n=""; prev_t=""; last_alert=0
+    [ -r "$f" ] && read -r prev_n prev_t last_alert < "$f" 2>/dev/null
+    : "${last_alert:=0}"
+
+    if $CHECK_ONLY; then
+        printf "  %-16s NRestarts=%s active=%s\n" "$unit" "$n" "$(systemctl is-active "$unit")"
+        continue
+    fi
+
+    # First run for this unit, or the counter went backwards because something ran
+    # daemon-reload. Either way there is no meaningful delta — record and move on
+    # rather than inventing one.
+    if [ -z "$prev_n" ] || [ "$n" -lt "$prev_n" ]; then
+        printf '%s %s %s\n' "$n" "$now" "$last_alert" > "$f"
+        continue
+    fi
+
+    delta=$(( n - prev_n ))
+    elapsed=$(( now - ${prev_t:-$now} ))
+
+    if [ "$delta" -ge "$RESTART_THRESHOLD" ]; then
+        mins=$(( elapsed / 60 )); [ "$mins" -lt 1 ] && mins=1
+        msg="$(hostname -s): ${unit} restarted ${delta} times in ${mins}m (total ${n})"
+
+        if [ $(( now - last_alert )) -ge "$RESTART_RENOTIFY_SECS" ]; then
+            logger -t ghost-restart-watch -p daemon.err -- "$msg" 2>/dev/null || true
+            echo "ALERT: $msg" >&2
+            if [ -n "$ALERT_WEBHOOK" ]; then
+                payload=$(printf '{"text":"Ghost alert: %s"}' "$msg")
+                curl -fsS -m 10 -X POST -H 'Content-Type: application/json' \
+                     -d "$payload" "$ALERT_WEBHOOK" >/dev/null 2>&1 \
+                  || logger -t ghost-restart-watch -p daemon.warning -- \
+                       "webhook POST failed for: $msg" 2>/dev/null || true
+            fi
+            last_alert=$now
+        fi
+        problems+=("$msg")
+    fi
+
+    printf '%s %s %s\n' "$n" "$now" "$last_alert" > "$f"
+done
+
+# Non-zero when something is looping, so this is usable as a check from elsewhere
+# (a fleet script, a CI job, a human) and not only as a timer that mails itself.
+[ ${#problems[@]} -eq 0 ]
+GHOST_RESTART_WATCH_SH_EOF
+chmod 755 /opt/ghost/bin/ghost-restart-watch.sh
+chown root:root /opt/ghost/bin/ghost-restart-watch.sh
+mkdir -p /var/lib/ghost/restart-watch
+
+cat > /etc/systemd/system/ghost-restart-watch.service <<'GHOST_RESTART_WATCH_SERVICE_EOF'
+[Unit]
+Description=Bitcoin Ghost restart-loop watchdog
+Documentation=https://github.com/bitcoin-ghost/ghost/issues/412
+# Only meaningful once the node is up; never block boot on it.
+After=network-online.target ghostd.service ghost-pool.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/opt/ghost/bin/ghost-restart-watch.sh
+# systemctl show and the state directory under /var/lib both need root.
+User=root
+# The script exits non-zero when a service is looping — that is a finding, not a
+# failure of the check. Without this, the thing that reports problems would itself
+# show up as a failed unit, which is exactly the noise that gets ignored.
+SuccessExitStatus=0 1
+GHOST_RESTART_WATCH_SERVICE_EOF
+
+cat > /etc/systemd/system/ghost-restart-watch.timer <<'GHOST_RESTART_WATCH_TIMER_EOF'
+[Unit]
+Description=Run the Bitcoin Ghost restart-loop watchdog every 5 minutes
+Documentation=https://github.com/bitcoin-ghost/ghost/issues/412
+
+[Timer]
+# Five minutes: short enough that a loop is caught while it is still happening rather
+# than reconstructed afterwards, long enough that the restart delta is meaningful.
+OnBootSec=5min
+OnUnitActiveSec=5min
+# Do not let every node in the fleet fire at the same instant and stampede a webhook.
+RandomizedDelaySec=60
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+GHOST_RESTART_WATCH_TIMER_EOF
+
+systemctl daemon-reload 2>/dev/null || true
+systemctl enable --now ghost-restart-watch.timer >/dev/null 2>&1 \
+  && log "Restart-loop watchdog enabled (every 5 min)" \
+  || log "WARNING: could not enable ghost-restart-watch.timer"
+
 # The privileged toggle the dashboard may sudo (scoped to on|off only).
 cat > /opt/ghost/bin/ghost-autoupdate-toggle <<'GHOST_AUTOUPDATE_TOGGLE_EOF'
 #!/usr/bin/env bash

--- a/scripts/ops/install-restart-watch.sh
+++ b/scripts/ops/install-restart-watch.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+#
+# Install the restart-loop watchdog on nodes that already exist.
+#
+# Re-running install-node.sh is not an option for an existing node: it rewrites
+# /etc/ghost/*.toml and would revert that node's stratum config (#431). This installs
+# only the watchdog.
+#
+# Usage:
+#   scripts/ops/install-restart-watch.sh <node> [<node> ...]
+#   scripts/ops/install-restart-watch.sh --check <node> [<node> ...]
+#
+#   --check   report whether it is installed and what it currently sees; change nothing
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+CHECK_ONLY=false
+if [ "${1:-}" = "--check" ]; then CHECK_ONLY=true; shift; fi
+[ $# -gt 0 ] || { echo "usage: $0 [--check] <node> [<node> ...]" >&2; exit 1; }
+
+SCRIPT="$REPO_ROOT/ghost-restart-watch.sh"
+SERVICE="$REPO_ROOT/systemd/ghost-restart-watch.service"
+TIMER="$REPO_ROOT/systemd/ghost-restart-watch.timer"
+for f in "$SCRIPT" "$SERVICE" "$TIMER"; do
+    [ -r "$f" ] || { echo "missing: $f" >&2; exit 1; }
+done
+
+rc=0
+for NODE in "$@"; do
+    echo "=== $NODE ==="
+
+    if $CHECK_ONLY; then
+        ssh -o ConnectTimeout=10 -o BatchMode=yes "$NODE" '
+            if [ -x /opt/ghost/bin/ghost-restart-watch.sh ]; then
+                printf "  installed=yes timer=%s\n" "$(systemctl is-active ghost-restart-watch.timer 2>/dev/null)"
+                /opt/ghost/bin/ghost-restart-watch.sh --check
+            else
+                echo "  installed=no"
+                exit 1
+            fi
+        ' 2>&1 || rc=1
+        continue
+    fi
+
+    if ! { tar -C "$(dirname "$SCRIPT")" -cf - "$(basename "$SCRIPT")" \
+             -C "$(dirname "$SERVICE")" "$(basename "$SERVICE")" "$(basename "$TIMER")" \
+           | ssh -o ConnectTimeout=10 "$NODE" '
+        set -e
+        S=$(command -v sudo >/dev/null && echo sudo || echo)
+        t=$(mktemp -d); trap "rm -rf $t" EXIT
+        tar -C "$t" -xf -
+        $S install -m 755 -o root -g root "$t/ghost-restart-watch.sh" /opt/ghost/bin/ghost-restart-watch.sh
+        $S install -m 644 -o root -g root "$t/ghost-restart-watch.service" /etc/systemd/system/
+        $S install -m 644 -o root -g root "$t/ghost-restart-watch.timer"   /etc/systemd/system/
+        $S mkdir -p /var/lib/ghost/restart-watch
+        $S systemctl daemon-reload
+        $S systemctl enable --now ghost-restart-watch.timer
+    '; }; then
+        echo "  FAILED to install"
+        rc=1
+        continue
+    fi
+
+    # Verify rather than assume. `enable --now` reports success for a timer whose
+    # service cannot run, so check the timer is active AND the script executes.
+    out="$(ssh -o ConnectTimeout=10 "$NODE" '
+        printf "  timer=%s\n" "$(systemctl is-active ghost-restart-watch.timer)"
+        /opt/ghost/bin/ghost-restart-watch.sh --check
+    ' 2>&1)" || rc=1
+    echo "$out"
+    grep -q "timer=active" <<<"$out" || { echo "  VERIFY FAILED: timer not active"; rc=1; }
+done
+
+if [ $rc -ne 0 ]; then
+    echo
+    echo "One or more nodes did not end up in the expected state."
+fi
+exit $rc

--- a/scripts/record-tests.sh
+++ b/scripts/record-tests.sh
@@ -30,6 +30,9 @@ cargo fmt --all -- --check || { echo "FAILED: formatting" >&2; exit 1; }
 echo "==> workflow line continuations"
 ./scripts/check-workflow-scalars.sh || { echo "FAILED: workflow scalars" >&2; exit 1; }
 
+echo "==> inlined installer copies"
+./scripts/check-inlined-copies.sh || { echo "FAILED: inlined copies drifted" >&2; exit 1; }
+
 # NB: do NOT write these as `cmd | grep ... && { fail }`. With `set -o pipefail` a failing
 # cargo makes the whole pipeline non-zero, the `&&` short-circuits, the failure branch never
 # runs — and the gate reports success while not gating. That exact bug let a commit with two

--- a/scripts/systemd/ghost-restart-watch.service
+++ b/scripts/systemd/ghost-restart-watch.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Bitcoin Ghost restart-loop watchdog
+Documentation=https://github.com/bitcoin-ghost/ghost/issues/412
+# Only meaningful once the node is up; never block boot on it.
+After=network-online.target ghostd.service ghost-pool.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/opt/ghost/bin/ghost-restart-watch.sh
+# systemctl show and the state directory under /var/lib both need root.
+User=root
+# The script exits non-zero when a service is looping — that is a finding, not a
+# failure of the check. Without this, the thing that reports problems would itself
+# show up as a failed unit, which is exactly the noise that gets ignored.
+SuccessExitStatus=0 1

--- a/scripts/systemd/ghost-restart-watch.timer
+++ b/scripts/systemd/ghost-restart-watch.timer
@@ -1,0 +1,15 @@
+[Unit]
+Description=Run the Bitcoin Ghost restart-loop watchdog every 5 minutes
+Documentation=https://github.com/bitcoin-ghost/ghost/issues/412
+
+[Timer]
+# Five minutes: short enough that a loop is caught while it is still happening rather
+# than reconstructed afterwards, long enough that the restart delta is meaningful.
+OnBootSec=5min
+OnUnitActiveSec=5min
+# Do not let every node in the fleet fire at the same instant and stampede a webhook.
+RandomizedDelaySec=60
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Fixes #412.

`sri-pool` reached 84-88 restarts on three nodes and nothing surfaced it. systemd restarts a crashing service forever and reports it `active` between crashes, so `is-active` and every dashboard call the node healthy while it is dying on a loop.

## What it watches

The restart **rate**, not the total. `NRestarts` is cumulative since the last `daemon-reload`, so a node that looped last week still shows a large number, and a `daemon-reload` silently resets it to zero. Neither tells you whether anything is wrong *now*. The delta between runs does.

A negative delta means the counter was reset, so the baseline is re-seeded rather than a bogus rate invented.

Watches `ghost-pool`, `sri-pool`, `sri-translator`, `ghostd`; skips any that are not installed.

## Where alerts go — needs your input

A webhook if `/etc/ghost/alerting.conf` sets `ALERT_WEBHOOK`, and always the journal at error priority.

**There is no webhook configured anywhere today.** `health-check.sh` has supported `--alert-webhook` for a long time and nothing passes one, and nothing schedules it either — `ghost-web/docs/deployment.md` says it should run every 15 minutes and no timer exists. So without a URL from you this logs and does nothing else, which is better than now but is not "an alert fires before it is noticed by hand".

Tell me where alerts should go and I will wire it up. Same URL would fix `health-check.sh` at the same time.

The journal half is only useful because the journal is now persistent (#414) — before that a restart loop erased its own evidence every few hours.

## Verified on ghost-vm5

```
seeded baseline                 -> no alert, exit 0
simulated 5 restarts over 10m   -> ALERT: ghost-pool restarted 5 times in 10m, exit 1
immediate re-run                -> silent, exit 0   (renotify window)
journal entry present under tag ghost-restart-watch
systemd run: Result=success ExecMainStatus=0, four state files seeded
timer active + enabled, next run in 5 min
```

Not exercised: the renotify branch itself. After an alert the baseline moves to current, so the delta resets and a second alert needs a fresh burst. Stating that rather than implying full coverage.

Exits non-zero when something is looping, so it works as a check from anywhere and not only as a timer. `SuccessExitStatus=0 1` stops that marking the unit failed — a watchdog that reports problems by failing is noise that gets ignored.

## Install path

- Fresh nodes: `install-node.sh`.
- Existing nodes: `scripts/ops/install-restart-watch.sh`. Re-running the installer is not an option there — it rewrites `/etc/ghost/*.toml` and would revert that node stratum config (#431).

## Also: a guard for the duplication problem

`install-node.sh` is fetched standalone over curl and has no repo to read, so it embeds copies of what it installs. Nothing has ever checked those stayed in step with the "canonical source" they each name. That is exactly how the vardiff floor came to be fixed in `config/sri/translator-config.toml` and not in the installer (#431).

`scripts/check-inlined-copies.sh` compares each pair byte-for-byte and reports the first differing line:

```
$ ./scripts/check-inlined-copies.sh
check-inlined-copies: 3 inlined copies match their sources

$ printf "\n# drift\n" >> scripts/ghost-restart-watch.sh
$ ./scripts/check-inlined-copies.sh
Inlined copies in scripts/install-node.sh have drifted from their canonical sources:
  scripts/ghost-restart-watch.sh
    100 inlined lines vs 102 canonical
exit=1
```

Wired into the Format job and `record-tests.sh`. It does not remove the duplication — the delivery model forces that — but it makes divergence loud instead of silent. It covers the three files added here; extending it to `ghost-auto-update.sh` is worth doing and belongs with #431.