### PR TITLE
test(sv1-smoke): name the difference between a late difficulty and a withheld one

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,12 @@ jobs:
       # and has no repo to read. They had silently diverged (#431).
       - name: Check stratum config agreement
         run: ./scripts/check-stratum-config-agreement.sh
+      # The pre-deploy SV1 smoke test's declared-difficulty case could not distinguish
+      # "delivered late" from "never delivered" — both printed the floor — which is what
+      # misdirected the #455 investigation. This runs that case against fake pools with known
+      # behaviour, so the check stays able to tell those apart. No node, no build.
+      - name: SV1 smoke self-test
+        run: python3 bins/translator-sv2/tests/sv1_handshake_smoke_selftest.py
 
   # Clippy lints
   clippy:

--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,7 @@ fuzz/artifacts/
 # wraithd binaries (target-triple-suffixed), never committed.
 apps/wraith-wallet/gui/src-tauri/binaries/
 build/
+
+# Python bytecode (the SV1 smoke self-test imports the smoke module)
+__pycache__/
+*.pyc

--- a/bins/translator-sv2/tests/sv1_handshake_smoke.py
+++ b/bins/translator-sv2/tests/sv1_handshake_smoke.py
@@ -134,27 +134,89 @@ def _first_set_difficulty(sock, timeout=8.0):
     return None
 
 
-def _declared_difficulty_case(label, requested, pre_subscribe=None, password="x"):
-    """Assert a miner-declared difficulty is honoured on the initial set_difficulty.
+def _set_difficulty_until(sock, timeout, wanted):
+    """(elapsed, difficulty) pairs in arrival order, stopping once `wanted` matches one.
+
+    Reads past the FIRST message deliberately: the declaration can arrive *behind* the floor
+    rather than instead of it, and only a transcript tells those two apart. Stopping on the
+    match rather than at the deadline keeps the healthy path as fast as it was — only a genuine
+    failure pays the full window.
+    """
+    sock.settimeout(timeout)
+    buf, out, t0 = b"", [], time.time()
+    try:
+        while time.time() - t0 < timeout:
+            data = sock.recv(4096)
+            if not data:
+                break
+            buf += data
+            while b"\n" in buf:
+                line, buf = buf.split(b"\n", 1)
+                if not line.strip():
+                    continue
+                try:
+                    msg = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if msg.get("method") == "mining.set_difficulty":
+                    params = msg.get("params") or []
+                    if params and isinstance(params[0], (int, float)):
+                        d = float(params[0])
+                        out.append((time.time() - t0, d))
+                        if wanted(d):
+                            return out
+    except (socket.timeout, OSError):
+        pass
+    return out
+
+
+def _declared_difficulty_case(label, requested, pre_subscribe=None, password="x", window=None):
+    """Assert a miner-declared difficulty REACHES THE MINER, and say how long it took.
 
     Without this, every connection starts at the configured floor (sized for the smallest
     expected miner) and vardiff needs several 60s ticks to climb — it caps corrections above
     1000% to x3-x5 per tick — so a farm or a rented-hashrate order floods shares for minutes
     before converging. Marketplaces reject a pool whose starting difficulty is far below the
     hashrate they are pointing at it.
