### PR TITLE
fix(ops): wait for the service to be SERVING before smoke-testing it

### DIFF
--- a/scripts/deploy-node.sh
+++ b/scripts/deploy-node.sh
@@ -214,19 +214,67 @@ case "$BINARY" in
 esac
 
 timeout "$REMOTE_TIMEOUT" ssh "${SSH_OPTS[@]}" "$NODE" "S=$SUDO; \$S systemctl restart $SERVICE" || exit 2
-sleep 20
+
+# Wait for the service to be SERVING, not merely started.
+#
+# This was `sleep 20`, and 20s is not enough for pool_sv2: it does not bind :34255 until it
+# has completed a Noise handshake with the template provider on :8442, which takes ~60s.
+# systemd reports the unit active almost immediately, and its monitoring port :9090 comes up
+# early too, so neither is a readiness signal.
+#
+# The cost of getting this wrong is not a slow deploy, it is a WRONG VERDICT: the smoke test
+# ran against a pool that was not serving yet, failed, and rolled back a binary that was in
+# fact fine — leaving the node half-rolled, which this script's own header calls out as
+# indistinguishable from a genuinely broken binary. Measured on ghost-vm5: rolled back, then
+# the identical build passed all 11 smoke cases once given time.
+#
+# So wait on the port the service is supposed to answer on.
+case "$BINARY" in
+  ghost-pool)      READY_PORT=8442 ;;   # TDP, what pool_sv2 connects to
+  pool_sv2)        READY_PORT=34255 ;;  # SV2, what the translator connects to
+  translator_sv2)  READY_PORT=3333 ;;   # SV1, what miners connect to
+esac
+
+READY_TIMEOUT="${READY_TIMEOUT:-180}"
+echo "  waiting for $SERVICE to listen on :$READY_PORT (up to ${READY_TIMEOUT}s)"
+READY=no
+for _ in $(seq 1 "$READY_TIMEOUT"); do
+    if timeout 10 ssh "${SSH_OPTS[@]}" "$NODE" \
+         "ss -ltn 2>/dev/null | grep -q ':${READY_PORT}'" 2>/dev/null; then
+        READY=yes
+        break
+    fi
+    sleep 1
+done
 
 # ---------------------------------------------------------------- verify
 
 ACTIVE=$(timeout "$REMOTE_TIMEOUT" ssh "${SSH_OPTS[@]}" "$NODE" "systemctl is-active $SERVICE" || echo failed)
 [ "$ACTIVE" = "active" ] || { echo "SERVICE NOT ACTIVE — rolling back" >&2; ROLLBACK=1; }
 
+if [ -z "${ROLLBACK:-}" ] && [ "$READY" != "yes" ]; then
+    echo "SERVICE NEVER LISTENED ON :$READY_PORT after ${READY_TIMEOUT}s — rolling back" >&2
+    ROLLBACK=1
+fi
+
 # Smoke test the stratum path for anything that serves miners. A green service that
 # cannot complete a handshake is not a successful deploy.
 if [ -z "${ROLLBACK:-}" ] && [ "$BINARY" != "ghost-pool" ]; then
     IP=$(timeout "$REMOTE_TIMEOUT" ssh "${SSH_OPTS[@]}" "$NODE" "hostname -I | awk '{print \$1}'")
-    if ! python3 "$REPO_ROOT/bins/translator-sv2/tests/sv1_handshake_smoke.py" "$IP" 3333 >/dev/null 2>&1; then
-        echo "SMOKE TEST FAILED — rolling back" >&2
+    # Retry rather than judge on one attempt. A listening port means the process is accepting,
+    # not that the whole SV1 -> SV2 -> TDP chain has settled — the translator can be listening
+    # while its upstream handshake is still in progress. One failed attempt used to roll back a
+    # working binary and leave the node half-rolled.
+    SMOKE_OK=no
+    for attempt in 1 2 3; do
+        if python3 "$REPO_ROOT/bins/translator-sv2/tests/sv1_handshake_smoke.py" "$IP" 3333 >/dev/null 2>&1; then
+            SMOKE_OK=yes
+            break
+        fi
+        [ "$attempt" -lt 3 ] && { echo "  smoke attempt $attempt failed, retrying in 20s"; sleep 20; }
+    done
+    if [ "$SMOKE_OK" != "yes" ]; then
+        echo "SMOKE TEST FAILED after 3 attempts — rolling back" >&2
         ROLLBACK=1
     fi
 fi


### PR DESCRIPTION
`deploy-node.sh` restarted the service, slept **20 seconds**, then smoke-tested.

Twenty seconds is not enough for `pool_sv2`. It does not bind `:34255` until it has completed a Noise handshake with the template provider on `:8442`, which takes around **60 seconds**. systemd reports the unit `active` almost immediately, and its monitoring port `:9090` comes up early too — so neither is a readiness signal.

## This produced a wrong verdict, not just a slow one

Hit today on `ghost-vm5`:

```
--- pool_sv2 ---
  deploying pool_sv2 @ 1ac87f819 to ghost-vm5
SMOKE TEST FAILED — rolling back
```

The identical build then passed **all 11 smoke cases** once given time:

```
[serializer] PASS  [probe-en2-size] PASS  [probe-no-auth] PASS  [default-diff] PASS
[pw-difficulty] PASS  [suggest-diff] PASS  [attribution] PASS  [pipeliner] PASS
[bare-username] PASS  [version-rolling] PASS
RESULT: ALL PASS
```

So a good binary was rolled back — **and** the node was left half-rolled (new `ghost-pool`, old `pool_sv2`), which this script's own header calls out as indistinguishable from a genuinely broken binary. The failure mode wasn't merely a false negative; it manufactured the exact ambiguous state the header warns about.

## Changes

**Wait for the port the service must answer on**, instead of a fixed sleep:

| binary | readiness port | why |
|---|---|---|
| `ghost-pool` | 8442 | TDP — what `pool_sv2` connects to |
| `pool_sv2` | 34255 | SV2 — what the translator connects to |
| `translator_sv2` | 3333 | SV1 — what miners connect to |

Bounded by `READY_TIMEOUT` (default 180s). Never listening is now itself a rollback reason — something the old code could not detect at all, since it only checked `is-active`.

**Retry the smoke test three times.** A listening port means the process is accepting connections, not that the whole SV1 → SV2 → TDP chain has settled.

## Same root cause seen twice today

The identical ~60s ordering was hit independently during the SV2 authority-key rotation, where `sri-translator` raced `pool_sv2` and only recovered via systemd auto-restart. Two callers, one cause — worth fixing centrally rather than in each.

## Verified

`scripts/test-deploy-gate.sh` — **all 5 checks pass**, so the guard that refuses untested, unsoaked, wrong-binary and short-soak deploys is intact.