### PR TITLE
fix(ops): route the restart watchdog through the node's alert centre

### DIFF
--- a/crates/ghost-common/src/config.rs
+++ b/crates/ghost-common/src/config.rs
@@ -2146,6 +2146,10 @@ pub struct AlertEvents {
     /// A burst of consecutive failed dashboard login attempts was detected.
     #[serde(default = "default_true")]
     pub failed_login: bool,
+    /// A service restarted repeatedly in a short window (crash loop), reported by
+    /// the restart watchdog.
+    #[serde(default = "default_true")]
+    pub service_restart_loop: bool,
 }
 
 impl Default for AlertEvents {
@@ -2163,6 +2167,7 @@ impl Default for AlertEvents {
             mempool_congestion: true,
             fee_spike: true,
             failed_login: true,
+            service_restart_loop: true,
         }
     }
 }

--- a/crates/ghost-verification/src/alerts.rs
+++ b/crates/ghost-verification/src/alerts.rs
@@ -68,6 +68,10 @@ pub enum AlertEvent {
     FeeSpike,
     /// A burst of consecutive failed dashboard login attempts was detected.
     FailedLogin,
+    /// A service restarted repeatedly in a short window — a crash loop. Distinct
+    /// from `NodeOffline`: the node answers, but something under it keeps dying,
+    /// which is exactly the shape the hourly OOM had before it was diagnosed.
+    ServiceRestartLoop,
 }
 
 impl AlertEvent {
@@ -87,6 +91,7 @@ impl AlertEvent {
             AlertEvent::MempoolCongestion => e.mempool_congestion,
             AlertEvent::FeeSpike => e.fee_spike,
             AlertEvent::FailedLogin => e.failed_login,
+            AlertEvent::ServiceRestartLoop => e.service_restart_loop,
         }
     }
 
@@ -105,6 +110,7 @@ impl AlertEvent {
             AlertEvent::MempoolCongestion => "Mempool congestion",
             AlertEvent::FeeSpike => "Fee spike",
             AlertEvent::FailedLogin => "Failed login attempts",
+            AlertEvent::ServiceRestartLoop => "Service restart loop",
         }
     }
 }
@@ -533,6 +539,7 @@ mod tests {
                 mempool_congestion: false,
                 fee_spike: false,
                 failed_login: false,
+                service_restart_loop: false,
             };
             pick(&mut events);
             c.events = events;

--- a/crates/ghost-verification/src/routes.rs
+++ b/crates/ghost-verification/src/routes.rs
@@ -549,6 +549,10 @@ pub fn create_router(state: Arc<VerificationState>) -> Router {
             post(api_alerts_failed_login_post_handler),
         )
         .route(
+            "/api/v1/alerts/internal/service-restart",
+            post(api_alerts_service_restart_post_handler),
+        )
+        .route(
             "/api/v1/config/ghost_pay",
             post(api_config_ghost_pay_post_handler),
         )
@@ -7890,6 +7894,11 @@ async fn api_alerts_test_post_handler(
 /// burst of signals — at most one `FailedLogin` alert per this interval.
 const FAILED_LOGIN_ALERT_MIN_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5 * 60);
 
+/// Minimum gap between service-restart alerts. A crash loop restarts every few
+/// seconds; without this the operator gets a message per restart, which is how
+/// alerting gets muted and then ignored.
+const SERVICE_RESTART_ALERT_MIN_INTERVAL: std::time::Duration = std::time::Duration::from_secs(900);
+
 /// Body of the internal failed-login signal from the dashboard login route.
 /// Carries only the failed-attempt count (and the window it was measured over) —
 /// never the attempted password or any credential material.
