### PR TITLE
fix(translator): stop logging ordinary miner disconnects as errors

### DIFF
--- a/bins/translator-sv2/src/lib/error.rs
+++ b/bins/translator-sv2/src/lib/error.rs
@@ -59,6 +59,30 @@ pub enum Action {
     Shutdown,
 }
 
+impl<Owner> TproxyError<Owner> {
+    /// Whether this error is an ordinary peer disconnect rather than a fault.
+    ///
+    /// A miner closing its socket, the mesh TCP proxy dropping a probe, or a port scanner
+    /// hanging up all surface as a receiver/IO error whose action is already `Disconnect` —
+    /// the handled, expected outcome. Logging those at ERROR made routine disconnects **86%
+    /// of all ERROR output** on a live production node (454 of 526 lines in 24h), which
+    /// buries genuine failures and makes any severity-based alerting fire constantly on
+    /// noise. See #465.
+    ///
+    /// Deliberately conservative: it requires BOTH that the action is `Disconnect` AND that
+    /// the kind is one that a peer going away actually produces. Anything else stays an
+    /// error, so a real handler fault is never quietly downgraded.
+    pub fn is_expected_disconnect(&self) -> bool {
+        matches!(self.action, Action::Disconnect(_))
+            && matches!(
+                self.kind,
+                TproxyErrorKind::ChannelErrorReceiver(_)
+                    | TproxyErrorKind::ChannelErrorSender
+                    | TproxyErrorKind::Io(_)
+            )
+    }
+}
+
 impl CanDisconnect for Downstream {}
 impl CanDisconnect for Sv1Server {}
 impl CanDisconnect for ChannelManager {}
@@ -412,5 +436,44 @@ impl<Owner> HandlerErrorType for TproxyError<Owner> {
 impl<Owner> std::fmt::Display for TproxyError<Owner> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "[{:?}/{:?}]", self.kind, self.action)
+    }
+}
+
+#[cfg(test)]
+mod expected_disconnect_tests {
+    use super::*;
+
+    /// A miner closing its socket must not be logged as an error, and a genuine handler
+    /// fault must still be. Getting this wrong in either direction is costly: too loud and
+    /// the 86% noise floor comes back (#465); too quiet and a real failure disappears.
+    #[test]
+    fn only_peer_went_away_errors_count_as_expected_disconnects() {
+        // What a peer going away actually produces, with the handled Disconnect action.
+        let recv: TproxyError<Downstream> = TproxyError::disconnect(async_channel::RecvError, 1);
+        assert!(
+            recv.is_expected_disconnect(),
+            "a receiver error on a disconnecting downstream is routine"
+        );
+
+        let io: TproxyError<Downstream> =
+            TproxyError::disconnect(std::io::Error::from(std::io::ErrorKind::BrokenPipe), 2);
+        assert!(io.is_expected_disconnect(), "broken pipe is routine");
+
+        // Same kind, but NOT a disconnect action — the connection is staying, so whatever
+        // happened is a fault worth reporting.
+        let logged: TproxyError<Downstream> = TproxyError::log(async_channel::RecvError);
+        assert!(
+            !logged.is_expected_disconnect(),
+            "action Log means this was not a disconnect"
+        );
+
+        // A disconnect for a reason that is NOT a peer going away stays an error, so a
+        // genuine bug on the disconnect path is never quietly downgraded.
+        let parser: TproxyError<Downstream> =
+            TproxyError::disconnect(TproxyErrorKind::UnexpectedMessage(0, 0), 3);
+        assert!(
+            !parser.is_expected_disconnect(),
+            "an unexpected message is a fault, not a routine disconnect"
+        );
     }
 }

--- a/bins/translator-sv2/src/lib/sv1/downstream/downstream.rs
+++ b/bins/translator-sv2/src/lib/sv1/downstream/downstream.rs
@@ -25,7 +25,7 @@ use stratum_apps::{
     utils::types::{DownstreamId, Hashrate},
 };
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info, trace, warn};
 
 /// Represents a downstream SV1 miner connection.
 ///
