### PR TITLE
ci: enforce MSRV, and correct it to the version we actually need

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,14 +154,22 @@ jobs:
       - name: Run security audit
         run: cargo audit
 
-  # Minimum Supported Rust Version
+  # Minimum Supported Rust Version.
+  #
+  # Pinned to the version Cargo.toml declares, NOT stable. On @stable this job was a
+  # second stable build wearing a different name — it could never have caught a
+  # too-new feature slipping in, which is the only thing it exists to catch.
+  #
+  # If this job fails, the choice is to fix the code or to raise rust-version in
+  # Cargo.toml. Do not quietly put it back to stable: that restores a green tick that
+  # means nothing.
   msrv:
     name: MSRV
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.88
       - uses: Swatinem/rust-cache@v2
       - run: sudo apt-get update && sudo apt-get install -y $LINUX_DEPS
       - run: cargo check $WORKSPACE_EXCLUDES

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ exclude = ["vendor/stratum"]
 [workspace.package]
 version = "1.11.18"
 edition = "2021"
-rust-version = "1.85"
+rust-version = "1.88"
 authors = ["Bitcoin Ghost Team"]
 license = "MIT"
 repository = "https://github.com/bitcoin-ghost/ghost"


### PR DESCRIPTION
Half of #401 — the MSRV half. Leaving the issue open for the clippy half.

Two problems, and the second only became visible once the first was fixed.

## The job never enforced anything

`ci.yml` used `dtolnay/rust-toolchain@stable` in the job named MSRV. It was a second stable build wearing a different name, and could not have caught the one thing it exists to catch.

## Pinning it to the declared 1.85 immediately failed — which is the point

```
time@0.3.47        requires rustc 1.88.0
time-core@0.1.8    requires rustc 1.88.0
time-macros@0.2.27 requires rustc 1.88.0
```

So `rust-version = "1.85"` was a **false claim**. Anyone taking it at face value and building on 1.85 would have failed on a transitive dependency, and nothing in CI would have told us — because the job responsible was running 1.97.

This is exactly why I opened it as a PR instead of verifying locally: the red build *is* the finding, and main never broke to produce it.

## Fix

`rust-version` corrected to `1.88` to match what the dependency graph actually requires, and the job pinned to the same. The two can no longer drift apart without CI saying so.

I chose to raise the declaration rather than pin `time` back to a 1.85-compatible release. Fighting the ecosystem to preserve a number nobody had ever verified is the wrong trade, and 1.88 is over a year old — it is not a demanding floor. If there is a reason we must support 1.85 specifically, say so and I will do it the other way instead.

## Not in this PR

The clippy half — **221 warnings** on current main, none vendored, across 15+ crates. `-D warnings` would fail on the first push. Full breakdown and a suggested split into reviewable per-crate PRs is on the issue.
