### PR TITLE
feat(pool): enable the farm/rental tier by default on public mining nodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9357,6 +9357,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util",
+ "toml 0.8.2",
  "tracing",
 ]
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ selects its own transactions according to its configured mempool policy.
 
 | Port | Purpose |
 |------|---------|
-| 3333 | Stratum V1 — native miner connections |
+| 3333 | Stratum V1 — hobby tier, ~2,328 starting difficulty |
+| 4444 | Stratum V1 — farm/rental tier, ~232,827 starting difficulty (public mining nodes) |
 | 34255 | Stratum V2 — via SRI pool |
 | 8080 | REST API |
 | 8555–8562 | P2P consensus mesh (shares, blocks, voting, health, discovery, elders, payouts) |

--- a/bins/translator-sv2/Cargo.toml
+++ b/bins/translator-sv2/Cargo.toml
@@ -45,3 +45,6 @@ hotpath-alloc = ["hotpath", "hotpath/hotpath-alloc"]
 
 [dev-dependencies]
 sha2 = "0.10.6"
+# Reads the SHIPPED config/sri/translator-config.toml in a test, so an enabled-in-code /
+# commented-out-in-config mismatch cannot pass again (#410).
+toml = { workspace = true }

--- a/bins/translator-sv2/src/lib/config.rs
+++ b/bins/translator-sv2/src/lib/config.rs
@@ -298,6 +298,49 @@ mod farm_tier_tests {
             "farm_tier must default to None so existing single-listener configs are unchanged"
         );
     }
+
+    /// The SHIPPED config must enable the farm tier, which the Rust default deliberately does
+    /// not (above). Those are different claims, and only this one is what a node actually runs.
+    ///
+    /// #410 sat "done" for a while on the strength of the listener existing, while every
+    /// shipped config still had `[farm_tier]` commented out — so no node ever opened 4444.
+    /// A test on the default value cannot catch that; this reads the file itself.
+    #[test]
+    fn shipped_config_enables_the_farm_tier() {
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../config/sri/translator-config.toml"
+        );
+        let raw = std::fs::read_to_string(path)
+            .unwrap_or_else(|e| panic!("cannot read the shipped translator config at {path}: {e}"));
+        let cfg: toml::Value = toml::from_str(&raw).expect("shipped translator config must parse");
+
+        let farm = cfg
+            .get("farm_tier")
+            .unwrap_or_else(|| panic!("[farm_tier] missing from {path} — no node will open 4444"));
+
+        assert_eq!(
+            farm.get("port").and_then(|v| v.as_integer()),
+            Some(4444),
+            "the farm tier must listen on 4444; the firewall and docs are written against it"
+        );
+
+        let hobby = cfg
+            .get("downstream_difficulty_config")
+            .and_then(|d| d.get("min_individual_miner_hashrate"))
+            .and_then(|v| v.as_float())
+            .expect("hobby floor must be set");
+        let farm_floor = farm
+            .get("min_individual_miner_hashrate")
+            .and_then(|v| v.as_float())
+            .expect("farm floor must be set");
+
+        assert!(
+            farm_floor > hobby,
+            "farm floor {farm_floor:e} must exceed the hobby floor {hobby:e}, or a large miner \
+             routed to 4444 gets an EASIER target than one left on 3333"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/config/README.md
+++ b/config/README.md
@@ -68,7 +68,8 @@ source mainnet.env && ghost-pool --config mainnet.toml
 
 | Port | Protocol | Purpose |
 |------|----------|---------|
-| 3333 | TCP | Stratum V1 (miners) |
+| 3333 | TCP | Stratum V1 — hobby tier (miners) |
+| 4444 | TCP | Stratum V1 — farm/rental tier (public mining nodes only) |
 | 34255 | TCP | Stratum V2 (miners) |
 | 8080 | TCP | HTTP API |
 | 8555-8562 | TCP | P2P consensus mesh |

--- a/config/sri/translator-config.toml
+++ b/config/sri/translator-config.toml
@@ -112,7 +112,12 @@ authority_pubkey = "9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72"
 # taking anything from anyone — it just costs this node ~20x the share
 # validation, bandwidth and database writes.
 #
-# [farm_tier]
-# port = 4444
-# min_individual_miner_hashrate = 100_000_000_000_000.0  # ~232,827 starting difficulty
-# hobby_max_individual_miner_hashrate = 50_000_000_000_000.0
+# ENABLED BY DEFAULT on public mining nodes (operator decision, 2026-07-27). The hobby
+# tier keeps `downstream_port`, so every miner already pointed at 3333 stays put; only
+# large miners need 4444 advertised to them. Private/solo nodes do not get this listener:
+# `install-node.sh` emits the block only for `mining_mode = "public_pool"`, and
+# `reconcile-mining-firewall.sh` opens 4444 on the same condition.
+[farm_tier]
+port = 4444
+min_individual_miner_hashrate = 100_000_000_000_000.0  # ~232,827 starting difficulty
+hobby_max_individual_miner_hashrate = 50_000_000_000_000.0

--- a/crates/ghost-verification/src/routes.rs
+++ b/crates/ghost-verification/src/routes.rs
@@ -3605,8 +3605,12 @@ async fn api_pool_status_handler(State(state): State<Arc<VerificationState>>) ->
         "total_shares": health.capabilities.total_shares,
         "current_round_duration_secs": current_round_duration_secs,
         "estimated_time_to_block_secs": estimated_time_to_block_secs,
-        "stratum_sv2_port": 4444,
-        "stratum_sv1_port": 3333,
+        // 4444 was hard-coded here and is NOT the SV2 port — it is the SV1 farm/rental tier
+        // (#410). The real SV2 listener is SV2_STRATUM_PORT (34255), which the rest of this
+        // file already reports correctly. Advertising 4444 as SV2 sent anyone reading the API
+        // to a port speaking the wrong protocol.
+        "stratum_sv2_port": SV2_STRATUM_PORT,
+        "stratum_sv1_port": SV1_STRATUM_PORT,
         "http_port": 8080
     }))
 }
