### PR TITLE
fix(ops): make the attribution checks say what they actually verified

### DIFF
--- a/scripts/ops/attribution_probe.py
+++ b/scripts/ops/attribution_probe.py
@@ -1,10 +1,29 @@
 #!/usr/bin/env python3
 """Submit a REAL share as `<address>.<worker>` and let the operator check who got credited.
 
-This is the test that was missing the two times channel-open-on-subscribe was deployed and
-misattributed ~395 shares. Both times the failure was silent: shares kept flowing, they
-simply landed on the translator's configured operator address instead of the miner. Nothing
-on the wire says which identity a share was credited to — only the node's database does.
+⚠ READ THIS BEFORE RELYING ON IT: at production difficulty this CANNOT SUCCEED.
+
+It mines in pure Python at roughly 750k H/s. A share needs `difficulty * 2^32` hashes on
+average, so at the hobby floor (~2,328) that is about 151 DAYS, and at the farm floor
+(~232,831) about 41 years. It was previously described here as "the test that was missing"
+when misattribution shipped — it could not have been that test, because it never finishes.
+See #464.
+
+It now measures its own hash rate against the difficulty the pool actually grants and refuses
+immediately, with the arithmetic, rather than burning its 900s budget to reach the same
+conclusion silently.
+
+A `d=<difficulty>` directive in the password does NOT help: a declared difficulty is clamped
+UP to the pool floor and never below it, so it can raise a miner above the floor but cannot
+lower it for probing. Verified against a live node.
+
+It is therefore useful only where a node can be made to grant a tiny difficulty — a canary
+configured for it. On a production node, use `verify_attribution.sh` against REAL miner
+traffic instead; that is the check that actually works.
+
+Both times misattribution shipped, the failure was silent: shares kept flowing, they simply
+landed on the translator's configured operator address instead of the miner. Nothing on the
+wire says which identity a share was credited to — only the node's database does.
 
 So this deliberately mines a share that is genuinely valid rather than asserting on
 handshake fields. It behaves as a SERIALISING client (subscribe -> wait for reply ->
@@ -18,7 +37,7 @@ Usage:
 Exits 0 once a share is accepted. The caller then reads the node's `miners` table and checks
 the credited miner_id.
 """
-import hashlib, json, socket, struct, sys, time
+import hashlib, json, os, socket, struct, sys, time
 
 HOST = sys.argv[1]
 PORT = int(sys.argv[2])
@@ -120,6 +139,29 @@ def main():
     print(f"  job {job_id} difficulty={difficulty} re_keyed={re_keyed}")
 
     target = difficulty_to_target(difficulty)
+
+    # Calibrate against THIS machine before committing to a 15-minute wait, and say plainly
+    # when the arithmetic makes success impossible. A check that fails silently after a long
+    # wait teaches nobody anything; one that says "this needs 151 days" is actionable.
+    budget = float(os.environ.get("PROBE_MAX_SECONDS", "900"))
+    cal_start = time.time()
+    cal_head = b"\x00" * 76
+    cal_n = 200_000
+    for i in range(cal_n):
+        sha256d(cal_head + struct.pack("<I", i))
+    rate = cal_n / max(time.time() - cal_start, 1e-9)
+    expected_s = difficulty * (2 ** 32) / rate
+    print(f"  calibrated at {rate:,.0f} H/s; a share at difficulty {difficulty:,.1f} "
+          f"needs ~{difficulty * (2 ** 32):,.0f} hashes")
+    if expected_s > budget:
+        print(f"REFUSING: expected time to find a share is ~{expected_s / 86400:,.1f} days "
+              f"({expected_s:,.0f}s), far beyond the {budget:,.0f}s budget.")
+        print("  This prober cannot verify attribution at this difficulty — see #464.")
+        print("  Use scripts/ops/verify_attribution.sh against real miner traffic instead,")
+        print("  or point this at a canary configured to grant a tiny difficulty.")
+        s.close()
+        return 2
+
     print(f"  mining for a share at difficulty {difficulty} ...")
 
     # --- actually mine ---
@@ -162,8 +204,9 @@ def main():
                 return 1
             if attempts % 2_000_000 == 0:
                 print(f"    {attempts:,} hashes, {time.time()-started:.0f}s ...")
-            if time.time() - started > 900:
-                print("FAIL: no share found in 900s — difficulty too high for this prober")
+            if time.time() - started > budget:
+                print(f"FAIL: no share found in {budget:,.0f}s — difficulty too high for this "
+                      f"prober (expected ~{expected_s / 86400:,.1f} days)")
                 return 1
     return 1
 

--- a/scripts/ops/verify_attribution.sh
+++ b/scripts/ops/verify_attribution.sh
@@ -6,6 +6,10 @@
 # — only the shares ledger does. That is how ~395 shares (6,913 on vm8) were misattributed
 # twice before anyone noticed.
 #
