### PR TITLE
chore: bump workspace version to 1.11.20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -828,7 +828,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-ghost-tests"
-version = "1.11.19"
+version = "1.11.20"
 dependencies = [
  "bitcoin",
  "chrono",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin_core_sv2"
-version = "1.11.19"
+version = "1.11.20"
 dependencies = [
  "async-channel 1.9.0",
  "bitcoin-capnp-types",
@@ -3162,7 +3162,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-accounting"
-version = "1.11.19"
+version = "1.11.20"
 dependencies = [
  "bitcoin",
  "ghost-common",
@@ -3176,7 +3176,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-buds"
-version = "1.11.19"
+version = "1.11.20"
 dependencies = [
  "bitcoin",
  "ghost-common",
@@ -3190,7 +3190,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-cli"
-version = "1.11.19"
+version = "1.11.20"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3208,7 +3208,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-common"
-version = "1.11.19"
+version = "1.11.20"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -3241,7 +3241,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-consensus"
-version = "1.11.19"
+version = "1.11.20"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3273,7 +3273,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-glyph"
-version = "1.11.19"
+version = "1.11.20"
 dependencies = [
  "hex",
  "serde",
@@ -3284,7 +3284,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-gsp"
-version = "1.11.19"
+version = "1.11.20"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3346,7 +3346,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-gsp-proto"
-version = "1.11.19"
+version = "1.11.20"
 dependencies = [
  "bitcoin",
  "chrono",
@@ -3363,7 +3363,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-keys"
-version = "1.11.19"
+version = "1.11.20"
 dependencies = [
  "bech32",
  "bitcoin",
@@ -3385,7 +3385,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-locks"
-version = "1.11.19"
+version = "1.11.20"
 dependencies = [
  "bitcoin",
  "getrandom 0.2.17",
@@ -3429,7 +3429,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-pay"
-version = "1.11.19"
+version = "1.11.20"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3477,7 +3477,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-policy"
-version = "1.11.19"
+version = "1.11.20"
 dependencies = [
  "bitcoin",
  "ghost-buds",
@@ -3490,7 +3490,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-pool"
-version = "1.11.19"
+version = "1.11.20"
 dependencies = [
  "anyhow",
  "async-channel 2.5.0",
@@ -3546,7 +3546,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-reaper"
-version = "1.11.19"
+version = "1.11.20"
 dependencies = [
  "bitcoin",
  "hex",
@@ -3558,7 +3558,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-reconciliation"
-version = "1.11.19"
+version = "1.11.20"
 dependencies = [
  "async-trait",
  "bitcoin",
@@ -3584,7 +3584,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-registry"
-version = "1.11.19"
+version = "1.11.20"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -3619,7 +3619,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-setup"
-version = "1.11.19"
+version = "1.11.20"
 dependencies = [
  "clap",
  "dirs 5.0.1",
@@ -3630,7 +3630,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-storage"
-version = "1.11.19"
+version = "1.11.20"
 dependencies = [
  "base64 0.22.1",
  "chacha20poly1305",
@@ -3651,7 +3651,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-tap-core"
-version = "1.11.19"
+version = "1.11.20"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3693,7 +3693,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-tap-desktop"
-version = "1.11.19"
+version = "1.11.20"
 dependencies = [
  "dirs 6.0.0",
  "getrandom 0.2.17",
@@ -3719,7 +3719,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-tap-integration"
-version = "1.11.19"
+version = "1.11.20"
 dependencies = [
  "ghost-gsp-proto",
  "ghost-tap-core",
@@ -3733,7 +3733,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-template"
-version = "1.11.19"
+version = "1.11.20"
 dependencies = [
  "bitcoin",
  "ghost-buds",
@@ -3749,7 +3749,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-verification"
-version = "1.11.19"
+version = "1.11.20"
 dependencies = [
  "axum 0.7.9",
  "base64 0.22.1",
@@ -4748,7 +4748,7 @@ dependencies = [
 
 [[package]]
 name = "jd_client_sv2"
-version = "1.11.19"
+version = "1.11.20"
 dependencies = [
  "async-channel 1.9.0",
  "bitcoin_core_sv2",
@@ -4764,7 +4764,7 @@ dependencies = [
 
 [[package]]
 name = "jd_server_sv2"
-version = "1.11.19"
+version = "1.11.20"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -6319,7 +6319,7 @@ dependencies = [
 
 [[package]]
 name = "pool_sv2"
-version = "1.11.19"
+version = "1.11.20"
 dependencies = [
  "async-channel 1.9.0",
  "bitcoin_core_sv2",
@@ -8077,7 +8077,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stratum-apps"
-version = "1.11.19"
+version = "1.11.20"
 dependencies = [
  "async-channel 1.9.0",
  "axum 0.8.9",
@@ -9340,7 +9340,7 @@ dependencies = [
 
 [[package]]
 name = "translator_sv2"
-version = "1.11.19"
+version = "1.11.20"
 dependencies = [
  "async-channel 1.9.0",
  "clap",
@@ -10689,7 +10689,7 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "wraith-coordinator"
-version = "1.11.19"
+version = "1.11.20"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -10726,7 +10726,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-protocol"
-version = "1.11.19"
+version = "1.11.20"
 dependencies = [
  "bitcoin",
  "getrandom 0.2.17",
@@ -10747,7 +10747,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-cli"
-version = "1.11.19"
+version = "1.11.20"
 dependencies = [
  "clap",
  "clap_complete",
@@ -10761,7 +10761,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-core"
-version = "1.11.19"
+version = "1.11.20"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -10798,7 +10798,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-daemon"
-version = "1.11.19"
+version = "1.11.20"
 dependencies = [
  "async-trait",
  "axum 0.7.9",
@@ -10825,7 +10825,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-gui"
-version = "1.11.19"
+version = "1.11.20"
 dependencies = [
  "interprocess",
  "serde",
@@ -10840,7 +10840,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-ipc"
-version = "1.11.19"
+version = "1.11.20"
 dependencies = [
  "interprocess",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ exclude = ["vendor/stratum"]
 # Use scripts/build-all-wallets.sh to build all wallet types.
 
 [workspace.package]
-version = "1.11.19"
+version = "1.11.20"
 edition = "2021"
 rust-version = "1.88"
 authors = ["Bitcoin Ghost Team"]


### PR DESCRIPTION
Eleven commits have landed on `main` since the `v1.11.19` tag, including the payout-route lockdown (#484), the byte-reproducible build fix (#469), the farm/rental listener (#471) and the hobby-floor drop (#474).

Bumping **before** the build, not after.

That ordering is the entire point. Both 1.11.17 and 1.11.18 shipped binaries stamped with the previous version, so `scripts/ops/check-fleet-uniformity.sh` reported a uniform fleet while the nodes were running materially different code — a fleet that looks consistent and is not is worse than one that visibly is not, because nobody goes looking.

Caught this cycle before the roll: the release binaries built from `a339160e6` reported `1.11.19` while containing eleven commits past that tag.

Same shape as #458: `Cargo.toml` version plus the `Cargo.lock` churn from the workspace members picking it up.

Deploy sequence this unblocks: re-record the gate against this sha, rebuild, canary **ghost-vm5** (which now carries a real bitaxe, so the soak actually exercises the share-submission path — see #461), soak, then roll vm4 → vm3 → vm2 → vm1.