@@ -5862,8 +5866,12 @@ async fn api_config_full_handler(State(state): State<Arc<VerificationState>>) ->
         "block_priority": block_priority_key(&state),
         "template_refresh_secs": state.template_refresh_secs(),
         "network": state.network.as_str(),
-        "stratum_sv2_port": 4444,
-        "stratum_sv1_port": 3333,
+        // 4444 was hard-coded here and is NOT the SV2 port — it is the SV1 farm/rental tier
+        // (#410). The real SV2 listener is SV2_STRATUM_PORT (34255), which the rest of this
+        // file already reports correctly. Advertising 4444 as SV2 sent anyone reading the API
+        // to a port speaking the wrong protocol.
+        "stratum_sv2_port": SV2_STRATUM_PORT,
+        "stratum_sv1_port": SV1_STRATUM_PORT,
         "http_port": 8080,
         "node_id": health.node_id,
         "version": health.version

--- a/ghost-web/docs/ghost-pool.md
+++ b/ghost-web/docs/ghost-pool.md
@@ -75,11 +75,12 @@ The username format is: `address.workername`
 
 | Protocol | Port | Status |
 | --- | --- | --- |
-| Stratum V1 | 3333 | Supported |
+| Stratum V1 — hobby | 3333 | Supported |
+| Stratum V1 — farm/rental | 4444 | Supported (public mining nodes) |
 | Stratum V2 | 34255 | Supported |
 
 :::warning Firewall Configuration
-If running public mining, ensure port 3333 is open in your firewall. For private mining (only your own hardware), keep it closed.
+If running public mining, ensure ports 3333 and 4444 are open in your firewall. For private mining (only your own hardware), keep them closed. `reconcile-mining-firewall.sh` does this automatically from `mining_mode`, so a hand edit is only needed if you manage the firewall yourself.
 :::
 
 ## Share System

--- a/ghost-web/docs/load-balancer.md
+++ b/ghost-web/docs/load-balancer.md
@@ -131,9 +131,21 @@ Total time from "peer goes down" to "load balancer stops routing to it": worst c
 
 | Protocol | Port | Notes |
 |---|---|---|
-| Stratum V1 | 3333 | SV1 miners. Translator runs SV1↔SV2 bridge here |
+| Stratum V1 — hobby | 3333 | SV1 miners. Translator runs the SV1↔SV2 bridge here. Starting difficulty ~2,328 (1 TH/s floor) |
+| Stratum V1 — farm/rental | 4444 | SV1, same bridge, higher floor: ~232,827 (100 TH/s). Public mining nodes only |
 | Stratum V2 (native) | 34255 | Modern SV2 miners. Direct to pool_sv2 |
