### PR TITLE
fix(ops): raise maxconnections from 50 to 125 so nodes stop refusing peers

### DIFF
--- a/scripts/install-node.sh
+++ b/scripts/install-node.sh
@@ -642,7 +642,18 @@ zmqpubhashblock=tcp://127.0.0.1:28332
 zmqpubhashtx=tcp://127.0.0.1:28333
 zmqpubsequence=tcp://127.0.0.1:28334
 dbcache=1024
-maxconnections=50
+# Core's default is 125. This was 50, which sounds merely conservative but is not: Core
+# reserves the outbound slots, so 50 leaves roughly 40 inbound, and a settled node sits at
+# ~39 of them. The node is then FULL, and a full node REFUSES new peers — including
+# crawlers, which then record it as unreachable and drop it from public listings. The fleet
+# vanished from node directories for exactly this reason while every node was healthy,
+# listening on 0.0.0.0:8333 and externally reachable.
+#
+# It also means the node contributes far less relay capacity than the hardware allows.
+#
+# Raise this only with the box's memory in mind. ghost-pool already holds a large working
+# set on the smaller nodes (#417/#418), and connections are not free.
+maxconnections=125
 fallbackfee=0.00001
 assumevalid=${ASSUMEVALID}
 EOF


### PR DESCRIPTION
Closes #497. Already applied to vm1-vm4; this stops a reinstall silently reverting it.

## What was actually wrong

Core's default is 125. `maxconnections=50` sounds merely conservative — it isn't. Core reserves the outbound slots, so 50 leaves roughly **40 inbound**, and a settled node sits at about **39** of them.

A full node **refuses new peers**. Including crawlers, which then record it unreachable and drop it from public listings.

All eight nodes reported, identically:

```
subversion:/Ghost:1.10.22/  connections:49  connections_in:39
```

while being completely healthy — `ghostd` active, bound `0.0.0.0:8333`, **externally reachable on a direct TCP connect from off-network**, `networkactive: true`, `reachable: true`, not `limited`. One contested inbound slot each, so whether a crawler got in was luck. Public directories showed 3 of 8, then none.

Nothing was broken. The nodes simply had no room to accept anyone.

The more interesting cost is that the fleet was contributing far less relay capacity to the network than the hardware allows.

## Rollout already done on vm1-vm4

`maxconnections` cannot change at runtime, so this needs a `ghostd` restart — which also drops the TDP template feed `pool_sv2` depends on. So: one node at a time, genesis last, verifying RPC, `:8442` and both SRI services between each.

| node | after |
|---|---|
| vm1 (genesis) | 34 conns / 24 in |
| vm2 | 35 / 25 |
| vm3 | 40 / 29 |
| vm4 | 43 / 33 |

Mesh quorum held throughout — 8 elders, consensus active, `mesh_active_miners` unaffected.

## vm5-vm8 deliberately left at 50

vm6 has the least free memory in the fleet (1376 MB available, ghostd RSS 1441 MB) and is one of the nodes in #417/#418, where ghost-pool is OOM-killed hourly. Connections are not free, so those should wait until that work lands.

The comment in the config records this, so the next person raising it knows to check memory first rather than copying the number.