### PR TITLE
fix(ops): reconcile the two firewall-script copies; gate the pair

### DIFF
--- a/scripts/check-inlined-copies.sh
+++ b/scripts/check-inlined-copies.sh
@@ -31,6 +31,11 @@ PAIRS = {
     "GHOST_RESTART_WATCH_SH_EOF":      "scripts/ghost-restart-watch.sh",
     "GHOST_RESTART_WATCH_SERVICE_EOF": "scripts/systemd/ghost-restart-watch.service",
     "GHOST_RESTART_WATCH_TIMER_EOF":   "scripts/systemd/ghost-restart-watch.timer",
+    # Added after the two copies were found implementing DIFFERENT RULES (#488): the repo
+    # copy closed the Stratum ports on private_pool and keyed off `public_mining`, a config
+    # field that no longer exists. Running it on a private pool would have dropped every
+    # miner. It had also never gained the Wraith coordinator block the installer copy has.
+    "RECONCILE_MINING_FW_EOF":         "scripts/reconcile-mining-firewall.sh",
 }
 
 src = open(INSTALLER).read()

--- a/scripts/install-node.sh
+++ b/scripts/install-node.sh
@@ -1290,8 +1290,16 @@ ufw --force enable      >/dev/null 2>&1
 # whenever the config changes — so toggling public mining later (dashboard /
 # ghost-setup / hand edit) updates the firewall live, with no manual ufw step.
 log "Installing mining-firewall reconcile (stratum + coordinator ports follow pool.toml)"
-cat > /opt/ghost/bin/reconcile-mining-firewall.sh <<'EOF'
+cat > /opt/ghost/bin/reconcile-mining-firewall.sh <<'RECONCILE_MINING_FW_EOF'
 #!/usr/bin/env bash
+# Reconcile the Stratum and Wraith coordinator firewall ports to the node's config.
+#
+# Run by `ghost-mining-firewall.service`, triggered at boot and by
+# `ghost-mining-firewall.path` whenever pool.toml changes. Idempotent.
+#
+# This file is inlined VERBATIM in scripts/install-node.sh, which is fetched
+# standalone over curl and has no repo to read from. check-inlined-copies.sh
+# compares the two byte-for-byte — edit both, or neither.
 set -euo pipefail
 CONF="${GHOST_POOL_CONF:-/etc/ghost/pool.toml}"
 PORTS=(3333 34255)
@@ -1327,7 +1335,7 @@ else
   ufw delete allow 9100/tcp >/dev/null 2>&1 || true
   logger -t ghost-mining-firewall "coordinator role OFF -> Wraith 9100 CLOSED"
 fi
-EOF
+RECONCILE_MINING_FW_EOF
 chmod 755 /opt/ghost/bin/reconcile-mining-firewall.sh
 
 cat > /etc/systemd/system/ghost-mining-firewall.service <<'EOF'

--- a/scripts/reconcile-mining-firewall.sh
+++ b/scripts/reconcile-mining-firewall.sh
@@ -1,38 +1,44 @@
 #!/usr/bin/env bash
-# Reconcile the Stratum firewall ports to the node's mining mode.
+# Reconcile the Stratum and Wraith coordinator firewall ports to the node's config.
 #
-# Opens BOTH Stratum V1 (3333) and V2 (34255) when the node is a public pool;
-# closes them for a private / solo node. Driven entirely by `mining_mode` in
-# /etc/ghost/pool.toml, so the firewall follows the operator's public-mining
-# choice however it is changed — dashboard, `ghost-setup`, or a hand edit.
-#
-# Run by `ghost-mining-firewall.service`, which is triggered at boot and by
+# Run by `ghost-mining-firewall.service`, triggered at boot and by
 # `ghost-mining-firewall.path` whenever pool.toml changes. Idempotent.
+#
+# This file is inlined VERBATIM in scripts/install-node.sh, which is fetched
+# standalone over curl and has no repo to read from. check-inlined-copies.sh
+# compares the two byte-for-byte — edit both, or neither.
 set -euo pipefail
-
 CONF="${GHOST_POOL_CONF:-/etc/ghost/pool.toml}"
 PORTS=(3333 34255)