-| Stratum V2 (alt) | 4444 | Alternative SV2 port (some firewalls block 34255) |
+
+**4444 is Stratum V1, not an alternate SV2 port.** It was previously documented as
+"Alternative SV2 port (some firewalls block 34255)", which was wrong: there is one SV2
+listener and it is 34255 (`SV2_STRATUM_PORT`). 4444 is the farm/rental tier added in #410 —
+the same SV1 protocol as 3333, differing only in starting difficulty. Pointing an SV2 miner
+at it will not work.
+
+Which SV1 port to use is about miner size, not capability. One difficulty cannot serve both
+a 500 GH/s bitaxe and a 1 PH/s rented order: sized for the bitaxe, a large order floods the
+pool while vardiff ramps; sized for the order, a bitaxe finds a share every few minutes and
+looks dead. Payout is unaffected either way — it is proportional to work, and a share's work
+IS its difficulty, so the same hashrate earns the same on either port.
 
 Miners can connect via:
 

--- a/scripts/check-stratum-config-agreement.sh
+++ b/scripts/check-stratum-config-agreement.sh
@@ -62,18 +62,82 @@ INVARIANTS = {
     "aggregate_channels": inv_aggregate,
 }
 
+# The farm tier (#410) repeats `min_individual_miner_hashrate` with a deliberately different
+# value, so a naive first-match comparison pairs the hobby floor in one file against the farm
+# floor in the other and reports a disagreement that is not one. Keys are therefore collected
+# per section, and the two tiers are compared separately.
+#
+# A TOML section header, but not bash `[[ -n "$x" ]]` — the installer is a shell script and is
+# full of those. Anchored and closed to the end of the line, which `[[ -n ... ]]` never is.
+SECTION_RE = re.compile(r"^\s*\[\[?[a-z0-9_.]+\]\]?\s*$")
+
+# `install-node.sh` builds the farm block as a shell assignment, so its header is not on a
+# line of its own.
+FARM_OPENS_RE = re.compile(r"\[farm_tier\]")
+
+FARM_SHARED = [
+    "port",
+    "min_individual_miner_hashrate",
+    "hobby_max_individual_miner_hashrate",
+]
+
 def values(path):
-    out = {}
+    """Return (hobby_keys, farm_keys). Farm-tier keys are kept out of the hobby set."""
+    out, farm = {}, {}
+    in_farm = False
     with open(path) as fh:
         for line in fh:
+            if FARM_OPENS_RE.search(line):
+                in_farm = True
+                continue
+            # The block ends at the next TOML section in the reference file, and at the end of
+            # the shell assignment (`fi`, or a blank line) in the installer.
+            if in_farm and (SECTION_RE.match(line) or re.match(r"^\s*(fi)?\s*$", line)):
+                in_farm = False
             m = re.match(r"^\s*([a-z0-9_]+)\s*=\s*(.+?)\s*$", line)
-            if m and m.group(1) in SHARED:
-                out.setdefault(m.group(1), m.group(2))
-    return out
+            if not m:
+                continue
+            key, val = m.group(1), m.group(2)
+            # Strip a trailing TOML comment so `100.0  # ~232,827` compares as `100.0`, and the
+            # closing quote of the installer's shell assignment so the last key of the block
+            # is not `50_000_000_000_000.0"`.
+            val = re.sub(r"\s+#.*$", "", val).rstrip('"')
+            if in_farm:
+                if key in FARM_SHARED:
+                    farm.setdefault(key, val)
+            elif key in SHARED:
+                out.setdefault(key, val)
+    return out, farm
 
-a, b = values(INSTALLER), values(REFERENCE)
+(a, a_farm), (b, b_farm) = values(INSTALLER), values(REFERENCE)
 
 problems = []
+
+# The farm tier is emitted only for public_pool, but both files must describe the SAME tier.
+# A mismatch here means a node listens on one port while the firewall opens another, or
+# starts farm miners at a floor the reference says is something else.
+for k in FARM_SHARED:
+    va, vb = a_farm.get(k), b_farm.get(k)
+    if va is None or vb is None:
+        missing = INSTALLER if va is None else REFERENCE
+        problems.append(f"[farm_tier] {k}: not found in {missing} — cannot verify agreement")
+        continue
+    if va != vb:
+        problems.append(f"[farm_tier] {k}: {INSTALLER} = {va!r} but {REFERENCE} = {vb!r}")
+
+# The farm floor must sit above the hobby floor, or the tiers are inverted and a large miner
+# routed to 4444 gets an EASIER target than one left on 3333.
+try:
+    hobby = float(b.get("min_individual_miner_hashrate", "nan").replace("_", ""))
+    farm = float(b_farm.get("min_individual_miner_hashrate", "nan").replace("_", ""))
+    if farm <= hobby:
+        problems.append(
+            f"[farm_tier] min_individual_miner_hashrate ({farm:g}) must exceed the hobby "
+            f"floor ({hobby:g}) — otherwise the tiers are inverted"
+        )
+except ValueError:
+    pass
+
 for k in SHARED:
     va, vb = a.get(k), b.get(k)
     # A key we cannot find in both files is not "in agreement" — it is unchecked, and

