### PR TITLE
docs: correct the dashboard auth model and ship a canonical systemd unit

### DIFF
--- a/.github/workflows/release-agathion.yml
+++ b/.github/workflows/release-agathion.yml
@@ -145,10 +145,59 @@ jobs:
 
           ## Deploying as a service
 
-          On the production fleet the unit is historically named
-          `ghost-dashboard.service` and launches `node server.js` from the
-          install directory. Keep that name for compatibility; only the
-          user-facing product is "Agathion Node".
+          The unit is named `ghost-dashboard.service` for historical reasons —
+          keep that name for compatibility; only the user-facing product is
+          "Agathion Node". Install it at
+          `/etc/systemd/system/ghost-dashboard.service`, replacing
+          `WorkingDirectory` with wherever you unpacked this tarball:
+
+          ```ini
+          [Unit]
+          Description=Ghost Node Dashboard
+          After=ghost-node.service
+          Wants=ghost-node.service
+
+          [Service]
+          Type=simple
+          User=ghost
+          Group=ghost
+          WorkingDirectory=/home/ghost/agathion-node
+          ExecStart=/usr/bin/node server.js
+          Environment=NODE_ENV=production
+          Environment=PORT=3000
+          Environment=HOSTNAME=127.0.0.1
+          Restart=on-failure
+          RestartSec=10
+
+          [Install]
+          WantedBy=multi-user.target
+          ```
+
+          `ExecStart` must be `node server.js`. Neither `npm start` nor
+          `next start` works here: this is a standalone build, so its minimal
+          `node_modules` has no `package.json` scripts for `npm start` to run,
+          and `next start` does not serve the authenticated WS relay.
+
+          Put `DASHBOARD_PASSWORD` and any other secrets in a root-only drop-in
+          rather than in the unit itself:
+
+          ```bash
+          sudo install -d -m 700 /etc/systemd/system/ghost-dashboard.service.d
+          sudo tee /etc/systemd/system/ghost-dashboard.service.d/override.conf >/dev/null <<'EOF'
+          [Service]
+          Environment=DASHBOARD_PASSWORD=your-password-here
+          EOF
+          sudo chmod 600 /etc/systemd/system/ghost-dashboard.service.d/override.conf
+          sudo systemctl daemon-reload && sudo systemctl enable --now ghost-dashboard
+          ```
+
+          After any redeploy, confirm the unit is running the tree you just
+          installed — a stale `WorkingDirectory` is the usual cause of
+          "I deployed but nothing changed":
+
+          ```bash
+          systemctl show -p WorkingDirectory --value ghost-dashboard
+          ```
           RUNEOF
 
           # Convenience launcher.

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -180,13 +180,56 @@ const { data } = useRewards({ refetchInterval: 60_000 });
 
 ### Systemd Service
 
-The dashboard runs as a systemd service on Ghost nodes:
+This is the canonical unit — `/etc/systemd/system/ghost-dashboard.service`,
+matching what runs on the fleet:
+
+```ini
+[Unit]
+Description=Ghost Node Dashboard
+After=ghost-node.service
+Wants=ghost-node.service
+
+[Service]
+Type=simple
+User=ghost
+Group=ghost
+WorkingDirectory=/home/ghost/agathion-node
+ExecStart=/usr/bin/node server.js
+Environment=NODE_ENV=production
+Environment=PORT=3000
+Environment=HOSTNAME=127.0.0.1
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Three details are load-bearing, and each has bitten us:
+
+- **`ExecStart=/usr/bin/node server.js`, never `npm start` or `next start`.**
+  The standalone build ships a minimal `node_modules` with no `package.json`
+  scripts, so `npm start` cannot run there at all, and `next start` does not
+  run the WS relay. See the deployment note above.
+- **`WorkingDirectory=/home/ghost/agathion-node`.** A stale value here is the
+  classic "I deployed but nothing changed" symptom — the unit runs an older
+  tree. Always confirm the *effective* value rather than trusting the unit
+  file, since drop-ins override it:
+  ```bash
+  systemctl show -p WorkingDirectory --value ghost-dashboard
+  ```
+- **`HOSTNAME=127.0.0.1`.** The dashboard must stay loopback-bound; it is
+  reached over an SSH tunnel. Auth does not depend on this (the JWT fails
+  closed regardless), but binding publicly removes a layer for no benefit.
+
+Secrets do **not** belong in this unit — keep them in a root-only drop-in at
+`/etc/systemd/system/ghost-dashboard.service.d/override.conf`, which is where
+`DASHBOARD_PASSWORD`, `DASHBOARD_TOKEN_TTL_SECS`, `INTERNAL_AUTH_KEY`,
+`GHOST_PAY_URL` and `GHOST_PAY_API_SECRET` live:
 
 ```ini
 [Service]
-ExecStart=/usr/bin/npm start
-WorkingDirectory=/home/ghost/ghost/ghost-node/dashboard
-User=ghost
+Environment=DASHBOARD_PASSWORD=<value>
 ```
 
 ### With ghost-node

--- a/ghost-web/docs/node-dashboard.md
+++ b/ghost-web/docs/node-dashboard.md
@@ -177,9 +177,14 @@ Tailscale uses WireGuard under the hood for encrypted connections. It handles NA
 
 The dashboard is powered by a REST API that you can also use directly:
 
+Note which service you are talking to. Port `8080` is the **node backend**
+(`ghost-verification`), a different process from the dashboard on port `3000`.
+The dashboard's authentication does not apply to it, and never did — the
+examples below work because these particular backend routes are unauthenticated
+in their own right, not because of any localhost exemption.
+
 ```bash
