### PR TITLE
docs: correct gate comments that still describe armed gates as dormant

### DIFF
--- a/bins/ghost-pool/src/lib.rs
+++ b/bins/ghost-pool/src/lib.rs
@@ -194,8 +194,8 @@ pub const SHARE_POW_VERIFY_HEIGHT: u64 = 959_030;
 /// Which nodes qualify is consensus-visible (it decides the coinbase node split), so this is a
 /// height gate, not a feature flag: both counting paths exist in the new binary and every node
 /// switches at the same block, so a mixed-version fleet computes an identical node split during
-/// the roll. DORMANT until the voter set + per-node subnet map are converged fleet-wide; SET
-/// comfortably past the roll window.
+/// the roll. Was held dormant until the voter set + per-node subnet map had converged fleet-wide,
+/// then set comfortably past the roll window. ARMED — this height is in the past.
 pub const VOTER_SET_QUALIFICATION_HEIGHT: u64 = 959_116;
 
 /// Multi-operator consensus-drawn challenger assignment (Surface A-2b). At and above this
@@ -210,8 +210,9 @@ pub const VOTER_SET_QUALIFICATION_HEIGHT: u64 = 959_116;
 /// rubber-stamps. Which verdicts count is consensus-visible (it decides the coinbase node
 /// split), so this is a height gate: every node recomputes the identical assignment at the
 /// checkpoint cutoff, so a mixed-version fleet agrees on the node split during the roll.
-/// DORMANT until challenges have been issued+recorded against their assigned round for a full
-/// lookback window; SET comfortably past the roll window.
+/// Was held dormant until challenges had been issued+recorded against their assigned round for a
+/// full lookback window, then set comfortably past the roll window. ARMED — this height is in the
+/// past.
 pub const CHALLENGER_ASSIGNMENT_HEIGHT: u64 = 959_161;
 
 /// Finality lag (in blocks) between a round and the block whose hash seeds it: a round at tip
@@ -223,9 +224,8 @@ pub const CHALLENGER_ASSIGNMENT_SEED_LAG: u64 = ghost_verification::challenger_a
 /// Active-voter-set scaffolding (Phase 4, v1.x). At and above this height, BFT payout voting
 /// draws its eligible-voter set from the QUALIFIED ACTIVE nodes at the block's cutoff (the same
 /// converged resolver Component E uses) instead of the static genesis MPC elder set — letting the
-/// voting membership track the fleet as it grows/shrinks. Below it, the MPC elder set is used
-/// (current behaviour), so with this gate DORMANT (`u64::MAX`) the binary is byte-identical to
-/// today. Which nodes vote is consensus-visible, so this is a height gate: every node resolves the
+/// voting membership track the fleet as it grows/shrinks. Below it, the MPC elder set is used.
+/// Which nodes vote is consensus-visible, so this is a height gate: every node resolves the
 /// identical set at the checkpoint cutoff. ARMED @959_200 — the checkpoint-path voter set was
 /// proven byte-identical fleet-wide first (`checkpoint_voter_set.hash` `98100ee8…` on all 8,
 /// count=8, floored=false), and the redesign soaked clean gate-off on v1.11.9. Revert = restore
@@ -355,8 +355,9 @@ pub fn share_pow_verify_height() -> u64 {
 }
 
 /// The height at which BFT payout voting draws its eligible-voter set from the qualified active
-/// nodes at the block's cutoff instead of the static MPC elder set (Phase 4 scaffolding). DORMANT
-/// (`u64::MAX`) — below it the MPC elder set is used, so the binary is behaviour-neutral today.
+/// nodes at the block's cutoff instead of the static MPC elder set (Phase 4). Below it the MPC
+/// elder set is used. See `ACTIVE_VOTER_SET_HEIGHT` for the height and the arming record — this
+/// doc deliberately does not restate the value, so it cannot go stale when the gate moves.
 pub fn active_voter_set_height() -> u64 {
     *gates::ACTIVE_VOTER_SET.get_or_init(|| ACTIVE_VOTER_SET_HEIGHT)
 }

