### PR TITLE
ci: build the fuzz targets, and assert every target file is registered

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,11 @@ jobs:
       # gate is driven against deliberately-bad state here. No ssh, no deploy.
       - name: Deploy-gate self-test
         run: ./scripts/test-deploy-gate.sh
+      # Fuzz targets depend on internal APIs and rot silently when a signature changes.
+      # One had been importing a module that no longer existed, unnoticed, because no job
+      # built them (#468). Build only — running the fuzzers belongs in a scheduled job.
+      - name: Fuzz targets build
+        run: ./scripts/check-fuzz-targets.sh
 
   # Clippy lints
   clippy:

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aead"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -361,18 +367,17 @@ dependencies = [
 [[package]]
 name = "binary_sv2"
 version = "5.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b508acc2616ce7faec993f6b4e4d0aa2227d74103552897bf833413bf7406681"
 dependencies = [
- "derive_codec_sv2 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "derive_codec_sv2 1.1.2",
 ]
 
 [[package]]
 name = "binary_sv2"
 version = "5.0.1"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#78585d7270c4f694bcbfa2b8dfbc4ee999fd3a66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b508acc2616ce7faec993f6b4e4d0aa2227d74103552897bf833413bf7406681"
 dependencies = [
- "derive_codec_sv2 1.1.2 (git+https://github.com/stratum-mining/stratum?branch=main)",
+ "derive_codec_sv2 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -569,7 +574,6 @@ dependencies = [
 [[package]]
 name = "buffer_sv2"
 version = "3.0.1"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#78585d7270c4f694bcbfa2b8dfbc4ee999fd3a66"
 dependencies = [
  "aes-gcm",
 ]
@@ -659,9 +663,8 @@ dependencies = [
 [[package]]
 name = "channels_sv2"
 version = "4.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#78585d7270c4f694bcbfa2b8dfbc4ee999fd3a66"
 dependencies = [
- "binary_sv2 5.0.1 (git+https://github.com/stratum-mining/stratum?branch=main)",
+ "binary_sv2 5.0.1",
  "bitcoin",
  "mining_sv2",
  "primitive-types",
@@ -760,11 +763,10 @@ dependencies = [
 [[package]]
 name = "codec_sv2"
 version = "5.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#78585d7270c4f694bcbfa2b8dfbc4ee999fd3a66"
 dependencies = [
- "binary_sv2 5.0.1 (git+https://github.com/stratum-mining/stratum?branch=main)",
+ "binary_sv2 5.0.1",
  "buffer_sv2 3.0.1",
- "framing_sv2 6.0.1 (git+https://github.com/stratum-mining/stratum?branch=main)",
+ "framing_sv2 6.0.1",
  "noise_sv2 1.4.2",
  "rand 0.8.5",
  "tracing",
@@ -788,9 +790,8 @@ dependencies = [
 [[package]]
 name = "common_messages_sv2"
 version = "7.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#78585d7270c4f694bcbfa2b8dfbc4ee999fd3a66"
 dependencies = [
- "binary_sv2 5.0.1 (git+https://github.com/stratum-mining/stratum?branch=main)",
+ "binary_sv2 5.0.1",
 ]
 
 [[package]]
@@ -915,6 +916,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1078,13 +1088,12 @@ dependencies = [
 [[package]]
 name = "derive_codec_sv2"
 version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40d67b9d87d96ca3b35000ad98ac7d940ebf8f93527229c5fc0938b0a013ea9e"
 
 [[package]]
 name = "derive_codec_sv2"
 version = "1.1.2"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#78585d7270c4f694bcbfa2b8dfbc4ee999fd3a66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40d67b9d87d96ca3b35000ad98ac7d940ebf8f93527229c5fc0938b0a013ea9e"
 
 [[package]]
 name = "digest"
@@ -1316,9 +1325,8 @@ checksum = "729eda2ea2f6c5ef85150c85a9b2ce0a8e01f040e59cdb32521eaa6c840c9d51"
 [[package]]
 name = "extensions_sv2"
 version = "0.1.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#78585d7270c4f694bcbfa2b8dfbc4ee999fd3a66"
 dependencies = [
- "binary_sv2 5.0.1 (git+https://github.com/stratum-mining/stratum?branch=main)",
+ "binary_sv2 5.0.1",
 ]
 
 [[package]]
@@ -1372,6 +1380,16 @@ dependencies = [
  "rand 0.8.5",
  "rustc-hex",
  "static_assertions",
+]
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -1432,20 +1450,19 @@ dependencies = [
 [[package]]
 name = "framing_sv2"
 version = "6.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc22163ceb4d6c0300942035964c466f0c5279fd91dfbae8b01e7295ab30648a"
 dependencies = [
- "binary_sv2 5.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "noise_sv2 1.4.1",
+ "binary_sv2 5.0.1",
+ "noise_sv2 1.4.2",
 ]
 
 [[package]]
 name = "framing_sv2"
 version = "6.0.1"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#78585d7270c4f694bcbfa2b8dfbc4ee999fd3a66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc22163ceb4d6c0300942035964c466f0c5279fd91dfbae8b01e7295ab30648a"
 dependencies = [
- "binary_sv2 5.0.1 (git+https://github.com/stratum-mining/stratum?branch=main)",
- "noise_sv2 1.4.2",
+ "binary_sv2 5.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "noise_sv2 1.4.1",
 ]
 
 [[package]]
@@ -1626,7 +1643,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-accounting"
-version = "1.8.0"
+version = "1.11.19"
 dependencies = [
  "bitcoin",
  "ghost-common",
@@ -1640,7 +1657,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-buds"
-version = "1.8.0"
+version = "1.11.19"
 dependencies = [
  "bitcoin",
  "ghost-common",
@@ -1654,7 +1671,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-common"
-version = "1.8.0"
+version = "1.11.19"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -1686,7 +1703,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-consensus"
-version = "1.8.0"
+version = "1.11.19"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1737,7 +1754,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-glyph"
-version = "1.8.0"
+version = "1.11.19"
 dependencies = [
  "hex",
  "serde",
@@ -1748,7 +1765,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-gsp-proto"
-version = "1.8.0"
+version = "1.11.19"
 dependencies = [
  "bitcoin",
  "chrono",
@@ -1764,7 +1781,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-keys"
-version = "1.8.0"
+version = "1.11.19"
 dependencies = [
  "bech32",
  "bitcoin",
@@ -1786,7 +1803,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-locks"
-version = "1.8.0"
+version = "1.11.19"
 dependencies = [
  "bitcoin",
  "getrandom 0.2.17",
@@ -1828,7 +1845,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-policy"
-version = "1.8.0"
+version = "1.11.19"
 dependencies = [
  "bitcoin",
  "ghost-buds",
@@ -1841,11 +1858,12 @@ dependencies = [
 
 [[package]]
 name = "ghost-pool"
-version = "1.8.0"
+version = "1.11.19"
 dependencies = [
  "anyhow",
  "async-channel 2.5.0",
  "async-trait",
+ "axum",
  "binary_sv2 5.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitcoin",
  "bs58",
@@ -1871,10 +1889,12 @@ dependencies = [
  "ghost-verification",
  "ghost-zkp",
  "hex",
+ "libc",
  "noise_sv2 1.4.1",
  "parking_lot",
  "rand 0.8.5",
  "reqwest",
+ "rustls",
  "secp256k1 0.28.2",
  "serde",
  "serde_json",
@@ -1886,11 +1906,13 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
+ "wraith-coordinator",
+ "wraith-protocol",
 ]
 
 [[package]]
 name = "ghost-reaper"
-version = "1.8.0"
+version = "1.11.19"
 dependencies = [
  "bitcoin",
  "serde",
@@ -1901,7 +1923,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-reconciliation"
-version = "1.8.0"
+version = "1.11.19"
 dependencies = [
  "async-trait",
  "bitcoin",
@@ -1927,7 +1949,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-storage"
-version = "1.8.0"
+version = "1.11.19"
 dependencies = [
  "base64 0.22.1",
  "chacha20poly1305",
@@ -1948,7 +1970,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-template"
-version = "1.8.0"
+version = "1.11.19"
 dependencies = [
  "bitcoin",
  "ghost-buds",
@@ -1964,9 +1986,10 @@ dependencies = [
 
 [[package]]
 name = "ghost-verification"
-version = "1.8.0"
+version = "1.11.19"
 dependencies = [
  "axum",
+ "base64 0.22.1",
  "bitcoin",
  "chrono",
  "futures",
@@ -1979,6 +2002,7 @@ dependencies = [
  "hex",
  "hmac",
  "hyper-util",
+ "ipnet",
  "libc",
  "parking_lot",
  "rand 0.8.5",
@@ -2080,12 +2104,11 @@ dependencies = [
 [[package]]
 name = "handlers_sv2"
 version = "0.2.2"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#78585d7270c4f694bcbfa2b8dfbc4ee999fd3a66"
 dependencies = [
- "binary_sv2 5.0.1 (git+https://github.com/stratum-mining/stratum?branch=main)",
+ "binary_sv2 5.0.1",
  "common_messages_sv2 7.0.0",
  "extensions_sv2",
- "framing_sv2 6.0.1 (git+https://github.com/stratum-mining/stratum?branch=main)",
+ "framing_sv2 6.0.1",
  "job_declaration_sv2",
  "mining_sv2",
  "parsers_sv2",
@@ -2281,7 +2304,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -2529,9 +2552,8 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 [[package]]
 name = "job_declaration_sv2"
 version = "7.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#78585d7270c4f694bcbfa2b8dfbc4ee999fd3a66"
 dependencies = [
- "binary_sv2 5.0.1 (git+https://github.com/stratum-mining/stratum?branch=main)",
+ "binary_sv2 5.0.1",
 ]
 
 [[package]]
@@ -2701,9 +2723,8 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 [[package]]
 name = "mining_sv2"
 version = "8.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#78585d7270c4f694bcbfa2b8dfbc4ee999fd3a66"
 dependencies = [
- "binary_sv2 5.0.1 (git+https://github.com/stratum-mining/stratum?branch=main)",
+ "binary_sv2 5.0.1",
 ]
 
 [[package]]
@@ -2715,6 +2736,16 @@ dependencies = [
  "bech32",
  "bitcoin",
  "hex-conservative 1.0.1",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -2768,7 +2799,6 @@ dependencies = [
 [[package]]
 name = "noise_sv2"
 version = "1.4.2"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#78585d7270c4f694bcbfa2b8dfbc4ee999fd3a66"
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
@@ -2979,12 +3009,11 @@ dependencies = [
 [[package]]
 name = "parsers_sv2"
 version = "0.2.2"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#78585d7270c4f694bcbfa2b8dfbc4ee999fd3a66"
 dependencies = [
- "binary_sv2 5.0.1 (git+https://github.com/stratum-mining/stratum?branch=main)",
+ "binary_sv2 5.0.1",
  "common_messages_sv2 7.0.0",
  "extensions_sv2",
- "framing_sv2 6.0.1 (git+https://github.com/stratum-mining/stratum?branch=main)",
+ "framing_sv2 6.0.1",
  "job_declaration_sv2",
  "mining_sv2",
  "template_distribution_sv2 5.0.0",
@@ -3480,7 +3509,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -3874,6 +3903,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3953,15 +3988,13 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stratum-apps"
-version = "0.2.0"
+version = "1.11.19"
 dependencies = [
  "async-channel 1.9.0",
  "bs58",
- "clap",
  "config",
  "dirs",
  "futures",
- "generic-array 0.14.7",
  "miniscript",
  "rand 0.8.5",
  "rustversion",
@@ -3978,16 +4011,15 @@ dependencies = [
 [[package]]
 name = "stratum-core"
 version = "0.2.1"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#78585d7270c4f694bcbfa2b8dfbc4ee999fd3a66"
 dependencies = [
- "binary_sv2 5.0.1 (git+https://github.com/stratum-mining/stratum?branch=main)",
+ "binary_sv2 5.0.1",
  "bitcoin",
  "buffer_sv2 3.0.1",
  "channels_sv2",
  "codec_sv2 5.0.0",
  "common_messages_sv2 7.0.0",
  "extensions_sv2",
- "framing_sv2 6.0.1 (git+https://github.com/stratum-mining/stratum?branch=main)",
+ "framing_sv2 6.0.1",
  "handlers_sv2",
  "job_declaration_sv2",
  "mining_sv2",
@@ -4110,9 +4142,8 @@ dependencies = [
 [[package]]
 name = "template_distribution_sv2"
 version = "5.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#78585d7270c4f694bcbfa2b8dfbc4ee999fd3a66"
 dependencies = [
- "binary_sv2 5.0.1 (git+https://github.com/stratum-mining/stratum?branch=main)",
+ "binary_sv2 5.0.1",
 ]
 
 [[package]]
@@ -4634,6 +4665,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64 0.22.1",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4852,6 +4901,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -5218,8 +5276,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "wraith-coordinator"
+version = "1.11.19"
+dependencies = [
+ "anyhow",
+ "axum",
+ "base64 0.22.1",
+ "bitcoin",
+ "chrono",
+ "clap",
+ "getrandom 0.2.17",
+ "ghost-common",
+ "hex",
+ "hmac",
+ "hyper",
+ "reqwest",
+ "rustls",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
+ "tokio",
+ "toml",
+ "tower 0.4.13",
+ "tower-http 0.5.2",
+ "tracing",
+ "tracing-subscriber",
+ "ureq",
+ "wraith-protocol",
+]
+
+[[package]]
 name = "wraith-protocol"
-version = "1.8.0"
+version = "1.11.19"
 dependencies = [
  "bitcoin",
  "getrandom 0.2.17",

--- a/fuzz/fuzz_targets/fuzz_stratum_username.rs
+++ b/fuzz/fuzz_targets/fuzz_stratum_username.rs
@@ -20,24 +20,31 @@
 //| FILE: fuzz_stratum_username.rs                                                                                       |
 //|======================================================================================================================|
 
-//! Fuzz target for Stratum username parsing
+//! Fuzz target for Stratum username parsing.
 //!
-//! Tests that parse_miner_username and is_valid_bitcoin_address
-//! never panic on arbitrary input.
+//! The username is attacker-controlled: it arrives verbatim in `mining.authorize` from anyone
+//! who can reach the stratum port, and the pool derives the payout address and worker name
+//! from it. A panic here is a remote crash; a mis-parse is a misattributed payout.
+//!
+//! Previously this also imported `ghost_pool::stratum::{parse_miner_username,
+//! is_valid_bitcoin_address}`, a module that no longer exists — so the target had not compiled
+//! for some time and nothing noticed, because no CI job builds the fuzz targets at all (#468).
 
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
-use ghost_pool::stratum::{parse_miner_username, is_valid_bitcoin_address};
 use ghost_pool::validation::{validate_username, ValidatedCredentials};
 
 fuzz_target!(|data: &[u8]| {
-    // Only test valid UTF-8 strings
+    // Only valid UTF-8 reaches the parsers; the stratum layer rejects the rest earlier.
     if let Ok(s) = std::str::from_utf8(data) {
-        // These should NEVER panic, only return values or errors
-        let _ = parse_miner_username(s);
-        let _ = is_valid_bitcoin_address(s);
+        // Neither may panic — only return a value or an error.
         let _ = validate_username(s);
-        let _ = ValidatedCredentials::parse(s, "password");
+
+        // The password is parsed alongside the username and carries the `d=` difficulty
+        // directive, so it is attacker-controlled too. Fuzz it against both a fixed password
+        // and the same arbitrary input, so a crash that needs BOTH fields hostile is reachable.
+        let _ = ValidatedCredentials::parse(s, "x");
+        let _ = ValidatedCredentials::parse(s, s);
     }
 });

--- a/scripts/check-fuzz-targets.sh
+++ b/scripts/check-fuzz-targets.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# Build every fuzz target.
+#
+# Fuzz targets depend on internal APIs, so they rot the moment a signature changes — and
+# nothing built them. `fuzz_stratum_username` had been importing a module that no longer
+# existed for some time, and it went unnoticed because no job compiled it (#468). You would
+# have discovered it on the day you actually wanted to fuzz something, which is the day you
+# are already worried about a bug.
+#
+# BUILD ONLY. Running the fuzzers belongs in a scheduled job, not on every PR. This also uses
+# plain `cargo check` rather than `cargo fuzz`, so it needs no nightly toolchain and no
+# sanitiser runtime — it catches API rot, which is the failure that actually happened.
+#
+# Also asserts every target FILE is registered as a [[bin]]. A file nothing references is a
+# target nobody builds, which is the same failure wearing different clothes.
+set -uo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+[ -d fuzz ] || { echo "check-fuzz-targets: no fuzz/ directory"; exit 0; }
+
+# NOTE the character class: [a-z0-9_], not [a-z_]. Target names contain digits
+# (fuzz_l2_requests, fuzz_p2p_payloads) and a letters-only class silently skips them —
+# the same bug that once made the stratum-config check report more keys than it compared.
+mapfile -t registered < <(grep -oE 'name = "fuzz_[a-z0-9_]+"' fuzz/Cargo.toml \
+    | sed -E 's/.*"(.*)"/\1/' | sort -u)
+mapfile -t files < <(find fuzz/fuzz_targets -name '*.rs' -exec basename {} .rs \; | sort -u)
+
+orphans=$(comm -23 <(printf '%s\n' "${files[@]}") <(printf '%s\n' "${registered[@]}"))
+if [ -n "$orphans" ]; then
+    echo "check-fuzz-targets: target files with no [[bin]] entry — nothing builds these:" >&2
+    printf '  %s\n' $orphans >&2
+    exit 1
+fi
+
+echo "check-fuzz-targets: ${#files[@]} targets, ${#registered[@]} registered — building"
+if ! ( cd fuzz && cargo check --bins --quiet ); then
+    echo "check-fuzz-targets: a fuzz target no longer builds against current APIs" >&2
+    exit 1
+fi
+echo "check-fuzz-targets: all ${#files[@]} fuzz targets build"

--- a/scripts/record-tests.sh
+++ b/scripts/record-tests.sh
@@ -44,6 +44,10 @@ echo "==> deploy-gate self-test"
 ./scripts/test-deploy-gate.sh \
     || { echo "FAILED: deploy-gate self-test" >&2; exit 1; }
 
+echo "==> fuzz targets build"
+./scripts/check-fuzz-targets.sh \
+    || { echo "FAILED: fuzz targets" >&2; exit 1; }
+
 echo "==> SV1 smoke self-test"
 python3 bins/translator-sv2/tests/sv1_handshake_smoke_selftest.py \
     || { echo "FAILED: SV1 smoke self-test" >&2; exit 1; }


### PR DESCRIPTION
Closes #468.

Fuzz targets depend on internal APIs, so they rot the moment a signature changes — and **nothing built them**. `fuzz_stratum_username` had been importing `ghost_pool::stratum`, a module that no longer exists, and nobody noticed because no job compiled it. You'd have found out on the day you actually wanted to fuzz something — the day you're already worried about a bug. Same shape as the MSRV job that used `@stable` and enforced nothing (#441).

## State found

| | |
|---|---|
| target files | 11 |
| registered `[[bin]]` | 11 |
| compile | **10** |
| broken | `fuzz_stratum_username` |

## The repair

`validate_username` and `ValidatedCredentials::parse` are still public and are the current entry points, so this is a repair rather than a deletion. That matters: the username is attacker-controlled — it arrives verbatim in `mining.authorize` from anyone who can reach the stratum port, and the payout address is derived from it. A panic there is a remote crash; a mis-parse is a misattributed payout.

It now also fuzzes the **password** alongside it, since that carries the `d=` difficulty directive and is equally hostile — including the case where *both* fields are arbitrary, so a crash needing two hostile inputs is reachable.

## The gate

`scripts/check-fuzz-targets.sh`, wired into CI and `record-tests.sh`. **Build only** — running the fuzzers belongs in a scheduled job, not per-PR. It uses `cargo check` rather than `cargo fuzz`, so it needs no nightly toolchain and no sanitiser runtime, and still catches the failure that actually occurred.

It also fails when a target **file** has no `[[bin]]` entry, because a file nothing references is a target nobody builds — the same failure wearing different clothes.

**Verified it fails on both**, rather than assuming:

```
A: reintroduce the dead import   -> ok: gate FAILED as it must
B: add an unregistered target    -> ok: gate FAILED as it must
   check-fuzz-targets: target files with no [[bin]] entry: fuzz_orphan9
restored                         -> check-fuzz-targets: all 11 fuzz targets build
```

## One note on the check itself

It matches `fuzz_[a-z0-9_]+`, **not** `[a-z_]+`. Two targets have digits in their names (`fuzz_l2_requests`, `fuzz_p2p_payloads`) and a letters-only class skips them silently. I made exactly that mistake while investigating and briefly concluded those two were unregistered orphans when both were fine — it's the same bug that once had `check-stratum-config-agreement.sh` reporting more keys than it compared.

## Not done here

Actually *running* the fuzzers with a seed corpus on a schedule. Worth doing, but it's a separate change with its own runtime budget, and the rot this issue is about is fixed by building.