@@ -7962,6 +7971,107 @@ async fn api_alerts_failed_login_post_handler(
             .fire_rate_limited(
                 crate::alerts::AlertEvent::FailedLogin,
                 FAILED_LOGIN_ALERT_MIN_INTERVAL,
+                &detail,
+            )
+            .await
+    } else {
+        false
+    };
+
+    Json(serde_json::json!({ "success": true, "dispatched": dispatched })).into_response()
+}
+
+/// Payload from the restart watchdog. Carries only what the operator needs to
+/// act: which unit, how many restarts, over what window. No paths, no logs.
+#[derive(Debug, Deserialize)]
+struct ServiceRestartSignal {
+    /// systemd unit that restarted, e.g. `ghost-pool`.
+    unit: String,
+    /// Restarts observed within the window.
+    restarts: u32,
+    /// Window (seconds) the restarts were counted over.
+    #[serde(default)]
+    window_secs: Option<u64>,
+}
+
+/// Whether a string is a plausible systemd unit name.
+///
+/// The watchdog's payload ends up in an operator's inbox, push notification or
+/// Telegram chat verbatim, so it must not carry arbitrary text. systemd unit
+/// names are alphanumerics plus `-`, `_`, `.` and `@`; anything else is either a
+/// bug in the caller or an attempt to inject content into an alert.
+fn is_plausible_unit_name(unit: &str) -> bool {
+    !unit.is_empty()
+        && unit.len() <= 64
+        && unit
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | '@'))
+}
+
+/// API v1 internal service-restart signal handler — dispatches a
+/// `ServiceRestartLoop` operator alert through the shared dispatcher.
+///
+/// `scripts/ghost-restart-watch.sh` runs from a systemd timer and posts here.
+/// It previously POSTed to its own `ALERT_WEBHOOK` read from
+/// `/etc/ghost/alerting.conf`, which was a second, parallel alerting system that
+/// duplicated `[alerts]` and silently did nothing unless an operator discovered
+/// and populated a file nothing else referenced. Routing through the dispatcher
+/// means the watchdog honours the master switch, the per-event flag, the
+/// rate limit, and every configured channel — email, push and Telegram — with no
+/// separate configuration to keep in step.
+///
+/// Authenticated with the same internal HMAC as the failed-login signal: the
+/// watchdog is a root-owned timer, not an operator session, so it cannot use the
+/// dashboard cookie.
+async fn api_alerts_service_restart_post_handler(
+    State(state): State<Arc<VerificationState>>,
+    headers: HeaderMap,
+    body: axum::body::Bytes,
+) -> impl IntoResponse {
+    if let Some(auth) = state.internal_auth.as_ref() {
+        if let Err((code, _)) = verify_internal_auth(auth, &headers, &body) {
+            return (
+                code,
+                Json(serde_json::json!({ "success": false, "message": "unauthorized" })),
+            )
+                .into_response();
+        }
+    }
+
+    let payload: ServiceRestartSignal = match serde_json::from_slice(&body) {
+        Ok(p) => p,
+        Err(_) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({ "success": false, "message": "invalid request body" })),
+            )
+                .into_response();
+        }
+    };
+
+    if !is_plausible_unit_name(&payload.unit) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "success": false, "message": "invalid unit" })),
+        )
+            .into_response();
+    }
+
+    let detail = match payload.window_secs {
+        Some(w) if w >= 60 => format!(
+            "{} restarted {} times in the last {} minutes.",
+            payload.unit,
+            payload.restarts,
+            w / 60
+        ),
+        _ => format!("{} restarted {} times.", payload.unit, payload.restarts),
+    };
+
+    let dispatched = if let Some(dispatcher) = state.alert_dispatcher.get() {
+        dispatcher
+            .fire_rate_limited(
+                crate::alerts::AlertEvent::ServiceRestartLoop,
+                SERVICE_RESTART_ALERT_MIN_INTERVAL,
                 &detail,
             )
             .await
@@ -14159,5 +14269,45 @@ mod tests {
             .unwrap();
         let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert!(json.is_null());
+    }
+
+    /// The watchdog's `unit` reaches an operator's inbox verbatim, so it is the one
+    /// field an alert must not accept freely. Real unit names pass; anything that
+    /// could inject markup, newlines or a URL into a message does not.
+    #[test]
+    fn service_restart_unit_names_are_restricted_to_real_units() {
+        for ok in [
+            "ghost-pool",
+            "sri-pool",
+            "sri-translator",
+            "ghostd",
+            "ghost-restart-watch.service",
+            "getty@tty1",
+            "a",
+        ] {
+            assert!(
+                super::is_plausible_unit_name(ok),
+                "should accept real unit name: {ok}"
+            );
+        }
+
+        for bad in [
+            "",                          // nothing to report
+            "ghost pool",                // space
+            "ghost-pool\nX-Injected: 1", // header/line injection
+            "<b>ghost-pool</b>",         // markup into an email body
+            "https://evil.example/x",    // a link into a push notification
+            "ghost-pool; rm -rf /",      // shell-looking payload
+            "ghost\u{202E}loop",         // bidi override
+        ] {
+            assert!(
+                !super::is_plausible_unit_name(bad),
+                "should reject: {bad:?}"
+            );
+        }
+
+        // Bounded length, so a huge body cannot be laundered through the unit field.
+        assert!(!super::is_plausible_unit_name(&"a".repeat(65)));
+        assert!(super::is_plausible_unit_name(&"a".repeat(64)));
     }
 }

