### PR TITLE
translator: optional second listener for farm and rented hashrate

### DIFF
--- a/bins/translator-sv2/src/lib/config.rs
+++ b/bins/translator-sv2/src/lib/config.rs
@@ -40,6 +40,24 @@ pub struct TranslatorConfig {
     pub user_identity: String,
     /// Configuration settings for managing difficulty on the downstream connection.
     pub downstream_difficulty_config: DownstreamDifficultyConfig,
+    /// Optional second listener for farm-scale and rented hashrate.
+    ///
+    /// One difficulty cannot serve both a 500 GH/s bitaxe and a 1 PH/s order. Sized for the
+    /// bitaxe, a large order floods the pool for minutes while vardiff ramps (it caps
+    /// corrections above 1000% to x3-x5 per 60s tick), and marketplaces reject a pool whose
+    /// starting difficulty is far below the hashrate they are pointing at it. Sized for the
+    /// order, a bitaxe finds a share every few minutes and looks dead.
+    ///
+    /// `None` (the default, and the shape of every existing config file) leaves the single
+    /// listener exactly as it was.
+    ///
+    /// Note this is a CAPACITY control, not an anti-fraud one. Payout is proportional to
+    /// work, and a share's work IS its difficulty (see `round.rs`), so 20 shares at
+    /// difficulty 1,164 and one share at 23,283 are worth the same. A large miner on the
+    /// hobby port gains nothing; it just costs the node 20x the share validation, bandwidth
+    /// and database writes.
+    #[serde(default)]
+    pub farm_tier: Option<FarmTierConfig>,
     /// Whether to aggregate all downstream connections into a single upstream channel.
     /// If true, all miners share one channel. If false, each miner gets its own channel.
     pub aggregate_channels: bool,
@@ -137,6 +155,9 @@ impl TranslatorConfig {
             monitoring_address,
             monitoring_cache_refresh_secs,
             load_balancer: None,
+            // Optional like the TLS listener: absent means the single hobby listener only,
+            // which is what every existing config file produces.
+            farm_tier: None,
             tls_port: None,
             tls_cert_path: None,
             tls_key_path: None,
@@ -181,6 +202,24 @@ pub struct DownstreamDifficultyConfig {
     pub job_keepalive_interval_secs: u16,
 }
 
+/// Second listener for farm-scale and rented hashrate, on its own port with its own floor.
+#[derive(Debug, Deserialize, Clone)]
+pub struct FarmTierConfig {
+    /// Port for the farm/rental listener. The hobby listener keeps `downstream_port`, so every
+    /// miner already pointed at this node stays where it is and nobody has to be told to move.
+    pub port: u16,
+    /// Starting hashrate assumed for a connection arriving on this port, in H/s. Applied as the
+    /// per-connection floor exactly as a miner-declared `mining.suggest_difficulty` would be, so
+    /// it reuses a path that is already exercised rather than adding a second one.
+    pub min_individual_miner_hashrate: Hashrate,
+    /// Hashrate above which a connection on the HOBBY port is told to move here, in H/s.
+    /// `None` disables the nudge. This is the capacity control described on `farm_tier`: it
+    /// exists because a large miner on the hobby port costs the node share-validation and
+    /// database load, not because it could earn more.
+    #[serde(default)]
+    pub hobby_max_individual_miner_hashrate: Option<Hashrate>,
+}
+
 impl DownstreamDifficultyConfig {
     /// Creates a new `DownstreamDifficultyConfig` instance.
     pub fn new(
@@ -195,6 +234,69 @@ impl DownstreamDifficultyConfig {
             enable_vardiff,
             job_keepalive_interval_secs,
         }
+    }
+}
+
+#[cfg(test)]
+mod farm_tier_tests {
+    use super::*;
+
+    /// The whole point of two ports is that they hand out DIFFERENT starting difficulties.
+    /// A config where both tiers resolve to the same floor is a misconfiguration that would
+    /// otherwise look fine — two listeners, no benefit.
+    #[test]
+    fn the_two_tiers_produce_different_starting_difficulties() {
+        // Same arithmetic vardiff uses: difficulty = hashrate * target_interval / (2^48/0xFFFF).
+        const HASHES_PER_DIFFICULTY: f64 = ((1u64 << 48) as f64) / (0xFFFF as f64);
+        let shares_per_minute = 6.0_f64;
+        let interval = 60.0 / shares_per_minute;
+
+        let hobby_hs = 500_000_000_000.0_f64; // a ~500 GH/s bitaxe
+        let farm_hs = 10_000_000_000_000.0_f64; // rented hashrate
+
+        let hobby_diff = hobby_hs * interval / HASHES_PER_DIFFICULTY;
+        let farm_diff = farm_hs * interval / HASHES_PER_DIFFICULTY;
+
+        assert!(
+            farm_diff > hobby_diff * 10.0,
+            "farm tier must start far above the hobby tier, else the two ports are pointless \
+             (hobby {hobby_diff:.0}, farm {farm_diff:.0})"
+        );
+
+        // And the hobby tier must stay low enough that a bitaxe still submits often enough to
+        // look alive — the failure that made the dashboard flap when the single floor was
+        // raised for rented hashrate.
+        let bitaxe_interval_s = hobby_diff * HASHES_PER_DIFFICULTY / hobby_hs;
+        assert!(
+            bitaxe_interval_s <= 30.0,
+            "a bitaxe on the hobby port would only submit every {bitaxe_interval_s:.0}s"
+        );
+    }
+
+    /// Absent `farm_tier` must leave the single-listener behaviour untouched, because every
+    /// config file currently deployed omits it. `#[serde(default)]` gives that for parsing;
+    /// this pins the constructor, which is the other way a config is built.
+    #[test]
+    fn farm_tier_defaults_to_absent() {
+        let cfg = TranslatorConfig::new(
+            vec![],
+            "0.0.0.0".to_string(),
+            3333,
+            DownstreamDifficultyConfig::new(500_000_000_000.0, 6.0, true, 60),
+            2,
+            2,
+            8,
+            "bc1qexample".to_string(),
+            false,
+            vec![],
+            vec![],
+            None,
+            None,
+        );
+        assert!(
+            cfg.farm_tier.is_none(),
+            "farm_tier must default to None so existing single-listener configs are unchanged"
+        );
     }
 }
 

--- a/bins/translator-sv2/src/lib/sv1/downstream/data.rs
+++ b/bins/translator-sv2/src/lib/sv1/downstream/data.rs
@@ -29,6 +29,12 @@ pub struct DownstreamData {
     /// 1000% to ×3–×5 per 60s tick, so a farm or a rented-hashrate order spends minutes
     /// flooding shares before converging. A declared size skips the ramp entirely.
     pub suggested_hashrate: Option<Hashrate>,
+    /// True when this connection arrived on the farm/rental listener rather than the hobby
+    /// one. Only used to decide whether an oversized miner should be nudged to move: a large
+    /// miner on the hobby port is not stealing anything (payout is proportional to work, and
+    /// a share's work IS its difficulty), it just costs this node far more share validation,
+    /// bandwidth and database writes than it needs to.
+    pub on_farm_tier: bool,
     /// True only when the ~1.5s subscribe-defer fallback actually answered `mining.subscribe`
     /// with the PLACEHOLDER extranonce, i.e. a serialising miner was waiting on the response
     /// before sending `mining.authorize`. Those miners — and only those — must be corrected
@@ -91,6 +97,7 @@ impl DownstreamData {
             target,
             hashrate,
             suggested_hashrate: None,
+            on_farm_tier: false,
             subscribe_answered_with_placeholder: false,
             channel_open_requested: false,
             version_rolling_mask: None,

--- a/bins/translator-sv2/src/lib/sv1/sv1_server/difficulty_manager.rs
+++ b/bins/translator-sv2/src/lib/sv1/sv1_server/difficulty_manager.rs
@@ -63,7 +63,7 @@ impl Sv1Server {
             let Some(downstream) = self.downstreams.get(downstream_id) else {
                 continue;
             };
-            let (channel_id, hashrate, target, upstream_target) =
+            let (channel_id, hashrate, target, upstream_target, on_farm_tier) =
                 downstream.downstream_data.super_safe_lock(|data| {
                     // It's safe to unwrap hashrate because we know that
                     // the downstream has a hashrate (we are
@@ -73,8 +73,35 @@ impl Sv1Server {
                         data.hashrate.unwrap(),
                         data.target,
                         data.upstream_target,
+                        data.on_farm_tier,
                     )
                 });
+
+            // Capacity nudge: a miner far larger than the hobby port is sized for costs this
+            // node share validation, bandwidth and database writes out of proportion to what it
+            // needs — the same database growth that caused the hourly OOM kills. It is NOT
+            // earning more by being here: payout is proportional to work and a share's work IS
+            // its difficulty, so the same hashrate earns the same on either port.
+            //
+            // So this warns rather than disconnects. Vardiff raises them to a sane difficulty
+            // within a few ticks regardless; the log is for the operator to follow up.
+            if !on_farm_tier {
+                if let Some(tier) = self.config.farm_tier.as_ref() {
+                    if let Some(ceiling) = tier.hobby_max_individual_miner_hashrate {
+                        if hashrate > ceiling {
+                            warn!(
+                                downstream_id = %downstream_id,
+                                measured_hs = hashrate,
+                                ceiling_hs = ceiling,
+                                farm_port = tier.port,
+                                "miner on the hobby port is above the hobby ceiling — it should \
+                                 connect to the farm port instead; it earns the same either way, \
+                                 but costs this node far more share validation here"
+                            );
+                        }
+                    }
+                }
+            }
 
             let Some(channel_id) = channel_id else {
                 // Unreachable in normal operation: vardiff entries are now inserted only at

--- a/bins/translator-sv2/src/lib/sv1/sv1_server/sv1_server.rs
+++ b/bins/translator-sv2/src/lib/sv1/sv1_server/sv1_server.rs
@@ -275,6 +275,12 @@ impl Sv1Server {
         status_sender: &Sender<Status>,
         task_manager: &Arc<TaskManager>,
         first_target: Target,
+        // Starting hashrate for this connection, in H/s. Differs per listener: the hobby port
+        // uses the configured floor, the farm port uses farm_tier.min_individual_miner_hashrate.
+        // Vardiff moves from here, so this only sets where the connection begins.
+        tier_floor_hs: Hashrate,
+        // Which listener accepted this connection.
+        on_farm_tier: bool,
     ) where
         S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
     {
@@ -296,14 +302,17 @@ impl Sv1Server {
                 .clone(),
             sv1_server_receiver,
             first_target,
-            Some(
-                self.config
-                    .downstream_difficulty_config
-                    .min_individual_miner_hashrate,
-            ),
+            Some(tier_floor_hs),
             self.config.downstream_extranonce2_size as usize,
             connection_token.clone(),
         );
+        // Record which listener this connection arrived on, so the vardiff loop can tell an
+        // oversized hobby-port miner to move without disturbing farm-port miners.
+        if on_farm_tier {
+            downstream
+                .downstream_data
+                .super_safe_lock(|d| d.on_farm_tier = true);
+        }
         self.downstreams.insert(downstream_id, downstream.clone());
         // NB: vardiff state is intentionally NOT inserted here. The channel
         // is opened lazily after the first message, so a freshly accepted
@@ -465,14 +474,37 @@ impl Sv1Server {
     ) -> TproxyResult<(), error::Sv1Server> {
         info!("Starting SV1 server on {}", self.listener_addr);
 
-        // get the first target for the first set difficulty message
-        let first_target: Target = hash_rate_to_target(
-            self.config
-                .downstream_difficulty_config
-                .min_individual_miner_hashrate as f64,
-            self.config.downstream_difficulty_config.shares_per_minute as f64,
-        )
-        .unwrap();
+        // Starting difficulty for the hobby listener (`downstream_port`). Vardiff moves from
+        // here; this only sets where a connection begins.
+        let hobby_floor_hs = self
+            .config
+            .downstream_difficulty_config
+            .min_individual_miner_hashrate;
+        let shares_per_minute = self.config.downstream_difficulty_config.shares_per_minute as f64;
+        let first_target: Target =
+            hash_rate_to_target(hobby_floor_hs as f64, shares_per_minute).unwrap();
+
+        // Optional farm/rental listener. `None` leaves the single-listener behaviour exactly
+        // as it was, which is what every existing config produces.
+        let farm_tier = self.config.farm_tier.clone();
+        let (farm_listener, farm_first_target, farm_floor_hs) = match farm_tier.as_ref() {
+            Some(t) => {
+                let addr = SocketAddr::new(self.listener_addr.ip(), t.port);
+                let l = TcpListener::bind(addr).await.map_err(|e| {
+                    error!("Failed to bind farm listener to {}: {}", addr, e);
+                    TproxyError::shutdown(e)
+                })?;
+                let target =
+                    hash_rate_to_target(t.min_individual_miner_hashrate as f64, shares_per_minute)
+                        .unwrap();
+                info!(
+                    "Translator Proxy: farm/rental listening on {} (floor {} H/s)",
+                    addr, t.min_individual_miner_hashrate
+                );
+                (Some(l), target, t.min_individual_miner_hashrate)
+            }
+            None => (None, first_target.clone(), hobby_floor_hs),
+        };
 
         let vardiff_future = self.clone().spawn_vardiff_loop();
 
@@ -563,6 +595,8 @@ impl Sv1Server {
                                     &status_sender,
                                     &task_manager,
                                     first_target,
+                                    hobby_floor_hs,
+                                    false,
                                 ).await;
                             }
                             Err(e) => {
@@ -572,6 +606,30 @@ impl Sv1Server {
                     }
                     // Opt-in TLS listener. `accept_optional` resolves to `Pending` forever when no
                     // TLS listener is configured, so this arm is inert in the default deployment.
+                    // Farm/rental listener. Inert when `farm_tier` is unset, exactly like the
+                    // TLS arm: `accept_optional` never resolves on `None`.
+                    result = Self::accept_optional(farm_listener.as_ref()) => {
+                        match result {
+                            Ok((stream, addr)) => {
+                                info!("New SV1 downstream connection from {} on the farm port", addr);
+                                self.register_downstream(
+                                    stream,
+                                    addr,
+                                    &cancellation_token,
+                                    &fallback_coordinator,
+                                    &status_sender,
+                                    &task_manager,
+                                    farm_first_target.clone(),
+                                    farm_floor_hs,
+                                    true,
+                                ).await;
+                            }
+                            Err(e) => {
+                                warn!("Failed to accept farm-port connection: {:?}", e);
+                            }
+                        }
+                    }
+
                     result = Self::accept_optional(tls_listener.as_ref()) => {
                         match result {
                             Ok((tcp, addr)) => {
@@ -611,6 +669,8 @@ impl Sv1Server {
                                             &status_sender,
                                             &task_manager,
                                             first_target,
+                                            hobby_floor_hs,
+                                            false,
                                         ).await;
                                     }
                                     Err(e) => {

--- a/config/sri/translator-config.toml
+++ b/config/sri/translator-config.toml
@@ -65,3 +65,29 @@ address = "127.0.0.1"
 port = 34256
 # Must match the pool's authority_public_key
 authority_pubkey = "9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72"
+
+# ── Port tiers (#410) ─────────────────────────────────────────────────────────
+# One difficulty cannot serve both a 500 GH/s bitaxe and a 1 PH/s rented order.
+# Sized for the bitaxe, a large order floods the pool for minutes while vardiff
+# ramps (it caps corrections above 1000% to x3-x5 per 60s tick) and marketplaces
+# reject the pool. Sized for the order, a bitaxe finds a share every ~200s and
+# looks dead — which is what made the dashboard flap after the floor was raised.
+#
+# Uncomment to run a SECOND listener for farm/rental traffic. The hobby tier keeps
+# `downstream_port`, so every miner already pointed here stays put and nobody has
+# to be told to move; only large miners need the new port advertised to them.
+#
+# BEFORE ENABLING: open the farm port on the firewall and the load balancer on
+# every node. A port that is advertised but unreachable is worse than no port.
+#
+# `hobby_max_individual_miner_hashrate` only logs a warning when a miner on the
+# hobby port measures above it. It is a CAPACITY control, not anti-fraud: payout
+# is proportional to work and a share's work IS its difficulty, so the same
+# hashrate earns the same on either port. A large miner on the hobby port is not
+# taking anything from anyone — it just costs this node ~20x the share
+# validation, bandwidth and database writes.
+#
+# [farm_tier]
+# port = 3334
+# min_individual_miner_hashrate = 10_000_000_000_000.0   # ~23,283 starting difficulty
+# hobby_max_individual_miner_hashrate = 50_000_000_000_000.0

--- a/scripts/install-node.sh
+++ b/scripts/install-node.sh
@@ -932,6 +932,33 @@ address = "127.0.0.1"
 port = 34255
 authority_pubkey = "${SV2_AUTH_PUB}"
 
+
+# ── Port tiers (#410) ─────────────────────────────────────────────────────────
+# One difficulty cannot serve both a 500 GH/s bitaxe and a 1 PH/s rented order.
+# Sized for the bitaxe, a large order floods the pool for minutes while vardiff
+# ramps (it caps corrections above 1000% to x3-x5 per 60s tick) and marketplaces
+# reject the pool. Sized for the order, a bitaxe finds a share every ~200s and
+# looks dead — which is what made the dashboard flap after the floor was raised.
+#
+# Uncomment to run a SECOND listener for farm/rental traffic. The hobby tier keeps
+# `downstream_port`, so every miner already pointed here stays put and nobody has
+# to be told to move; only large miners need the new port advertised to them.
+#
+# BEFORE ENABLING: open the farm port on the firewall and the load balancer on
+# every node. A port that is advertised but unreachable is worse than no port.
+#
+# `hobby_max_individual_miner_hashrate` only logs a warning when a miner on the
+# hobby port measures above it. It is a CAPACITY control, not anti-fraud: payout
+# is proportional to work and a share's work IS its difficulty, so the same
+# hashrate earns the same on either port. A large miner on the hobby port is not
+# taking anything from anyone — it just costs this node ~20x the share
+# validation, bandwidth and database writes.
+#
+# [farm_tier]
+# port = 3334
+# min_individual_miner_hashrate = 10_000_000_000_000.0   # ~23,283 starting difficulty
+# hobby_max_individual_miner_hashrate = 50_000_000_000_000.0
+
 [load_balancer]
 ghost_pool_url = "127.0.0.1:8080"
 poll_interval_secs = 30


### PR DESCRIPTION
Fixes #410. Stacked on #447 (#411) — review that first.

One difficulty cannot serve both a 500 GH/s bitaxe and a 1 PH/s order:

| | at 1,164 (old floor) | at 23,283 (current floor) |
|---|---|---|
| bitaxe ~500 GH/s | share every 10s ✓ | share every **200s** — looks dead |
| rented 1 PH/s | **floods** the pool while vardiff ramps | fine ✓ |

Sized for the bitaxe, a large order floods for minutes while vardiff ramps (it caps corrections above 1000% to x3–x5 per 60s tick) and marketplaces reject the pool. Sized for the order, small miners blink out — which is exactly what made the active-miner count flap after the floor was raised for Braiins (#445).

## What this adds

An optional `[farm_tier]` listener on its own port with its own floor. The **hobby tier keeps `downstream_port`**, so every miner already pointed at a node stays put and only large miners need the new port advertised.

Absent `farm_tier` — the shape of every deployed config — leaves single-listener behaviour byte-identical. Same optional-listener pattern as the existing TLS port: `accept_optional` never resolves on `None`, so the arm is inert.

The tier floor rides the per-connection hashrate `Downstream::new` already takes — the same field a miner-declared `mining.suggest_difficulty` writes — rather than threading a second config path through the difficulty code.

## On "how do we stop big miners jumping on the small port?"

**They cannot gain by it.** Payout is proportional to work, and `round.rs` states the model plainly:

> The work model is ABSOLUTE: a share's work == its difficulty

So 20 shares at difficulty 1,164 and 1 share at 23,283 are worth **exactly the same**. The same hashrate earns the same on either port. There are also two existing guards: the H6 anomaly check against network difficulty, and the L-7 1%-per-miner-per-round cap.

So `hobby_max_individual_miner_hashrate` **warns rather than disconnects**, and is documented as what it actually is — a *capacity* control. A large miner on the hobby port costs the node ~20x the share validation, bandwidth and database writes (the same database growth behind the hourly OOM kills) while earning no more. Vardiff raises them within a few ticks regardless.

I did not build fraud protection against an attack that does not pay. If you would rather it hard-disconnected above the ceiling, that is a one-line change — say so.

## Shipped commented out, deliberately

Both config sources carry the block with recommended values, commented. Enabling it needs the farm port opened on the firewall and load balancer on **every** node, and a port that is advertised but unreachable is worse than no port. That is a deploy decision, not a code one.

## Tests — both verified to fail when they should

```
the_two_tiers_produce_different_starting_difficulties
  both tiers same floor  -> FAILS: "the two ports are pointless (hobby 1164, farm 1164)"
  hobby floor = farm value -> FAILS  (the exact change that started this)

farm_tier_defaults_to_absent
  pins the backward compatibility every deployed config depends on
```

`cargo test -p translator_sv2 --lib`: 38 passed. `fmt` clean. All three config gates green (`check-stratum-config-agreement`, `check-inlined-copies`, `check-workflow-scalars`).

## Follow-ups this creates

- #445's `default-diff` smoke case and #438's uniformity check both assume **one** port. When the farm tier is enabled they need to become per-port, or they will silently stop checking the tier they are not looking at. Worth doing in the same change that enables it.
