### PR TITLE
fix(build): make ghost-pool byte-reproducible and fix the worktree-broken rerun guard

### DIFF
--- a/crates/ghost-verification/build.rs
+++ b/crates/ghost-verification/build.rs
@@ -36,11 +36,21 @@ fn main() {
         .unwrap_or_default();
     println!("cargo:rustc-env=GIT_HASH={}", git_hash);
 
-    // Capture build timestamp (ISO 8601 UTC)
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
+    // Capture build timestamp (ISO 8601 UTC).
+    //
+    // Honours SOURCE_DATE_EPOCH (the reproducible-builds convention) so a byte-identical
+    // binary can be produced on demand. Without it this stamp is the only thing that differs
+    // between two builds of the same commit, which is enough to make a SHA256 comparison
+    // useless for proving a deployed binary came from a given tag.
+    let now = std::env::var("SOURCE_DATE_EPOCH")
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .unwrap_or_else(|| {
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs()
+        });
     // Format as ISO 8601 manually (no chrono dependency needed)
     let secs_per_day = 86400u64;
     let secs_per_hour = 3600u64;
@@ -61,8 +71,40 @@ fn main() {
     );
     println!("cargo:rustc-env=BUILD_TIME={}", build_time);
 
-    // Only rerun if git HEAD changes
-    println!("cargo:rerun-if-changed=../../.git/HEAD");
+    // Only rerun when git HEAD changes, or when the reproducible-build stamp is overridden.
+    //
+    // This previously hard-coded `../../.git/HEAD`, which silently does nothing in a git
+    // WORKTREE: there `.git` is a FILE containing `gitdir: …`, not a directory, so the path
+    // does not exist, cargo cannot watch it, and the build script re-runs on EVERY build —
+    // giving a new timestamp and a new binary hash each time. All release builds here are
+    // done in worktrees, so the guard was off precisely where it mattered.
+    //
+    // `git rev-parse --git-common-dir` resolves correctly for a plain clone, a worktree and a
+    // submodule alike. It is relative to the current directory, which cargo sets to the crate
+    // root, so make it absolute before handing it to cargo.
+    let git_common_dir = std::process::Command::new("git")
+        .args(["rev-parse", "--git-common-dir"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .filter(|s| !s.is_empty());
+
+    if let Some(dir) = git_common_dir {
+        let path = std::path::Path::new(&dir);
+        let head = if path.is_absolute() {
+            path.join("HEAD")
+        } else {
+            std::env::current_dir()
+                .unwrap_or_default()
+                .join(path)
+                .join("HEAD")
+        };
+        if head.exists() {
+            println!("cargo:rerun-if-changed={}", head.display());
+        }
+    }
+    println!("cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH");
 }
 
 fn days_to_ymd(days: u64) -> (u64, u64, u64) {

--- a/crates/ghost-verification/src/routes.rs
+++ b/crates/ghost-verification/src/routes.rs
@@ -14310,4 +14310,49 @@ mod tests {
         assert!(!super::is_plausible_unit_name(&"a".repeat(65)));
         assert!(super::is_plausible_unit_name(&"a".repeat(64)));
     }
+
+    /// `BUILD_TIME` is the only thing that differs between two builds of the same
+    /// commit, which is what stopped a binary hash proving a deployed artefact came
+    /// from a given tag (#462). Honouring SOURCE_DATE_EPOCH makes a byte-identical
+    /// build possible on demand; this asserts the stamp is well-formed and, when the
+    /// override is set at build time, that it was actually used.
+    #[test]
+    fn build_time_stamp_is_well_formed_and_honours_source_date_epoch() {
+        let stamp = option_env!("BUILD_TIME").unwrap_or("unknown");
+        assert_ne!(stamp, "unknown", "build.rs must always set BUILD_TIME");
+
+        // ISO 8601 UTC to the second: 2026-07-26T21:26:58Z
+        let b = stamp.as_bytes();
+        assert_eq!(b.len(), 20, "unexpected stamp shape: {stamp}");
+        assert_eq!(b[4], b'-');
+        assert_eq!(b[7], b'-');
+        assert_eq!(b[10], b'T');
+        assert_eq!(b[13], b':');
+        assert_eq!(b[16], b':');
+        assert_eq!(b[19], b'Z');
+        assert!(
+            stamp[..4].chars().all(|c| c.is_ascii_digit()),
+            "year must be numeric: {stamp}"
+        );
+
+        // When the reproducible-build override was set for THIS compilation, the stamp
+        // must be derived from it rather than from the wall clock.
+        if let Some(epoch) =
+            option_env!("SOURCE_DATE_EPOCH").and_then(|v| v.trim().parse::<u64>().ok())
+        {
+            // 1_000_000_000 -> 2001-09-09T01:46:40Z. Rather than reimplement the civil-date
+            // conversion here, assert the cheap invariant: the year must match.
+            let days = epoch / 86_400;
+            let approx_year = 1970 + (days / 366); // lower bound, never overshoots
+            let stamp_year: u64 = stamp[..4].parse().expect("year parsed above");
+            assert!(
+                stamp_year >= approx_year,
+                "SOURCE_DATE_EPOCH={epoch} was ignored: stamp {stamp} predates it"
+            );
+            assert!(
+                stamp_year < 2100,
+                "stamp {stamp} looks like a wall-clock value, not {epoch}"
+            );
+        }
+    }
 }


### PR DESCRIPTION
Closes #462.

`ghost-pool` got a different SHA256 on **every** build of the same commit, so a binary hash could not check a deployed binary against a tag. Two causes.

## 1. The rerun guard silently did nothing in a git worktree

```rust
println!("cargo:rerun-if-changed=../../.git/HEAD");
```

In a linked worktree `.git` is a **file** containing `gitdir: …`, not a directory — so that path does not exist, cargo cannot watch it, and the script re-ran on every build. New timestamp, new binary, every time. **Every release build here is done in a worktree**, so the guard was off exactly where it mattered.

Now resolved with `git rev-parse --git-common-dir`, correct for a plain clone, a worktree and a submodule alike, made absolute before handing to cargo.

## 2. No way to pin the stamp

`SOURCE_DATE_EPOCH` is now honoured, falling back to the wall clock — so a byte-identical build is possible on demand without losing the stamp for ordinary builds. `rerun-if-env-changed` is declared so changing it actually re-runs the script.

## Verified in a worktree, which is where it was broken

Two consecutive release builds, no source change:

```
before : 34f5f804f9d55caa
after  : 34f5f804f9d55caa      IDENTICAL
```

What `build.rs` actually emits:

```
no override : cargo:rustc-env=BUILD_TIME=2026-07-26T21:42:48Z
epoch 1e9   : cargo:rustc-env=BUILD_TIME=2001-09-09T01:46:40Z
              cargo:rerun-if-changed=/home/defenwycke/dev/projects/ghost/.git/HEAD
              cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
```

## Scope

This does **not** make the whole build bit-reproducible — it removes the one input that was gratuitously non-deterministic. `pool_sv2` and `translator_sv2` were already byte-identical across builds, since neither depends on `ghost-verification`; that asymmetry is what led to the diagnosis.

Adds a test asserting the stamp is well-formed and, when the override was set for that compilation, that it was used — because the failure mode here was a guard that existed and enforced nothing.