### PR TITLE
fix: reconcile the two stratum config sources and gate them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,11 @@ jobs:
       # vardiff floor was fixed in one copy and not the other (#431).
       - name: Check inlined installer copies
         run: ./scripts/check-inlined-copies.sh
+      # The stratum config is defined twice — the installer heredoc and
+      # config/sri/translator-config.toml — because the installer is fetched standalone
+      # and has no repo to read. They had silently diverged (#431).
+      - name: Check stratum config agreement
+        run: ./scripts/check-stratum-config-agreement.sh
 
   # Clippy lints
   clippy:

--- a/config/sri/translator-config.toml
+++ b/config/sri/translator-config.toml
@@ -15,7 +15,7 @@ min_supported_version = 2
 
 # Extranonce size for downstream miners
 # Max value for CGminer: 8, Min value: 2
-downstream_extranonce2_size = 4
+downstream_extranonce2_size = 8
 
 # User identity prefix (miner usernames will be username.miner1, username.miner2, etc.)
 user_identity = "ghost_miner"
@@ -23,7 +23,7 @@ user_identity = "ghost_miner"
 # Channel aggregation
 # true = all miners share one upstream channel (recommended for many small miners)
 # false = each miner gets its own channel
-aggregate_channels = true
+aggregate_channels = false
 
 # Protocol extensions
 supported_extensions = []

--- a/scripts/check-stratum-config-agreement.sh
+++ b/scripts/check-stratum-config-agreement.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+#
+# Catch divergence between the two places the stratum config is defined.
+#
+# install-node.sh is fetched standalone over curl and has no repo to read from, so it
+# writes /etc/ghost/translator-config.toml from a heredoc. config/sri/translator-config.toml
+# is a second copy of the same values. Nothing has ever checked they agree, and they did not:
+#
+#   min_individual_miner_hashrate   installer 500_000_000_000.0   repo 10_000_000_000_000.0
+#   aggregate_channels              installer false               repo true
+#   downstream_extranonce2_size     installer 4                   repo 4     <- both wrong
+#
+# The vardiff floor was corrected in the repo copy by #426 and not in the installer, so a
+# fresh node would have been provisioned with the value that #426 existed to fix. The repo
+# copy had aggregate_channels = true, which collapses per-miner channels and would have
+# undone the attribution fix in #422 if anyone had applied it. And extranonce2_size was 4
+# in both while every live node ran 8 — the value rented-hashrate marketplaces require,
+# recorded nowhere.
+#
+# The duplication cannot be removed while the installer is delivered standalone. This makes
+# the divergence loud instead of silent.
+#
+# Absolute invariants are checked too, because agreement is not correctness: both files
+# agreeing on extranonce2_size = 4 is exactly the state that shipped.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+python3 - <<'PY'
+import re, sys
+
+INSTALLER = "scripts/install-node.sh"
+REFERENCE = "config/sri/translator-config.toml"
+
+# Keys that must be identical in both files.
+SHARED = [
+    "downstream_extranonce2_size",
+    "min_individual_miner_hashrate",
+    "aggregate_channels",
+    "shares_per_minute",
+    "enable_vardiff",
+    "downstream_port",
+    "max_supported_version",
+    "min_supported_version",
+]
+
+# Invariants that must hold regardless of whether the two files agree.
+def inv_extranonce(v):
+    try:
+        return (int(v) >= 7, "must be >= 7 or rented-hashrate marketplaces reject the pool")
+    except ValueError:
+        return (False, "not an integer")
+
+def inv_aggregate(v):
+    return (v == "false",
+            "true collapses per-miner channels and breaks share attribution")
+
+INVARIANTS = {
+    "downstream_extranonce2_size": inv_extranonce,
+    "aggregate_channels": inv_aggregate,
+}
+
+def values(path):
+    out = {}
+    with open(path) as fh:
+        for line in fh:
+            m = re.match(r"^\s*([a-z0-9_]+)\s*=\s*(.+?)\s*$", line)
+            if m and m.group(1) in SHARED:
+                out.setdefault(m.group(1), m.group(2))
+    return out
+
+a, b = values(INSTALLER), values(REFERENCE)
+
+problems = []
+for k in SHARED:
+    va, vb = a.get(k), b.get(k)
+    # A key we cannot find in both files is not "in agreement" — it is unchecked, and
+    # silently counting it as passing is how a gate ends up reporting a clean run while
+    # testing nothing. The original version of this script could not match a key
+    # containing a digit, so `downstream_extranonce2_size` was skipped entirely and it
+    # still printed "8 shared keys agree".
+    if va is None or vb is None:
+        missing = INSTALLER if va is None else REFERENCE
+        problems.append(f"{k}: not found in {missing} — cannot verify agreement")
+        continue
+    if va != vb:
+        problems.append(f"{k}: {INSTALLER} = {va!r} but {REFERENCE} = {vb!r}")
+
+for k, check in INVARIANTS.items():
+    for path, vals in ((INSTALLER, a), (REFERENCE, b)):
+        v = vals.get(k)
+        if v is None:
+            continue
+        ok, why = check(v)
+        if not ok:
+            problems.append(f"{k} = {v} in {path} — {why}")
+
+if problems:
+    print("Stratum config sources disagree, or an invariant is broken:\n", file=sys.stderr)
+    for p in problems:
+        print(f"  {p}", file=sys.stderr)
+    print(f"\nBoth {INSTALLER} and {REFERENCE} define these values. A node is provisioned",
+          file=sys.stderr)
+    print("from the installer, so a change made only in the reference file never reaches a node.",
+          file=sys.stderr)
+    sys.exit(1)
+
+checked = [k for k in SHARED if k in a and k in b]
+print(f"check-stratum-config-agreement: {len(checked)}/{len(SHARED)} shared keys compared "
+      f"and in agreement, invariants hold")
+PY

