### PR TITLE
fix(api): make the live event socket loopback-only; stop publishing miner_id on it

### DIFF
--- a/crates/ghost-verification/src/routes.rs
+++ b/crates/ghost-verification/src/routes.rs
@@ -166,14 +166,10 @@ pub fn create_router(state: Arc<VerificationState>) -> Router {
 
     // Public routes (no authentication required)
     let public_router = Router::new()
-        // WebSocket for real-time updates (AUTH4-M3: supports optional authentication)
-        .route(
-            "/ws",
-            get(move |ws: WebSocketUpgrade, auth: Query<WsAuthQuery>| {
-                let ws_state = Arc::clone(&ws_state);
-                async move { ws_handler(ws, auth, State(ws_state)).await }
-            }),
-        )
+        // `/ws` used to be here. It is now in `localhost_router`: production wires
+        // `WsState::new()`, i.e. `require_auth: false`, so the socket was reachable from
+        // anywhere that could reach :8080 — which on a default install is the internet.
+        //
         // Health and node info
         .route("/health", get(health_handler))
         .route("/node-info", get(node_info_handler))
@@ -457,6 +453,18 @@ pub fn create_router(state: Arc<VerificationState>) -> Router {
     // SRI Pool runs on localhost and doesn't support HMAC auth headers.
     // These are protected by a localhost-only middleware instead.
     let localhost_router = Router::new()
+        // Live event stream. Loopback only: the dashboard reaches it through its own
+        // authenticated `/api/ws` relay, which dials `127.0.0.1:8080` server-side (see
+        // `dashboard/server.js` — `NEXT_PUBLIC_API_URL` defaults to loopback), so nothing
+        // legitimate connects to this from off-box. No mesh peer uses it either; the
+        // peer-to-peer surface is `/health`, `/verify/*` and `/api/v1/mpc/*`.
+        .route(
+            "/ws",
+            get(move |ws: WebSocketUpgrade, auth: Query<WsAuthQuery>| {
+                let ws_state = Arc::clone(&ws_state);
+                async move { ws_handler(ws, auth, State(ws_state)).await }
+            }),
+        )
         .route("/api/internal/share", post(share_notification_handler))
         .route("/api/internal/shares", post(share_batch_handler))
         .route("/api/internal/pool-nodes", get(pool_nodes_handler))
@@ -13578,6 +13586,38 @@ mod tests {
                 endpoint
             );
         }
+    }
+
+    /// The live event socket must not be reachable from off-box.
+    ///
+    /// Production wires `WsState::new()`, i.e. `require_auth: false`, so anything that could
+    /// reach :8080 could subscribe — and on a default install `ufw allow 8080/tcp` makes that
+    /// the internet. It is now in the loopback-only tier, where the dashboard's authenticated
+    /// `/api/ws` relay still reaches it because that relay dials 127.0.0.1 server-side.
+    ///
+    /// A request with no `ConnectInfo` (which is what `oneshot` produces) is treated as
+    /// non-loopback and refused, so a 403 here is the gate working.
+    #[tokio::test]
+    async fn ws_is_not_reachable_from_off_box() {
+        let state = create_test_state_with_auth();
+        let app = super::create_router(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/ws")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response.status(),
+            StatusCode::FORBIDDEN,
+            "/ws must be loopback-only — it streams live node events with no authentication"
+        );
     }
 
     /// Read endpoints carrying payout identities must not be readable unauthenticated.

