### PR TITLE
fix(pool_sv2): drop the tracing import the revert orphaned

### DIFF
--- a/bins/pool-sv2/src/lib/channel_manager/mining_message_handler.rs
+++ b/bins/pool-sv2/src/lib/channel_manager/mining_message_handler.rs
@@ -21,7 +21,7 @@ use stratum_apps::stratum_core::{
     parsers_sv2::{Mining, TemplateDistribution, Tlv, TlvField},
     template_distribution_sv2::SubmitSolution,
 };
-use tracing::{debug, error, info};
+use tracing::{error, info};
 
 use jd_server_sv2::job_declarator::SetCustomMiningJobResponse;
 


### PR DESCRIPTION
One line. Reverting #447/#449 removed the only `debug!` call in `channel_manager/mining_message_handler.rs` but left `debug` in the `use tracing::{...}` list, so a release build of `pool_sv2` warns:

```
warning: unused import: `debug`
  --> bins/pool-sv2/src/lib/channel_manager/mining_message_handler.rs:24:15
```

Cosmetic today, but it sits in the release build path and becomes a hard error as soon as #401 makes clippy blocking with `-D warnings`. Better cleared before the `v1.11.19` tag than found by that change.

**How it got through is the more interesting part:** CI is green on this. Clippy is not yet blocking (#401 — 221 warnings outstanding) and the Test jobs compile with warnings permitted, so `unused_imports` satisfies every gate we have. It surfaced only from reading the release build output instead of trusting its exit code.

Verified: `cargo build --release -p pool_sv2` now emits no warnings, `cargo fmt --check` clean.