--- a/scripts/install-node.sh
+++ b/scripts/install-node.sh
@@ -896,8 +896,10 @@ downstream_port = 3333
 max_supported_version = 2
 min_supported_version = 2
 
-# Extranonce size for downstream miners (CGminer max 8, min 2)
-downstream_extranonce2_size = 4
+# Extranonce size for downstream miners (CGminer max 8, min 2).
+# Must be >= 7: rented-hashrate marketplaces subdivide extranonce2 across their
+# fan-out connections and reject a pool that advertises less. Braiins requires 7.
+downstream_extranonce2_size = 8
 
 # Default miner-username prefix (this node's payout address). Miners may override
 # per connection by authorising as <address>.<worker>.
@@ -915,7 +917,7 @@ monitoring_address = "0.0.0.0:9092"
 
 # Difficulty configuration for SV1 miners
 [downstream_difficulty_config]
-min_individual_miner_hashrate = 500_000_000_000.0
+min_individual_miner_hashrate = 10_000_000_000_000.0
 shares_per_minute = 6.0
 enable_vardiff = true
 idle_timeout_secs = 600

--- a/scripts/record-tests.sh
+++ b/scripts/record-tests.sh
@@ -33,6 +33,9 @@ echo "==> workflow line continuations"
 echo "==> inlined installer copies"
 ./scripts/check-inlined-copies.sh || { echo "FAILED: inlined copies drifted" >&2; exit 1; }
 
+echo "==> stratum config agreement"
+./scripts/check-stratum-config-agreement.sh || { echo "FAILED: stratum config sources disagree" >&2; exit 1; }
+
 # NB: do NOT write these as `cmd | grep ... && { fail }`. With `set -o pipefail` a failing
 # cargo makes the whole pipeline non-zero, the `&&` short-circuits, the failure branch never
 # runs — and the gate reports success while not gating. That exact bug let a commit with two


### PR DESCRIPTION
Fixes #431.

The stratum config is defined twice — the `install-node.sh` heredoc, which is what actually writes `/etc/ghost/translator-config.toml` onto a node, and `config/sri/translator-config.toml`, which is read by nothing. Nothing checked they agreed, and they did not:

| key | install-node.sh | config/sri/translator-config.toml |
|---|---|---|
| `min_individual_miner_hashrate` | 500_000_000_000.0 | 10_000_000_000_000.0 |
| `aggregate_channels` | false | **true** |
| `downstream_extranonce2_size` | 4 | 4 — **both wrong** |

## Three separate problems

**#426 corrected the vardiff floor in the repo copy only.** A fresh install, or a re-run of `install-node.sh` on an existing node, would have provisioned the exact condition #426 was raised to fix — a starting difficulty of 1,164 instead of 23,283.

**`aggregate_channels = true` in the repo copy** collapses per-miner channels, which is the basis of per-miner share attribution. Applying that file would have undone #422.

**`downstream_extranonce2_size` was 4 in both** while every live node runs 8. That is the value rented-hashrate marketplaces require (Braiins rejects below 7), and it was recorded nowhere in the repo — so a fresh node would have re-broken large miners with no trace of why.

All three corrected in both files. The comment beside `extranonce2_size` now says *why* the floor exists rather than only what the protocol allows.

## The gate

The duplication cannot be removed — `install-node.sh` is delivered by `curl … | sudo bash` and has no repo to read. So `scripts/check-stratum-config-agreement.sh` compares every shared key and fails on divergence.

It also asserts **absolute invariants**, because agreement is not correctness: both files agreeing on `extranonce2_size = 4` is precisely the state that shipped. `extranonce2_size >= 7` and `aggregate_channels != true` are checked per file regardless of whether the two match.

Verified in three directions — passes with both corrected, catches the original divergence, and catches the agreed-but-wrong case:

```
downstream_extranonce2_size = 4 in scripts/install-node.sh — must be >= 7 or
  rented-hashrate marketplaces reject the pool
downstream_extranonce2_size = 4 in config/sri/translator-config.toml — must be >= 7 ...
exit=1
```

## One thing worth flagging, because it nearly shipped a check that checked nothing

My first version matched keys with `[a-z_]+`, which cannot match the digit in `downstream_extranonce2_size`. That key was silently skipped — never compared, never invariant-checked — while the script printed `8 shared keys agree`. I only caught it because the agreed-but-wrong test case came back green when it should have failed.

Fixed to `[a-z0-9_]+`. A key missing from either file is now reported as unverifiable rather than counted as passing, and the summary states how many keys were *actually* compared (`8/8`), so a silent skip cannot look like a clean run again.

Wired into the CI Format job and `record-tests.sh`.