--- a/crates/ghost-verification/src/websocket.rs
+++ b/crates/ghost-verification/src/websocket.rs
@@ -135,11 +135,20 @@ impl WsEvent {
     ///
     /// Public events are safe to broadcast to anyone (no sensitive info).
     /// Sensitive events (shares, votes, wraith, peer details) require auth.
+    /// Events an UNAUTHENTICATED subscriber may receive.
+    ///
+    /// `BlockFound` was on this list and is not any more: it carries `miner_id`, the exact
+    /// value `redact_miner_id` and the M-11/M-13 work exist to keep off public responses.
+    /// Publishing it on a socket while redacting it on every REST route would have undone
+    /// that the first time a block was found.
+    ///
+    /// It was latent rather than live — nothing constructs `BlockFound` outside tests today,
+    /// so no such event has ever been broadcast. That is a property of current callers, not
+    /// of the allowlist, and it is the wrong thing to rely on.
     pub fn is_public(&self) -> bool {
         matches!(
             self,
             WsEvent::HealthUpdate { .. }
-                | WsEvent::BlockFound { .. }
                 | WsEvent::RoundStarted { .. }
                 | WsEvent::RoundEnded { .. }
                 | WsEvent::Error { .. }
@@ -895,12 +904,18 @@ mod tests {
             uptime_secs: 1,
         }
         .is_public());
-        assert!(WsEvent::BlockFound {
-            height: 1,
-            hash: "".to_string(),
-            miner_id: "".to_string(),
-        }
-        .is_public());
+        // BlockFound is NOT public: it carries `miner_id`. This assertion was the other way
+        // round, which is how the leak survived — the allowlist and its test agreed with each
+        // other and disagreed with `redact_miner_id` everywhere else.
+        assert!(
+            !WsEvent::BlockFound {
+                height: 1,
+                hash: "".to_string(),
+                miner_id: "".to_string(),
+            }
+            .is_public(),
+            "BlockFound carries miner_id and must not reach an unauthenticated subscriber"
+        );
         assert!(WsEvent::RoundStarted {
             round_id: 1,
             height: 1


### PR DESCRIPTION
Two problems on the same socket. Follows #484, which moved the payout-identity REST routes off the public tier — this is the streaming half of the same surface.

## 1. `/ws` was reachable from anywhere

It sat in the public router, and production wires `WsState::new()` — i.e. `require_auth: false`. So anything able to reach `:8080` could subscribe to the node's live event stream, and `install-node.sh` runs `ufw allow 8080/tcp` while the node binds `0.0.0.0`.

Moved to the loopback-only tier. **Nothing legitimate is affected:**

| consumer | reaches `/ws` how | affected? |
|---|---|---|
| Dashboard | its own authenticated `/api/ws` relay, which dials `127.0.0.1:8080` server-side (`dashboard/server.js`, `NEXT_PUBLIC_API_URL` defaults to loopback) | no |
| Mesh peers | don't use it — peer surface is `/health`, `/verify/*`, `/api/internal/share`, `/api/v1/mpc/*` | no |
| Public site | doesn't use it | no |

The gate is `localhost_only_middleware`, which reads the real socket address via `ConnectInfo` and is not header-spoofable.

## 2. `BlockFound` was on the unauthenticated allowlist

```rust
BlockFound { height: u64, hash: String, miner_id: String }
```

It carries **`miner_id`** — the exact value `redact_miner_id` and the M-11/M-13 work exist to keep out of public responses. Publishing it on a socket while redacting it on every REST route would have undone that the first time a block was found.

**Latent, not live:** nothing constructs `BlockFound` outside tests today, so no such event has ever been broadcast. But that is a property of the current callers, not of the allowlist — the allowlist is what will still be there when someone wires it up.

The existing test asserted `BlockFound.is_public()` was **true**, which is how this survived: the allowlist and its own test agreed with each other and disagreed with every REST handler in the codebase. Now inverted, with the reason recorded next to it.

## Tests

- `ws_is_not_reachable_from_off_box` — `/ws` is refused without a loopback peer address
- `test_event_is_public` — inverted for `BlockFound`, with a message naming why
- `cargo test -p ghost-verification --lib` — **234 passed, 0 failed**

## Not touched

The ten pre-existing clippy warnings in `routes.rs`. None are in the lines changed here, and clearing them would bury a security fix in unrelated churn — they belong with #401.