### PR TITLE
chore: bump fuzz/Cargo.lock to 1.11.20 and make a stale one fail loudly

### DIFF
--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1643,7 +1643,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-accounting"
-version = "1.11.19"
+version = "1.11.20"
 dependencies = [
  "bitcoin",
  "ghost-common",
@@ -1657,7 +1657,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-buds"
-version = "1.11.19"
+version = "1.11.20"
 dependencies = [
  "bitcoin",
  "ghost-common",
@@ -1671,7 +1671,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-common"
-version = "1.11.19"
+version = "1.11.20"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -1703,7 +1703,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-consensus"
-version = "1.11.19"
+version = "1.11.20"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1754,7 +1754,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-glyph"
-version = "1.11.19"
+version = "1.11.20"
 dependencies = [
  "hex",
  "serde",
@@ -1765,7 +1765,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-gsp-proto"
-version = "1.11.19"
+version = "1.11.20"
 dependencies = [
  "bitcoin",
  "chrono",
@@ -1781,7 +1781,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-keys"
-version = "1.11.19"
+version = "1.11.20"
 dependencies = [
  "bech32",
  "bitcoin",
@@ -1803,7 +1803,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-locks"
-version = "1.11.19"
+version = "1.11.20"
 dependencies = [
  "bitcoin",
  "getrandom 0.2.17",
@@ -1845,7 +1845,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-policy"
-version = "1.11.19"
+version = "1.11.20"
 dependencies = [
  "bitcoin",
  "ghost-buds",
@@ -1858,7 +1858,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-pool"
-version = "1.11.19"
+version = "1.11.20"
 dependencies = [
  "anyhow",
  "async-channel 2.5.0",
@@ -1912,7 +1912,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-reaper"
-version = "1.11.19"
+version = "1.11.20"
 dependencies = [
  "bitcoin",
  "serde",
@@ -1923,7 +1923,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-reconciliation"
-version = "1.11.19"
+version = "1.11.20"
 dependencies = [
  "async-trait",
  "bitcoin",
@@ -1949,7 +1949,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-storage"
-version = "1.11.19"
+version = "1.11.20"
 dependencies = [
  "base64 0.22.1",
  "chacha20poly1305",
@@ -1970,7 +1970,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-template"
-version = "1.11.19"
+version = "1.11.20"
 dependencies = [
  "bitcoin",
  "ghost-buds",
@@ -1986,7 +1986,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-verification"
-version = "1.11.19"
+version = "1.11.20"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3988,7 +3988,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stratum-apps"
-version = "1.11.19"
+version = "1.11.20"
 dependencies = [
  "async-channel 1.9.0",
  "bs58",
@@ -5277,7 +5277,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-coordinator"
-version = "1.11.19"
+version = "1.11.20"
 dependencies = [
  "anyhow",
  "axum",
@@ -5308,7 +5308,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-protocol"
-version = "1.11.19"
+version = "1.11.20"
 dependencies = [
  "bitcoin",
  "getrandom 0.2.17",

--- a/scripts/check-fuzz-targets.sh
+++ b/scripts/check-fuzz-targets.sh
@@ -34,8 +34,14 @@ if [ -n "$orphans" ]; then
 fi
 
 echo "check-fuzz-targets: ${#files[@]} targets, ${#registered[@]} registered — building"
-if ! ( cd fuzz && cargo check --bins --quiet ); then
-    echo "check-fuzz-targets: a fuzz target no longer builds against current APIs" >&2
+# `--locked` because `fuzz/` is a SEPARATE cargo workspace with its own lockfile, and
+# `cargo update --workspace` at the repo root does not reach it. Without this flag a version
+# bump leaves fuzz/Cargo.lock stale, this build silently rewrites it, and the rewrite dirties
+# the tree — which then trips `deploy-node.sh`'s clean-tree check AFTER the gate has already
+# reported success. That is a confusing way to discover a stale lockfile; failing here names it.
+if ! ( cd fuzz && cargo check --bins --quiet --locked ); then
+    echo "check-fuzz-targets: a fuzz target no longer builds, or fuzz/Cargo.lock is stale" >&2
+    echo "  if the workspace version changed, run: ( cd fuzz && cargo update --workspace )" >&2
     exit 1
 fi
 echo "check-fuzz-targets: all ${#files[@]} fuzz targets build"


### PR DESCRIPTION
Follow-up to #485, found while deploying 1.11.20 — the deploy was blocked by exactly this.

## What happened

`fuzz/` is a **separate cargo workspace** with its own lockfile. The `cargo update --workspace` used for the version bump in #485 does not reach it, so `fuzz/Cargo.lock` still pinned the workspace crates at `1.11.19`.

The failure order made that hard to see:

1. `record-tests.sh` checks the tree is clean — it is.
2. It runs `check-fuzz-targets.sh`, whose `cargo check` **silently rewrites** the stale lockfile.
3. The gate reports success and records the commit as deployable.
4. `deploy-node.sh` then refuses with `working tree is dirty — commit or stash first`.

The message points at neither the cause nor the fix, and it arrives from a different script than the one that caused it. #477 added the fuzz build to the gate, which is what surfaced this; the stale lock predates it.

## Changes

- **`fuzz/Cargo.lock` → 1.11.20.** 18 crate versions, no dependency changes.
- **Build the fuzz targets with `--locked`.** A stale lockfile now fails at the gate, named, with the command to fix it — instead of being rewritten invisibly and tripping something else two steps later.

## Note for the next version bump

`cargo update --workspace` at the repo root is not sufficient. The bump needs:

```bash
( cd fuzz && cargo update --workspace )
```

With `--locked` in place, forgetting it is now a loud gate failure rather than a silent rewrite, so this should not need remembering twice.

## Gates

- `./scripts/check-fuzz-targets.sh` — 11/11 targets build, exit 0, tree stays clean afterwards