### PR TITLE
translator: open the channel on subscribe, and carry the full identity in the TLV

### DIFF
--- a/bins/pool-sv2/src/lib/channel_manager/mining_message_handler.rs
+++ b/bins/pool-sv2/src/lib/channel_manager/mining_message_handler.rs
@@ -45,6 +45,18 @@ use crate::{
 /// the channel user_identity has no `.` we treat the whole thing as the address.
 fn build_webhook_user_identity(channel_uid: String, tlv_worker: Option<&str>) -> String {
     match tlv_worker.filter(|s| !s.is_empty()) {
+        // A TLV that already carries `<addr>.<worker>` is authoritative and used verbatim.
+        //
+        // This matters for miners whose SV2 channel had to be opened BEFORE their SV1
+        // `mining.authorize` arrived — proxies and rented-hashrate marketplaces wait for the
+        // `mining.subscribe` response before authorising, so the channel cannot carry their
+        // address at open time and holds the translator's provisional identity instead. Taking
+        // the address from the TLV rather than the channel keeps their payouts correct. The
+        // address is validated downstream by ghost-pool's `parse_user_identity` exactly as
+        // before, so a malformed TLV cannot redirect a payout to an unparseable target.
+        Some(worker) if worker.contains('.') => worker.to_string(),
+        // Worker-only TLV (the common case): splice it onto the address portion of the
+        // channel's identity, which is where the address lives for a normally-opened channel.
         Some(worker) => {
             let addr = channel_uid
                 .split_once('.')

--- a/bins/pool-sv2/src/lib/channel_manager/mining_message_handler.rs
+++ b/bins/pool-sv2/src/lib/channel_manager/mining_message_handler.rs
@@ -21,7 +21,7 @@ use stratum_apps::stratum_core::{
     parsers_sv2::{Mining, TemplateDistribution, Tlv, TlvField},
     template_distribution_sv2::SubmitSolution,
 };
-use tracing::{debug, error, info};
+use tracing::{error, info};
 
 use jd_server_sv2::job_declarator::SetCustomMiningJobResponse;
 

--- a/bins/translator-sv2/src/lib/sv1/downstream/data.rs
+++ b/bins/translator-sv2/src/lib/sv1/downstream/data.rs
@@ -29,6 +29,25 @@ pub struct DownstreamData {
     /// 1000% to ×3–×5 per 60s tick, so a farm or a rented-hashrate order spends minutes
     /// flooding shares before converging. A declared size skips the ramp entirely.
     pub suggested_hashrate: Option<Hashrate>,
+    /// True only when the ~1.5s subscribe-defer fallback actually answered `mining.subscribe`
+    /// with the PLACEHOLDER extranonce, i.e. a serialising miner was waiting on the response
+    /// before sending `mining.authorize`. Those miners — and only those — must be corrected
+    /// with `mining.set_extranonce` once the channel opens.
+    ///
+    /// A pipelining miner's queued subscribe is answered by the channel-open path with the REAL
+    /// extranonce, so it needs no correction. Sending one anyway is not merely redundant: it
+    /// puts an unsolicited `mining.set_extranonce` on the wire BEFORE the client's subscribe
+    /// reply, and `mining.set_extranonce` is an optional extension a client opts into via
+    /// `mining.extranonce.subscribe`. Strict clients hang up on it.
+    pub subscribe_answered_with_placeholder: bool,
+    /// Set as soon as an `OpenExtendedMiningChannel` has been SENT upstream, not when the
+    /// success comes back.
+    ///
+    /// `channel_id` stays `None` until the pool replies, so it cannot be used to decide whether
+    /// an open is already in flight: `mining.subscribe` requests the open, and a
+    /// `mining.authorize` arriving in that window would see `channel_id == None` and request a
+    /// second one, burning an extra upstream channel per miner.
+    pub channel_open_requested: bool,
     pub version_rolling_mask: Option<HexU32Be>,
     pub version_rolling_min_bit: Option<HexU32Be>,
     pub last_job_version_field: Option<u32>,
@@ -72,6 +91,8 @@ impl DownstreamData {
             target,
             hashrate,
             suggested_hashrate: None,
+            subscribe_answered_with_placeholder: false,
+            channel_open_requested: false,
             version_rolling_mask: None,
             version_rolling_min_bit: None,
             last_job_version_field: None,

--- a/bins/translator-sv2/src/lib/sv1/sv1_server/downstream_message_handler.rs
+++ b/bins/translator-sv2/src/lib/sv1/sv1_server/downstream_message_handler.rs
@@ -238,7 +238,7 @@ impl IsServer<'static> for Sv1Server {
                 data.authorized_worker_name = name.to_string();
             }
             // Extract the worker-name portion of `<addr>.<worker>` so the TLV carries the
-            // per-device identifier (which fits in 32 bytes) rather than the wallet address
+            // per-device identifier rather than the wallet address
             // (which doesn't and would duplicate the channel-level user_identity anyway).
             // Carry the FULL `<address>.<worker>` in the TLV, not just the worker name.
             //

--- a/bins/translator-sv2/src/lib/sv1/sv1_server/downstream_message_handler.rs
+++ b/bins/translator-sv2/src/lib/sv1/sv1_server/downstream_message_handler.rs
@@ -240,8 +240,15 @@ impl IsServer<'static> for Sv1Server {
             // Extract the worker-name portion of `<addr>.<worker>` so the TLV carries the
             // per-device identifier (which fits in 32 bytes) rather than the wallet address
             // (which doesn't and would duplicate the channel-level user_identity anyway).
-            data.user_identity =
-                tlv_compatible_username(super::extract_worker_name(name)).to_string();
+            // Carry the FULL `<address>.<worker>` in the TLV, not just the worker name.
+            //
+            // The channel's own `user_identity` is only correct when the channel was opened
+            // after `mining.authorize`. Miners that wait for the `mining.subscribe` response
+            // before authorising — proxies and rented-hashrate marketplaces — get their channel
+            // opened early under a provisional identity, so the TLV is the only place their
+            // real payout address can travel. pool_sv2 uses a dotted TLV verbatim and falls
+            // back to splicing a worker-only TLV onto the channel address.
+            data.user_identity = tlv_compatible_username(name).to_string();
             debug!(
                 "Down: Set user_identity to '{}' for downstream {}",
                 data.user_identity, downstream_id

--- a/bins/translator-sv2/src/lib/sv1/sv1_server/mod.rs
+++ b/bins/translator-sv2/src/lib/sv1/sv1_server/mod.rs
@@ -149,22 +149,6 @@ pub(super) fn parse_suggest_difficulty(msg: &Message) -> Option<f64> {
     (difficulty.is_finite() && difficulty > 0.0).then_some(difficulty)
 }
 
-/// Extracts the worker-identifier portion of an SV1 `mining.authorize` username for use as the
-/// per-downstream identity that flows into the Worker-Specific Hashrate Tracking TLV.
-///
-/// Public-pool convention is `<payout_address>.<worker_name>` (e.g.
-/// `bc1qabc...xyz.bitaxe1`). The address part is too long for the 32-byte TLV cap and would
-/// duplicate information already carried in the channel-level `user_identity` (which the
-/// translator config sources from the operator's wallet). The worker part — the bit that
-/// actually distinguishes one device from another behind the same wallet — is short and fits.
-///
-/// If the username has no `.` separator, the whole string is treated as the worker name and
-/// returned. The caller still passes the result through [`tlv_compatible_username`] to enforce
-/// the 32-byte ceiling for safety against pathological inputs.
-pub(super) fn extract_worker_name(name: &str) -> &str {
-    name.rsplit_once('.').map(|(_, w)| w).unwrap_or(name)
-}
-
 /// Truncates a string to [`MAX_USER_IDENTITY_BYTES`], respecting UTF-8 character boundaries.
 ///
 /// If the input string exceeds the limit, it is truncated at the last valid UTF-8 character
@@ -336,7 +320,9 @@ mod username_difficulty_tests {
         let username = format!("{ADDR}.braiins.d=9300000");
         let (name, _) = split_username_difficulty(&username);
         assert!(name.contains('.'));
-        assert_eq!(extract_worker_name(name), "braiins");
+        // The full `<address>.<worker>` must survive intact — it is now what the TLV
+        // carries, so losing either half misattributes the share.
+        assert_eq!(name, format!("{ADDR}.braiins"));
     }
 }
 

--- a/bins/translator-sv2/src/lib/sv1/sv1_server/mod.rs
+++ b/bins/translator-sv2/src/lib/sv1/sv1_server/mod.rs
@@ -170,7 +170,11 @@ pub(super) fn extract_worker_name(name: &str) -> &str {
 /// If the input string exceeds the limit, it is truncated at the last valid UTF-8 character
 /// boundary before or at [`MAX_USER_IDENTITY_BYTES`] and a warning is logged.
 fn tlv_compatible_username(s: &str) -> &str {
-    const MAX_USER_IDENTITY_BYTES: usize = 32;
+    // The SV2 wire type is `Str0255`, so 255 bytes are permitted; this cap is ours. It was 32,
+    // which fits a worker name but truncates a full `<address>.<worker>` — a bech32 address is
+    // 42 bytes on its own. The TLV now carries the full identity for miners whose channel was
+    // opened before `mining.authorize` arrived, so it must fit one.
+    const MAX_USER_IDENTITY_BYTES: usize = 255;
     let len = s.len();
 
     if len <= MAX_USER_IDENTITY_BYTES {

--- a/bins/translator-sv2/src/lib/sv1/sv1_server/sv1_server.rs
+++ b/bins/translator-sv2/src/lib/sv1/sv1_server/sv1_server.rs
@@ -478,9 +478,6 @@ impl Sv1Server {
 
         let keepalive_future = self.clone().spawn_job_keepalive_loop();
 
-        // Compute-protection miner shedding (opt-in; inert unless enabled). Fire-and-forget,
-        // like the zombie-connection reaper.
-
         let listener = TcpListener::bind(self.listener_addr).await.map_err(|e| {
             error!("Failed to bind to {}: {}", self.listener_addr, e);
             TproxyError::shutdown(e)

--- a/bins/translator-sv2/src/lib/sv1/sv1_server/sv1_server.rs
+++ b/bins/translator-sv2/src/lib/sv1/sv1_server/sv1_server.rs
@@ -480,7 +480,6 @@ impl Sv1Server {
 
         // Compute-protection miner shedding (opt-in; inert unless enabled). Fire-and-forget,
         // like the zombie-connection reaper.
-        tokio::spawn(self.clone().spawn_shed_loop());
 
         let listener = TcpListener::bind(self.listener_addr).await.map_err(|e| {
             error!("Failed to bind to {}: {}", self.listener_addr, e);
@@ -975,7 +974,7 @@ impl Sv1Server {
                 .downstream_data
                 .super_safe_lock(|d| d.user_identity.clone());
             // The downstream's user_identity is set during mining.authorize via
-            // extract_worker_name + tlv_compatible_username, so it's already capped at 32
+            // tlv_compatible_username, so it is already within MAX_USER_IDENTITY_LENGTH
             // bytes. If it somehow isn't (empty downstream pre-authorize), skip the TLV
             // gracefully rather than disconnecting the miner.
             if user_identity.is_empty() {
@@ -1521,8 +1520,9 @@ impl Sv1Server {
         };
 
         // NOTE: do NOT overwrite `data.user_identity` here — that field carries the per-share
-        // TLV worker-name (set by `mining.authorize` via `extract_worker_name`) and is bounded
-        // to 32 bytes by the spec. It must stay independent of the channel-level user_identity.
+        // TLV identity (set by `mining.authorize`, carrying the full `<address>.<worker>`) and is bounded
+        // by MAX_USER_IDENTITY_LENGTH. It must stay independent of the channel-level
+        // user_identity.
         let _ = downstream
             .downstream_data
             .safe_lock(|_d| ())
@@ -1810,56 +1810,6 @@ impl Sv1Server {
             }
         }
         Ok(())
-    }
-
-    /// Spawns the job keepalive loop that sends periodic mining.notify messages.
-    ///
-    /// This prevents SV1 miners from timing out when there are no new jobs received from the
-    /// upstream for a while.
-    /// Compute-protection miner shedding (opt-in via `[load_balancer].compute_shed_enabled`).
-    /// When this node is `Critical` — its per-core 1-minute load average is at/over
-    /// `compute_evict_pct`, or it is over its miner-capacity evict threshold — evict up to
-    /// `shed_batch_size` miners per tick by cancelling their connection token, so they reconnect
-    /// via DNS to a less-loaded node. Returns immediately (inert) unless compute-protection is on,
-    /// so the default build is behaviour-neutral. Same eviction primitive as the zombie reaper
-    /// (`connection_token.cancel()` + idempotent `handle_downstream_disconnect`).
-    pub async fn spawn_shed_loop(self: Arc<Self>) {
-        let Some(lb) = self.load_balancer.clone() else {
-            return;
-        };
-        if !lb.compute_shed_enabled() {
-            return;
-        }
-        let check_interval = Duration::from_secs(15);
-        info!("Starting compute-protection miner-shed loop");
-        loop {
-            tokio::time::sleep(check_interval).await;
-            if !lb.should_shed().await {
-                continue;
-            }
-            // Shed the lowest-id (oldest) downstreams first, a small batch per tick; we
-            // re-evaluate each tick so shedding stops as soon as pressure drops.
-            let mut victims: Vec<DownstreamId> =
-                self.downstreams.iter().map(|e| *e.key()).collect();
-            victims.sort_unstable();
-            victims.truncate(lb.shed_batch_size());
-            for id in victims {
-                // Extract + drop the DashMap ref BEFORE handle_downstream_disconnect (which
-                // removes from the same map) to avoid holding a guard across the removal.
-                let token = self
-                    .downstreams
-                    .get(&id)
-                    .map(|ds| ds.downstream_channel_state.connection_token.clone());
-                if let Some(token) = token {
-                    token.cancel();
-                }
-                self.handle_downstream_disconnect(id).await;
-                warn!(
-                    "Shed downstream {} — node under compute pressure (miner will reconnect via DNS)",
-                    id
-                );
-            }
-        }
     }
 
     pub async fn spawn_job_keepalive_loop(self: Arc<Self>) {

--- a/bins/translator-sv2/src/lib/sv1/sv1_server/sv1_server.rs
+++ b/bins/translator-sv2/src/lib/sv1/sv1_server/sv1_server.rs
@@ -244,14 +244,16 @@ impl Sv1Server {
         downstream.downstream_data.super_safe_lock(|data| {
             data.suggested_hashrate = Some(clamped as Hashrate);
             data.hashrate = Some(clamped as Hashrate);
-            // Channel already open: the open path can no longer pick this up, so stage it for
-            // the vardiff loop, which pushes UpdateChannel upstream and mining.set_difficulty
-            // downstream on its next tick.
-            if data.channel_id.is_some() {
-                data.set_pending_hashrate(Some(clamped as Hashrate), downstream_id);
-                if let Some(target) = pending_target {
-                    data.set_pending_target(target, downstream_id);
-                }
+            // Always stage the target, whether or not the channel exists yet.
+            //
+            // A declaration can land before the channel opens (`mining.suggest_difficulty`, in
+            // which case the open path reads `suggested_hashrate` directly), while the channel
+            // open is in flight (an authorize password, since the channel is now requested at
+            // subscribe), or after it is open. Only the middle case has no other pickup point,
+            // so the channel-open handler drains this staged target once the channel exists.
+            data.set_pending_hashrate(Some(clamped as Hashrate), downstream_id);
+            if let Some(target) = pending_target {
+                data.set_pending_target(target, downstream_id);
             }
         });
     }
@@ -475,6 +477,10 @@ impl Sv1Server {
         let vardiff_future = self.clone().spawn_vardiff_loop();
 
         let keepalive_future = self.clone().spawn_job_keepalive_loop();
+
+        // Compute-protection miner shedding (opt-in; inert unless enabled). Fire-and-forget,
+        // like the zombie-connection reaper.
+        tokio::spawn(self.clone().spawn_shed_loop());
 
         let listener = TcpListener::bind(self.listener_addr).await.map_err(|e| {
             error!("Failed to bind to {}: {}", self.listener_addr, e);
@@ -752,65 +758,35 @@ impl Sv1Server {
                         .push(downstream_message.clone())
                 });
 
-                // mining.subscribe timeout fallback (serializer safety).
+                // `mining.subscribe` opens the channel itself.
                 //
-                // PIPELINING miners (AxeOS/bitaxe) fire subscribe + authorize back-to-back, so
-                // the channel opens within ~100ms and the queued subscribe is answered with the
-                // REAL extranonce by the channel-open path (no set_extranonce needed). But
-                // SERIALIZING miners (cgminer / Avalon) wait for the subscribe RESPONSE before
-                // sending authorize — and the channel only opens on authorize. Queuing subscribe
-                // with no fallback deadlocks them: no response → no authorize → no channel → no
-                // response. After ~1.5s with no channel, answer subscribe with the placeholder
-                // extranonce so the serializer proceeds; the channel then opens and the existing
-                // set_extranonce path corrects the extranonce (serializing miners support that
-                // extension). The channel-open path and this timer both claim the queued subscribe
-                // atomically under the data lock, so exactly one of them answers it.
+                // The subscribe response carries `[subscriptions, extranonce1, extranonce2_size]`,
+                // and it must carry the REAL channel-allocated extranonce. Proxies and
+                // rented-hashrate marketplaces subdivide that extranonce across the miners they
+                // fan out to, then treat the allocation as fixed — so answering with a
+                // placeholder and correcting later via `mining.set_extranonce` does not work for
+                // them. The correction changes `extranonce1` from the 8-byte placeholder to the
+                // real 12-byte prefix, invalidating every sub-range they derived, and they drop
+                // the connection and retry forever.
+                //
+                // Those clients are also SERIALISERS: they wait for the subscribe response
+                // before sending `mining.authorize`. Opening the channel only on authorize
+                // therefore deadlocks them. Opening it here breaks the deadlock and lets the
+                // response carry the real extranonce first time, for every client.
+                //
+                // The channel opens under a provisional `user_identity` (the config prefix,
+                // since no username is known yet). `mining.authorize` does NOT re-open it —
+                // re-keying is precisely what these clients cannot tolerate. Attribution
+                // instead travels in the per-miner TLV, which carries the full
+                // `<address>.<worker>` once authorize lands; pool_sv2 prefers a dotted TLV over
+                // the channel identity, so payouts follow the miner, not the provisional value.
                 if is_mining_subscribe(&downstream_message) {
-                    let server = self.clone();
-                    let did = downstream_id;
-                    tokio::spawn(async move {
-                        tokio::time::sleep(std::time::Duration::from_millis(1500)).await;
-                        let Some(downstream) =
-                            server.downstreams.get(&did).map(|r| r.value().clone())
-                        else {
-                            return;
-                        };
-                        // Claim the queued subscribe iff the channel still hasn't opened (i.e. the
-                        // open path hasn't already answered it — a pipelining miner).
-                        let subscribe_msg = downstream.downstream_data.super_safe_lock(|data| {
-                            if data.channel_id.is_some() {
-                                return None;
-                            }
-                            data.queued_sv1_handshake_messages
-                                .iter()
-                                .position(|m| is_mining_subscribe(m))
-                                .map(|pos| data.queued_sv1_handshake_messages.remove(pos))
-                        });
-                        if let Some(msg) = subscribe_msg {
-                            info!(
-                                "Down: subscribe-response timeout for downstream {} — serializing \
-                                 miner waiting on subscribe before authorize; answering with \
-                                 placeholder extranonce (set_extranonce corrects it on channel open)",
-                                did
-                            );
-                            match server.clone().handle_message(Some(did), msg) {
-                                Ok(Some(resp)) => {
-                                    if let Err(e) = downstream
-                                        .downstream_channel_state
-                                        .downstream_sv1_sender
-                                        .send(resp.into())
-                                        .await
-                                    {
-                                        warn!("Down: failed to send fallback subscribe response to downstream {}: {:?}", did, e);
-                                    }
-                                }
-                                Ok(None) => {}
-                                Err(e) => {
-                                    error!("Down: error building fallback subscribe response for downstream {}: {:?}", did, e);
-                                }
-                            }
-                        }
-                    });
+                    debug!(
+                        "Down: opening channel for downstream {} on subscribe so the response \
+                         carries the real extranonce",
+                        downstream_id
+                    );
+                    self.handle_open_channel_request(downstream_id).await?;
                 }
 
                 return Ok(());
@@ -883,6 +859,36 @@ impl Sv1Server {
                 error!("Down: Error handling downstream message: {:?}", e);
                 return Err(TproxyError::disconnect(e, downstream_id));
             }
+        }
+
+        // Second pickup point for a declared difficulty: the channel was ALREADY open when the
+        // declaration arrived.
+        //
+        // Which of the two fires is a race between the miner's authorize and the pool's
+        // OpenExtendedMiningChannelSuccess, and it flips with pool latency — a co-located pool
+        // answers before authorize is processed, a remote one after. Draining the staged target
+        // in both places makes the outcome latency-independent; whichever runs first takes it
+        // and the other finds nothing.
+        let declared_update = downstream.downstream_data.super_safe_lock(|d| {
+            match (d.channel_id, d.pending_target, d.suggested_hashrate) {
+                (Some(channel_id), Some(target), Some(hashrate)) => {
+                    d.pending_target = None;
+                    Some((channel_id, target, hashrate))
+                }
+                _ => None,
+            }
+        });
+        if let Some((channel_id, target, hashrate)) = declared_update {
+            debug!(
+                "Down: applying declared difficulty for downstream {} post-authorize (channel {})",
+                downstream_id, channel_id
+            );
+            self.send_set_difficulty_to_specific_downstream(
+                channel_id,
+                target,
+                Some(hashrate as f64),
+            )
+            .await?;
         }
 
         // Check if there's a pending share to send to the Sv1Server
@@ -1027,6 +1033,30 @@ impl Sv1Server {
         &self,
         downstream_id: DownstreamId,
     ) -> TproxyResult<(), error::Sv1Server> {
+        // Exactly one open per downstream. Both `mining.subscribe` (which opens the channel so
+        // the response can carry the real extranonce) and `mining.authorize` (the historical
+        // trigger, still needed for clients that never subscribe first) reach here, and the
+        // window between sending the request and receiving the success is wide enough for both
+        // to fire. Test-and-set under the data lock so the loser is a no-op.
+        let already_requested = self
+            .downstreams
+            .get(&downstream_id)
+            .map(|d| {
+                d.downstream_data.super_safe_lock(|data| {
+                    let seen = data.channel_open_requested;
+                    data.channel_open_requested = true;
+                    seen
+                })
+            })
+            .unwrap_or(false);
+        if already_requested {
+            debug!(
+                "SV1 server: channel open already in flight for downstream {}, skipping",
+                downstream_id
+            );
+            return Ok(());
+        }
+
         info!(
             "SV1 server: opening extended mining channel for downstream {} after first message",
             downstream_id
@@ -1105,13 +1135,19 @@ impl Sv1Server {
                     let already_subscribed = downstream
                         .downstream_data
                         .safe_lock(|d| {
-                            // Detect whether subscribe was already responded to with a placeholder
-                            // extranonce — i.e. the public-pool defer-open path. We treat the
-                            // initial DownstreamData::new value (8 bytes of zero) as the
-                            // placeholder. Any other prior value means we shouldn't send a
-                            // post-hoc set_extranonce (would be confusing for the miner).
-                            let was_placeholder = d.extranonce1.as_ref().len() == 8
-                                && d.extranonce1.as_ref().iter().all(|b| *b == 0);
+                            // Send the corrective `mining.set_extranonce` ONLY to a miner whose
+                            // subscribe was actually answered with the placeholder by the ~1.5s
+                            // fallback (a serialiser). This used to be inferred by checking
+                            // whether `extranonce1` was still 8 zero bytes — but that is true of
+                            // EVERY downstream at channel open, including pipelining miners whose
+                            // queued subscribe is answered moments later, in this same handler,
+                            // with the real extranonce. Those miners were being sent an
+                            // unsolicited `mining.set_extranonce` BEFORE their subscribe reply.
+                            // `mining.set_extranonce` is an optional extension a client opts into
+                            // via `mining.extranonce.subscribe`; strict clients disconnect on
+                            // receiving one they never asked for, which is what rented-hashrate
+                            // clients were doing ~200ms after every handshake.
+                            let was_placeholder = d.subscribe_answered_with_placeholder;
                             d.extranonce1 = real_extranonce1.clone();
                             d.extranonce2_len = real_extranonce2_size;
                             d.channel_id = Some(m.channel_id);
@@ -1191,6 +1227,38 @@ impl Sv1Server {
                             info!(
                                 "Down: sent mining.set_extranonce to downstream {} (real extranonce={} bytes, extranonce2_size={})",
                                 downstream_id, real_extranonce1.as_ref().len(), real_extranonce2_size
+                            );
+                        }
+                    }
+
+                    // A difficulty declared while this channel's open was in flight (an authorize
+                    // password, which arrives after subscribe has already requested the open)
+                    // could not size the channel. Apply it now that the channel exists, rather
+                    // than leaving the miner at the pool floor until a vardiff tick up to 60s
+                    // later. `mining.suggest_difficulty` needs nothing here — it precedes
+                    // subscribe, so the open path already used it.
+                    let staged = downstream.downstream_data.super_safe_lock(|d| {
+                        match (d.pending_target.take(), d.suggested_hashrate) {
+                            (Some(t), Some(h)) => Some((t, h)),
+                            _ => None,
+                        }
+                    });
+                    if let Some((target, hashrate)) = staged {
+                        debug!(
+                            "Down: applying declared difficulty for downstream {} on channel open (channel {})",
+                            downstream_id, m.channel_id
+                        );
+                        if let Err(e) = self
+                            .send_set_difficulty_to_specific_downstream(
+                                m.channel_id,
+                                target,
+                                Some(hashrate as f64),
+                            )
+                            .await
+                        {
+                            warn!(
+                                "Down: failed to apply declared difficulty for downstream {}: {:?}",
+                                downstream_id, e
                             );
                         }
                     }
@@ -1748,6 +1816,52 @@ impl Sv1Server {
     ///
     /// This prevents SV1 miners from timing out when there are no new jobs received from the
     /// upstream for a while.
+    /// Compute-protection miner shedding (opt-in via `[load_balancer].compute_shed_enabled`).
+    /// When this node is `Critical` — its per-core 1-minute load average is at/over
+    /// `compute_evict_pct`, or it is over its miner-capacity evict threshold — evict up to
+    /// `shed_batch_size` miners per tick by cancelling their connection token, so they reconnect
+    /// via DNS to a less-loaded node. Returns immediately (inert) unless compute-protection is on,
+    /// so the default build is behaviour-neutral. Same eviction primitive as the zombie reaper
+    /// (`connection_token.cancel()` + idempotent `handle_downstream_disconnect`).
+    pub async fn spawn_shed_loop(self: Arc<Self>) {
+        let Some(lb) = self.load_balancer.clone() else {
+            return;
+        };
+        if !lb.compute_shed_enabled() {
+            return;
+        }
+        let check_interval = Duration::from_secs(15);
+        info!("Starting compute-protection miner-shed loop");
+        loop {
+            tokio::time::sleep(check_interval).await;
+            if !lb.should_shed().await {
+                continue;
+            }
+            // Shed the lowest-id (oldest) downstreams first, a small batch per tick; we
+            // re-evaluate each tick so shedding stops as soon as pressure drops.
+            let mut victims: Vec<DownstreamId> =
+                self.downstreams.iter().map(|e| *e.key()).collect();
+            victims.sort_unstable();
+            victims.truncate(lb.shed_batch_size());
+            for id in victims {
+                // Extract + drop the DashMap ref BEFORE handle_downstream_disconnect (which
+                // removes from the same map) to avoid holding a guard across the removal.
+                let token = self
+                    .downstreams
+                    .get(&id)
+                    .map(|ds| ds.downstream_channel_state.connection_token.clone());
+                if let Some(token) = token {
+                    token.cancel();
+                }
+                self.handle_downstream_disconnect(id).await;
+                warn!(
+                    "Shed downstream {} — node under compute pressure (miner will reconnect via DNS)",
+                    id
+                );
+            }
+        }
+    }
+
     pub async fn spawn_job_keepalive_loop(self: Arc<Self>) {
         let keepalive_interval_secs = self
             .config

--- a/scripts/ops/attribution_probe.py
+++ b/scripts/ops/attribution_probe.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Submit a REAL share as `<address>.<worker>` and let the operator check who got credited.
+
+This is the test that was missing the two times channel-open-on-subscribe was deployed and
+misattributed ~395 shares. Both times the failure was silent: shares kept flowing, they
+simply landed on the translator's configured operator address instead of the miner. Nothing
+on the wire says which identity a share was credited to — only the node's database does.
+
+So this deliberately mines a share that is genuinely valid rather than asserting on
+handshake fields. It behaves as a SERIALISING client (subscribe -> wait for reply ->
+authorize), because that is the shape that forced this change: proxies and rented-hashrate
+marketplaces wait for the subscribe response before authorising, so their channel has to be
+opened before their address is known.
+
+Usage:
+  attribution_probe.py HOST PORT ADDRESS.WORKER [PASSWORD]
+
+Exits 0 once a share is accepted. The caller then reads the node's `miners` table and checks
+the credited miner_id.
+"""
+import hashlib, json, socket, struct, sys, time
+
+HOST = sys.argv[1]
+PORT = int(sys.argv[2])
+USER = sys.argv[3]
+PASSWORD = sys.argv[4] if len(sys.argv) > 4 else "x"
+
+
+def sha256d(b):
+    return hashlib.sha256(hashlib.sha256(b).digest()).digest()
+
+
+def send(sock, obj):
+    sock.sendall(json.dumps(obj).encode() + b"\n")
+
+
+def reader(sock):
+    """Yield decoded JSON messages as they arrive."""
+    buf = b""
+    while True:
+        data = sock.recv(8192)
+        if not data:
+            return
+        buf += data
+        while b"\n" in buf:
+            line, buf = buf.split(b"\n", 1)
+            if not line.strip():
+                continue
+            try:
+                yield json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+
+def difficulty_to_target(diff):
+    # Stratum difficulty 1 target, scaled. Uses the exact constant, not 2^32.
+    return int((0xFFFF * (1 << 208)) / diff) if diff > 0 else (1 << 256) - 1
+
+
+def main():
+    s = socket.create_connection((HOST, PORT), timeout=30)
+    s.settimeout(60)
+    rx = reader(s)
+
+    # --- serialising handshake: subscribe, WAIT for the reply, only then authorize ---
+    send(s, {"id": 1, "method": "mining.subscribe", "params": ["attribution-probe/1.0"]})
+
+    extranonce1 = None
+    extranonce2_size = None
+    t0 = time.time()
+    for msg in rx:
+        if msg.get("id") == 1 and "result" in msg:
+            res = msg["result"]
+            extranonce1, extranonce2_size = res[1], res[2]
+            break
+        if time.time() - t0 > 30:
+            print("FAIL: no subscribe reply"); return 1
+
+    print(f"  subscribe -> extranonce1={extranonce1} extranonce2_size={extranonce2_size} "
+          f"in {time.time()-t0:.2f}s")
+    if extranonce1 is None:
+        print("FAIL: no extranonce in subscribe reply"); return 1
+    # A placeholder (all-zero, 8 bytes) means the channel had NOT opened yet — the very
+    # behaviour this change exists to remove.
+    if len(extranonce1) == 16 and set(extranonce1) == {"0"}:
+        print("  NOTE: placeholder extranonce — channel was not open at subscribe time")
+    else:
+        print("  real extranonce at subscribe (no re-key needed)")
+
+    send(s, {"id": 2, "method": "mining.authorize", "params": [USER, PASSWORD]})
+
+    job = None
+    difficulty = None
+    authorized = None
+    re_keyed = False
+    t0 = time.time()
+    for msg in rx:
+        if msg.get("id") == 2 and "result" in msg:
+            authorized = msg["result"]
+            print(f"  authorize({USER}) -> {authorized}")
+            if authorized is not True:
+                print("FAIL: not authorized"); return 1
+        m = msg.get("method")
+        if m == "mining.set_difficulty":
+            difficulty = float(msg["params"][0])
+            print(f"  set_difficulty -> {difficulty}")
+        elif m == "mining.set_extranonce":
+            extranonce1, extranonce2_size = msg["params"][0], msg["params"][1]
+            re_keyed = True
+            print(f"  set_extranonce -> RE-KEYED to {extranonce1} (size {extranonce2_size})")
+        elif m == "mining.notify":
+            job = msg["params"]
+        if job and difficulty and authorized:
+            break
+        if time.time() - t0 > 60:
+            print("FAIL: no job/difficulty within 60s"); return 1
+
+    (job_id, prevhash, coinb1, coinb2, merkle_branch,
+     version, nbits, ntime, _clean) = job[:9]
+    print(f"  job {job_id} difficulty={difficulty} re_keyed={re_keyed}")
+
+    target = difficulty_to_target(difficulty)
+    print(f"  mining for a share at difficulty {difficulty} ...")
+
+    # --- actually mine ---
+    en1 = bytes.fromhex(extranonce1)
+    started = time.time()
+    attempts = 0
+    for en2_int in range(0, 1 << 32):
+        en2 = en2_int.to_bytes(extranonce2_size, "little")
+        coinbase = bytes.fromhex(coinb1) + en1 + en2 + bytes.fromhex(coinb2)
+        merkle = sha256d(coinbase)
+        for h in merkle_branch:
+            merkle = sha256d(merkle + bytes.fromhex(h))
+
+        # Stratum sends prevhash WORD-swapped: reverse each 4-byte word, not the whole
+        # 32 bytes. Reversing wholesale produces a header the pool rejects as an
+        # invalid share, which is what happened on the first attempt here.
+        prev = bytes.fromhex(prevhash)
+        prev_hdr = b"".join(prev[i:i + 4][::-1] for i in range(0, 32, 4))
+
+        head = (bytes.fromhex(version)[::-1]
+                + prev_hdr
+                + merkle
+                + bytes.fromhex(ntime)[::-1]
+                + bytes.fromhex(nbits)[::-1])
+
+        for nonce in range(0, 1 << 32):
+            attempts += 1
+            h = sha256d(head + struct.pack("<I", nonce))
+            if int.from_bytes(h[::-1], "big") < target:
+                elapsed = time.time() - started
+                print(f"  FOUND after {attempts:,} hashes in {elapsed:.1f}s")
+                send(s, {"id": 4, "method": "mining.submit",
+                         "params": [USER, job_id, en2.hex(), ntime, f"{nonce:08x}"]})
+                for msg in rx:
+                    if msg.get("id") == 4:
+                        ok = msg.get("result")
+                        print(f"  submit -> {ok}  error={msg.get('error')}")
+                        s.close()
+                        return 0 if ok else 1
+                return 1
+            if attempts % 2_000_000 == 0:
+                print(f"    {attempts:,} hashes, {time.time()-started:.0f}s ...")
+            if time.time() - started > 900:
+                print("FAIL: no share found in 900s — difficulty too high for this prober")
+                return 1
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/vendor/stratum/sv2/parsers-sv2/src/tlv_extensions/mod.rs
+++ b/vendor/stratum/sv2/parsers-sv2/src/tlv_extensions/mod.rs
@@ -62,7 +62,8 @@ impl TlvField for UserIdentity {
             return Err(UserIdentityError::InvalidFieldType(tlv.r#type.field_type).into());
         }
 
-        // Enforce 32-byte maximum
+        // Enforce the identity length cap (MAX_USER_IDENTITY_LENGTH, owned by
+        // extensions_sv2). It was 32, which truncated a full `<address>.<worker>`.
         if tlv.value.len() > MAX_USER_IDENTITY_LENGTH {
             return Err(UserIdentityError::TooLong(tlv.value.len()).into());
         }


### PR DESCRIPTION
Fixes #411. Also resolves #416.

Cherry-picked from `836ea1c5` on `pool-hardening`, with the parts that did not belong to it removed, the blocker that shelved it re-examined, and — for the first time — **attribution validated end to end against a real share**.

## What it fixes

A serialising client (proxies, rented-hashrate marketplaces — they wait for the subscribe response before authorising) received an 8-byte **placeholder** extranonce, corrected afterwards by `mining.set_extranonce` to a 12-byte prefix. That re-key invalidates the sub-ranges a fanning-out proxy has already handed to its workers.

The channel now opens on `mining.subscribe` under a provisional identity, so those clients get the real extranonce in the subscribe reply with no re-key. A request-level guard stops subscribe and authorize both opening a channel.

## Why it is no longer blocked

`836ea1c5` was committed explicitly **NOT SAFE TO DEPLOY**: it had misattributed ~395 shares across two production deploys and the author could not find the cause, guessing at extension `0x0002` negotiation. The recorded symptom was *"the TLV still does not override the channel identity, so shares land on the translator's provisional config address."*

That is exactly the bug **#422** later diagnosed and fixed: `MAX_USER_IDENTITY_LENGTH` was declared independently in `extensions_sv2` and in `parsers-sv2`. Raising the former fixed `UserIdentity::new` but left the latter gating `to_tlv`/`from_tlv` at 32 bytes, so a full `<address>.<worker>` failed to encode — and because the caller discarded that error with `.ok()`, the share went out with **no identity TLV at all** and fell back to the channel identity.

The guess was also wrong on its own terms: vm8 logs `Extension negotiation success: supported=[2]`, so `0x0002` negotiates fine.

## Validated on ghost-vm8 (canary, zero miners)

Rather than assert on handshake fields, a probe mines a **genuinely valid share** as a serialising client and the credited row is then read from the database. That is the check that was missing both times this went wrong — the failure was silent, shares kept flowing, they simply landed on the wrong identity.

The node's `user_identity` is `bc1q9z23a6yl…q0ej`, so misattribution is unambiguous.

**Before (current binary `287725e5`) — the control:**

```
subscribe -> extranonce1=0000000000000000    PLACEHOLDER
set_extranonce -> RE-KEYED to 000100070000000000000001
submit -> True
credited: bc1q7zvdh3….attribBASE            (correct — #422 already fixed attribution)
```

**After (this branch):**

```
subscribe -> extranonce1=000100010000000000000001   real, no re-key
submit -> True
credited: bc1q7zvdh3….attribNEW
```

Five runs total. Every one got a real extranonce at subscribe with **zero** `set_extranonce` re-keys, and the `shares` ledger credits each to the right miner:

```
bc1q7zvdh3….attribr3 | 1 share | work 0.000465654414707473
bc1q7zvdh3….attribr2 | 1 share | work 0.000465654414707473
bc1q7zvdh3….attribr1 | 1 share | work 0.000465654414707473
bc1q7zvdh3….attribNEW| 1 share | work 0.000465654414707473
```

Work equals difficulty, matching the absolute work model in `round.rs`. **Zero rows** credited to the provisional/operator identity `bc1q9z23a6yl%` across the whole test window.

The probe is `scripts/ops/attribution_probe.py` so this is repeatable rather than a one-off.

## Removed from the original commit

`spawn_shed_loop` — a compute-protection miner-eviction feature — came along because `836ea1c5` was authored on top of `f75fb327` (decentralised discovery) and depends on `LoadBalancer` methods that do not exist on main. It has nothing to do with extranonce allocation. Dropped, so this no longer depends on the decentralisation work and `pool-hardening` is one commit closer to being resolvable.

## Resolves #416

`extract_worker_name` becomes genuinely dead once the TLV carries the full identity rather than just the worker part. Removed, along with the comments still describing a 32-byte, worker-only TLV in `mod.rs`, `sv1_server.rs`, `downstream_message_handler.rs` and the parsers TLV module. Those comments were a trap: 32 bytes is precisely the figure behind the months-long misattribution.

I had previously called #416's premise invalid because `extract_worker_name` is live on main — it was written expecting this change to land, which is now the case.

## Checks

```
cargo check / test -p translator_sv2 -p pool_sv2   clean, 43 tests pass
clippy on these two crates: 26 warnings vs 30 on main (-4)
```

## Still to do before production

This is soaking on vm8 with `.bak.411test.*` rollbacks in place. It should not go to a node carrying miners until it has run a full soak there, and the first production node should be watched with the same probe plus a read of the real miners' credited rows.