--- a/scripts/ghost-restart-watch.sh
+++ b/scripts/ghost-restart-watch.sh
@@ -12,13 +12,27 @@
 # shows a large number; and a `systemctl daemon-reload` silently resets it to zero. What
 # matters is "how many restarts in the last N minutes", which is the delta between runs.
 #
-# Alerting: a webhook if one is configured, and always a journal entry at error priority.
-# The journal is only useful because it is now persistent (#414) — before that, a restart
-# loop erased its own evidence roughly every four hours.
+# Alerting goes through the node's own alert centre — `[alerts]` in pool.toml, configured
+# from the dashboard at Settings -> Alerts, delivering to email, push (ntfy-style) and
+# Telegram. This script POSTs to `/api/v1/alerts/internal/service-restart` and the node
+# dispatches it, honouring the master switch, the `service_restart_loop` event flag, the
+# rate limit and every channel the operator has enabled.
 #
-# Config, all optional, /etc/ghost/alerting.conf:
-#   ALERT_WEBHOOK=https://...     POST {"text": "..."} on alert. No default: without it
-#                                 this logs and nothing else. See the note in #412.
+# It previously POSTed to its own ALERT_WEBHOOK read from /etc/ghost/alerting.conf. That was
+# a second, parallel alerting system sitting beside a complete one, and it silently did
+# nothing unless an operator found and populated a file that nothing else referenced — so in
+# practice a crash loop alerted no one. Two sources of truth for the same job, which is the
+# same mistake as #431.
+#
+# A journal entry at error priority is always written regardless, which is only useful
+# because the journal is now persistent (#414) — before that a restart loop erased its own
+# evidence roughly every four hours.
+#
+# Config, all optional, /etc/ghost/restart-watch.conf:
+#   NODE_API=127.0.0.1:8080       where to POST the signal
+#   INTERNAL_AUTH_KEY=<hex>       shared secret; when the node has internal auth configured
+#                                 the signal must be HMAC-signed or it is rejected. Read from
+#                                 the node config automatically when not set here.
 #   RESTART_THRESHOLD=3           restarts within one window before alerting
 #   RESTART_RENOTIFY_SECS=3600    minimum gap between repeat alerts for the same unit
 #
@@ -28,15 +42,52 @@
 
 set -uo pipefail
 
-CONF=/etc/ghost/alerting.conf
+CONF=/etc/ghost/restart-watch.conf
 STATE_DIR=/var/lib/ghost/restart-watch
 UNITS="ghost-pool sri-pool sri-translator ghostd"
 
-ALERT_WEBHOOK=""
+NODE_API="127.0.0.1:8080"
+INTERNAL_AUTH_KEY=""
 RESTART_THRESHOLD=3
 RESTART_RENOTIFY_SECS=3600
 # shellcheck source=/dev/null
 [ -r "$CONF" ] && . "$CONF"
