### PR TITLE
fix(ops): stop the deploy gate vouching for reverted, rolled-back and unsoaked binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,11 @@ jobs:
       # behaviour, so the check stays able to tell those apart. No node, no build.
       - name: SV1 smoke self-test
         run: python3 bins/translator-sv2/tests/sv1_handshake_smoke_selftest.py
+      # deploy-node.sh gates every production deploy and its whole value is refusing. It once
+      # would have deployed a reverted commit reporting all four gates satisfied (#459), so the
+      # gate is driven against deliberately-bad state here. No ssh, no deploy.
+      - name: Deploy-gate self-test
+        run: ./scripts/test-deploy-gate.sh
 
   # Clippy lints
   clippy:

--- a/scripts/deploy-node.sh
+++ b/scripts/deploy-node.sh
@@ -45,8 +45,13 @@ CANARY="${3:-}"
 CANARY_NODES="ghost-vm5 ghost-vm6 ghost-vm7 ghost-vm8"
 PRODUCTION_NODES="ghost-vm1 ghost-vm2 ghost-vm3 ghost-vm4"
 SOAK_MINUTES="${SOAK_MINUTES:-60}"
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-STATE_DIR="${HOME}/.ghost-deploy"
+# Overridable alongside STATE_DIR so scripts/test-deploy-gate.sh can drive the gate against a
+# clean throwaway checkout while running THIS copy of the script. A guard nobody can drive is a
+# guard nobody has checked, which is how #459 went unnoticed.
+REPO_ROOT="${GHOST_DEPLOY_REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+# Overridable so the gate can be exercised against throwaway state by
+# scripts/test-deploy-gate.sh. A guard nobody can drive is a guard nobody has checked.
+STATE_DIR="${STATE_DIR:-${HOME}/.ghost-deploy}"
 mkdir -p "$STATE_DIR"
 
 die()  { echo "REFUSED: $*" >&2; exit 1; }
@@ -81,19 +86,63 @@ MARKER="$STATE_DIR/tested-$SHA"
 [ -f "$MARKER" ] || die "no passing test record for $SHORT
        run: scripts/deploy-node.sh --record-tests   (after a green suite)"
 
+# 3b. The commit must still be what main says, not merely something main once contained.
+#
+#     `git merge-base --is-ancestor` above stays true FOREVER once a commit is merged, so a
+#     REVERTED commit passes it happily. That is not theoretical: 7706f2870 sat on main with a
+#     full tested+soaked record while carrying the #455 regression that #456 reverted, and this
+#     script would have deployed it to production reporting every gate satisfied (#459).
+#
+#     Cheapest sound check: the paths this deploy actually ships must match current main. If a
+#     revert (or anything else) has moved them, the built binary no longer represents main.
+if echo "$PRODUCTION_NODES" | grep -qw "$NODE"; then
+    case "$BINARY" in
+        ghost-pool)      SRC_PATHS="bins/ghost-pool crates" ;;
+        pool_sv2)        SRC_PATHS="bins/pool-sv2 crates" ;;
+        translator_sv2)  SRC_PATHS="bins/translator-sv2 crates" ;;
+        *)               SRC_PATHS="" ;;
+    esac
+    if [ -n "$SRC_PATHS" ] && ! git diff --quiet "$SHA" origin/main -- $SRC_PATHS 2>/dev/null; then
+        die "$SHORT no longer matches origin/main for: $SRC_PATHS
+       main has moved (a revert, or newer commits) — rebuild from current main.
+       This is the guard that would have caught the #447 revert (#459)."
+    fi
+fi
+
 # 4. Canary soak before production. The bugs that hurt were behavioural and only showed
 #    under real traffic over time — an hourly livelock, and attribution that looked fine
 #    until a share was actually mined and its DB row inspected.
+#
+#    The marker is per-BINARY as well as per-commit. It used to be per-commit-per-node only,
+#    which meant soaking `ghost-pool` alone on a canary satisfied this gate for
+#    `translator_sv2` — a binary that had then never run on any canary (#459).
+#
+#    It also records the deployed binary's hash ON THE NODE. A soak asserts "this build ran
+#    here for N minutes"; if the node no longer runs that build the claim is void, which is
+#    exactly what a mid-roll rollback produces.
 if echo "$PRODUCTION_NODES" | grep -qw "$NODE"; then
     SOAKED=""
     for c in $CANARY_NODES; do
