### PR TITLE
fix(dashboard): wire the Ghost ID key-generation flow

### DIFF
--- a/dashboard/src/app/(dashboard)/connect/page.tsx
+++ b/dashboard/src/app/(dashboard)/connect/page.tsx
@@ -128,8 +128,11 @@ export default function ConnectPage() {
                   className="p-3 rounded-lg"
                   style={{ background: "var(--surface-2, rgba(120,120,120,0.08))", border: "1px solid var(--rule)" }}
                 >
+                  {/* This is the mesh/consensus node identity. It is NOT the Ghost ID, which is
+                      the node's L2 receive address from ghost-pay and lives in Settings. Labelling
+                      this one "Ghost ID" made two unrelated identifiers look interchangeable. */}
                   <div className="text-xs uppercase tracking-wide mb-1" style={{ color: "var(--dim)" }}>
-                    Ghost ID (node_id)
+                    Node ID (mesh identity)
                   </div>
                   <div className="flex items-center gap-2">
                     <code className="font-mono text-xs break-all select-all" style={{ color: "var(--fg)" }}>

--- a/dashboard/src/app/(dashboard)/settings/wizards/GhostIdWizard.tsx
+++ b/dashboard/src/app/(dashboard)/settings/wizards/GhostIdWizard.tsx
@@ -5,11 +5,27 @@ import { Dialog } from '@/components/ui/Dialog';
 import { Button } from '@/components/ui/Button';
 import { Badge } from '@/components/ui/Badge';
 import { useToast } from '@/components/ui/Toast';
-import { getGhostId } from '@/lib/api/ghostpay';
+import { getGhostId, generateGhostKeys, GhostPayApiError } from '@/lib/api/ghostpay';
 
 interface GhostIdWizardProps {
   isOpen: boolean;
   onClose: () => void;
+}
+
+/// Render a failure using whatever the backend actually said.
+///
+/// The ghostpay proxy answers 503 when `GHOST_PAY_API_SECRET` is unset, which is a deployment
+/// problem rather than a node problem — worth naming, because otherwise it looks identical to
+/// ghost-pay being down.
+function describeError(err: unknown): string {
+  if (err instanceof GhostPayApiError) {
+    if (err.status === 503) {
+      return 'The dashboard cannot reach Ghost Pay: no API secret is configured for the proxy.';
+    }
+    return err.remedy ? `${err.message} — ${err.remedy}` : err.message;
+  }
+  if (err instanceof Error) return err.message;
+  return 'Unable to retrieve the node Ghost ID.';
 }
 
 export default function GhostIdWizard({ isOpen, onClose }: GhostIdWizardProps) {
@@ -20,6 +36,11 @@ export default function GhostIdWizard({ isOpen, onClose }: GhostIdWizardProps) {
   const [error, setError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
   const [prevOpen, setPrevOpen] = useState(false);
+  // A node that has never had a keypair created is not an error state — it has a next step.
+  const [notGenerated, setNotGenerated] = useState<{ reason?: string; remedy?: string } | null>(
+    null
+  );
+  const [isGenerating, setIsGenerating] = useState(false);
 
   // Reset the transient UI state the moment the dialog opens, during render
   // (guarded on the open transition so it can't loop) rather than in the effect.
@@ -31,6 +52,7 @@ export default function GhostIdWizard({ isOpen, onClose }: GhostIdWizardProps) {
       setIsLoading(true);
       setError(null);
       setCopied(false);
+      setNotGenerated(null);
     }
   }
 
@@ -42,9 +64,14 @@ export default function GhostIdWizard({ isOpen, onClose }: GhostIdWizardProps) {
     getGhostId()
       .then((result) => {
         if (cancelled) return;
+        if (!result.generated) {
+          setNotGenerated({ reason: result.reason, remedy: result.remedy });
+          setGhostId(null);
+          return;
+        }
         const id = result.ghost_id?.trim();
         if (!id) {
-          setError('The node did not return a Ghost ID.');
+          setError('The node reported a generated keypair but returned no Ghost ID.');
           setGhostId(null);
         } else {
           setGhostId(id);
@@ -52,7 +79,7 @@ export default function GhostIdWizard({ isOpen, onClose }: GhostIdWizardProps) {
       })
       .catch((err) => {
         if (cancelled) return;
-        setError(err instanceof Error ? err.message : 'Unable to retrieve the node Ghost ID.');
+        setError(describeError(err));
         setGhostId(null);
       })
       .finally(() => {
@@ -63,6 +90,27 @@ export default function GhostIdWizard({ isOpen, onClose }: GhostIdWizardProps) {
       cancelled = true;
     };
   }, [isOpen]);
+
+  const handleGenerate = async () => {
+    setIsGenerating(true);
+    setError(null);
+    try {
+      const result = await generateGhostKeys();
+      const id = result.ghost_id?.trim();
+      if (!id) {
+        setError('The node generated a keypair but returned no Ghost ID.');
+        return;
+      }
+      setGhostId(id);
+      setNotGenerated(null);
+      toast.success('Ghost ID created', 'The node keypair has been generated.');
+    } catch (err) {
+      setError(describeError(err));
+      toast.error('Generation failed', describeError(err));
+    } finally {
+      setIsGenerating(false);
+    }
+  };
 
   const handleCopy = async () => {
     if (!ghostId) return;
@@ -117,7 +165,25 @@ export default function GhostIdWizard({ isOpen, onClose }: GhostIdWizardProps) {
             </div>
           )}
 
-          {!isLoading && !error && ghostId && (
+          {!isLoading && !error && notGenerated && (
+            <div className="space-y-3">
+              <div className="p-3 rounded-lg bg-[var(--surface)]/70 border border-[var(--rule-strong)]">
+                <p className="text-sm text-[color:var(--fg)]">
+                  {notGenerated.reason ??
+                    'This node does not have a Ghost Pay keypair yet.'}
+                </p>
+                <p className="mt-2 text-sm text-[color:var(--dim)]">
+                  Generating one creates the node&apos;s L2 identity. It is a one-time action and
+                  does not move any funds.
+                </p>
+              </div>
+              <Button variant="primary" onClick={handleGenerate} disabled={isGenerating}>
+                {isGenerating ? 'Generating...' : 'Generate keypair'}
+              </Button>
+            </div>
+          )}
+
+          {!isLoading && !error && !notGenerated && ghostId && (
             <div className="flex items-center gap-2">
               <code className="flex-1 break-all rounded bg-[var(--surface)]/70 px-3 py-2 text-sm text-[color:var(--accent)]">
                 {ghostId}

--- a/dashboard/src/lib/api/ghostpay.ts
+++ b/dashboard/src/lib/api/ghostpay.ts
@@ -23,6 +23,32 @@ function getGhostPayProxyBase(): string {
   return 'http://localhost:3000';
 }
 
+/// Error that preserves the backend's response body.
+///
+/// ghost-pay answers failures with a structured payload (`reason`, `remedy`), not an
+/// `error` string. Collapsing that to `API error: <status>` threw the useful half away and
+/// left the UI showing a bare status code — which is what #404 was reporting.
+export class GhostPayApiError extends Error {
+  readonly status: number;
+  readonly body: Record<string, unknown>;
+
+  constructor(status: number, body: Record<string, unknown>) {
+    const detail =
+      (typeof body.reason === 'string' && body.reason) ||
+      (typeof body.error === 'string' && body.error) ||
+      `API error: ${status}`;
+    super(detail);
+    this.name = 'GhostPayApiError';
+    this.status = status;
+    this.body = body;
+  }
+
+  /// The operator-facing next step, when the backend supplied one.
+  get remedy(): string | null {
+    return typeof this.body.remedy === 'string' ? this.body.remedy : null;
+  }
+}
+
 async function fetchGhostPay<T>(endpoint: string, options?: RequestInit): Promise<T> {
   const proxyUrl = `${getGhostPayProxyBase()}/api/ghostpay-proxy${endpoint}`;
 
@@ -35,20 +61,43 @@ async function fetchGhostPay<T>(endpoint: string, options?: RequestInit): Promis
   });
 
   if (!response.ok) {
-    const err = await response.json().catch(() => ({ error: 'Unknown error' }));
-    throw new Error(err.error || `API error: ${response.status}`);
+    const body = await response.json().catch(() => ({}));
+    throw new GhostPayApiError(response.status, body as Record<string, unknown>);
   }
 
   return response.json();
 }
 
 // Node Ghost ID (the node's single derived L2 receive address).
+//
+// `generated: false` is a legitimate state, not a failure: a node that has never had a
+// keypair created answers 404 with that body. It is surfaced as data so the wizard can offer
+// to generate one, rather than as an exception the UI can only render as red text.
 export interface GhostIdResponse {
-  ghost_id: string;
+  generated: boolean;
+  ghost_id: string | null;
+  scan_pubkey?: string;
+  spend_pubkey?: string;
+  identity_kind?: string;
+  reason?: string;
+  remedy?: string;
 }
 
 export async function getGhostId(): Promise<GhostIdResponse> {
-  return fetchGhostPay<GhostIdResponse>('/api/v1/keys/ghost-id');
+  try {
+    return await fetchGhostPay<GhostIdResponse>('/api/v1/keys/ghost-id');
+  } catch (err) {
+    // Only the specific "no keypair yet" 404 is a state; anything else is a real error.
+    if (err instanceof GhostPayApiError && err.status === 404 && err.body.generated === false) {
+      return err.body as unknown as GhostIdResponse;
+    }
+    throw err;
+  }
+}
+
+/// Create the node's ghost-pay keypair. Mutating, so the proxy HMAC-signs it.
+export async function generateGhostKeys(): Promise<GhostIdResponse> {
+  return fetchGhostPay<GhostIdResponse>('/api/v1/keys/generate', { method: 'POST' });
 }
 
 // Ghost Pay Status


### PR DESCRIPTION
Closes #404. #452 fixed the backend half; this is the dashboard half, plus the mislabel.

## The 404 body was being thrown away

#452 replaced the bare 404 with a structured payload naming the cause and the remedy. The dashboard discarded it: `fetchGhostPay` collapsed every failure to

```ts
throw new Error(err.error || `API error: ${response.status}`);
```

and ghost-pay does not send an `error` field. So on a fresh node the wizard rendered the literal string **`API error: 404`** — the same bare-error symptom the issue was filed about, moved one layer up. The useful half of #452 never reached a screen.

## Changes

**`GhostPayApiError`** carries the status and the parsed body, so `reason` and `remedy` survive the client boundary. `GhostIdResponse` now models what the backend actually returns instead of `{ ghost_id: string }`.

**`generated: false` is a state, not a failure.** It arrives as a 404, but "this node has never had a keypair" is a legitimate condition with a next step, so `getGhostId` returns it as data. Any *other* 404, and every other status, still throws — the special case is narrow: `status === 404 && body.generated === false`.

**`POST /api/v1/keys/generate` now has a caller.** It had none anywhere in the dashboard — repo-wide the only callers were the mobile wallet and seven shell scripts — so the only way to create a keypair on a fresh node was a shell. The wizard calls it through the ghostpay proxy, which signs mutations.

A **503** from that proxy is now reported as what it is — no API secret configured for the dashboard — rather than as a node failure. Otherwise the two are indistinguishable, and the deployment-side one is the likelier.

## The mislabel

`connect/page.tsx` titled the node's mesh identity **"Ghost ID (node_id)"**. That is the consensus identity, not the L2 receive address that lives in Settings. Two unrelated identifiers under one name is what invited the confusion in the first place, so it now reads "Node ID (mesh identity)" with a comment saying why.

## Gates

- `npx tsc --noEmit` — clean
- `npm run build` — succeeds, all routes emitted
- `npm run lint` — **0 errors**, 3 warnings, all pre-existing in `pool/page.tsx` and `useWebSocket.ts`, neither touched here

## Not verified

The generate path is exercised against a node that has *no* keypair. Every node on the fleet already has one, so this could not be tested end to end without creating a node in that state — worth a look on a canary before it is relied on.