### PR TITLE
test(sniffer): bound the two remaining queue reads; fail the test instead of the CI job

### DIFF
--- a/tests/integration-sv2/lib/message_aggregator.rs
+++ b/tests/integration-sv2/lib/message_aggregator.rs
@@ -6,10 +6,16 @@ use stratum_apps::{
 
 use crate::types::MsgType;
 
-#[allow(clippy::type_complexity)]
+/// The intercepted-message queue: message type, the message itself, and any TLV extension
+/// fields that rode along with it.
+///
+/// Named rather than repeated so the accessors can return it without each needing its own
+/// `#[allow(clippy::type_complexity)]`.
+type MessageQueue = Arc<Mutex<VecDeque<(MsgType, AnyMessage<'static>, Option<Vec<Tlv>>)>>>;
+
 #[derive(Debug, Clone)]
 pub struct MessagesAggregator {
-    messages: Arc<Mutex<VecDeque<(MsgType, AnyMessage<'static>, Option<Vec<Tlv>>)>>>,
+    messages: MessageQueue,
 }
 
 impl Default for MessagesAggregator {
@@ -45,9 +51,7 @@ impl MessagesAggregator {
 
     /// Direct access to the inner lock, for tests that need to hold it deliberately.
     #[cfg(test)]
-    pub(crate) fn messages_for_test(
-        &self,
-    ) -> &Arc<Mutex<VecDeque<(MsgType, AnyMessage<'static>, Option<Vec<Tlv>>)>>> {
+    pub(crate) fn messages_for_test(&self) -> &MessageQueue {
         &self.messages
     }
 

--- a/tests/integration-sv2/lib/mock_roles.rs
+++ b/tests/integration-sv2/lib/mock_roles.rs
@@ -256,8 +256,38 @@ mod tests {
         mining_sv2::MESSAGE_TYPE_OPEN_EXTENDED_MINING_CHANNEL,
     };
 
+    /// Upper bound on any single test here.
+    ///
+    /// The queue reads have their own internal deadlines, but those are the thing most likely
+    /// to regress — #408 was exactly an unbounded read making its own timeout unreachable, and
+    /// it burned a CI run to the six-hour cap. `timeout-minutes: 45` in the workflow caps the
+    /// damage; this turns it into a test failure that names which test, which the job timeout
+    /// cannot do.
+    ///
+    /// Generous on purpose: these tests stand up real sockets and are slower under coverage
+    /// instrumentation, which is where the hang appeared. It is a backstop, not a performance
+    /// assertion.
+    const TEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
+
+    async fn with_timeout<F: std::future::Future<Output = ()>>(name: &str, fut: F) {
+        if tokio::time::timeout(TEST_TIMEOUT, fut).await.is_err() {
+            panic!(
+                "{name} exceeded {}s — most likely an unbounded queue read; see #408",
+                TEST_TIMEOUT.as_secs()
+            );
+        }
+    }
+
     #[tokio::test]
     async fn test_implicit_setup_connection() {
+        with_timeout(
+            "test_implicit_setup_connection",
+            test_implicit_setup_connection_body(),
+        )
+        .await;
+    }
+
+    async fn test_implicit_setup_connection_body() {
         let port = TcpListener::bind("127.0.0.1:0")
             .unwrap()
             .local_addr()
@@ -301,6 +331,18 @@ mod tests {
 
     #[tokio::test]
     async fn test_assert_message_not_present() {
+        with_timeout(
+            "test_assert_message_not_present",
+            test_assert_message_not_present_body(),
+        )
+        .await;
+    }
+
+    /// This is the test that hung for 5h38m under `cargo llvm-cov` in the v1.11.17 run.
+    /// It exercises all three queue-read paths — `wait_for_message_type`,
+    /// `has_message_type` and `assert_message_not_present` — which is why hardening only the
+    /// first one in #450 did not settle it.
+    async fn test_assert_message_not_present_body() {
         let port = TcpListener::bind("127.0.0.1:0")
             .unwrap()
             .local_addr()
@@ -365,6 +407,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_setup_connection_wrong_protocol() {
+        with_timeout(
+            "test_setup_connection_wrong_protocol",
+            test_setup_connection_wrong_protocol_body(),
+        )
+        .await;
+    }
+
+    async fn test_setup_connection_wrong_protocol_body() {
         let port = TcpListener::bind("127.0.0.1:0")
             .unwrap()
             .local_addr()

--- a/tests/integration-sv2/lib/sniffer.rs
+++ b/tests/integration-sv2/lib/sniffer.rs
@@ -269,7 +269,32 @@ impl<'a> Sniffer<'a> {
         let start = std::time::Instant::now();
 
         while start.elapsed() < deadline {
-            if self.has_message_type(message_direction, message_type) {
+            // Same trap as `wait_for_message_type`, and for the same reason: the queue read
+            // takes a BLOCKING std::sync::Mutex, and `#[tokio::test]` is a current-thread
+            // runtime. Taking it inline here blocks the only executor thread, so neither the
+            // `start.elapsed()` check above nor tokio's timer can run — and `deadline` becomes
+            // unreachable rather than an upper bound.
+            //
+            // #450 hardened only `wait_for_message_type`. This path and
+            // `wait_for_message_type_and_clean_queue` kept the original shape, which is how
+            // `test_assert_message_not_present` — a test that exercises all three — could still
+            // hang for six hours instead of failing on its own deadline (#408).
+            //
+            // A read that does not answer within a second counts as "not present"; the loop
+            // re-checks its deadline and returns on schedule.
+            let agg = match message_direction {
+                MessageDirection::ToDownstream => self.messages_from_upstream.clone(),
+                MessageDirection::ToUpstream => self.messages_from_downstream.clone(),
+            };
+            let has_message_type = tokio::time::timeout(
+                std::time::Duration::from_secs(1),
+                tokio::task::spawn_blocking(move || agg.has_message_type(message_type)),
+            )
+            .await
+            .map(|joined| joined.unwrap_or(false))
+            .unwrap_or(false);
+
+            if has_message_type {
                 return false;
             }
             tokio::time::sleep(std::time::Duration::from_millis(100)).await;
@@ -287,14 +312,26 @@ impl<'a> Sniffer<'a> {
     ) -> bool {
         let now = std::time::Instant::now();
         loop {
-            let has_message_type = match message_direction {
-                MessageDirection::ToDownstream => self
-                    .messages_from_upstream
-                    .has_message_type_with_remove(message_type),
-                MessageDirection::ToUpstream => self
-                    .messages_from_downstream
-                    .has_message_type_with_remove(message_type),
+            // Blocking lock off the executor thread, plus a bound on the read itself, so the
+            // elapsed check below stays reachable. See the note in `wait_for_message_type`;
+            // this path had the same unbounded shape until #408.
+            //
+            // Note this read MUTATES — `has_message_type_with_remove` drains the queue up to
+            // and including the match. If the timeout fires, the read may still be running and
+            // may still remove messages. That is acceptable here because a timing-out read
+            // means the test is failing anyway, but it is the reason this cannot simply be
+            // retried in a tight loop.
+            let agg = match message_direction {
+                MessageDirection::ToDownstream => self.messages_from_upstream.clone(),
+                MessageDirection::ToUpstream => self.messages_from_downstream.clone(),
             };
+            let has_message_type = tokio::time::timeout(
+                std::time::Duration::from_secs(1),
+                tokio::task::spawn_blocking(move || agg.has_message_type_with_remove(message_type)),
+            )
+            .await
+            .map(|joined| joined.unwrap_or(false))
+            .unwrap_or(false);
 
             // ready to unblock test runtime
             if has_message_type {
@@ -540,6 +577,95 @@ mod poll_loop_liveness_tests {
         let elapsed = started.elapsed();
 
         let joined = result.expect("wait_for_message_type never returned while the lock was held");
+        assert!(
+            joined.is_err(),
+            "expected the sniffer timeout to fire (it panics on timeout)"
+        );
+        assert!(
+            elapsed < Duration::from_secs(LOCK_HELD_S - 2),
+            "gave up after {elapsed:?}, i.e. only once the lock was released after \
+             {LOCK_HELD_S}s — the read is still postponing the timeout"
+        );
+    }
+
+    /// Same guarantee for `assert_message_not_present`.
+    ///
+    /// #450 hardened only `wait_for_message_type`, leaving this path with the original
+    /// unbounded shape. `test_assert_message_not_present` exercises both, so the test could
+    /// still hang — which is why #408 stayed open after that fix.
+    ///
+    /// Unlike its sibling this returns a bool rather than panicking, so the assertion is that
+    /// it returns `true` (no message seen) on roughly its own deadline instead of waiting out
+    /// the lock.
+    #[tokio::test(flavor = "current_thread")]
+    async fn a_held_lock_cannot_postpone_assert_message_not_present() {
+        const DEADLINE_S: u64 = 2;
+        const LOCK_HELD_S: u64 = 12;
+
+        let agg = MessagesAggregator::new();
+        let holder = agg.clone();
+        std::thread::spawn(move || {
+            holder
+                .messages_for_test()
+                .safe_lock(|_| std::thread::sleep(Duration::from_secs(LOCK_HELD_S)))
+                .unwrap();
+        });
+        std::thread::sleep(Duration::from_millis(200));
+
+        let sniffer = Sniffer::for_timeout_test(agg, None);
+
+        let started = Instant::now();
+        let absent = sniffer
+            .assert_message_not_present(
+                MessageDirection::ToUpstream,
+                0x00,
+                Duration::from_secs(DEADLINE_S),
+            )
+            .await;
+        let elapsed = started.elapsed();
+
+        assert!(
+            absent,
+            "no message was ever queued, so this must report the type as absent"
+        );
+        assert!(
+            elapsed < Duration::from_secs(LOCK_HELD_S - 2),
+            "returned after {elapsed:?}, i.e. only once the lock was released after \
+             {LOCK_HELD_S}s — the read is still postponing the deadline"
+        );
+    }
+
+    /// Same guarantee for `wait_for_message_type_and_clean_queue`, the third read path.
+    ///
+    /// Like `wait_for_message_type` it panics on timeout, so it runs in a task and the
+    /// `JoinError` is the signal.
+    #[tokio::test(flavor = "current_thread")]
+    async fn a_held_lock_cannot_postpone_the_clean_queue_timeout() {
+        const SNIFFER_TIMEOUT_S: u64 = 2;
+        const LOCK_HELD_S: u64 = 12;
+
+        let agg = MessagesAggregator::new();
+        let holder = agg.clone();
+        std::thread::spawn(move || {
+            holder
+                .messages_for_test()
+                .safe_lock(|_| std::thread::sleep(Duration::from_secs(LOCK_HELD_S)))
+                .unwrap();
+        });
+        std::thread::sleep(Duration::from_millis(200));
+
+        let sniffer = Sniffer::for_timeout_test(agg, Some(SNIFFER_TIMEOUT_S));
+
+        let started = Instant::now();
+        let handle = tokio::spawn(async move {
+            sniffer
+                .wait_for_message_type_and_clean_queue(MessageDirection::ToUpstream, 0x00)
+                .await;
+        });
+        let result = tokio::time::timeout(Duration::from_secs(LOCK_HELD_S + 6), handle).await;
+        let elapsed = started.elapsed();
+
+        let joined = result.expect("the clean-queue read never returned while the lock was held");
         assert!(
             joined.is_err(),
             "expected the sniffer timeout to fire (it panics on timeout)"

--- a/tests/integration-sv2/tests/mining_device_fast_hasher_equivalence.rs
+++ b/tests/integration-sv2/tests/mining_device_fast_hasher_equivalence.rs
@@ -31,7 +31,7 @@ fn fast_hasher_matches_baseline() {
     for _ in 0..1000 {
         // Advance nonce, occasionally tweak time
         h.nonce = h.nonce.wrapping_add(1);
-        if h.nonce % 128 == 0 {
+        if h.nonce.is_multiple_of(128) {
             h.time = h.time.wrapping_add(1);
         }
         let fast_hash = fast.hash_with_nonce_time(h.nonce, h.time);

--- a/tests/integration-sv2/tests/pool_integration.rs
+++ b/tests/integration-sv2/tests/pool_integration.rs
@@ -555,7 +555,7 @@ async fn pool_group_extended_channels() {
         // send OpenExtendedMiningChannel message to the pool
         let open_extended_mining_channel = AnyMessage::Mining(Mining::OpenExtendedMiningChannel(
             OpenExtendedMiningChannel {
-                request_id: i.into(),
+                request_id: i,
                 user_identity: b"user_identity".to_vec().try_into().unwrap(),
                 nominal_hash_rate: 1000.0,
                 max_target: vec![0xff; 32].try_into().unwrap(),

--- a/tests/integration-sv2/tests/pool_solo_mining.rs
+++ b/tests/integration-sv2/tests/pool_solo_mining.rs
@@ -94,7 +94,7 @@ fn assert_payout_percentage(payout_info: &PayoutInfo, expected_percentages: &[(S
             .addresses
             .iter()
             .position(|a| a == addr)
-            .expect(&format!("Address {} not found in coinbase", addr));
+            .unwrap_or_else(|| panic!("Address {} not found in coinbase", addr));
         let actual_pct = (payout_info.amounts[idx] as f64 / payout_info.total as f64) * 100.0;
         assert!(
             (actual_pct - expected_pct).abs() < 0.1,

--- a/tests/integration-sv2/tests/translator_integration.rs
+++ b/tests/integration-sv2/tests/translator_integration.rs
@@ -1542,8 +1542,7 @@ async fn translator_does_not_shutdown_on_missing_downstream_channel() {
         .await
         .unwrap();
 
-    let (_minerd_process, _minerd_addr) =
-        start_minerd(tproxy_addr.clone(), None, None, false).await;
+    let (_minerd_process, _minerd_addr) = start_minerd(tproxy_addr, None, None, false).await;
 
     sniffer_a
         .wait_for_message_type(


### PR DESCRIPTION
Addresses #408. Bounds the damage; does **not** claim to have found the deadlock — see the end.

## Why #450 did not settle it

#450 was explicit that it fixed no deadlock, and it hardened only `wait_for_message_type`. The other two read paths kept the original shape, and `test_assert_message_not_present` — the test that hung for **5h38m** under `cargo llvm-cov` — exercises all three. So the hang was still reachable.

Both remaining paths took the blocking `std::sync::Mutex` inline. `#[tokio::test]` gives a current-thread runtime, so that blocks the only executor thread; neither the elapsed check nor tokio's timer can then run, and the deadline becomes unreachable rather than an upper bound.

| path | before | after |
|---|---|---|
| `wait_for_message_type` | bounded by #450 | unchanged |
| `assert_message_not_present` | **inline blocking read** | `spawn_blocking` + 1s timeout |
| `wait_for_message_type_and_clean_queue` | **inline blocking read** | `spawn_blocking` + 1s timeout |

The clean-queue read *mutates* — it drains the queue up to and including the match — so a timing-out read may still be removing messages. Acceptable, because a timeout there means the test is failing regardless, but it is noted in the code as the reason it cannot be retried tightly.

## The tests were confirmed to fail without the fix

A regression test that has only ever seen the fixed code proves nothing. I temporarily restored the unbounded read and ran the new test:

```
returned after 11.90555557s, i.e. only once the lock was released after 12s
  — the read is still postponing the deadline
```

A **2-second** deadline, ignored for **11.9 seconds**. That is the bug, reproduced in 12 seconds instead of six hours. With the fix restored, all 20 tests pass.

Two liveness tests added, mirroring the one #450 introduced — one per newly-bounded path.

## Outer timeout

All three tests in `mock_roles` now run under a 120s bound, so a future regression fails **with the test's name attached** rather than running to the workflow's 45-minute cap. A job timeout cannot tell you which test hung; this can. Bodies were moved into inner functions rather than re-indented, to keep the diff reviewable.

## Deliberately not done

**The port TOCTOU** (issue item 3). The suggestion is to hold the listener until the mock binds — but `MockUpstream::start` binds asynchronously inside a spawned task, so holding it would block the mock's *own* bind. The real fix is handing the listener over, which is a harness API change that does not belong in a deadlock fix. It also fails fast rather than hanging.

**Re-including the crate in Coverage.** It is still `--exclude`d at `ci.yml:220`, which means a green Coverage job says nothing about this either way. Re-including it should be its own change, so it can be reverted on its own if the hang returns.

**Root cause.** Item 1 of the issue — reproduce and get a stack dump — has not been done. This makes an unbounded read fail in one minute rather than six hours; it does not explain why the read stopped returning. I would keep #408 open for that.

## Gates

- `cargo test -p integration_tests_sv2 --lib` — **20 passed, 0 failed**
- `cargo fmt` clean
- `cargo clippy -p integration_tests_sv2 --all-targets` — **now clean**; cleared all 5 warnings in the crate, including swapping an `#[allow(clippy::type_complexity)]` for a named `MessageQueue` alias