### PR TITLE
fix(translator): correct the TLV identity record; drop the no-op left by the revert

### DIFF
--- a/bins/translator-sv2/src/lib/sv1/sv1_server/mod.rs
+++ b/bins/translator-sv2/src/lib/sv1/sv1_server/mod.rs
@@ -154,13 +154,24 @@ pub(super) fn parse_suggest_difficulty(msg: &Message) -> Option<f64> {
 ///
 /// Public-pool convention is `<payout_address>.<worker_name>` (e.g.
 /// `bc1qabc...xyz.bitaxe1`). The address part is too long for the 32-byte TLV cap and would
-/// duplicate information already carried in the channel-level `user_identity` (which the
-/// translator config sources from the operator's wallet). The worker part — the bit that
-/// actually distinguishes one device from another behind the same wallet — is short and fits.
+/// duplicate information already carried in the channel-level `user_identity`, which
+/// `handle_open_channel_request` builds from `authorized_worker_name` — i.e. the miner's own
+/// full `<address>.<worker>` as sent to `mining.authorize`, not anything from operator config.
+/// The worker part — the bit that actually distinguishes one device from another behind the
+/// same wallet — is short and fits.
+///
+/// The pool recombines the two halves: `build_webhook_user_identity` takes the address from the
+/// channel identity and the worker from this TLV. So this function deliberately returns only the
+/// worker; the address is never expected to travel in the TLV.
 ///
 /// If the username has no `.` separator, the whole string is treated as the worker name and
 /// returned. The caller still passes the result through [`tlv_compatible_username`] to enforce
 /// the 32-byte ceiling for safety against pathological inputs.
+///
+/// HAZARD: a username with an empty final segment (`bc1qabc...xyz.`) yields `""`, which makes the
+/// caller omit the TLV entirely. Where the pool has the extension negotiated as *required* that
+/// share is marked unattributable and silently earns nothing, while the miner still receives
+/// `SubmitSharesSuccess`. `mining.authorize` does not currently reject that shape.
 pub(super) fn extract_worker_name(name: &str) -> &str {
     name.rsplit_once('.').map(|(_, w)| w).unwrap_or(name)
 }
@@ -333,6 +344,36 @@ mod username_difficulty_tests {
         let (name, _) = split_username_difficulty(&username);
         assert!(name.contains('.'));
         assert_eq!(extract_worker_name(name), "braiins");
+    }
+
+    /// Pins what the per-share TLV identity actually is on `main`: the WORKER SEGMENT ONLY.
+    ///
+    /// #447 briefly made the TLV carry the full `<address>.<worker>`; #456 reverted it. The
+    /// stale description outlived the code and #416 was filed against it, asserting this
+    /// function was dead and should be deleted — it is neither dead nor safe to delete. This
+    /// test exists so the next reader learns the contract from an assertion rather than a
+    /// comment: the address travels in the channel-level identity, the worker in the TLV, and
+    /// the pool recombines them.
+    #[test]
+    fn tlv_identity_is_the_worker_segment_only() {
+        let username = format!("{ADDR}.bitaxe1");
+        let identity = tlv_compatible_username(extract_worker_name(&username));
+        assert_eq!(identity, "bitaxe1");
+        assert!(
+            !identity.contains(ADDR),
+            "TLV must not carry the payout address; the channel identity does"
+        );
+    }
+
+    /// An empty final segment yields an empty identity, which makes the caller omit the TLV.
+    ///
+    /// Where the pool has extension 0x0002 negotiated as *required* — which the live fleet does
+    /// (`required_extensions = [0x0002]` in the installed translator config) — such a share is
+    /// marked unattributable and earns nothing, while the miner still gets `SubmitSharesSuccess`.
+    /// `mining.authorize` accepts this shape today because it only checks for a `.`.
+    #[test]
+    fn an_empty_worker_segment_yields_no_tlv_identity() {
+        assert_eq!(extract_worker_name(&format!("{ADDR}.")), "");
     }
 }
 

--- a/bins/translator-sv2/src/lib/sv1/sv1_server/sv1_server.rs
+++ b/bins/translator-sv2/src/lib/sv1/sv1_server/sv1_server.rs
@@ -1534,13 +1534,13 @@ impl Sv1Server {
             format!("{}.miner{}", self.config.user_identity, miner_id)
         };
 