+
+    Reads the whole window rather than just the first `set_difficulty`, because #455 was
+    *delay*, not refusal: the declaration was applied internally and then queued behind the
+    floor waiting for a `mining.notify` that never came. Asserting on the first message alone
+    reported "pool set 23,282.7", which reads as "ignored" and sends you looking in the wrong
+    place. Whether the value is late or absent, the miner is at the wrong difficulty, so both
+    still fail — but the message now names which one it is.
     """
+    window = window or float(os.environ.get("GHOST_DIFFICULTY_WINDOW_SECS", "20"))
     s = socket.create_connection((HOST, PORT), timeout=10)
     if pre_subscribe is not None:
         send(s, pre_subscribe)
     send(s, {"id": 1, "method": "mining.subscribe", "params": ["synthtest/1.0"]})
     send(s, {"id": 2, "method": "mining.authorize", "params": [USER, password]})
-    got = _first_set_difficulty(s)
-    s.close()
     # Allow 1% for the target->difficulty rounding through the SV2 channel.
-    ok = got is not None and abs(got - requested) / requested < 0.01
-    print(f"  [{label}]{' ' * max(0, 16 - len(label))}{'PASS' if ok else 'FAIL'} — "
-          f"asked for difficulty {requested:,.0f}, pool set {got if got is None else f'{got:,.1f}'}")
-    return ok
+    def matches(d):
+        return abs(d - requested) / requested < 0.01
+
+    seen = _set_difficulty_until(s, window, matches)
+    s.close()
+
+    hit = next(((i, t, d) for i, (t, d) in enumerate(seen) if matches(d)), None)
+    pad = " " * max(0, 16 - len(label))
+    if hit is None:
+        if not seen:
+            detail = f"pool sent NO set_difficulty within {window:.0f}s"
+        else:
+            got = ", ".join(f"{d:,.1f}@{t:.1f}s" for t, d in seen)
+            detail = (f"pool set {got} and never sent the declared value within {window:.0f}s"
+                      " — applied internally but not delivered, see #455")
+        print(f"  [{label}]{pad}FAIL — asked for difficulty {requested:,.0f}, {detail}")
+        return False
+
+    idx, t, d = hit
+    when = "on the first set_difficulty" if idx == 0 else f"only after {idx} other value(s)"
+    late = "" if idx == 0 else "  ** DELAYED — the miner mined at the wrong difficulty until then **"
+    print(f"  [{label}]{pad}PASS — asked for difficulty {requested:,.0f}, pool set "
+          f"{d:,.1f} {when} at {t:.1f}s{late}")
+    return True
 
 
 def test_password_difficulty():

--- a/bins/translator-sv2/tests/sv1_handshake_smoke_selftest.py
+++ b/bins/translator-sv2/tests/sv1_handshake_smoke_selftest.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Self-test for sv1_handshake_smoke.py's declared-difficulty case.
+
+Drives that case against four fake pools with KNOWN behaviour and asserts it reports each one
+correctly. Needs no node, no build and no network — just localhost sockets.
+
+This exists because the case it guards was, in its first form, unable to tell "the pool delivered
+the declaration two seconds late" from "the pool never delivered it": both printed
+`pool set 23,282.7`. That identical message is what sent the #455 investigation looking for a
+value being *ignored* when it was being *delayed*. A check that cannot distinguish the states it
+claims to check is worth nothing, and the only way to find that out is to run it against
+deliberately broken behaviour — which is what this file is.
+
+Usage: sv1_handshake_smoke_selftest.py [path/to/sv1_handshake_smoke.py]
+Exit 0 iff every discrimination check holds.
+"""
+import sys
+
+# Loading the smoke module would otherwise litter a __pycache__ next to it, which is how a
+# .pyc first got committed here.
+sys.dont_write_bytecode = True
+
+import importlib.util, json, os, socket, threading, time  # noqa: E402
+
+SMOKE = sys.argv[1] if len(sys.argv) > 1 else os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "sv1_handshake_smoke.py")
+DECLARED = 1_000_000.0
+FLOOR = 23_282.7
+
+
+def serve(behaviour, port_box, ready):
+    srv = socket.socket()
+    srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    srv.bind(("127.0.0.1", 0))
+    port_box.append(srv.getsockname()[1])
+    srv.listen(1)
+    ready.set()
+    conn, _ = srv.accept()
+    try:
+        def sd(v):
+            conn.sendall(json.dumps(
+                {"id": None, "method": "mining.set_difficulty", "params": [v]}).encode() + b"\n")
+        if behaviour == "immediate":
+            sd(DECLARED)
+        elif behaviour == "floor_only":
+            sd(FLOOR)
+        elif behaviour == "floor_then_declared":
+            sd(FLOOR); time.sleep(2.0); sd(DECLARED)
+        elif behaviour == "silent":
+            pass
+        time.sleep(8)
+    except OSError:
+        pass
+    finally:
+        try:
+            conn.close()
+        except OSError:
+            pass
+        srv.close()
+
+
+CASES = [
+    ("immediate",           True,  "on the first set_difficulty"),
+    ("floor_then_declared", True,  "DELAYED"),
+    ("floor_only",          False, "never sent the declared value"),
+    ("silent",              False, "NO set_difficulty"),
+]
+
+failures = 0
+for behaviour, want_pass, want_text in CASES:
+    box, ready = [], threading.Event()
+    t = threading.Thread(target=serve, args=(behaviour, box, ready), daemon=True)
+    t.start(); ready.wait(5)
+
+    # Load a fresh copy of the smoke module pointed at this fake pool.
+    spec = importlib.util.spec_from_file_location(f"smoke_{behaviour}", SMOKE)
+    mod = importlib.util.module_from_spec(spec)
+    sys.argv = ["smoke", "127.0.0.1", str(box[0]), "bc1qtest.worker"]
+    spec.loader.exec_module(mod)
+
+    import io, contextlib
+    cap = io.StringIO()
+    with contextlib.redirect_stdout(cap):
+        got_pass = mod._declared_difficulty_case("probe", DECLARED, window=5.0)
+    out = cap.getvalue().strip()
+
+    ok = (got_pass == want_pass) and (want_text in out)
+    if not ok:
+        failures += 1
+    print(f"  [{'ok ' if ok else 'BAD'}] server={behaviour:<20} "
+          f"expect={'PASS' if want_pass else 'FAIL'} got={'PASS' if got_pass else 'FAIL'}")
+    print(f"        {out}")
+
+print()
+if failures:
+    print(f"*** {failures} of {len(CASES)} discrimination checks FAILED — the case is not "
+          f"distinguishing what it claims to ***")
+    sys.exit(1)
+print(f"All {len(CASES)} discrimination checks passed: the case separates honoured / delayed / "
+      f"withheld / silent.")