--- a/scripts/install-node.sh
+++ b/scripts/install-node.sh
@@ -879,6 +879,18 @@ SV2_AUTH_PUB="$(sed -n 's/^authority_public_key *= *"\(.*\)"$/\1/p' <<<"$SV2_KEY
 SV2_AUTH_SEC="$(sed -n 's/^authority_secret_key *= *"\(.*\)"$/\1/p' <<<"$SV2_KEYPAIR")"
 [[ -n "$SV2_AUTH_PUB" && -n "$SV2_AUTH_SEC" ]] || err "Could not parse the generated SV2 authority keypair."
 
+# Farm/rental tier (#410). Emitted ONLY for public_pool: a private or solo node has a
+# known set of miners and no rented hashrate to serve, so a second public listener is
+# surface it does not need. `reconcile-mining-firewall.sh` opens 4444 on the same
+# condition, so the port and the listener can never disagree.
+FARM_TIER_BLOCK=""
+if [[ "$MINING_MODE" == "public_pool" ]]; then
+  FARM_TIER_BLOCK="[farm_tier]
+port = 4444
+min_individual_miner_hashrate = 100_000_000_000_000.0  # ~232,827 starting difficulty
+hobby_max_individual_miner_hashrate = 50_000_000_000_000.0"
+fi
+
 # translator_sv2 — accepts SV1 miners on :3333 and forwards SV2 to the local pool.
 # user_identity is this node's own payout address (public, not a secret): it is
 # the default miner-username prefix, and each SV1 miner may still authorise as
@@ -979,10 +991,10 @@ authority_pubkey = "${SV2_AUTH_PUB}"
 # taking anything from anyone — it just costs this node ~20x the share
 # validation, bandwidth and database writes.
 #
-# [farm_tier]
-# port = 4444
-# min_individual_miner_hashrate = 100_000_000_000_000.0  # ~232,827 starting difficulty
-# hobby_max_individual_miner_hashrate = 50_000_000_000_000.0
+# Enabled by default on public mining nodes (operator decision, 2026-07-27); the block
+# below is emitted only for mining_mode = "public_pool". Private and solo nodes get no
+# farm listener and no 4444 firewall rule.
+${FARM_TIER_BLOCK}
 
 [load_balancer]
 ghost_pool_url = "127.0.0.1:8080"
@@ -1319,6 +1331,26 @@ if [[ "$accept_miners" == "yes" ]]; then
 else
   for p in "${PORTS[@]}"; do ufw delete allow "${p}/tcp" >/dev/null 2>&1 || true; done
   logger -t ghost-mining-firewall "external miners OFF (private_solo) -> Stratum 3333+34255 CLOSED"
+fi
+
+# Farm/rental tier (#410) listens on 4444 and is enabled ONLY for public_pool — a private
+# or solo node has a known miner set and no rented hashrate to serve. This deliberately uses
+# a narrower condition than the Stratum ports above, which also open for private_pool.
+#
+# It must track `install-node.sh`, which emits the [farm_tier] block on the same condition.
+# If these two ever disagree the node either advertises a port nothing listens on, or listens
+# on a port nothing can reach — the second is what the config comment warns about.
+farm_tier="no"
+if [[ -r "$CONF" ]] \
+ && grep -qE '^[[:space:]]*mining_mode[[:space:]]*=[[:space:]]*"?public_pool"?' "$CONF" 2>/dev/null; then
+  farm_tier="yes"
+fi
+if [[ "$farm_tier" == "yes" ]]; then
+  ufw allow 4444/tcp >/dev/null 2>&1 || true
+  logger -t ghost-mining-firewall "farm tier ON (public_pool) -> Stratum 4444 OPEN"
+else
+  ufw delete allow 4444/tcp >/dev/null 2>&1 || true
+  logger -t ghost-mining-firewall "farm tier OFF -> Stratum 4444 CLOSED"
 fi
 
 # Wraith coordinator listen port (9100) follows [coordinator]

--- a/scripts/reconcile-mining-firewall.sh
+++ b/scripts/reconcile-mining-firewall.sh
@@ -28,6 +28,26 @@ else
   logger -t ghost-mining-firewall "external miners OFF (private_solo) -> Stratum 3333+34255 CLOSED"
 fi
 
