### PR TITLE
chore(clippy): clamp, sort_by_key and iterator loops in the non-consensus crates

### DIFF
--- a/apps/ghost-tap/core/src/l2/note_store.rs
+++ b/apps/ghost-tap/core/src/l2/note_store.rs
@@ -153,7 +153,7 @@ impl NoteStore {
 
         // Greedy selection: largest notes first, up to 4
         let mut unspent: Vec<&OwnedNote> = self.notes.values().filter(|n| !n.spent).collect();
-        unspent.sort_by(|a, b| b.value.cmp(&a.value));
+        unspent.sort_by_key(|n| std::cmp::Reverse(n.value));
 
         let mut selected_indices = Vec::new();
         let mut running_total = 0u64;

--- a/apps/ghost-tap/core/src/transaction/builder.rs
+++ b/apps/ghost-tap/core/src/transaction/builder.rs
@@ -267,7 +267,7 @@ pub fn select_utxos(utxos: &[Utxo], target: u64) -> Result<Vec<Utxo>, Transactio
 
     // 3. Largest-first fallback (should be unreachable given the total check
     //    above, but included for completeness).
-    confirmed.sort_by(|a, b| b.amount.cmp(&a.amount));
+    confirmed.sort_by_key(|u| std::cmp::Reverse(u.amount));
     let mut selected = Vec::new();
     let mut total = 0u64;
     for utxo in confirmed {

--- a/apps/ghost-tap/core/src/wallet/balance.rs
+++ b/apps/ghost-tap/core/src/wallet/balance.rs
@@ -149,7 +149,7 @@ impl UtxoSet {
             })
             .collect();
 
-        sorted.sort_by(|a, b| b.amount.cmp(&a.amount));
+        sorted.sort_by_key(|e| std::cmp::Reverse(e.amount));
 
         let mut selected = Vec::new();
         let mut total = 0u64;

--- a/crates/ghost-storage/src/mpc_lineage.rs
+++ b/crates/ghost-storage/src/mpc_lineage.rs
@@ -455,8 +455,7 @@ mod tests {
             let ch = contribution_hash(&c.contributor, pos, &c.new_params_hash);
             let msg = vote_signing_message(&ch, true);
             let mut row = Vec::new();
-            for elder_idx in 0..(pos - 1) as usize {
-                let elder = &identities[elder_idx];
+            for elder in identities.iter().take((pos - 1) as usize) {
                 row.push(VoteLineageRow {
                     voter: elder.node_id(),
                     approve: true,

--- a/crates/ghost-storage/src/queries.rs
+++ b/crates/ghost-storage/src/queries.rs
@@ -11259,10 +11259,7 @@ mod tests {
     // =========================================================================
 
     fn test_glyph_pixels() -> Vec<u8> {
-        let mut pixels = vec![0u8; 256];
-        for i in 0..256 {
-            pixels[i] = (i % 26) as u8;
-        }
+        let pixels: Vec<u8> = (0..256).map(|i| (i % 26) as u8).collect();
         pixels
     }
 
@@ -11418,10 +11415,7 @@ mod tests {
         db.insert_glyph_claim("ghost1alice", &pixels1, &bh1, &cm1, 1000)
             .expect("Insert should succeed");
 
-        let mut pixels2 = vec![1u8; 256];
-        for i in 0..256 {
-            pixels2[i] = ((i + 1) % 26) as u8;
-        }
+        let pixels2: Vec<u8> = (0..256).map(|i| ((i + 1) % 26) as u8).collect();
         let bh2 = test_bitmap_hash(&pixels2);
         let cm2 = test_commitment(&pixels2, "ghost1bob");
         db.insert_glyph_claim("ghost1bob", &pixels2, &bh2, &cm2, 1001)

--- a/crates/ghost-verification/src/routes.rs
+++ b/crates/ghost-verification/src/routes.rs
@@ -2614,7 +2614,7 @@ async fn api_pool_recent_shares_handler(
         .unwrap_or_default()
         .as_secs() as i64;
 
-    let limit = params.limit.unwrap_or(500).min(2000).max(1);
+    let limit = params.limit.unwrap_or(500).clamp(1, 2000);
     // No watermark → start from a short look-back so the quasar has a
     // few particles to render immediately instead of waiting for the
     // next incoming share. 30 seconds is one emit-cycle at most rates.
@@ -3324,7 +3324,7 @@ async fn api_pool_leaderboard_handler(
         .as_deref()
         .unwrap_or("day")
         .to_ascii_lowercase();
-    let limit = params.limit.unwrap_or(10).min(50).max(1);
+    let limit = params.limit.unwrap_or(10).clamp(1, 50);
 
     // "lifetime" queries the `miners` table directly and ignores the
     // pruned shares timeline. Only the shares-contributed tab is useful

--- a/crates/wraith-protocol/src/coordinator_redundancy.rs
+++ b/crates/wraith-protocol/src/coordinator_redundancy.rs
@@ -757,7 +757,7 @@ impl CoordinatorPool {
         }
 
         // Sort by trust score (descending)
-        candidates.sort_by(|a, b| b.1.trust_score.cmp(&a.1.trust_score));
+        candidates.sort_by_key(|c| std::cmp::Reverse(c.1.trust_score));
 
         // CRIT-PANIC-2: Use .first() instead of [0] indexing
         candidates

--- a/crates/wraith-protocol/src/single_round.rs
+++ b/crates/wraith-protocol/src/single_round.rs
@@ -727,8 +727,8 @@ mod tests {
         let addrs = test_addrs();
         let mut b = mix_builder_with_addrs(&addrs);
         let p_amt = b.min_participant_input();
-        for i in 0..5 {
-            let mut p = fake_input(i as u32, p_amt, &addrs[i]);
+        for (i, addr) in addrs.iter().enumerate().take(5) {
+            let mut p = fake_input(i as u32, p_amt, addr);
             p.change_address = None; // exact amount, no surplus
             b.add_participant(p).unwrap();
         }


### PR DESCRIPTION
Third pass on #401. Ten warnings across four crates, all behaviour-preserving.

## What changed and why it's worth doing rather than allowing

**`.min(2000).max(1)` → `.clamp(1, 2000)`** — same result, but it says what it means. The two-call form is quietly fragile: `.max(2000).min(1)` also compiles and always returns `1`, and nothing in review flags it.

**Descending `sort_by(|a, b| b.x.cmp(&a.x))` → `sort_by_key(|v| Reverse(v.x))`** — the comparator direction is exactly the detail that gets misread. `Reverse` names it instead of encoding it in argument order.

**Index loops → iterators.** `for i in 0..256 { pixels[i] = … }` becomes a `map().collect()`; two `for i in 0..n { let x = &items[i]; }` loops become `iter().take(n)` and `iter().enumerate().take(n)`. Removes the per-element bounds check, and removes the possibility of the index and the slice drifting apart.

## Verified

864 tests pass across `ghost-tap-core`, `ghost-storage`, `wraith-protocol` and `ghost-verification`. `cargo fmt --all` applied, all targets compile.

## Still to come on #401

`ghost-pool` and `pool_sv2` — ~46 warnings, consensus-adjacent, being read by hand rather than tool-fixed, and deliberately last.

Two items are parked for an operator decision rather than being decided unattended: the 15 `result_large_err` warnings in `jd_client_sv2` (box the error type across a vendored-derived crate, or crate-scoped `allow` — the variant sits exactly on clippy's 128-byte threshold), and two `expect`-after-`is_some` sites in the same crate that would need a mutable-borrow reorder inside the job-declaration client.