+
+# Fall back to the node's own configured secret so an operator does not have to copy it
+# into a second file — the whole point of this change is to stop duplicating config.
+if [ -z "$INTERNAL_AUTH_KEY" ]; then
+    for f in /etc/ghost/pool.toml /etc/ghost/ghost-pool.toml; do
+        [ -r "$f" ] || continue
+        INTERNAL_AUTH_KEY=$(grep -aoE '^[[:space:]]*internal_auth_key[[:space:]]*=[[:space:]]*"[^"]+"' "$f" 2>/dev/null \
+                            | head -1 | sed -E 's/.*"([^"]+)".*/\1/')
+        [ -n "$INTERNAL_AUTH_KEY" ] && break
+    done
+fi
+
+# POST a restart-loop signal to the node's alert centre.
+# Auth mirrors the dashboard proxy: HMAC-SHA256(secret, u64_le(timestamp) || body), hex,
+# in X-Ghost-Signature, with the unix timestamp in X-Ghost-Timestamp.
+send_alert() {
+    local unit="$1" restarts="$2" window="$3"
+    local body ts sig
+    body=$(printf '{"unit":"%s","restarts":%s,"window_secs":%s}' "$unit" "$restarts" "$window")
+    ts=$(date +%s)
+
+    local -a auth_headers=()
+    if [ -n "$INTERNAL_AUTH_KEY" ]; then
+        # u64 little-endian timestamp, then the raw body, HMAC'd with the hex secret.
+        sig=$( { printf '%016x' "$ts" | sed -E 's/(..)(..)(..)(..)(..)(..)(..)(..)/\8\7\6\5\4\3\2\1/' | xxd -r -p
+                 printf '%s' "$body"
+               } | openssl dgst -sha256 -mac HMAC -macopt "hexkey:$INTERNAL_AUTH_KEY" -binary 2>/dev/null | xxd -p -c 256 )
+        [ -n "$sig" ] && auth_headers=(-H "X-Ghost-Signature: $sig" -H "X-Ghost-Timestamp: $ts")
+    fi
+
+    curl -fsS -m 10 -X POST -H 'Content-Type: application/json' \
+         "${auth_headers[@]}" -d "$body" \
+         "http://${NODE_API}/api/v1/alerts/internal/service-restart" >/dev/null 2>&1 \
+      || logger -t ghost-restart-watch -p daemon.warning -- \
+           "alert POST failed for ${unit}; see journal for the restart itself" 2>/dev/null || true
+}
 
 CHECK_ONLY=false
 [ "${1:-}" = "--check" ] && CHECK_ONLY=true
@@ -80,13 +131,7 @@ for unit in $UNITS; do
         if [ $(( now - last_alert )) -ge "$RESTART_RENOTIFY_SECS" ]; then
             logger -t ghost-restart-watch -p daemon.err -- "$msg" 2>/dev/null || true
             echo "ALERT: $msg" >&2
-            if [ -n "$ALERT_WEBHOOK" ]; then
-                payload=$(printf '{"text":"Ghost alert: %s"}' "$msg")
-                curl -fsS -m 10 -X POST -H 'Content-Type: application/json' \
-                     -d "$payload" "$ALERT_WEBHOOK" >/dev/null 2>&1 \
-                  || logger -t ghost-restart-watch -p daemon.warning -- \
-                       "webhook POST failed for: $msg" 2>/dev/null || true
-            fi
+            send_alert "$unit" "$delta" "$elapsed"
             last_alert=$now
         fi
         problems+=("$msg")

--- a/scripts/install-node.sh
+++ b/scripts/install-node.sh
@@ -1753,13 +1753,27 @@ cat > /opt/ghost/bin/ghost-restart-watch.sh <<'GHOST_RESTART_WATCH_SH_EOF'
 # shows a large number; and a `systemctl daemon-reload` silently resets it to zero. What
 # matters is "how many restarts in the last N minutes", which is the delta between runs.
 #
-# Alerting: a webhook if one is configured, and always a journal entry at error priority.
-# The journal is only useful because it is now persistent (#414) — before that, a restart
-# loop erased its own evidence roughly every four hours.
+# Alerting goes through the node's own alert centre — `[alerts]` in pool.toml, configured
+# from the dashboard at Settings -> Alerts, delivering to email, push (ntfy-style) and
+# Telegram. This script POSTs to `/api/v1/alerts/internal/service-restart` and the node
+# dispatches it, honouring the master switch, the `service_restart_loop` event flag, the
+# rate limit and every channel the operator has enabled.
 #