@@ -43,6 +43,11 @@ use tracing::{debug, error, info, warn};
 #[derive(Clone, Debug)]
 pub struct Downstream {
     pub downstream_id: DownstreamId,
+    /// Peer address of this connection. Carried purely so a disconnect can name WHO
+    /// disconnected: a miner losing its session, the mesh TCP proxy, and a port scanner
+    /// were previously indistinguishable in the log, which made connection churn
+    /// impossible to attribute.
+    pub peer_addr: std::net::SocketAddr,
     pub downstream_data: Arc<Mutex<DownstreamData>>,
     pub downstream_channel_state: DownstreamChannelState,
     // Flag to track if SV1 handshake is complete (subscribe + authorize)
@@ -55,6 +60,7 @@ impl Downstream {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         downstream_id: DownstreamId,
+        peer_addr: std::net::SocketAddr,
         downstream_sv1_sender: Sender<json_rpc::Message>,
         downstream_sv1_receiver: Receiver<json_rpc::Message>,
         sv1_server_sender: Sender<(DownstreamId, json_rpc::Message)>,
@@ -78,6 +84,7 @@ impl Downstream {
         );
         Self {
             downstream_id,
+            peer_addr,
             downstream_data,
             downstream_channel_state,
             sv1_handshake_complete: Arc::new(AtomicBool::new(false)),
@@ -103,6 +110,7 @@ impl Downstream {
         task_manager: Arc<TaskManager>,
     ) {
         let downstream_id = self.downstream_id;
+        let peer_addr = self.peer_addr;
         task_manager.spawn(async move {
             // we just spawned a new task that's relevant to fallback coordination
             // so register it with the fallback coordinator
@@ -125,7 +133,20 @@ impl Downstream {
                     // Handle downstream -> server message
                     res = self.handle_downstream_message() => {
                         if let Err(e) = res {
-                            error!("Downstream {downstream_id}: error in downstream message handler: {e:?}");
+                            // A client closing its socket is not an error — the handler
+                            // maps it to `action: Disconnect`, the expected outcome. Logging
+                            // it at ERROR made routine disconnects 86% of all ERROR output on
+                            // a live node, which buries real failures and makes
+                            // severity-based alerting useless (#465).
+                            if e.is_expected_disconnect() {
+                                debug!(
+                                    "Downstream {downstream_id} ({peer_addr}) disconnected: {e:?}"
+                                );
+                            } else {
+                                error!(
+                                    "Downstream {downstream_id} ({peer_addr}): error in downstream message handler: {e:?}"
+                                );
+                            }
                             if handle_error(&status_sender, e).await {
                                 break;
                             }
@@ -345,7 +366,9 @@ impl Downstream {
         {
             Ok(msg) => msg,
             Err(e) => {
-                error!("Error receiving downstream message: {:?}", e);
+                // Redundant with the handler's own line, which carries the downstream id
+                // and peer address. Kept at trace for anyone debugging the channel itself.
+                trace!("Error receiving downstream message: {:?}", e);
                 return Err(TproxyError::disconnect(e, downstream_id));
             }
         };

--- a/bins/translator-sv2/src/lib/sv1/sv1_server/sv1_server.rs
+++ b/bins/translator-sv2/src/lib/sv1/sv1_server/sv1_server.rs
@@ -287,6 +287,7 @@ impl Sv1Server {
 
         let downstream = Downstream::new(
             downstream_id,
+            addr,
             connection.sender().clone(),
             connection.receiver().clone(),
             self.sv1_server_channel_state


### PR DESCRIPTION
Closes #465.

A client closing its socket is not an error — the handler already knows, because it maps the condition to `action: Disconnect`, the expected outcome. Logging it at ERROR made routine disconnects **454 of 526 ERROR lines in 24h** on ghost-vm4: **86% of all ERROR output**.

That buries real failures and makes severity-based alerting useless before anyone builds it — which matters now that the restart watchdog delivers through the alert centre (#466). It also cost real time today: my canary soak monitor flagged `ERRSPIKE:26` on vm8, and every one was a test client disconnecting.

## Changes

- `TproxyError::is_expected_disconnect()`, deliberately conservative: requires **both** that the action is `Disconnect` **and** that the kind is one a peer going away actually produces. A genuine fault on the disconnect path is never quietly downgraded.
- Expected disconnects log at DEBUG; everything else stays ERROR.
- The duplicate `Error receiving downstream message` line drops to TRACE — it carried no identifying detail and always preceded the handler's own line.

## The peer address is the other half

Each downstream now carries its peer address, so a disconnect names **who** went away.

This was the actual blocker on measuring connection churn. Downstream ids reached **1282 in 15.8h** on vm4 — ~81 connections/hour against 7 miners — and a miner reconnect, a mesh TCP proxy connection and a port scanner were indistinguishable in the log. vm8 carries **no miners at all** and shows the same pattern, so most of it is infrastructure rather than miners losing work. But that could only be *inferred*. Now it can be measured, which is what the secondary question on #465 needs.

## Verification

The test asserts both directions — routine disconnects classified as expected; `action: Log` and non-peer-error kinds still errors. Verified it **fails** when the predicate is neutered:

```
test only_peer_went_away_errors_count_as_expected_disconnects ... FAILED
panicked: action Log means this was not a disconnect
```

`cargo fmt --check` clean, 37 translator tests pass.