-
-# Public mining is ON if EITHER form is set: the production boolean
-# `public_mining = true`, or the installer's `mining_mode = "public_pool"`.
-# (The two provisioning paths use different keys; accept both.)
-public="no"
-if [[ -r "$CONF" ]]; then
-  if grep -qE '^[[:space:]]*public_mining[[:space:]]*=[[:space:]]*true([[:space:]]|$)' "$CONF" 2>/dev/null \
-   || grep -qE '^[[:space:]]*mining_mode[[:space:]]*=[[:space:]]*"?public_pool"?' "$CONF" 2>/dev/null; then
-    public="yes"
-  fi
+# External miners are accepted in public_pool AND private_pool — both open the
+# Stratum ports (public_pool to anyone, private_pool to password-holders). Only
+# private_solo keeps them closed. mining_mode is the single source of truth: the
+# legacy public_mining bool was removed and is ignored by ghost-pool, so we key
+# purely off mining_mode here to stay consistent with the running node.
+accept_miners="no"
+if [[ -r "$CONF" ]] \
+ && grep -qE '^[[:space:]]*mining_mode[[:space:]]*=[[:space:]]*"?(public_pool|private_pool)"?' "$CONF" 2>/dev/null; then
+  accept_miners="yes"
+fi
+if [[ "$accept_miners" == "yes" ]]; then
+  for p in "${PORTS[@]}"; do ufw allow "${p}/tcp" >/dev/null 2>&1 || true; done
+  logger -t ghost-mining-firewall "external miners ON (public_pool/private_pool) -> Stratum 3333+34255 OPEN"
+else
+  for p in "${PORTS[@]}"; do ufw delete allow "${p}/tcp" >/dev/null 2>&1 || true; done
+  logger -t ghost-mining-firewall "external miners OFF (private_solo) -> Stratum 3333+34255 CLOSED"
 fi
 
-if [[ "$public" == "yes" ]]; then
-  for p in "${PORTS[@]}"; do
-    ufw allow "${p}/tcp" >/dev/null 2>&1 || true
-  done
-  logger -t ghost-mining-firewall "public mining ON -> Stratum 3333+34255 OPEN"
+# Wraith coordinator listen port (9100) follows [coordinator]
+# coordinator_role_enabled, exactly as the Stratum ports follow public mining.
+coord="no"
+if [[ -r "$CONF" ]] \
+ && grep -qE '^[[:space:]]*coordinator_role_enabled[[:space:]]*=[[:space:]]*true([[:space:]]|$)' "$CONF" 2>/dev/null; then
+  coord="yes"
+fi
+if [[ "$coord" == "yes" ]]; then
+  ufw allow 9100/tcp >/dev/null 2>&1 || true
+  logger -t ghost-mining-firewall "coordinator role ON -> Wraith 9100 OPEN"
 else
-  # Private/solo (or unset/unreadable): don't expose stratum to the network.
-  for p in "${PORTS[@]}"; do
-    ufw delete allow "${p}/tcp" >/dev/null 2>&1 || true
-  done
-  logger -t ghost-mining-firewall "public mining OFF -> Stratum 3333+34255 CLOSED"
+  ufw delete allow 9100/tcp >/dev/null 2>&1 || true
+  logger -t ghost-mining-firewall "coordinator role OFF -> Wraith 9100 CLOSED"
 fi


### PR DESCRIPTION
Closes #488.

`scripts/reconcile-mining-firewall.sh` and the copy inlined in `scripts/install-node.sh` implemented **different rules**, and nothing checked them.

| | repo copy | installer copy |
|---|---|---|
| opens on `public_pool` | yes | yes |
| opens on `private_pool` | **no — closes** | yes |
| honours `public_mining = true` | yes | no (treats as removed) |
| Wraith coordinator port 9100 | **absent entirely** | present |

Running the repo copy on a `private_pool` node executes `ufw delete allow 3333/tcp` and drops every miner. `ghost-mining-firewall.path` triggers the unit on any `pool.toml` change, so it does not need a human to fire.

## Which copy is right

The installer's, and both points are settled in `crates/ghost-common/src/config.rs`:

- **`:857`** — "The legacy `public_mining` bool was removed — mining_mode is [the source of truth]". The repo copy branches on a field nothing sets any more.
- **`:1183-1184`** — `MiningMode::PrivatePool` is *"Password required, pool-aggregated rewards, not in DNS"*. Those miners connect over Stratum with a password; the node is merely unadvertised. The port must be open.

So the repo copy is replaced with the installer's logic, not the other way round.

## Impact today: none, and that is the point

The fleet is entirely `public_pool`, which both copies open. This was latent, and it failed in the direction of *silently disconnected miners* — the kind that gets diagnosed as a network problem.

## The gate

Adds the pair to `check-inlined-copies.sh`, which covered only the three restart-watch files. That gate exists because the vardiff floor was corrected in one copy and not the other (#431). This is the same bug in a different file — and it was found by reading the two side by side, not by the gate built to find exactly this.

The installer heredoc used a bare `EOF`, which the gate cannot address, so it gains a named marker.

## Verified

- `check-inlined-copies.sh` — **4 pairs match** (was 3)
- Confirmed it actually refuses: a one-line edit to either side is reported with the first differing line and a non-zero exit; passes again once both match
- `bash -n` clean on both files