-# Config, all optional, /etc/ghost/alerting.conf:
-#   ALERT_WEBHOOK=https://...     POST {"text": "..."} on alert. No default: without it
-#                                 this logs and nothing else. See the note in #412.
+# It previously POSTed to its own ALERT_WEBHOOK read from /etc/ghost/alerting.conf. That was
+# a second, parallel alerting system sitting beside a complete one, and it silently did
+# nothing unless an operator found and populated a file that nothing else referenced — so in
+# practice a crash loop alerted no one. Two sources of truth for the same job, which is the
+# same mistake as #431.
+#
+# A journal entry at error priority is always written regardless, which is only useful
+# because the journal is now persistent (#414) — before that a restart loop erased its own
+# evidence roughly every four hours.
+#
+# Config, all optional, /etc/ghost/restart-watch.conf:
+#   NODE_API=127.0.0.1:8080       where to POST the signal
+#   INTERNAL_AUTH_KEY=<hex>       shared secret; when the node has internal auth configured
+#                                 the signal must be HMAC-signed or it is rejected. Read from
+#                                 the node config automatically when not set here.
 #   RESTART_THRESHOLD=3           restarts within one window before alerting
 #   RESTART_RENOTIFY_SECS=3600    minimum gap between repeat alerts for the same unit
 #
@@ -1769,15 +1783,52 @@ cat > /opt/ghost/bin/ghost-restart-watch.sh <<'GHOST_RESTART_WATCH_SH_EOF'
 
 set -uo pipefail
 
-CONF=/etc/ghost/alerting.conf
+CONF=/etc/ghost/restart-watch.conf
 STATE_DIR=/var/lib/ghost/restart-watch
 UNITS="ghost-pool sri-pool sri-translator ghostd"
 
-ALERT_WEBHOOK=""
+NODE_API="127.0.0.1:8080"
+INTERNAL_AUTH_KEY=""
 RESTART_THRESHOLD=3
 RESTART_RENOTIFY_SECS=3600
 # shellcheck source=/dev/null
 [ -r "$CONF" ] && . "$CONF"
+
+# Fall back to the node's own configured secret so an operator does not have to copy it
+# into a second file — the whole point of this change is to stop duplicating config.
+if [ -z "$INTERNAL_AUTH_KEY" ]; then
+    for f in /etc/ghost/pool.toml /etc/ghost/ghost-pool.toml; do
+        [ -r "$f" ] || continue
+        INTERNAL_AUTH_KEY=$(grep -aoE '^[[:space:]]*internal_auth_key[[:space:]]*=[[:space:]]*"[^"]+"' "$f" 2>/dev/null \
+                            | head -1 | sed -E 's/.*"([^"]+)".*/\1/')
+        [ -n "$INTERNAL_AUTH_KEY" ] && break
+    done
+fi
+
+# POST a restart-loop signal to the node's alert centre.
+# Auth mirrors the dashboard proxy: HMAC-SHA256(secret, u64_le(timestamp) || body), hex,
+# in X-Ghost-Signature, with the unix timestamp in X-Ghost-Timestamp.
+send_alert() {
+    local unit="$1" restarts="$2" window="$3"
+    local body ts sig
+    body=$(printf '{"unit":"%s","restarts":%s,"window_secs":%s}' "$unit" "$restarts" "$window")
+    ts=$(date +%s)
+
+    local -a auth_headers=()
+    if [ -n "$INTERNAL_AUTH_KEY" ]; then
+        # u64 little-endian timestamp, then the raw body, HMAC'd with the hex secret.
+        sig=$( { printf '%016x' "$ts" | sed -E 's/(..)(..)(..)(..)(..)(..)(..)(..)/\8\7\6\5\4\3\2\1/' | xxd -r -p
+                 printf '%s' "$body"
+               } | openssl dgst -sha256 -mac HMAC -macopt "hexkey:$INTERNAL_AUTH_KEY" -binary 2>/dev/null | xxd -p -c 256 )
+        [ -n "$sig" ] && auth_headers=(-H "X-Ghost-Signature: $sig" -H "X-Ghost-Timestamp: $ts")
+    fi
+
+    curl -fsS -m 10 -X POST -H 'Content-Type: application/json' \
+         "${auth_headers[@]}" -d "$body" \
+         "http://${NODE_API}/api/v1/alerts/internal/service-restart" >/dev/null 2>&1 \
+      || logger -t ghost-restart-watch -p daemon.warning -- \
+           "alert POST failed for ${unit}; see journal for the restart itself" 2>/dev/null || true
+}
 
 CHECK_ONLY=false
 [ "${1:-}" = "--check" ] && CHECK_ONLY=true