--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -6169,13 +6169,16 @@ async fn main() -> Result<()> {
         vote_handler.set_proposal_validator(validator);
     }
 
-    // Phase 4 (DORMANT scaffolding): install the active-voter-set resolver. Below
-    // ACTIVE_VOTER_SET_HEIGHT (u64::MAX on mainnet today) it returns None and the vote handler
-    // keeps using the static MPC elder set — byte-identical to current behaviour. When armed in
-    // v1.x, the eligible-voter set becomes the qualified active nodes at the cutoff of the latest
-    // finalised payout checkpoint at/below the block — resolved identically fleet-wide via the
-    // same converged resolver + height scoping the payout root uses (so voters and the node split
-    // agree). The gate lives inside the closure, so this wiring is behaviour-neutral until armed.
+    // Phase 4: install the active-voter-set resolver. Below ACTIVE_VOTER_SET_HEIGHT it returns
+    // None and the vote handler keeps using the static MPC elder set. At and above it, the
+    // eligible-voter set becomes the qualified active nodes at the cutoff of the latest finalised
+    // payout checkpoint at/below the block — resolved identically fleet-wide via the same
+    // converged resolver + height scoping the payout root uses (so voters and the node split
+    // agree). The gate lives inside the closure, so the wiring itself is inert below the height.
+    //
+    // This gate is ARMED and has fired; see ACTIVE_VOTER_SET_HEIGHT for the value and the arming
+    // record. Do not describe it as dormant or restate the height here — that is how this comment
+    // came to claim `u64::MAX` long after the gate went live.
     {
         let db_c = Arc::clone(&db);
         let oracle_c = block_hash_oracle.clone();


### PR DESCRIPTION
Part of #406 — the gate-doc half. The dashboard-docs half is separate and not in this PR.

Three consensus gates are armed and have fired while their doc comments say otherwise, and two state a specific wrong value:

| location | height | comment claims |
|---|---|---|
| `VOTER_SET_QUALIFICATION_HEIGHT` | 959_116 | "DORMANT until … converged fleet-wide" |
| `CHALLENGER_ASSIGNMENT_HEIGHT` | 959_161 | "DORMANT until challenges have been …" |
| `ACTIVE_VOTER_SET_HEIGHT` | 959_200 | "with this gate DORMANT (`u64::MAX`) the binary is byte-identical to today" |
| `active_voter_set_height()` | 959_200 | "DORMANT (`u64::MAX`) — … behaviour-neutral today" |
| `main.rs` | 959_200 | "(`u64::MAX` on mainnet today)" |

All seven gates have fired — 946743, 955200, 959030, 959116, 959161, 959200, 959290 — and the chain is past 959600.

## Why this is worth a PR rather than a shrug

"byte-identical to current behaviour" and "behaviour-neutral today" are the dangerous phrasings. During an incident they lead a reader to rule out precisely the mechanism that is now live. Someone reasoning about why a payout vote resolved a particular way would read this and discount the active-voter-set path entirely.

## Worth noting

The `ACTIVE_VOTER_SET_HEIGHT` block already carried an accurate `ARMED @959_200` paragraph with the full arming record — proven byte-identical voter set fleet-wide, soak details, revert procedure. The stale sentence sat directly above it, contradicting it in the same comment.

So this was not an unmaintained doc. It was a doc updated in one place and not the other, which is the more common and harder-to-spot failure.

## Approach

The comments were accurate when each gate was written and were not revisited when it was armed. Correcting the words alone just resets that clock. So the accessor docs no longer restate the height or its dormancy at all — they describe behaviour above and below the gate and point at the constant, which is the single source of truth.

A doc that does not repeat a value cannot disagree with it.

## Checks

Comments only, no code changed — verified by filtering the diff for non-comment lines. `cargo fmt --all -- --check` clean; `cargo check -p ghost-pool` passes.