### PR TITLE
test: stop test_022 failing 1 run in 256 by coincidence

### DIFF
--- a/tests/integration_tests/cryptography.rs
+++ b/tests/integration_tests/cryptography.rs
@@ -286,12 +286,33 @@ fn test_021_pow_verify_rejects_wrong_nonce() {
 #[test]
 fn test_022_pow_verify_rejects_wrong_public_key() {
     let identity1 = NodeIdentity::generate();
-    let identity2 = NodeIdentity::generate();
-
     let proof = NodeIdProof::mine(&identity1.node_id(), 8).unwrap();
 
+    // A proof is (key, nonce) -> hash, and difficulty 8 means 8 leading ZERO BITS. So a
+    // second, unrelated key reused with this nonce satisfies the difficulty by chance
+    // 1 time in 256 — and then it verifies legitimately, because it genuinely is a valid
+    // proof for that key. Asserting `!verify` unconditionally therefore fails ~0.39% of
+    // runs on correct code. That is what happened on macOS in CI, on a pull request that
+    // changed nothing but a shell script.
+    //
+    // test_021 above and the unit test in ghost-common/src/identity.rs both guard against
+    // this exact coincidence; this one did not.
+    //
+    // Rather than skip the assertion on the unlucky draw (which leaves the test asserting
+    // nothing ~0.39% of the time), draw until we have a key that does NOT coincidentally
+    // satisfy the difficulty. Expected iterations: 1.004.
+    let wrong_key = loop {
+        let candidate = NodeIdentity::generate().node_id();
+        let hash = NodeIdProof::compute_hash(&candidate, proof.nonce);
+        if NodeIdProof::leading_zeros(&hash) < 8 {
+            break candidate;
+        }
+        // Landed on a key for which this nonce is a genuinely valid proof. Not a bug —
+        // draw again so the assertion below stays meaningful.
+    };
+
     // Verify against wrong key should fail
-    assert!(!proof.verify(&identity2.node_id(), 8));
+    assert!(!proof.verify(&wrong_key, 8));
 }
 
 #[test]


### PR DESCRIPTION
`test_022_pow_verify_rejects_wrong_public_key` failed on macOS in CI, on #442 — a pull request whose only change is a shell script. It is unrelated to that change, and it is not a real defect. The test is probabilistic and nobody had noticed.

## Why it fails

The test mines a proof for one key at difficulty 8, then asserts the same nonce does **not** verify for a second, unrelated key:

```rust
let proof = NodeIdProof::mine(&identity1.node_id(), 8).unwrap();
assert!(!proof.verify(&identity2.node_id(), 8));
```

Difficulty 8 means 8 leading **zero bits**, and `verify` is:

```rust
zeros >= required_difficulty && self.difficulty >= required_difficulty
```

The second clause always holds for a proof mined at 8, so it reduces to `leading_zeros(sha256(key2 || nonce)) >= 8` on an effectively random hash. That is satisfied by chance **1 time in 256** — and when it is, the wrong key verifies *legitimately*, because it genuinely is a valid proof for that key. The assertion then fails on entirely correct code.

## Measured, not assumed

Reproduced `compute_hash` exactly (`sha256(pubkey || nonce_le)`) and ran 200,000 mine-then-test cycles:

```
coincidences:    772 / 200,000
measured rate:   1 in 259.1
predicted rate:  1 in 256      (2^-8)
mean mined nonce: 255.8
```

## The codebase already knew about this

`test_021`, immediately above, guards the same coincidence with `if actual_zeros < 8`. The unit test in `crates/ghost-common/src/identity.rs:609` does the same and even documents it:

```rust
// Extremely rare case (~1/256): document but don't fail
```

So the hazard was understood and handled in two places. This one test missed it — the same shape as the `#[serial]` gap in #437, where a known problem was guarded on one side of a shared resource and not the other.

## The fix

Draw a key that does not coincidentally satisfy the difficulty, rather than skipping the assertion on an unlucky draw. Skipping would leave the test asserting nothing 0.39% of the time, which is a quieter version of the same problem. Expected iterations: 1.004.

## A note on method

My first attempt to demonstrate the flake ran the original 700 times and got **0 failures**. At this rate that is a 6.5% outcome — unlucky, not evidence. Had I stopped there I would have concluded the test was fine and closed this. Measuring the underlying rate directly is what settled it, and it is the reason the number in this PR is 259.1 rather than "seems flaky".