-        if [ -f "$STATE_DIR/soaked-$SHA-$c" ]; then
-            started=$(cat "$STATE_DIR/soaked-$SHA-$c")
-            elapsed=$(( ( $(date +%s) - started ) / 60 ))
-            [ "$elapsed" -ge "$SOAK_MINUTES" ] && SOAKED="$c (${elapsed}m)" && break
+        f="$STATE_DIR/soaked-$SHA-$c-$BINARY"
+        [ -f "$f" ] || continue
+        read -r started recorded_hash < "$f" 2>/dev/null || continue
+        elapsed=$(( ( $(date +%s) - started ) / 60 ))
+        [ "$elapsed" -ge "$SOAK_MINUTES" ] || continue
+
+        # Still running what it soaked? A rollback restores the .bak and the hash changes.
+        if [ -n "${recorded_hash:-}" ]; then
+            live_hash=$(timeout "$REMOTE_TIMEOUT" ssh "${SSH_OPTS[@]}" "$c" \
+                "sha256sum /opt/ghost/bin/$BINARY 2>/dev/null | cut -d' ' -f1" 2>/dev/null || true)
+            if [ -n "$live_hash" ] && [ "$live_hash" != "$recorded_hash" ]; then
+                info "ignoring soak on $c: $BINARY no longer matches what soaked (rolled back?)"
+                rm -f "$f"
+                continue
+            fi
         fi
+        SOAKED="$c (${elapsed}m)"
+        break
     done
-    [ -n "$SOAKED" ] || die "$SHORT has not soaked ${SOAK_MINUTES}m on a canary
+    [ -n "$SOAKED" ] || die "$BINARY @ $SHORT has not soaked ${SOAK_MINUTES}m on a canary
        deploy to a canary first: scripts/deploy-node.sh <canary> $BINARY --canary"
     info "soak satisfied: $SOAKED"
 fi
@@ -191,14 +240,21 @@ S=$SUDO
 \$S mv /opt/ghost/bin/$BINARY.staged /opt/ghost/bin/$BINARY
 \$S systemctl restart $SERVICE
 "
-    echo "rolled back to $BINARY.bak.$TS" >&2
+    # The node no longer runs this build, so any soak record claiming it does is a lie.
+    # Leaving it is how a half-rolled canary went on vouching for a commit (#459).
+    rm -f "$STATE_DIR/soaked-$SHA-$NODE-$BINARY"
+    echo "rolled back to $BINARY.bak.$TS (soak record for $BINARY @ $SHORT on $NODE cleared)" >&2
     exit 3
 fi
 
 # Start the soak clock for this commit on this node.
 if echo "$CANARY_NODES" | grep -qw "$NODE"; then
-    date +%s > "$STATE_DIR/soaked-$SHA-$NODE"
-    info "soak clock started for $SHORT on $NODE (${SOAK_MINUTES}m required before production)"
+    # Record WHAT soaked, not just when. The hash lets the production gate confirm the node is
+    # still running this build rather than something a rollback restored underneath it.
+    LIVE_HASH=$(timeout "$REMOTE_TIMEOUT" ssh "${SSH_OPTS[@]}" "$NODE" \
+        "sha256sum /opt/ghost/bin/$BINARY 2>/dev/null | cut -d' ' -f1" 2>/dev/null || true)
+    printf '%s %s\n' "$(date +%s)" "${LIVE_HASH:-}" > "$STATE_DIR/soaked-$SHA-$NODE-$BINARY"
+    info "soak clock started for $BINARY @ $SHORT on $NODE (${SOAK_MINUTES}m required before production)"
 fi
 
 info "OK: $BINARY @ $SHORT live on $NODE (backup: $BINARY.bak.$TS)"