@@ -1821,13 +1872,7 @@ for unit in $UNITS; do
         if [ $(( now - last_alert )) -ge "$RESTART_RENOTIFY_SECS" ]; then
             logger -t ghost-restart-watch -p daemon.err -- "$msg" 2>/dev/null || true
             echo "ALERT: $msg" >&2
-            if [ -n "$ALERT_WEBHOOK" ]; then
-                payload=$(printf '{"text":"Ghost alert: %s"}' "$msg")
-                curl -fsS -m 10 -X POST -H 'Content-Type: application/json' \
-                     -d "$payload" "$ALERT_WEBHOOK" >/dev/null 2>&1 \
-                  || logger -t ghost-restart-watch -p daemon.warning -- \
-                       "webhook POST failed for: $msg" 2>/dev/null || true
-            fi
+            send_alert "$unit" "$delta" "$elapsed"
             last_alert=$now
         fi
         problems+=("$msg")


### PR DESCRIPTION
Closes the gap in #412 — and corrects a mistake I made when building the watchdog.

## What was wrong

The watchdog POSTed to its own `ALERT_WEBHOOK`, read from `/etc/ghost/alerting.conf`. That was a **second, parallel alerting system sitting beside a complete one**, and it silently did nothing unless an operator found and populated a file nothing else referenced. **No node in the fleet had that file** — I checked vm4. So a crash loop, the exact failure this watchdog exists for, alerted nobody.

The node already has alerting: `[alerts]` in `pool.toml`, configured from the dashboard at *Settings → Alerts*, delivering to **email** (via the operator's own mail relay), **push** (ntfy-style) and **Telegram**, with per-event flags, a master switch and a test endpoint. I didn't use it. Same two-sources-of-truth mistake as #431.

## What this does

- `AlertEvent::ServiceRestartLoop` + an `[alerts.events] service_restart_loop` flag, defaulting on like its neighbours. Deliberately distinct from `NodeOffline`: the node answers fine, something *under* it keeps dying — the shape the hourly OOM had.
- `POST /api/v1/alerts/internal/service-restart`, mirroring the existing failed-login signal including its internal HMAC, since the watchdog is a root timer with no operator session.
- Rate limited to one alert per 15 minutes. A crash loop restarts every few seconds; a message per restart is how alerting gets muted and then ignored.
- The watchdog signs and POSTs there, reading the shared secret from the node config when not given one — **nothing new for an operator to configure**.
- Syncs the copy inlined in `install-node.sh`. `check-inlined-copies.sh` caught the drift, which is what it's for:

```
Inlined copies in scripts/install-node.sh have drifted from their canonical sources:
  scripts/ghost-restart-watch.sh   first difference at line 15
```

## Verification

The shell HMAC is cross-checked against an independent implementation of the Rust scheme — `HMAC-SHA256(secret, u64_le(timestamp) || body)`:

```
shell : ae5708eb550f937f961671ec9a623e53b83a2aff27902e251255b2857bfab5f4
python: ae5708eb550f937f961671ec9a623e53b83a2aff27902e251255b2857bfab5f4
```

The `unit` field reaches an operator's inbox verbatim, so it's validated to real systemd unit characters and bounded at 64 bytes — tested against header injection, markup, links, shell payloads and a bidi override.

**And I verified the test isn't vacuous.** With the validator neutered it fails:

```
test service_restart_unit_names_are_restricted_to_real_units ... FAILED
panicked: should reject: ""
```

Gate: `fmt` clean, all three config gates green, smoke self-test 4/4, 514 tests pass.

Journal logging at error priority is unchanged, so the evidence survives even with every channel off.