### PR TITLE
test(verification): serialise the second test that mutates the reaper env hook

### DIFF
--- a/crates/ghost-verification/src/routes.rs
+++ b/crates/ghost-verification/src/routes.rs
@@ -12267,7 +12267,14 @@ mod tests {
     }
 
     /// CRIT-6: Test that config POST with valid auth succeeds
+    ///
+    /// `#[serial]` because this mutates `GHOST_REAPER_APPLY_TEST_MODE`, which is
+    /// process-global. `test_config_reaper_post_auto_applies_ghostd` reads the same
+    /// variable and is already serial — but `#[serial]` only serialises against other
+    /// `#[serial]` tests, so leaving this one unmarked let it clear the variable while
+    /// that test was awaiting `post_reaper`, flipping it onto the non-test-mode path.
     #[tokio::test]
+    #[serial]
     async fn test_config_post_with_valid_auth_succeeds() {
         use ghost_common::config::NodeConfig as FullNodeConfig;
         use ghost_common::types::NodeCapabilities;


### PR DESCRIPTION
Blocks the v1.11.18 release (#433). Found because `test_config_reaper_post_auto_applies_ghostd` failed on macOS on the version-bump PR — a change that touches nothing but version strings.

It is not flaky in the usual sense. Run alongside its neighbour it fails **every time**.

## Cause

`GHOST_REAPER_APPLY_TEST_MODE` is process-global. Two tests touch it:

| test | mutates | `#[serial]` |
|---|---|---|
| `test_config_reaper_post_auto_applies_ghostd` | set + remove | **yes** |
| `test_config_post_with_valid_auth_succeeds` | set | **no** |

`#[serial]` only serialises against *other* `#[serial]` tests. The unmarked one therefore ran concurrently and could clear the variable while the first was awaiting `post_reaper`, dropping the apply onto the non-test-mode path — so `ghostd_apply.state` is no longer `"applying"` and the assertion at `routes.rs:12198` fails.

The guarded tests own doc comment says it:

> runs both cases in one test so the process-global env vars cant race a parallel test

So the race was known and that test was protected. The second test touching the same variable was missed. The mitigation was incomplete in precisely the way that bit us.

## Measured

Running only these two, `--test-threads=8`:

```
without #[serial]:   0 passed, 20 failed    (every failure at routes.rs:12198)
with    #[serial]:  20 passed,  0 failed
```

Full crate suite: `229 passed; 0 failed`.

## Scope

Audited the whole file: this was the only remaining test mutating process env without `#[serial]`. Now 4 of 54.

## Why it looked intermittent

In CI the scheduling of these two among 229 tests varies by machine and load, so it surfaced on macOS and not ubuntu. Deterministic locally once the pair is isolated — which is what made it findable rather than something to shrug at and re-run.

Worth noting for the future: a `#[serial]` on one side of a shared global is not a guard, it is half a guard, and the half that is missing is invisible. If more process-env hooks get added, the rule has to be "every test touching it is serial", enforced rather than remembered.