-# From the node itself (localhost requests bypass auth via the
-# isLocalhost check in dashboard middleware), you can call the API directly:
+# Against the node backend on :8080 (not the dashboard):
 
 # Example: Get node status
 $ curl http://localhost:8080/api/v1/node/status
@@ -194,9 +199,12 @@ $ curl -X PATCH \
      http://localhost:8080/api/v1/config
 ```
 
-For remote access (e.g. via SSH tunnel), authenticate at `/login` with the
-configured `DASHBOARD_PASSWORD` to receive the `ghost-session` JWT cookie;
-subsequent requests include the cookie automatically.
+The dashboard's own API (port `3000`, including the `/api/v1/*` proxy) is a
+different matter: it requires a session on **every** request, including from
+localhost. Authenticate at `/login` with the configured `DASHBOARD_PASSWORD` to
+receive the `ghost-session` JWT cookie; subsequent requests include the cookie
+automatically. A request without one is redirected to `/login` (pages) or
+answered `401` (API) — there is no local exemption.
 
 Full API documentation: [docs.ghostpool.io/api](https://docs.ghostpool.io/api)
 
@@ -210,11 +218,17 @@ Full API documentation: [docs.ghostpool.io/api](https://docs.ghostpool.io/api)
 - **JWT session cookie** — On successful login at `/login`, the dashboard
   issues a signed cookie named `ghost-session`. Middleware
   (`dashboard/src/middleware.ts`) verifies the JWT on every request.
-- **Localhost bypass** — Requests originating from `127.0.0.1` / `::1` /
-  `localhost` skip authentication entirely. The dashboard is per-operator
-  and assumes anything reaching it from localhost is the operator. Remote
-  access (via SSH tunnel with `X-Forwarded-For` set, or any non-localhost
-  origin) requires the password.
+- **No localhost bypass** — there is no origin-based exemption. An earlier
+  version of the dashboard skipped authentication for `127.0.0.1` / `::1` /
+  `localhost`; that was removed. The middleware deliberately does not consult
+  `X-Forwarded-For` or `Host` for any auth decision, because both are
+  client-spoofable and the old bypass they powered let a direct connection to a
+  mis-bound dashboard skip authentication entirely. Auth is the JWT cookie and
+  nothing else, and it fails closed even if the server is mis-bound to
+  `0.0.0.0`.
+- **Access model: SSH tunnel only** — the dashboard binds to `127.0.0.1:3000`
+  and is reached with `ssh -L 3000:localhost:3000 <node>`. The loopback bind and
+  the JWT are independent layers; neither is relied upon to cover the other.
 
 ### Network Security
 


### PR DESCRIPTION
Closes #406. Part (c) — the `active_voter_set_height()` gate doc — was already fixed by #439, so this covers (a) and (b).

## (a) The auth model documented did not exist

`node-dashboard.md` described a localhost bypass in three places. It was removed from the code; `dashboard/src/middleware.ts` now gates every route on the JWT cookie and deliberately ignores `X-Forwarded-For` and `Host`, because the old origin-based bypass let a direct connection to a mis-bound dashboard skip auth entirely.

Verified against a live node rather than inferred from the source:

| request | result |
|---|---|
| `:3000/` no cookie | `307` → `/login` |
| `:3000/api/v1/node/status` no cookie | `401` |
| `:3000/api/ws` upgrade, no cookie | `401` |
| `:3000/login` | `200` |

The curl examples were also attributed to the wrong cause. They target `:8080`, which is the **node backend** — a different process from the dashboard on `:3000` — and they succeed because those backend routes are unauthenticated in their own right, not because of any dashboard exemption. The doc now names which service each port is, so nobody reads a working `curl` as evidence the dashboard has a local exemption.

## (b) The documented unit could not start the service

`dashboard/README.md` shipped:

```ini
ExecStart=/usr/bin/npm start
WorkingDirectory=/home/ghost/ghost/ghost-node/dashboard
```

Both wrong. That directory exists on no node, and neither `npm start` nor `next start` can work — this is a standalone build, so its minimal `node_modules` carries no `package.json` scripts, and `next start` does not serve the WS relay. The same README already says exactly that 80 lines above, contradicting its own example.

Replaced with the unit the fleet actually runs, captured off a production node and reconciled with its drop-ins. `RUN.md` in the release tarball previously described the unit in prose without giving one; it now carries the same unit.

Secrets stay in a root-only drop-in rather than in the unit. Also documents checking the **effective** `WorkingDirectory` — a stale value there is the usual cause of a deploy that appears to change nothing, and it is exactly what is overridden on the live fleet today.

## Gates

- `python3 -c "yaml.safe_load(...)"` on the changed workflow — parses, jobs intact
- `scripts/check-workflow-scalars.sh` — 5 workflows clean
- Rendered the `RUN.md` heredoc and confirmed the unit ships intact through it (89 lines, `[Unit]`…`WantedBy` correct)

Docs and one workflow heredoc only; no code paths touched.