### PR TITLE
feat(pool): drop the hobby-tier floor to 1 TH/s (~2,328)

### DIFF
--- a/bins/translator-sv2/tests/sv1_handshake_smoke.py
+++ b/bins/translator-sv2/tests/sv1_handshake_smoke.py
@@ -244,10 +244,13 @@ def test_default_difficulty():
     reading config files by hand.
 
     Expected value comes from min_individual_miner_hashrate: difficulty =
-    hashrate * (2^48 / 0xFFFF) / 2^32 / shares_per_minute-normalised — in practice
-    10 TH/s -> ~23,283. Override for a node deliberately configured otherwise.
+    hashrate * 60 / (shares_per_minute * 2^32) — in practice the hobby floor of
+    1 TH/s -> ~2,328, and the farm tier (:4444) at 100 TH/s -> ~232,831. Override for a
+    node deliberately configured otherwise, and note this case only ever covers the port
+    it is pointed at: with a second listener running it must be run once per port or it
+    silently stops checking half the surface.
     """
-    expected = float(os.environ.get("GHOST_EXPECT_DEFAULT_DIFFICULTY", "23282.7"))
+    expected = float(os.environ.get("GHOST_EXPECT_DEFAULT_DIFFICULTY", "2328.27"))
     tol = float(os.environ.get("GHOST_DEFAULT_DIFFICULTY_TOLERANCE", "0.02"))
     s = socket.create_connection((HOST, PORT), timeout=10)
     send(s, {"id": 1, "method": "mining.subscribe", "params": ["synthtest/1.0"]})

--- a/config/sri/translator-config.toml
+++ b/config/sri/translator-config.toml
@@ -48,7 +48,23 @@ monitoring_address = "0.0.0.0:9092"
 #
 # A BitAxe (~0.5-1.5 TH/s) converges down in about 3 vardiff ticks, and payouts are
 # work-weighted, so a small miner loses share cadence during that window, not earnings.
-min_individual_miner_hashrate = 10_000_000_000_000.0
+# Hobby-tier floor: 1 TH/s -> starting difficulty ~2,328.
+#
+# Was 10 TH/s (~23,283), which is a bar set for a machine 10x larger than anything that
+# actually connects here. Measured on a live Bitaxe Gamma: its ASIC finds results averaging
+# 688 difficulty and peaking around 1,386, so at a 23,283 floor it had to get ~34x luckier
+# than its typical result to submit ANYTHING. It found a share about every 267s, which left
+# AxeOS estimating hashrate from two or three samples and displaying 26 TH/s for a 1.13 TH/s
+# machine — the operator reasonably read that as a broken miner.
+#
+# The control group is bitaxe4, which reaches pool_sv2 directly at difficulty 2,215 and reads
+# stable and truthful on the same hardware class.
+#
+# Payout is unaffected: it is proportional to work, and a share's work IS its difficulty, so
+# the same hashrate earns the same at any floor. The cost is share VOLUME (~10x more rows,
+# each gossiped to 8 nodes), which is why large miners belong on the farm tier (:4444) rather
+# than here.
+min_individual_miner_hashrate = 1_000_000_000_000.0
 # Target shares per minute
 shares_per_minute = 6.0
 # Enable variable difficulty adjustment

--- a/scripts/install-node.sh
+++ b/scripts/install-node.sh
@@ -917,7 +917,23 @@ monitoring_address = "0.0.0.0:9092"
 
 # Difficulty configuration for SV1 miners
 [downstream_difficulty_config]
-min_individual_miner_hashrate = 10_000_000_000_000.0
+# Hobby-tier floor: 1 TH/s -> starting difficulty ~2,328.
+#
+# Was 10 TH/s (~23,283), which is a bar set for a machine 10x larger than anything that
+# actually connects here. Measured on a live Bitaxe Gamma: its ASIC finds results averaging
+# 688 difficulty and peaking around 1,386, so at a 23,283 floor it had to get ~34x luckier
+# than its typical result to submit ANYTHING. It found a share about every 267s, which left
+# AxeOS estimating hashrate from two or three samples and displaying 26 TH/s for a 1.13 TH/s
+# machine — the operator reasonably read that as a broken miner.
+#
+# The control group is bitaxe4, which reaches pool_sv2 directly at difficulty 2,215 and reads
+# stable and truthful on the same hardware class.
+#
+# Payout is unaffected: it is proportional to work, and a share's work IS its difficulty, so
+# the same hashrate earns the same at any floor. The cost is share VOLUME (~10x more rows,
+# each gossiped to 8 nodes), which is why large miners belong on the farm tier (:4444) rather
+# than here.
+min_individual_miner_hashrate = 1_000_000_000_000.0
 shares_per_minute = 6.0
 enable_vardiff = true
 idle_timeout_secs = 600


### PR DESCRIPTION
Part of #410. Operator-approved.

The 10 TH/s floor (~23,283) is a bar set for a machine **ten times larger** than anything that actually connects on `:3333`.

## Measured, from the miner's own ASIC log

```
diff  1386.0  of 23282.7
diff  1378.7  of 23282.7
diff   276.6  of 23282.7
diff   441.7  of 23282.7
diff   310.1  of 23282.7
diff   536.7  of 23282.7
diff   488.6  of 23282.7
```

Seven results in 18.2s summing to 4,818 difficulty — **1.13 TH/s**, comfortably above the 795 GH/s its low frequency setting predicts. The chip is healthy.

But the best of those was **17× short** of the threshold and the average **34× short**. The miner does good work and discards essentially all of it.

| | value |
|---|---|
| mean ASIC result | 688 |
| best in window | 1,386 |
| pool threshold | **23,283** |
| share interval | ~267s |

That interval is why the dashboard read **26 TH/s for a 1.13 TH/s machine**: AxeOS estimates from shares × difficulty ÷ time, so a 10-minute window held two or three samples. Its own figures disagreed by 4× across windows (1m 21.2, 10m 26.5, 1h 6.83) — the signature of too few samples, not a broken miner.

## The control group already exists

`bitaxe4` reaches `pool_sv2` directly at difficulty **2,215** — almost exactly this new floor — and reads stable and truthful on the same hardware class: **671 samples in 2h against bitaxe3's 27**.

## Payout is unaffected

Proportional to work, and a share's work *is* its difficulty, so the same hashrate earns the same at any floor. The cost is share **volume** — ~10× the rows, each gossiped to 8 nodes — which is exactly why large miners belong on the farm tier (`:4444`) rather than here.

## Also updated

The smoke test's `default-diff` expectation, from 23,282.7 to 2,328.27. Without it the deploy would fail its own smoke test and roll back — the gate behaving correctly. Its docstring now also records that the case only covers the port it's pointed at, so it must be run per-port once a second listener exists.

Both config sources changed in step; `check-stratum-config-agreement` and `check-inlined-copies` green.
