### PR TITLE
pool: widen the active-miner window to 900s and define it once

### DIFF
--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -42,6 +42,7 @@ use tracing::{debug, error, info, warn, Level};
 use tracing_subscriber::prelude::*;
 
 use ghost_common::config::{MiningMode, NodeConfig, ReaperSettings};
+use ghost_common::constants::ACTIVE_MINER_WINDOW_SECS;
 use ghost_common::identity::NodeIdentity;
 use ghost_common::metrics::Metrics;
 use ghost_common::rpc::BitcoinRpc;
@@ -2884,7 +2885,7 @@ async fn main() -> Result<()> {
     let db_for_active_hashes = Arc::clone(&db);
     mesh_inner.set_active_miner_hashes_provider(Arc::new(move || {
         db_for_active_hashes
-            .active_miner_id_hashes(300)
+            .active_miner_id_hashes(ACTIVE_MINER_WINDOW_SECS)
             .unwrap_or_default()
     }));
 
@@ -6379,14 +6380,14 @@ async fn main() -> Result<()> {
 
     // Wire pool-peers callback for the translator load-balancer endpoint.
     // `deduped_miner_count` is the per-node share of the mesh-wide active-miner
-    // total (attributed over the same 300s window as `mesh_active_miners`), so
+    // total (attributed over the same active-miner window as `mesh_active_miners`), so
     // the Capacity page's per-node rows sum to the deduped grand total instead
     // of over-counting miners that fail over between nodes. The raw
     // `miner_count` is left untouched for the LB's utilisation routing.
     let mesh_for_pool_peers = Arc::clone(&mesh);
     verification_state = verification_state.with_pool_peers(move || {
         use ghost_verification::PoolPeerInfo;
-        let deduped = mesh_for_pool_peers.deduped_miner_counts(300);
+        let deduped = mesh_for_pool_peers.deduped_miner_counts(ACTIVE_MINER_WINDOW_SECS as u64);
         mesh_for_pool_peers
             .peers()
             .get_connected_peers(30)
@@ -6412,9 +6413,9 @@ async fn main() -> Result<()> {
     let mesh_for_node_list = Arc::clone(&mesh);
     verification_state = verification_state.with_mesh_nodes(move || {
         use ghost_verification::MeshNodeInfo;
-        // Deduped per-node counts over the 300s active-miner window (matching
+        // Deduped per-node counts over the shared active-miner window (matching
         // the mesh grand total) so the mesh-nodes list sums consistently.
-        let deduped = mesh_for_node_list.deduped_miner_counts(300);
+        let deduped = mesh_for_node_list.deduped_miner_counts(ACTIVE_MINER_WINDOW_SECS as u64);
         mesh_for_node_list
             .peers()
             .get_connected_peers(120)
@@ -6452,8 +6453,8 @@ async fn main() -> Result<()> {
     // Mesh-wide deduplicated active miner count. Unions local active miner_id
     // hashes with the most-recent set from each connected peer.
     //
-    // The freshness window must match the 300s miner-activity window the local
-    // and gossiped sets are computed over (`active_miner_id_hashes(300)`), NOT a
+    // The freshness window must match the shared miner-activity window the local
+    // and gossiped sets are computed over (`ACTIVE_MINER_WINDOW_SECS`), NOT a
     // tight 60s. At 60s a peer that simply missed a few ~10s health pings (jitter,
     // GC, momentary load) was excluded entirely, dropping ALL of its active miners
     // from the union — so a node would report e.g. 4 of 5 miners, and since the
@@ -6462,15 +6463,16 @@ async fn main() -> Result<()> {
     // still ages out at the source node's 300s `last_seen`, so the count stays
     // honest while becoming robust to transient ping loss.
     let mesh_for_active = Arc::clone(&mesh);
-    verification_state = verification_state
-        .with_mesh_active_miners(move || mesh_for_active.mesh_active_miner_count(300) as u32);
+    verification_state = verification_state.with_mesh_active_miners(move || {
+        mesh_for_active.mesh_active_miner_count(ACTIVE_MINER_WINDOW_SECS as u64) as u32
+    });
 
     // This node's (self) deduped share of that mesh-wide total, from the same
     // attribution that fills each peer's `deduped_miner_count`. Surfaced on the
     // self/`this_node` entries so `self + peers` sum to `mesh_active_miners`.
     let mesh_for_self_deduped = Arc::clone(&mesh);
     verification_state = verification_state.with_self_deduped_miner_count(move || {
-        let counts = mesh_for_self_deduped.deduped_miner_counts(300);
+        let counts = mesh_for_self_deduped.deduped_miner_counts(ACTIVE_MINER_WINDOW_SECS as u64);
         counts
             .get(&mesh_for_self_deduped.peers().our_node_id())
             .copied()

--- a/crates/ghost-common/src/constants.rs
+++ b/crates/ghost-common/src/constants.rs
@@ -440,8 +440,84 @@ pub const GHOST_PROTOCOL_VERSION: u32 = 140;
 /// Minimum supported protocol version
 pub const MIN_PROTOCOL_VERSION: u32 = 140;
 
+/// How far back a miner's last share may be while it still counts as "active".
+///
+/// Every place that computes an active-miner figure MUST use this same value — the
+/// node-local count, the gossiped per-node counts and the mesh-wide deduplicated total
+/// are compared against each other, so a mismatch makes them disagree and the totals
+/// stop reconciling. It was previously the literal `300` repeated at seven call sites
+/// across three crates, with a comment at one of them warning that they had to match.
+///
+/// ## Why it is 900 and not 300
+///
+/// A share arrives on average every `difficulty * 2^48 / 0xFFFF / hashrate` seconds, and
+/// share-finding is Poisson, so the chance a genuinely-mining miner submits nothing
+/// inside the window is `e^(-window / mean_interval)`.
+///
+/// When the SV1 vardiff floor was 500 GH/s (difficulty ~1,164) a small bitaxe found a
+/// share every ~10s, so a 300s window missed it with probability `e^-30` — never.
+/// Raising the floor to 10 TH/s (difficulty ~23,283) to serve rented hashrate moved that
+/// same miner to a ~200s mean, and `e^(-300/200)` = **22%**. With several small miners
+/// connected, roughly one was always invisible, and the public pool page flapped between
+/// 8, 7 and 6 while nothing was wrong.
+///
+/// At 900s the same miner is missed with probability `e^(-900/200)` = 1.1%.
+///
+/// ## If the vardiff floor changes again
+///
+/// This value is coupled to `min_individual_miner_hashrate` in the translator config, and
+/// nothing enforces that coupling automatically — the floor lives in the translator's TOML
+/// and this count lives in ghost-pool. Raise the floor materially and this window must be
+/// re-checked against the arithmetic above, or the same bug returns silently.
+pub const ACTIVE_MINER_WINDOW_SECS: i64 = 900;
+
 #[cfg(test)]
 mod tests {
+    /// The active-miner window must stay comfortably longer than the mean share
+    /// interval of the SMALLEST miner we expect to serve, or genuinely-mining miners
+    /// blink out of the count and the pool page looks like it is losing them.
+    ///
+    /// This is the arithmetic that was wrong when the window was 300s: a 500 GH/s
+    /// bitaxe at the 10 TH/s vardiff floor has a ~200s mean, and `e^(-300/200)` is 22%.
+    /// Pinning it here means raising the floor again without revisiting the window
+    /// fails this test instead of silently degrading the dashboard.
+    #[test]
+    fn test_active_miner_window_covers_the_smallest_expected_miner() {
+        use super::ACTIVE_MINER_WINDOW_SECS;
+
+        // difficulty -> hashes, using the exact stratum constant 2^48 / 0xFFFF.
+        const HASHES_PER_DIFFICULTY: f64 = ((1u64 << 48) as f64) / (0xFFFF as f64);
+
+        // The SV1 vardiff floor from config/sri/translator-config.toml, in H/s, and the
+        // difficulty it produces. Keep both in step with that file.
+        //
+        // Difficulty is NOT hashrate/HASHES_PER_DIFFICULTY: vardiff sizes it so the miner
+        // submits `shares_per_minute` shares, so the target share interval is part of it.
+        //   D = hashrate * target_interval / HASHES_PER_DIFFICULTY
+        // 10 TH/s at 6 shares/min gives 23,283, which is what the pool actually advertises
+        // (measured 23,282.7 against a live node). Omitting the interval gives 2,328 and
+        // makes this test pass on a window that is far too narrow.
+        const VARDIFF_FLOOR_HS: f64 = 10_000_000_000_000.0;
+        const SHARES_PER_MINUTE: f64 = 6.0;
+        const TARGET_SHARE_INTERVAL_S: f64 = 60.0 / SHARES_PER_MINUTE;
+        const FLOOR_DIFFICULTY: f64 =
+            VARDIFF_FLOOR_HS * TARGET_SHARE_INTERVAL_S / HASHES_PER_DIFFICULTY;
+
+        // Smallest miner we intend to serve on the low-difficulty path: a ~500 GH/s bitaxe.
+        const SMALLEST_MINER_HS: f64 = 500_000_000_000.0;
+
+        let mean_interval = FLOOR_DIFFICULTY * HASHES_PER_DIFFICULTY / SMALLEST_MINER_HS;
+        let miss_probability = (-(ACTIVE_MINER_WINDOW_SECS as f64) / mean_interval).exp();
+
+        assert!(
+            miss_probability < 0.05,
+            "a {SMALLEST_MINER_HS:.0} H/s miner has a {mean_interval:.0}s mean share \
+             interval at the current floor; a {ACTIVE_MINER_WINDOW_SECS}s window misses it \
+             {:.1}% of the time. Widen ACTIVE_MINER_WINDOW_SECS or lower the vardiff floor.",
+            miss_probability * 100.0
+        );
+    }
+
     use super::*;
 
     #[test]

--- a/crates/ghost-verification/src/routes.rs
+++ b/crates/ghost-verification/src/routes.rs
@@ -35,7 +35,9 @@ use std::sync::Arc;
 use tracing::{debug, error, info, warn};
 
 use ghost_buds::{BudsClassifier, BudsTier};
-use ghost_common::constants::{SV1_STRATUM_PORT, SV2_AUTHORITY_PUBLIC_KEY, SV2_STRATUM_PORT};
+use ghost_common::constants::{
+    ACTIVE_MINER_WINDOW_SECS, SV1_STRATUM_PORT, SV2_AUTHORITY_PUBLIC_KEY, SV2_STRATUM_PORT,
+};
 use ghost_common::rpc::MempoolFilterStats;
 
 use crate::auth::{verify_internal_auth, InternalAuth};
@@ -1801,7 +1803,7 @@ async fn api_mining_status_handler(
     let active_miners = state
         .database
         .as_ref()
-        .and_then(|db| db.count_active_miners(300).ok())
+        .and_then(|db| db.count_active_miners(ACTIVE_MINER_WINDOW_SECS).ok())
         .unwrap_or(0);
     let mesh_active_miners = state.mesh_active_miners().unwrap_or(active_miners);
     // Pool-wide hashrate (sum of every node's own realized hashrate) is the
@@ -3532,7 +3534,7 @@ async fn api_pool_status_handler(State(state): State<Arc<VerificationState>>) ->
     let active_miners = state
         .database
         .as_ref()
-        .and_then(|db| db.count_active_miners(300).ok())
+        .and_then(|db| db.count_active_miners(ACTIVE_MINER_WINDOW_SECS).ok())
         .unwrap_or(0);
     let mesh_active_miners = state.mesh_active_miners().unwrap_or(active_miners);
 


### PR DESCRIPTION
Fixes #445.

The active-miner count flapped between 8, 7 and 6 while nothing was wrong. Miners took turns dropping off and coming back:

```
bitaxe3   553s -> 699s -> 314s   recovered
bitaxe1   213s -> 359s ->  36s   recovered
bitaxe2   118s ->  29s -> 444s   went stale

connections: vm3=1 vm4=6 = 7, steady throughout
API:         local_connected_miners=7   active_miners=5
```

## Cause

The count only includes miners that submitted a share in the last 300s. That was fine at the old vardiff floor of 500 GH/s (difficulty 1,164), where a small bitaxe found a share every ~10s and a 300s window missed it with probability `e^-30`. Raising the floor to 10 TH/s to serve rented hashrate moved that same miner to a ~200s mean, and `e^(-300/200)` = **22%**.

So this was a consequence of raising the floor, not a miner problem.

## Changes

Widened to **900s** (1.1% for the same miner), and moved into `ghost-common` as `ACTIVE_MINER_WINDOW_SECS`. It was the literal `300` at seven call sites across three crates — `main.rs` ×5, `routes.rs` ×2 — with a comment at one of them warning they all had to match. That is precisely how they would have drifted.

Added a test that derives the mean share interval from the configured floor and fails if the window does not cover it. At 300s it reports:

```
a 500000000000 H/s miner has a 200s mean share interval at the current floor;
a 300s window misses it 22.3% of the time. Widen ACTIVE_MINER_WINDOW_SECS or
lower the vardiff floor.
```

So raising the floor again cannot silently reintroduce this.

## One thing worth flagging

The first version of that test **passed at both 300 and 900** — it tested nothing, and I nearly shipped it.

It computed `difficulty = hashrate / HASHES_PER_DIFFICULTY` = 2,328. But vardiff also targets `shares_per_minute`, so the real figure is `hashrate * target_interval / HASHES_PER_DIFFICULTY` = **23,283** — which is what the pool actually advertises, measured at 23,282.7 against a live node. With the wrong figure the mean came out as 20s instead of 200s, and `e^-15` passes trivially.

I only caught it because I ran the test against the *buggy* value expecting a failure and did not get one. Worth doing routinely: a guard that has only ever been seen to pass has not been shown to work.

## Not addressed here

`active_miners` and `local_connected_miners` measure two different things — "recently submitted work" versus "currently connected" — and the page shows the first while operators read it as the second. Widening the window makes them agree in practice, but the conflation is still there. Left alone rather than changing what the page reports without asking.