--- a/scripts/record-tests.sh
+++ b/scripts/record-tests.sh
@@ -39,6 +39,11 @@ echo "==> stratum config agreement"
 # The pre-deploy SV1 smoke test asserts a declared difficulty reaches the miner. Its first
 # form could not tell "delivered late" from "never delivered" — both printed the floor — which
 # is what misdirected the #455 investigation. This checks the check.
+# The deploy gate's only value is that it refuses. Drive it against deliberately-bad state.
+echo "==> deploy-gate self-test"
+./scripts/test-deploy-gate.sh \
+    || { echo "FAILED: deploy-gate self-test" >&2; exit 1; }
+
 echo "==> SV1 smoke self-test"
 python3 bins/translator-sv2/tests/sv1_handshake_smoke_selftest.py \
     || { echo "FAILED: SV1 smoke self-test" >&2; exit 1; }

--- a/scripts/test-deploy-gate.sh
+++ b/scripts/test-deploy-gate.sh
@@ -15,24 +15,27 @@ set -uo pipefail
 
 SRC_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
 
-# Gate 1 is "clean working tree", and it fires before everything else — so running this from a
-# dirty checkout would mask every gate under test and report a false pass. Drive the gate from a
-# throwaway worktree at HEAD, which is clean by construction.
-REPO_ROOT="$TMP/wt"
-git -C "$SRC_ROOT" worktree add -q --detach "$REPO_ROOT" origin/main 2>/dev/null || {
-    echo "could not create a test worktree" >&2; exit 1; }
-# Run the script being EDITED (otherwise this passes while the change under review is broken)
-# against the CLEAN worktree. Copying it into the worktree would make that tree dirty, and
-# committing it there would put HEAD off origin/main — either way an earlier gate fires first
-# and every later assertion becomes vacuous. Hence GHOST_DEPLOY_REPO_ROOT.
-DEPLOY="$SRC_ROOT/scripts/deploy-node.sh"
-
-cleanup() {
-    git -C "$SRC_ROOT" worktree remove --force "$REPO_ROOT" >/dev/null 2>&1
-    rm -rf "$TMP"
-}
-trap cleanup EXIT
+# Build a HERMETIC repo to drive the gate against, rather than borrowing the real one.
+#
+# Two reasons. First, gate 1 is "clean working tree" and gate 2 is "commit is on origin/main";
+# either fires before anything under test, so a dirty checkout or a missing ref makes every
+# later assertion pass for the wrong reason. Second, CI checks out shallow and without an
+# `origin/main` ref at all, so a worktree-based harness dies there — which is exactly how this
+# first failed.
+#
+# So: a throwaway repo, committed clean, with refs/remotes/origin/main pointed at that commit.
+REPO_ROOT="$TMP/repo"
+mkdir -p "$REPO_ROOT/scripts" "$REPO_ROOT/bins/translator-sv2/tests" "$REPO_ROOT/crates"
+cp "$SRC_ROOT/scripts/deploy-node.sh" "$REPO_ROOT/scripts/deploy-node.sh"
+: > "$REPO_ROOT/crates/.keep"
+git -C "$REPO_ROOT" init -q
+git -C "$REPO_ROOT" add -A
+git -C "$REPO_ROOT" -c user.email=t@t -c user.name=t commit -qm "gate under test"
+# Make the commit look like current main so gate 2 and the revert check both pass cleanly.
+git -C "$REPO_ROOT" update-ref refs/remotes/origin/main HEAD
+DEPLOY="$REPO_ROOT/scripts/deploy-node.sh"
 
 pass=0
 fail=0