+# Farm/rental tier (#410) listens on 4444 and is enabled ONLY for public_pool — a private
+# or solo node has a known miner set and no rented hashrate to serve. This deliberately uses
+# a narrower condition than the Stratum ports above, which also open for private_pool.
+#
+# It must track `install-node.sh`, which emits the [farm_tier] block on the same condition.
+# If these two ever disagree the node either advertises a port nothing listens on, or listens
+# on a port nothing can reach — the second is what the config comment warns about.
+farm_tier="no"
+if [[ -r "$CONF" ]] \
+ && grep -qE '^[[:space:]]*mining_mode[[:space:]]*=[[:space:]]*"?public_pool"?' "$CONF" 2>/dev/null; then
+  farm_tier="yes"
+fi
+if [[ "$farm_tier" == "yes" ]]; then
+  ufw allow 4444/tcp >/dev/null 2>&1 || true
+  logger -t ghost-mining-firewall "farm tier ON (public_pool) -> Stratum 4444 OPEN"
+else
+  ufw delete allow 4444/tcp >/dev/null 2>&1 || true
+  logger -t ghost-mining-firewall "farm tier OFF -> Stratum 4444 CLOSED"
+fi
+
 # Wraith coordinator listen port (9100) follows [coordinator]
 # coordinator_role_enabled, exactly as the Stratum ports follow public mining.
 coord="no"


### PR DESCRIPTION
Closes #410. **Stacked on #490** — it touches `reconcile-mining-firewall.sh`, whose two copies were implementing different rules. Review that one first; this diff will shrink once it merges.

## Why this was still open

The listener has existed since #471. But `[farm_tier]` was commented out in **every** shipped config, so no node ever opened 4444. #410's acceptance is "both ports live with distinct defaults" — a listener that nothing enables does not meet it.

Enabled for `mining_mode = "public_pool"` only, per the operator decision of 2026-07-27. A private or solo node has a known miner set and no rented hashrate to serve, so a second public listener is surface it does not need.

`install-node.sh` emits the block on that condition and `reconcile-mining-firewall.sh` opens 4444 on the same one, so the port and the listener cannot disagree. The config's own comment warns that "a port that is advertised but unreachable is worse than no port" — the reverse is just as bad, and tying both to one condition is what prevents either.

## A port collision, corrected

`stratum_sv2_port` was hard-coded to `4444` in two API handlers, and `load-balancer.md` described 4444 as "Alternative SV2 port (some firewalls block 34255)".

Both wrong. There is one SV2 listener and it is **34255** (`SV2_STRATUM_PORT` — already imported and used correctly elsewhere in the same file). 4444 is **SV1**. Anyone who believed the API and pointed an SV2 miner at it reached a port speaking a different protocol.

## Docs

Updated where the ports are actually listed: `README.md`, `config/README.md`, `ghost-web/docs/ghost-pool.md`, `ghost-web/docs/load-balancer.md`. The last now states plainly that 4444 is SV1, not an alternate SV2 port, since that claim is what caused the confusion.

## Two new guards

"It exists in code" was precisely the failure mode here, so both guards target the gap between code and shipped config:

**`check-stratum-config-agreement.sh`** now treats the farm tier as its own section and asserts the farm floor **exceeds** the hobby floor — otherwise the tiers are inverted and a large miner routed to 4444 gets an *easier* target than one left on 3333.

Adding `[farm_tier]` initially broke this check, which was the useful part: it repeats `min_individual_miner_hashrate`, and the naive first-match comparison paired the hobby floor in one file against the farm floor in the other. Both new checks were confirmed to refuse on a deliberate edit:

```
[farm_tier] port: install-node.sh = '4444' but translator-config.toml = '5555'
[farm_tier] min_individual_miner_hashrate (5e+11) must exceed the hobby floor (1e+12)
```

**`shipped_config_enables_the_farm_tier`** reads the actual `config/sri/translator-config.toml` and asserts `[farm_tier]` is present on 4444 above the hobby floor. The existing `farm_tier_defaults_to_absent` covers the Rust default — which is still `None`, correctly — and by construction could never have caught a config that was commented out.

## Gates

- `cargo test -p translator_sv2 --lib` — 42 passed
- `cargo test -p ghost-verification --lib` — 233 passed
- `check-inlined-copies.sh` — 4 pairs match
- `check-stratum-config-agreement.sh` — 8/8 agree, invariants hold
- `bash -n` clean on both changed scripts

## Follow-up

#472 becomes load-bearing now rather than optional: the load balancer's proxy target is hard-coded to `{peer}:3333`, so with the tier live fleet-wide the busiest node still cannot shed a farm miner — it serves locally or rejects. Next in the batch.