--- a/scripts/record-tests.sh
+++ b/scripts/record-tests.sh
@@ -36,6 +36,13 @@ echo "==> inlined installer copies"
 echo "==> stratum config agreement"
 ./scripts/check-stratum-config-agreement.sh || { echo "FAILED: stratum config sources disagree" >&2; exit 1; }
 
+# The pre-deploy SV1 smoke test asserts a declared difficulty reaches the miner. Its first
+# form could not tell "delivered late" from "never delivered" — both printed the floor — which
+# is what misdirected the #455 investigation. This checks the check.
+echo "==> SV1 smoke self-test"
+python3 bins/translator-sv2/tests/sv1_handshake_smoke_selftest.py \
+    || { echo "FAILED: SV1 smoke self-test" >&2; exit 1; }
+
 # NB: do NOT write these as `cmd | grep ... && { fail }`. With `set -o pipefail` a failing
 # cargo makes the whole pipeline non-zero, the `&&` short-circuits, the failure branch never
 # runs — and the gate reports success while not gating. That exact bug let a commit with two


### PR DESCRIPTION
Test-only. No binary change.

The declared-difficulty case in `sv1_handshake_smoke.py` read only the **first**
`mining.set_difficulty`. When #455 queued a `d=` declaration behind the floor, the case printed:

```
[pw-difficulty]   FAIL — asked for difficulty 1,000,000, pool set 23,282.7
```

which reads as *the pool ignored the declaration*. The truth was *the pool applied it and never
sent it*. Failing the deploy was correct either way — the miner is at the wrong difficulty — but
that wording sent the investigation looking in the wrong place for a while.

Now it reads the whole window and names which of four things happened:

```
PASS — pool set 1,000,000.0 on the first set_difficulty at 0.3s
PASS — pool set 1,000,000.0 only after 1 other value(s) at 2.0s  ** DELAYED — the miner mined at the wrong difficulty until then **
FAIL — pool set 23,282.7@0.0s and never sent the declared value within 20s — applied internally but not delivered, see #455
FAIL — pool sent NO set_difficulty within 20s
```

Verdicts are unchanged; only the diagnosis is new.

It exits as soon as the declared value arrives, so a healthy node costs what it did before —
**14s for the whole suite** against ghost-vm8, matching on the first message at 0.3s. Only a real
failure waits out the window.

## The self-test is the point

`sv1_handshake_smoke_selftest.py` drives the case against four fake pools with known behaviour.
Without it this change is unfalsifiable, and that is not hypothetical — the previous form
**passed against pools it could not tell apart**. Confirmed both directions:

| implementation | delivered-late vs never-delivered |
|---|---|
| before | **indistinguishable** — both print `pool set 23,282.7` (2 of 2 shapes fail to discriminate) |
| after | 4 of 4 distinguished |

Wired into `record-tests.sh` and the CI **Format** job, alongside the other three cheap gates —
no node, no build, no network beyond localhost sockets. Runs in ~12s.

Also adds `__pycache__/` and `*.pyc` to `.gitignore` and sets `sys.dont_write_bytecode`, because
loading the smoke module for the self-test otherwise drops a `.pyc` next to it — which it did, on
the first commit here.

Refs #455.