--- a/scripts/test-deploy-gate.sh
+++ b/scripts/test-deploy-gate.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+#
+# Self-test for deploy-node.sh's preconditions.
+#
+# The whole value of that script is that it REFUSES. A gate that cannot fail is worth nothing,
+# and that is not a hypothetical here: for a while it would have deployed a reverted commit to
+# production reporting all four gates satisfied (#459). So this drives the gate against
+# deliberately-bad state and asserts it says no.
+#
+# Runs entirely against a temporary STATE_DIR and a fake node list. Nothing is deployed, no ssh
+# is attempted for the cases that must fail before reaching one.
+#
+# Usage: scripts/test-deploy-gate.sh
+set -uo pipefail
+
+SRC_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP="$(mktemp -d)"
+
+# Gate 1 is "clean working tree", and it fires before everything else — so running this from a
+# dirty checkout would mask every gate under test and report a false pass. Drive the gate from a
+# throwaway worktree at HEAD, which is clean by construction.
+REPO_ROOT="$TMP/wt"
+git -C "$SRC_ROOT" worktree add -q --detach "$REPO_ROOT" origin/main 2>/dev/null || {
+    echo "could not create a test worktree" >&2; exit 1; }
+# Run the script being EDITED (otherwise this passes while the change under review is broken)
+# against the CLEAN worktree. Copying it into the worktree would make that tree dirty, and
+# committing it there would put HEAD off origin/main — either way an earlier gate fires first
+# and every later assertion becomes vacuous. Hence GHOST_DEPLOY_REPO_ROOT.
+DEPLOY="$SRC_ROOT/scripts/deploy-node.sh"
+
+cleanup() {
+    git -C "$SRC_ROOT" worktree remove --force "$REPO_ROOT" >/dev/null 2>&1
+    rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+pass=0
+fail=0
+
+# Run the gate with an isolated state dir; returns its exit code and captures stderr.
+run_gate() {
+    local node="$1" binary="$2"
+    ( cd "$REPO_ROOT" \
+        && GHOST_DEPLOY_REPO_ROOT="$REPO_ROOT" STATE_DIR="$TMP/state" SOAK_MINUTES=60 \
+        timeout 60 bash "$DEPLOY" "$node" "$binary" 2>&1 )
+}
+
+check() {
+    local name="$1" expect="$2" out="$3"
+    if grep -qiE "$expect" <<<"$out"; then
+        printf "  [ok ] %s\n" "$name"
+        pass=$((pass+1))
+    else
+        printf "  [BAD] %s\n" "$name"
+        printf "        expected to match: %s\n" "$expect"
+        printf "        got: %s\n" "$(head -3 <<<"$out" | tr '\n' ' ')"
+        fail=$((fail+1))
+    fi
+}
+
+mkdir -p "$TMP/state"
+SHA="$(cd "$REPO_ROOT" && git rev-parse HEAD)"
+
+# Neither the clean-tree nor the on-main gate may be what we are measuring — if either fires,
+# every later assertion passes for the wrong reason.
+_probe="$(run_gate ghost-vm1 ghost-pool)"
+if grep -qiE "working tree is dirty|is not on origin/main" <<<"$_probe"; then
+    echo "test harness bug: an earlier gate fires first, later assertions would be vacuous" >&2
+    echo "  $(head -1 <<<"$_probe")" >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# 1. No test record -> refuse. The most basic gate.
+# ---------------------------------------------------------------------------
+out="$(run_gate ghost-vm1 ghost-pool)"
+check "refuses with no passing test record" "no passing test record" "$out"
+
+# ---------------------------------------------------------------------------
+# 2. Test record present, but no soak -> still refuse, and the message must name
+#    the BINARY. A per-commit-only message is what let a soak of one binary vouch
+#    for another (#459).
+# ---------------------------------------------------------------------------
+: > "$TMP/state/tested-$SHA"
+out="$(run_gate ghost-vm1 translator_sv2)"
+check "refuses with no soak, naming the binary" "translator_sv2 @ .* has not soaked" "$out"
+
+# ---------------------------------------------------------------------------
+# 3. THE #459 CASE: a soak recorded for a DIFFERENT binary must not satisfy the
+#    gate for this one. Soaking ghost-pool alone used to green-light translator_sv2.
+# ---------------------------------------------------------------------------
+printf '%s %s\n' "$(( $(date +%s) - 7200 ))" "deadbeef" \
+    > "$TMP/state/soaked-$SHA-ghost-vm5-ghost-pool"
+out="$(run_gate ghost-vm1 translator_sv2)"
+check "a soak of another binary does NOT satisfy this one" "translator_sv2 @ .* has not soaked" "$out"
+
+# ---------------------------------------------------------------------------
+# 4. A soak that has not run long enough must not satisfy the gate.
+# ---------------------------------------------------------------------------
+printf '%s %s\n' "$(( $(date +%s) - 300 ))" "deadbeef" \
+    > "$TMP/state/soaked-$SHA-ghost-vm5-translator_sv2"
+out="$(run_gate ghost-vm1 translator_sv2)"
+check "a 5-minute soak does not satisfy a 60-minute requirement" "has not soaked" "$out"
+
+# ---------------------------------------------------------------------------
+# 5. Canary deploys must NOT require a soak — that is the point of a canary.
+#    It should get past the soak gate and fail later (on ssh or a missing binary).
+# ---------------------------------------------------------------------------
+rm -f "$TMP/state/soaked-$SHA"-*
+out="$(run_gate ghost-vm5 translator_sv2)"
+# Must get PAST the soak gate and fail on something later (the binary is not built here).
+if grep -qi "has not soaked\|working tree is dirty\|no passing test record" <<<"$out"; then
+    printf "  [BAD] canary blocked before reaching the deploy stage: %s\n" "$(head -1 <<<"$out")"
+    fail=$((fail+1))
+elif grep -qiE "not built|No such file" <<<"$out"; then
+    printf "  [ok ] canary passes the soak gate and proceeds to the deploy stage\n"
+    pass=$((pass+1))
+else
+    printf "  [BAD] canary reached an unexpected state: %s\n" "$(head -1 <<<"$out")"
+    fail=$((fail+1))
+fi
+
+echo
+if [ "$fail" -ne 0 ]; then
+    echo "*** $fail of $((pass+fail)) deploy-gate checks FAILED — the gate is not refusing what it must ***"
+    exit 1
+fi
+echo "All $pass deploy-gate checks passed: the gate refuses untested, unsoaked, wrong-binary and short soaks."


### PR DESCRIPTION
Closes #459.

The deploy gate's entire value is that it **refuses**, and it had three ways to say yes when it should have said no. One of them would have put the #455 regression into production reporting all four gates satisfied.

## 1. A reverted commit still passed

`git merge-base --is-ancestor` stays true **forever** once a commit is merged. It answers *"was this ever on main"*, not *"is this what main says now"*. `7706f2870` sat on main with a full `tested` + `soaked` record while carrying the regression #456 reverted.

Now the paths a deploy actually ships must still match `origin/main`:

```
REFUSED: 7706f2870 no longer matches origin/main for: bins/translator-sv2 crates
   main has moved (a revert, or newer commits) — rebuild from current main.
```

## 2. A rollback left the soak record intact

The marker asserts *"this build ran here for N minutes"*. After a rollback the node runs the backup instead, so the claim is void — but the record survived and went on vouching for the commit.

The rollback path now clears that node's record, and the production gate **re-checks the binary hash on the canary** before honouring a soak. A rollback changes it.

## 3. A soak of one binary satisfied the gate for another

**Not in the original report — this turned up while fixing the other two.** The marker was per-commit-per-node, not per-binary, so soaking `ghost-pool` alone on a canary green-lit deploying `translator_sv2`, a binary that had then never run on any canary. Markers are now per-binary.

## The test is the point

`scripts/test-deploy-gate.sh`, wired into `record-tests.sh` and the CI Format job. It drives the gate against deliberately-bad state and asserts refusal:

```
[ok ] refuses with no passing test record
[ok ] refuses with no soak, naming the binary
[ok ] a soak of another binary does NOT satisfy this one
[ok ] a 5-minute soak does not satisfy a 60-minute requirement
[ok ] canary passes the soak gate and proceeds to the deploy stage
```

Two things had to become overridable for this to be possible at all — `STATE_DIR` and `REPO_ROOT`. The script could not be driven against throwaway state, which is precisely why nobody noticed it had stopped refusing.

## Writing the harness surfaced two ways it could pass vacuously

Both fixed, and worth stating because they are the same failure this issue is about:

- a **dirty working tree** makes gate 1 fire first
- an **off-main HEAD** makes gate 2 fire first

Either way every later assertion passes for the wrong reason. I hit both while building it — the first run reported 4 failures that were all really "working tree is dirty", and a later run had one check passing purely because the expected string was absent. The harness now probes for both up front and aborts as a *harness bug* rather than reporting green.