+# Exit: 0 = verified clean, 1 = misattribution detected, 2 = INCONCLUSIVE (no shares to judge).
+# The 2 matters: it used to return 0 on a node with no miners, which is every canary, so the
+# post-deploy check reported PASS having examined nothing (#461, #464).
+#
 # Usage: verify_attribution.sh <node> [window_secs]
 set -uo pipefail
 NODE="${1:?usage: verify_attribution.sh <node> [window_secs]}"
@@ -25,12 +29,29 @@ BAD=$(ssh -o ConnectTimeout=10 "$NODE" "$SQL_PREFIX /home/ghost/.ghost/ghost.db 
   and timestamp > strftime('%s','now') - $WINDOW;\"" 2>/dev/null)
 BAD="${BAD:-0}"
 
+# Total locally-submitted shares in the window. Without this the check passes VACUOUSLY on any
+# node with no miners — "0 credited to the operator identity" is trivially true when nothing was
+# credited to anyone. Every canary (vm5-8) is in exactly that state, which is why a 60-minute
+# soak there proves nothing about attribution (#461, #464). Say so rather than reporting PASS.
+TOTAL=$(ssh -o ConnectTimeout=10 "$NODE" "$SQL_PREFIX /home/ghost/.ghost/ghost.db \
+  \"select count(*) from shares where timestamp > strftime('%s','now') - $WINDOW
+     and length(received_by) > 8;\"" 2>/dev/null)
+TOTAL="${TOTAL:-0}"
+
 echo
+if [ "$TOTAL" = "0" ]; then
+    echo "  INCONCLUSIVE: no locally-submitted shares on $NODE in the last ${WINDOW}s."
+    echo "  There is nothing to attribute, so this proves nothing either way."
+    echo "  Attribution can only be checked on a node carrying real miners (vm3/vm4 today)."
+    exit 2
+fi
+
 if [ "$BAD" = "0" ]; then
-    echo "  PASS: 0 shares credited to the operator identity in the last ${WINDOW}s"
+    echo "  PASS: 0 of $TOTAL locally-submitted shares credited to the operator identity"
+    echo "        in the last ${WINDOW}s"
     exit 0
 fi
-echo "  *** FAIL: $BAD share(s) credited to $OP in the last ${WINDOW}s ***"
+echo "  *** FAIL: $BAD of $TOTAL share(s) credited to $OP in the last ${WINDOW}s ***"
 echo "  *** This is the misattribution failure. ROLL BACK NOW: ***"
 echo "  ***   ssh $NODE 'ls -t /opt/ghost/bin/*.bak.* | head -3' ***"
 exit 1


### PR DESCRIPTION
Closes #464. Also fixes the vacuous-pass half of #461.

Two checks reported success without checking anything.

## `attribution_probe.py` could never succeed at production difficulty

It mines in pure Python at ~750k–1.1M H/s, and a share needs `difficulty × 2³²` hashes:

| difficulty | expected time |
|---|---|
| 2,328 (new hobby floor) | **~105 days** |
| 23,283 (old floor) | ~4.1 years |
| 232,831 (farm tier) | ~41 years |

Its docstring called it *"the test that was missing"* when misattribution shipped twice. It cannot have been — it never finishes. It did have a 900s bound so it never hung; it just spent 15 minutes reaching a conclusion available instantly from arithmetic.

It now calibrates its own rate against the difficulty the pool actually grants, and refuses with the numbers:

```
calibrated at 1,106,425 H/s; a share at difficulty 2,328.3 needs ~9,999,847,371,151 hashes
REFUSING: expected time to find a share is ~104.6 days (9,037,977s), far beyond the 900s budget.
  This prober cannot verify attribution at this difficulty — see #464.
  Use scripts/ops/verify_attribution.sh against real miner traffic instead,
  or point this at a canary configured to grant a tiny difficulty.
```

Also records that a `d=` declaration is clamped **up** to the floor and never below it, so it can't be used to make probing feasible. Verified against a live node.

## `verify_attribution.sh` passed vacuously where it mattered most

"0 shares credited to the operator identity" is trivially true when nothing was credited to *anyone*. **Every canary is in that state**, so the post-deploy check reported PASS having examined nothing — which is precisely the gap #461 describes.

It now counts locally-submitted shares first and reports the denominator:

```
ghost-vm4  exit=0  PASS: 0 of 149 locally-submitted shares credited to the operator identity
ghost-vm6  exit=2  INCONCLUSIVE: no locally-submitted shares ... proves nothing either way
```

New exit code **2 = inconclusive**, distinct from 0 = verified clean and 1 = misattribution detected. Both verified against live nodes, one with miners and one without.

## What this does not fix

Attribution still can only be verified on a node carrying real miners — today vm3 and vm4, both production. That is #461's remaining half, and the operator is addressing it by pointing a bitaxe at a canary. This change makes the tooling stop *claiming* otherwise.