-        // NOTE: do NOT overwrite `data.user_identity` here — that field carries the per-share
-        // TLV worker-name (set by `mining.authorize` via `extract_worker_name`) and is bounded
-        // to 32 bytes by the spec. It must stay independent of the channel-level user_identity.
-        let _ = downstream
-            .downstream_data
-            .safe_lock(|_d| ())
-            .map_err(TproxyError::shutdown)?;
+        // NOTE: do NOT overwrite `data.user_identity` here. That field carries the per-share TLV
+        // worker-name — set during `mining.authorize` by `extract_worker_name` +
+        // `tlv_compatible_username` — and must stay independent of the channel-level
+        // `user_identity` built above, which carries the full `<address>.<worker>`. The pool
+        // recombines the two: the address comes from the channel, the worker from the TLV.
+        // The 32-byte bound is ours (`MAX_USER_IDENTITY_BYTES`), not a spec limit; the SV2 wire
+        // type is `Str0255`.
 
         if let Ok(open_channel_msg) = build_sv2_open_extended_mining_channel(
             request_id,

--- a/vendor/stratum/sv2/extensions-sv2/src/worker_specific_hashrate_tracking.rs
+++ b/vendor/stratum/sv2/extensions-sv2/src/worker_specific_hashrate_tracking.rs
@@ -15,12 +15,16 @@ use alloc::{
 /// the `Str0255` limit used for identity strings elsewhere in SV2.
 ///
 /// This was 32, which fits a bare worker name but not a full `<address>.<worker>` — a bech32
-/// address is 42 bytes by itself. That mattered once the TLV became the authoritative source of
-/// a miner's payout address: `UserIdentity::new` returns `Err` past the cap and the caller
-/// discards it with `.ok()`, so an over-long identity did not truncate, it silently sent NO TLV
-/// at all, and the pool fell back to the channel's identity. For a channel opened before
-/// `mining.authorize` that identity is the translator's provisional config value, so shares
-/// were credited to the operator's configured address instead of the miner's.
+/// address is 42 bytes by itself. It was raised because `UserIdentity::new` returns `Err` past
+/// the cap and the caller discards that error with `.ok()`, so an over-long identity did not
+/// truncate — it silently sent NO TLV at all and the pool fell back to the channel identity.
+/// The cap staying generous is what keeps that failure mode out of reach.
+///
+/// NOTE: this is the *wire* ceiling for the extension, not what the translator actually sends.
+/// Since the revert of #447 the translator puts only the worker segment in the TLV, capped at 32
+/// bytes by its own `tlv_compatible_username`; the payout address travels in the channel-level
+/// identity and the pool recombines the two in `build_webhook_user_identity`. Do not read this
+/// constant as evidence that the TLV carries a payout address — on `main` it does not.
 pub const MAX_USER_IDENTITY_LENGTH: usize = 255;
 
 /// Extension type for Worker-Specific Hashrate Tracking


### PR DESCRIPTION
Closes #416 — but not as written. The issue describes a tree that the revert of #447 removed, and following it literally would have broken share attribution.

## What #416 gets wrong

| #416 claims | `main` today |
|---|---|
| `extract_worker_name` is dead in non-test builds, delete it | **Live** — called at `downstream_message_handler.rs:244`. Deleting it strips the worker identity from every share TLV. |
| `tlv_compatible_username` caps at 255 (raised by `3becab1b`) | **32 bytes.** `3becab1b` raised `MAX_USER_IDENTITY_LENGTH` in the *extension* crate — the wire ceiling — not the translator's own cap. |
| The per-share TLV carries the full dotted `<address>.<worker>` | It carries the **worker segment only**. |

All three date from `c058ad698` (the #456 revert of #447), which restored both the 32-byte cap and the live call site. The issue text outlived the code.

## What is actually true

The address travels in the **channel-level** identity, built from `authorized_worker_name`; the worker travels in the **TLV**; the pool recombines them in `build_webhook_user_identity` — address from the channel, worker from the TLV. So attribution on `main` is correct, and two miners with the same worker name under different payout addresses stay distinct. Verified against production: `vm3`/`vm4` show `0` malformed identities, and every dotless `miner_id` is a 16-hex gossip hash, as expected.

## Changes

Comment and doc corrections only, plus one dead-code removal — **no behavioural change**:

- `mod.rs` — the doc claimed the channel identity comes from operator config. It comes from the miner's own `mining.authorize` username; the config-prefix branches are unreachable on the SV1 path. Documents the recombination, and records the empty-final-segment hazard.
- `sv1_server.rs` — "bounded to 32 bytes by the spec" is wrong: 32 is our cap, the wire type is `Str0255`.
- `worker_specific_hashrate_tracking.rs` — the rationale still described the reverted #447 design in which the TLV was the authoritative source of a payout address. Reading it that way is what produced #416.
- Removes a `safe_lock(|_d| ())` the revert left behind, whose only effect was a poisoned-lock check on a closure that did nothing.

## Tests

Two new tests pin the contract by assertion rather than prose:

- `tlv_identity_is_the_worker_segment_only`
- `an_empty_worker_segment_yields_no_tlv_identity`

## Gates

- `cargo fmt -p translator_sv2 --check` — clean
- `cargo test -p translator_sv2 --lib` — **41 passed, 0 failed**
- `cargo clippy -p translator_sv2 --all-targets` — 5 warnings, all pre-existing in `sv1_server.rs`/`channel_manager.rs`; **none in the files touched**

## Follow-ups filed separately

Two latent bugs surfaced while tracing this. Neither is bundled here, since this PR is deliberately behaviour-neutral.