### PR TITLE
ci: surface a red main by opening an issue

### DIFF
--- a/.github/workflows/main-ci-alert.yml
+++ b/.github/workflows/main-ci-alert.yml
@@ -1,0 +1,108 @@
+name: Main CI Alert
+
+# Surface a red main.
+#
+# The Coverage job is gated on `github.ref == 'refs/heads/main'`, so it never runs on a
+# pull request. Six consecutive PRs merged green and turned main red behind them, and it
+# stayed red for six commits — 911496d7, 61cd542c, af657270, 0cd88e7e, c9af8b48, c5009886
+# — because nothing looks at main after a merge. It was found by chance while checking
+# whether a release could be cut (#428).
+#
+# A job that can only fail after merge needs something watching, or the failure is
+# invisible by construction. This opens an issue when CI fails on main, and closes it when
+# main goes green again, so the signal is impossible to miss and does not accumulate.
+#
+# Deliberately NOT a webhook: there is no alert destination configured anywhere in this
+# repo (see #412), so anything requiring a URL would silently do nothing. An issue needs no
+# configuration and is visible to everyone.
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [main]
+
+permissions:
+  issues: write
+  actions: read
+
+jobs:
+  alert:
+    name: Alert on red main
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Open or close the red-main issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const run = context.payload.workflow_run;
+            const TITLE = 'CI is failing on main';
+            const { owner, repo } = context.repo;
+
+            // Find an existing open alert issue so repeated failures update one thread
+            // rather than filing a new issue per commit.
+            //
+            // Tolerate the label being absent: a label filter against a label that does not
+            // exist can error, and an alerting workflow that fails to alert because of its
+            // own bookkeeping is worse than no workflow. Fall back to matching on title.
+            let issue;
+            try {
+              const byLabel = await github.rest.issues.listForRepo({
+                owner, repo, state: 'open', labels: 'ci-failure', per_page: 10,
+              });
+              issue = byLabel.data.find(i => i.title === TITLE);
+            } catch (e) {
+              core.warning(`label lookup failed (${e.message}); falling back to title search`);
+              const all = await github.rest.issues.listForRepo({
+                owner, repo, state: 'open', per_page: 100,
+              });
+              issue = all.data.find(i => i.title === TITLE);
+            }
+
+            if (run.conclusion === 'success') {
+              if (issue) {
+                await github.rest.issues.createComment({
+                  owner, repo, issue_number: issue.number,
+                  body: `main is green again as of ${run.head_sha.slice(0, 8)} — ${run.html_url}`,
+                });
+                await github.rest.issues.update({
+                  owner, repo, issue_number: issue.number, state: 'closed',
+                });
+              }
+              return;
+            }
+
+            // Anything other than success is worth surfacing — including `cancelled`,
+            // which is how the 6-hour hang presented before job timeouts were added.
+            const jobs = await github.rest.actions.listJobsForWorkflowRun({
+              owner, repo, run_id: run.id, per_page: 50,
+            });
+            const bad = jobs.data.jobs
+              .filter(j => j.conclusion && j.conclusion !== 'success' && j.conclusion !== 'skipped')
+              .map(j => `- **${j.name}** — ${j.conclusion}  \n  ${j.html_url}`)
+              .join('\n') || '_(no individual job reported a failure — check the run itself)_';
+
+            const body = [
+              `CI concluded **${run.conclusion}** on main at \`${run.head_sha.slice(0, 8)}\`.`,
+              '',
+              `Run: ${run.html_url}`,
+              '',
+              '### Failing jobs',
+              bad,
+              '',
+              '---',
+              'Opened automatically because a job gated on `main` cannot fail on a pull request,',
+              'so a red main is otherwise invisible. Coverage sat red for six commits before',
+              'anyone noticed (#428). This issue closes itself when main goes green.',
+            ].join('\n');
+
+            if (issue) {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: issue.number, body,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner, repo, title: TITLE, body, labels: ['ci-failure'],
+              });
+            }


### PR DESCRIPTION
Closes the remaining half of #428.

#429 fixed the Coverage break. This fixes the reason nobody saw it for six commits.

## The gap

Coverage is gated on `github.ref == 'refs/heads/main'`, so it never runs on a pull request. Six consecutive PRs merged green and turned main red behind them — 911496d7, 61cd542c, af657270, 0cd88e7e, c9af8b48, c5009886 — and it stayed red because nothing looks at main after a merge. It was found by chance, while checking whether a release could be cut.

A job that can only fail *after* merge is invisible by construction unless something watches.

## What this does

On a CI run completing on main with anything other than success:

- opens an issue titled **CI is failing on main**, listing the failing jobs with links
- comments on the existing issue rather than filing a new one per commit
- comments and **closes** it when main goes green again

So the signal is impossible to miss and does not accumulate.

## Two deliberate choices

**Triggers on any non-success conclusion, not just `failure`.** `cancelled` is how the six-hour hang presented before job timeouts existed, and that is precisely the case worth hearing about. Filtering to `failure` would have missed the original incident.

**An issue, not a webhook.** There is no alert destination configured anywhere in this repo — `health-check.sh` has supported `--alert-webhook` for ages and nothing passes one (#412). A notification requiring a URL would silently do nothing, which is the same failure mode this issue is about. An issue needs no configuration and everyone can see it.

## Robustness

It tolerates the `ci-failure` label being missing and falls back to matching on title. An alerting workflow that fails to alert because of its own bookkeeping is worse than no workflow at all.

The label has been created on the repo (`#B60205`).

## Verified

```
workflow parses as YAML; trigger/permissions/jobs as intended
embedded script: node --check passes, braces/parens/brackets balanced
check-workflow-scalars.sh: 5 workflow(s) clean
```

I cannot fully exercise it without deliberately breaking main, which I am not going to do. The next real red main will be its first live test — and if it misbehaves the failure mode is a spurious or missing issue, not a broken build.
