### PR TITLE
fix(api): move payout-identity reads off the unauthenticated tier

### DIFF
--- a/crates/ghost-verification/src/routes.rs
+++ b/crates/ghost-verification/src/routes.rs
@@ -179,9 +179,8 @@ pub fn create_router(state: Arc<VerificationState>) -> Router {
         .route("/node-info", get(node_info_handler))
         // Informational endpoints
         .route("/peers", get(peers_handler))
-        .route("/shares", get(shares_handler))
-        .route("/rounds", get(rounds_handler))
-        .route("/payouts", get(payouts_handler))
+        // `/shares`, `/rounds` and `/payouts` used to sit here. They emit raw miner
+        // identities, payout addresses and txids, so they are now in `internal_router`.
         .route("/consensus-state", get(consensus_state_handler))
         // Verification challenges
         .route("/verify/archive", get(archive_handler))
@@ -320,7 +319,7 @@ pub fn create_router(state: Arc<VerificationState>) -> Router {
             "/api/v1/filtering/activity",
             get(api_filtering_activity_handler),
         )
-        .route("/api/v1/payments", get(api_payments_handler))
+        // `/api/v1/payments` moved to `internal_router` — it emits payout addresses and txids.
         .route("/api/v1/backup/history", get(api_backup_history_handler))
         .route("/api/v1/wraith/sessions", get(api_wraith_sessions_handler))
         .route("/api/v1/network/elder", get(api_network_elder_handler))
@@ -337,14 +336,8 @@ pub fn create_router(state: Arc<VerificationState>) -> Router {
             "/api/v1/mining/best-hash",
             get(api_mining_best_hash_handler),
         )
-        .route(
-            "/api/v1/network/payout-history",
-            get(api_payout_history_handler),
-        )
-        .route(
-            "/api/v1/ghostpay/payout-history",
-            get(api_ghostpay_payout_history_handler),
-        )
+        // `/api/v1/network/payout-history` and `/api/v1/ghostpay/payout-history` moved to
+        // `internal_router` — they emit recipient addresses, destinations and L1 txids.
         .route(
             "/api/v1/rewards/node-history",
             get(api_rewards_node_history_handler),
@@ -363,7 +356,8 @@ pub fn create_router(state: Arc<VerificationState>) -> Router {
         )
         // Config endpoints (GET only - reading is public, POST requires auth via internal router)
         // CRIT-6: POST handlers moved to internal_router to require authentication
-        .route("/api/v1/config/full", get(api_config_full_handler))
+        // `/api/v1/config/full` moved to `internal_router` — it carries `payout.address` and
+        // `payout.ghostpay_address`.
         .route(
             "/api/v1/config/archive_mode",
             get(api_config_archive_mode_handler),
@@ -378,7 +372,8 @@ pub fn create_router(state: Arc<VerificationState>) -> Router {
         )
         .route("/api/v1/config/reaper", get(api_config_reaper_handler))
         .route("/api/v1/config/daemon", get(api_config_daemon_handler))
-        .route("/api/v1/config/alerts", get(api_config_alerts_handler))
+        // `/api/v1/config/alerts` GET moved to `internal_router` alongside its POST — it carries
+        // notification destinations and webhook URLs, which routinely embed their own tokens.
         .route(
             "/api/v1/config/backup_schedule",
             get(api_config_backup_schedule_handler),
@@ -485,6 +480,32 @@ pub fn create_router(state: Arc<VerificationState>) -> Router {
     // Internal/admin endpoints with HMAC authentication (AUTH4-1 fix)
     // CRIT-6: All config POST endpoints moved here to require authentication
     let internal_router = Router::new()
+        // Read endpoints carrying payout identities, moved off the public tier.
+        //
+        // These were served unauthenticated on the same listener as the mesh protocol, so the
+        // pool's recent payout ledger — miner ids, raw payout addresses and L1 txids — was
+        // readable by anyone who could reach the port, which on a default install is the whole
+        // internet (`scripts/install-node.sh` opens 8080/tcp, and the node binds 0.0.0.0).
+        // Publishing raw addresses here also nullified `redact_miner_id`, since a pseudonymous
+        // miner id in one response could be resolved against a real address in another.
+        //
+        // The dashboard is unaffected: its proxy signs GET requests as well as mutations
+        // (`dashboard/src/app/api/proxy/[...path]/route.ts`). None of these is on the
+        // peer-to-peer path, so mesh verification, discovery and gossip are untouched.
+        .route("/shares", get(shares_handler))
+        .route("/rounds", get(rounds_handler))
+        .route("/payouts", get(payouts_handler))
+        .route("/api/v1/payments", get(api_payments_handler))
+        .route(
+            "/api/v1/network/payout-history",
+            get(api_payout_history_handler),
+        )
+        .route(
+            "/api/v1/ghostpay/payout-history",
+            get(api_ghostpay_payout_history_handler),
+        )
+        .route("/api/v1/config/full", get(api_config_full_handler))
+        .route("/api/v1/config/alerts", get(api_config_alerts_handler))
         // Admin endpoints for testing
         .route("/admin/test-consensus", post(admin_test_consensus_handler))
         // Internal API for dashboard config updates (triggers graceful restart)
@@ -12908,14 +12929,20 @@ mod tests {
                 PolicyProfile::default(),
                 NodeCapabilities::default(),
             )
-            .with_full_node_config(cfg, path.clone()),
+            .with_full_node_config(cfg, path.clone())
+            .with_internal_auth(crate::auth::InternalAuth::new(&test_secret()).unwrap()),
         );
 
+        // `/api/v1/config/full` carries the operator's payout addresses, so it is served from
+        // the authenticated tier. Sign the read the way the dashboard proxy does.
+        let (signature, timestamp) = operator_get_signature();
         let response = super::create_router(Arc::clone(&state))
             .oneshot(
                 Request::builder()
                     .method("GET")
                     .uri("/api/v1/config/full")
+                    .header("X-Ghost-Signature", signature)
+                    .header("X-Ghost-Timestamp", timestamp.to_string())
                     .body(Body::empty())
                     .unwrap(),
             )
@@ -12968,14 +12995,21 @@ mod tests {
                 PolicyProfile::default(),
                 NodeCapabilities::default(),
             )
-            .with_full_node_config(cfg, path.clone()),
+            .with_full_node_config(cfg, path.clone())
+            .with_internal_auth(crate::auth::InternalAuth::new(&test_secret()).unwrap()),
         );
 
+        // This test asserts the response carries `node_payout_address` and the Ghost Pay
+        // payout address — which is precisely why the route is no longer public. Sign the
+        // read the way the dashboard proxy does.
+        let (signature, timestamp) = operator_get_signature();
         let response = super::create_router(Arc::clone(&state))
             .oneshot(
                 Request::builder()
                     .method("GET")
                     .uri("/api/v1/config/full")
+                    .header("X-Ghost-Signature", signature)
+                    .header("X-Ghost-Timestamp", timestamp.to_string())
                     .body(Body::empty())
                     .unwrap(),
             )
@@ -13541,6 +13575,82 @@ mod tests {
                 response.status(),
                 StatusCode::UNAUTHORIZED,
                 "CRIT-6: {} POST without auth must return 401",
+                endpoint
+            );
+        }
+    }
+
+    /// Read endpoints carrying payout identities must not be readable unauthenticated.
+    ///
+    /// These were public. Anyone able to reach `:8080` — the whole internet on a default
+    /// install — could pull the pool's recent payout ledger with raw addresses and txids,
+    /// which also defeated `redact_miner_id` elsewhere by making pseudonymous ids resolvable.
+    #[tokio::test]
+    async fn test_payout_identity_get_endpoints_require_auth() {
+        let state = create_test_state_with_auth();
+
+        let locked_endpoints = [
+            "/shares",
+            "/rounds",
+            "/payouts",
+            "/api/v1/payments",
+            "/api/v1/network/payout-history",
+            "/api/v1/ghostpay/payout-history",
+            "/api/v1/config/full",
+            "/api/v1/config/alerts",
+        ];
+
+        for endpoint in locked_endpoints {
+            let app = super::create_router(Arc::clone(&state));
+
+            let response = app
+                .oneshot(
+                    Request::builder()
+                        .method("GET")
+                        .uri(endpoint)
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(
+                response.status(),
+                StatusCode::UNAUTHORIZED,
+                "{} GET without auth must return 401 — it carries payout identities",
+                endpoint
+            );
+        }
+    }
+
+    /// The same endpoints must still answer a correctly signed GET, because that is exactly
+    /// what the dashboard proxy sends: it signs reads as well as mutations, over an empty body.
+    /// If this regresses, every dashboard payouts/treasury/settings page breaks at once.
+    #[tokio::test]
+    async fn test_payout_identity_get_endpoints_accept_operator_signature() {
+        let state = create_test_state_with_auth();
+
+        for endpoint in ["/payouts", "/api/v1/config/full"] {
+            let app = super::create_router(Arc::clone(&state));
+            let (signature, timestamp) = operator_get_signature();
+
+            let response = app
+                .oneshot(
+                    Request::builder()
+                        .method("GET")
+                        .uri(endpoint)
+                        .header("X-Ghost-Signature", signature)
+                        .header("X-Ghost-Timestamp", timestamp.to_string())
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+
+            assert_ne!(
+                response.status(),
+                StatusCode::UNAUTHORIZED,
+                "{} must accept the operator GET signature the dashboard proxy sends",
                 endpoint
             );
         }

--- a/scripts/test-dashboard-endpoints.sh
+++ b/scripts/test-dashboard-endpoints.sh
@@ -139,6 +139,31 @@ test_endpoint() {
     sleep 0.5  # Stay under 5 req/s rate limit
 }
 
+# Endpoints that carry payout identities are served from the authenticated tier, so an
+# unsigned probe must be REFUSED. Asserting 401 checks the property that matters — the gate
+# is holding — without this script needing to hold the operator secret. A 200 here means the
+# route has fallen back onto the public tier and the payout ledger is world-readable again.
+test_endpoint_gated() {
+    local id="$1" name="$2" url="$3"
+    run_test "$id" "$name (must require auth)"
+    local http_code attempt
+    for attempt in 1 2 3; do
+        http_code=$(curl -s -o /dev/null --connect-timeout 5 --max-time 15 -w "%{http_code}" "$url" 2>/dev/null)
+        if [[ "$attempt" -lt 3 ]] && { [[ "$http_code" == "429" ]] || [[ "$http_code" == "000" ]]; }; then
+            sleep 3  # Back off and retry on rate limit or connection failure
+            continue
+        fi
+        break
+    done
+    case "$http_code" in
+        000) fail "Connection failed" ;;
+        401) pass ;;
+        200) fail "HTTP 200 — endpoint is PUBLIC but must require auth" ;;
+        *)   fail "HTTP $http_code — expected 401" ;;
+    esac
+    sleep 0.5  # Stay under 5 req/s rate limit
+}
+
 # Test endpoint that may return non-JSON (health, metrics)
 test_endpoint_raw() {
     local id="$1" name="$2" url="$3"
@@ -179,7 +204,7 @@ run_all_tests() {
     test_endpoint "1.3" "/api/v1/rewards/current"           "$pool/api/v1/rewards/current"
     test_endpoint "1.4" "/api/v1/mesh/status"               "$pool/api/v1/mesh/status"
     test_endpoint "1.5" "/api/v1/ghostpay/status"           "$pool/api/v1/ghostpay/status"
-    test_endpoint "1.6" "/api/v1/ghostpay/payout-history"   "$pool/api/v1/ghostpay/payout-history"
+    test_endpoint_gated "1.6" "/api/v1/ghostpay/payout-history"   "$pool/api/v1/ghostpay/payout-history"
 
     # ── Group 2: Mining (7 endpoints) ────────────────────────────────
 
@@ -190,7 +215,7 @@ run_all_tests() {
     test_endpoint "2.3" "/api/v1/mining/payout_address"     "$pool/api/v1/mining/payout_address"
     test_endpoint "2.4" "/api/v1/mining/private"            "$pool/api/v1/mining/private"
     test_endpoint "2.5" "/api/v1/mining/public"             "$pool/api/v1/mining/public"
-    test_endpoint "2.6" "/shares"                           "$pool/shares"
+    test_endpoint_gated "2.6" "/shares"                           "$pool/shares"
     test_endpoint "2.7" "/api/v1/node/shares"               "$pool/api/v1/node/shares"
 
     # ── Group 3: Network/Peers (6 endpoints) ─────────────────────────
@@ -202,13 +227,13 @@ run_all_tests() {
     test_endpoint "3.3" "/api/v1/network/pool"              "$pool/api/v1/network/pool"
     test_endpoint "3.4" "/api/v1/network/public-nodes"      "$pool/api/v1/network/public-nodes"
     test_endpoint "3.5" "/api/v1/network/treasury"          "$pool/api/v1/network/treasury"
-    test_endpoint "3.6" "/api/v1/network/payout-history"    "$pool/api/v1/network/payout-history"
+    test_endpoint_gated "3.6" "/api/v1/network/payout-history"    "$pool/api/v1/network/payout-history"
 
     # ── Group 4: Settings/Config (13 endpoints) ──────────────────────
 
     group_header 4 "Settings/Config" 13
 
-    test_endpoint "4.01" "/api/v1/config/full"              "$pool/api/v1/config/full"
+    test_endpoint_gated "4.01" "/api/v1/config/full"              "$pool/api/v1/config/full"
     test_endpoint "4.02" "/api/v1/config/archive_mode"      "$pool/api/v1/config/archive_mode"
     test_endpoint "4.03" "/api/v1/config/ghost_mode"        "$pool/api/v1/config/ghost_mode"
     test_endpoint "4.04" "/api/v1/config/mempool_profile"   "$pool/api/v1/config/mempool_profile"
@@ -267,7 +292,7 @@ run_all_tests() {
     group_header 10 "Locks/Payments" 2
 
     test_endpoint "10.1" "/api/v1/locks"                    "$pool/api/v1/locks"
-    test_endpoint "10.2" "/api/v1/payments"                 "$pool/api/v1/payments"
+    test_endpoint_gated "10.2" "/api/v1/payments"                 "$pool/api/v1/payments"
 
     # ── Group 11: Swarm (2 endpoints) ────────────────────────────────
 


### PR DESCRIPTION
Closes #483.

Eight read endpoints carrying miner identities, payout addresses and L1 txids were served from the public router on `:8080` — reachable from the internet on a default install. This moves them to `internal_router`, which is HMAC-gated and already fails closed when no secret is configured.

```
/shares
/rounds
/payouts
/api/v1/payments
/api/v1/network/payout-history
/api/v1/ghostpay/payout-history
/api/v1/config/full
/api/v1/config/alerts
```

`/api/v1/config/alerts` GET now sits alongside its POST, which was already internal.

## Why these and not others

Each was checked for consumers before moving. The three things that could have broken:

| | verdict |
|---|---|
| **Mesh peers** | Unaffected. The peer-to-peer surface is `/health`, `/verify/*`, `/api/internal/share`, `/api/v1/mpc/*` — enumerated from `client.rs` and `ghost-pool/src/main.rs`. None of the eight is on it, so verification, discovery and gossip are untouched. |
| **Dashboard** | Unaffected. Its proxy signs GETs as well as mutations, over an empty body (`dashboard/src/app/api/proxy/[...path]/route.ts:50-59`), and `INTERNAL_AUTH_KEY` is set fleet-wide. |
| **Public website** | Unaffected. `ghost-web` takes its node list from `/api/v1/pool/mesh-nodes`, and none of the eight is fetched from a browser. |

## Tests

Two new, one for each direction:

- `test_payout_identity_get_endpoints_require_auth` — all eight return 401 unauthenticated.
- `test_payout_identity_get_endpoints_accept_operator_signature` — they still answer a correctly signed GET. This is the one that matters operationally: if the signed-read path regresses, every dashboard payouts, treasury and settings page breaks at once, and that should fail in CI rather than in production.

Two existing tests — `test_config_full_reads_real_config` and `test_config_full_surfaces_policy` — read `/api/v1/config/full` unauthenticated and asserted the response contained the operator's payout addresses. That is precisely why the route moved, so they now sign the read rather than the gate being loosened.

`scripts/test-dashboard-endpoints.sh` gains `test_endpoint_gated`, asserting **401** for these five paths instead of 200. That tests the property that matters without the script needing to hold the operator secret — a 200 there now means the route has fallen back onto the public tier.

The chaos endpoint-coverage tests needed no change: they assert only that a route is mounted (`assert_ne!(status, 404)`), which 401 satisfies.

## Gates

- `cargo test -p ghost-verification --lib` — **233 passed, 0 failed**
- `cargo fmt -p ghost-verification --check` — clean
- `cargo clippy -p ghost-verification --all-targets` — 19 warnings, all pre-existing; none in the regions touched
- `bash -n scripts/test-dashboard-endpoints.sh` — clean

## Deliberately out of scope

Tracked as follow-ups on #483: the two `miners/*` routes the public site depends on (redaction, not gating — and a product decision about what a pool should disclose), `/peers` topology, a router-level deny-by-default read tier, and the unauthenticated `address/scan` path that can stall `getblocktemplate`.