### PR TITLE
fix(web): stop the pool page painting zeros before it has any data

### DIFF
--- a/ghost-web/pool.html
+++ b/ghost-web/pool.html
@@ -607,6 +607,26 @@
     if (rlNotice) rlNotice.classList.toggle('show', !!on);
   }
 
+  // Have we ever had a real answer from a node? Until we have, the tiles keep the
+  // `—` they ship with, because a measured 0 and an unknown are different claims and
+  // only one of them is ours to make. `failedPolls` counts consecutive empty polls
+  // from a cold start so we can say "unreachable" instead of dashing forever.
+  var haveData = false;
+  var failedPolls = 0;
+  function setPoolUnreachable(on) {
+    var el = document.getElementById('m-hashrate');
+    if (!el) return;
+    // Only ever touches the tiles while haveData is false, so this cannot overwrite
+    // real numbers with an error state.
+    if (on) {
+      document.getElementById('m-hashrate').textContent = '—';
+      document.getElementById('m-miners').textContent = '—';
+      document.getElementById('m-blocks').textContent = '—';
+      document.getElementById('m-height').textContent = '—';
+      dbg('all nodes unreachable — tiles left blank rather than zeroed');
+    }
+  }
+
   function fetchNode(node) {
     var ctl = new AbortController();
     var t = setTimeout(function () { ctl.abort(); }, 5000);
@@ -652,13 +672,37 @@
       // we were throttled this tick and have no fresh data to show.
       if (okCount > 0) setRateLimited(false);
       else if (rateLimited) setRateLimited(true);
-      // No usable responses (throttled or transient) — don't blank the tiles.
-      // Keep the last good numbers; the notice explains the pause.
-      if (okCount === 0 && lastStats.height) {
-        dbg(rateLimited ? 'poll skip · rate-limited — preserving last view'
-                        : 'poll skip · 0/4 nodes — preserving last view');
+      // No usable responses (throttled or transient) — don't blank the tiles, and
+      // never paint zeros we have not measured.
+      //
+      // This used to be gated on `lastStats.height`, i.e. "only preserve if we have
+      // something to preserve". That inverted the intent on the very first poll:
+      // lastStats starts all-zero, so height was falsy, the guard did not fire, and
+      // the code fell through and rendered `0 TH/s · 0 MINERS · 0 BLOCKS`. The one
+      // moment we have nothing to show was the one moment we claimed the pool was
+      // dead — on the public page a prospective miner lands on. Zero is a factual
+      // claim about the pool; we must not make it while we simply do not know yet.
+      //
+      // The markup ships the tiles as `—`, so returning early on a first-poll
+      // failure leaves them in their loading state, which is the honest answer.
+      if (okCount === 0) {
+        if (haveData) {
+          dbg(rateLimited ? 'poll skip · rate-limited — preserving last view'
+                          : 'poll skip · 0/4 nodes — preserving last view');
+        } else {
+          // Nothing measured yet AND nobody answered. Distinguish "still connecting"
+          // from "every node is unreachable" rather than showing a bare dash forever.
+          failedPolls++;
+          dbg('poll skip · 0/' + POOL_NODES.length + ' nodes, no data yet (attempt ' + failedPolls + ')');
+          if (failedPolls >= 3) setPoolUnreachable(true);
+        }
         return;
       }
+      // Somebody answered: we now have measured numbers, so the tiles may show them.
+      // No need to clear an unreachable state — renderMetrics below overwrites every
+      // tile with a real value on this same tick.
+      haveData = true;
+      failedPolls = 0;
       var hashrate = 0, meshHashrate = null, sumLocal = 0, blocks = 0, height = 0, mesh = null, maxActive = 0;
       good.forEach(function (r) {
         if (!r) return;


### PR DESCRIPTION
Fixes #427.

Loading `/pool` showed `0 TH/s · 0 MINERS · 0 BLOCKS` with `BLOCK HEIGHT` as a dash, while the pool was fine — `mesh_active_miners` 8 at 109 TH/s, all four nodes answering HTTP 200.

## Cause

The tiles ship as em-dashes in the markup and `renderMetrics` has a single call site, after the poll. So the zeros could only come from the one guard that exists to prevent exactly this:

```js
if (okCount === 0 && lastStats.height) { ...preserve last view...; return; }
```

`lastStats` starts all-zero, so on the **first** poll `height` is falsy, the guard does not fire, execution falls through, and the tiles are painted from those initial zeros.

The one moment there is nothing to preserve is the one moment the check declined to protect. And it is the moment a first-time visitor is looking.

Zero is a factual claim about the pool being dead. We should not make it while we simply do not know yet — on the public page, that costs us miners.

## Fix

The guard now returns on any empty poll, not only when there is a previous value. Because the markup already ships dashes, returning early leaves the tiles in their loading state, which is the honest answer.

A `haveData` flag distinguishes a cold start from a later dropped poll, and after three consecutive empty polls from cold the tiles are explicitly set to dashes, so an all-nodes-down case reads as *unknown* rather than sitting blank by coincidence.

## Verified

Ran the old and new guard against a first poll that returns nothing. The old one reproduces the reported screenshot exactly:

```
First poll, 0/4 nodes answered, nothing measured yet:
  OLD        hashrate=0 miners=0 blocks=0 height=—
  NEW        hashrate=— miners=— blocks=— height=—
```

Audited every write path: `renderMetrics` has one call site, after the guard and after `haveData` is set; the only other tile writes are the dash ones. Zeros cannot be painted before a node has answered.

Syntax-checked all four inline script blocks with `node --check` — block 2 (the one changed) parses. Block 1 fails, but it is the `importmap`, i.e. JSON, and it fails identically on `origin/main`; not introduced here.

## Not done: the hardcoded node list

#427 also notes `POOL_NODES` is hardcoded `vm1..vm4` while we run eight nodes. I have left that alone deliberately — the page fetches `/api/pool/<id>/...`, which needs a matching proxy entry on the web server for each id, and I cannot verify that side from here. Adding vm5-vm8 without the proxy would just produce four failed fetches per poll. Worth doing, but it is a web-server change first and a page change second.

Note the fleet-wide figures are unaffected either way: `mesh_active_miners` and `total_hashrate` are mesh-wide, so any single responding node already yields the correct totals.