### PR TITLE
fix(ops): declare REMOTE_TIMEOUT before the soak check that uses it

### DIFF
--- a/scripts/deploy-node.sh
+++ b/scripts/deploy-node.sh
@@ -45,6 +45,16 @@ CANARY="${3:-}"
 CANARY_NODES="ghost-vm5 ghost-vm6 ghost-vm7 ghost-vm8"
 PRODUCTION_NODES="ghost-vm1 ghost-vm2 ghost-vm3 ghost-vm4"
 SOAK_MINUTES="${SOAK_MINUTES:-60}"
+
+# Declared HERE, not further down: the soak-verification block below reaches for both to
+# ssh a canary and confirm it still runs the binary it soaked. They used to be defined
+# after that block, so a production deploy died with
+#   deploy-node.sh: line 135: REMOTE_TIMEOUT: unbound variable
+# the moment a soak record carried a recorded hash. Canary deploys skip the block, so it
+# only ever failed on the production path — the one that matters.
+SSH_OPTS=(-o ConnectTimeout=10 -o ServerAliveInterval=10 -o ServerAliveCountMax=3 -o BatchMode=yes)
+XFER_TIMEOUT="${XFER_TIMEOUT:-300}"
+REMOTE_TIMEOUT="${REMOTE_TIMEOUT:-120}"
 # Overridable alongside STATE_DIR so scripts/test-deploy-gate.sh can drive the gate against a
 # clean throwaway checkout while running THIS copy of the script. A guard nobody can drive is a
 # guard nobody has checked, which is how #459 went unnoticed.
@@ -162,9 +172,6 @@ info "deploying $BINARY @ $SHORT to $NODE"
 # leaving the node with a new ghost-pool against an old pool_sv2 and nothing saying so.
 #
 # ServerAliveInterval makes a dead peer detectable; the hard `timeout` bounds the rest.
-SSH_OPTS=(-o ConnectTimeout=10 -o ServerAliveInterval=10 -o ServerAliveCountMax=3 -o BatchMode=yes)
-XFER_TIMEOUT="${XFER_TIMEOUT:-300}"
-REMOTE_TIMEOUT="${REMOTE_TIMEOUT:-120}"
 
 LOCAL_SHA="$(sha256sum "$BIN_PATH" | cut -d' ' -f1)"
 LOCAL_SIZE="$(stat -c%s "$BIN_PATH")"


### PR DESCRIPTION
A production deploy died on the first command:

```
./scripts/deploy-node.sh: line 135: REMOTE_TIMEOUT: unbound variable
```

`REMOTE_TIMEOUT` and `SSH_OPTS` were declared at lines 165-167, but the soak-verification block at line 133 already uses both — it sshes the canary to confirm it still runs the binary it soaked.

## Why it stayed hidden

Two conditions had to line up:

1. **Canary deploys skip that block entirely.** Only the production path reaches it — so every canary today passed while production was broken.
2. **The ssh only runs when a soak record carries a recorded hash.** That is the newer record format from #459/#473; older records had no hash, so the branch was skipped.

So the first production deploy following a fresh canary soak was always going to be the one to find it. That is tonight.

`SSH_OPTS` escaped notice because bash tolerates `"${arr[@]}"` on an unset array under `set -u` — only the scalar aborts. Both are moved together anyway; leaving one behind would be relying on that quirk.

## Fix

Moved the three declarations above first use, rather than adding a default at the use site. One declaration, and the ordering constraint is documented where someone editing it will actually see it.

## Verified

`scripts/test-deploy-gate.sh` — all 5 checks pass, so the untested / unsoaked / wrong-binary / short-soak guards are intact.