### PR TITLE
chore(clippy): behaviour-preserving fixes in ghost-pool and pool_sv2

### DIFF
--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -11072,7 +11072,7 @@ mod tests {
         let map = parse_param_hashes(&format!("BLOCK:{}", block));
         // This is the exact key `try_fetch_params_from_seed` passes for note_spend.
         assert!(
-            map.get("BLOCK").is_some(),
+            map.contains_key("BLOCK"),
             "note_spend must resolve a pinned BLOCK hash, never None, in production"
         );
         // And a non-trivial blob with the None branch IS accepted — proving the

--- a/bins/ghost-pool/src/self_check.rs
+++ b/bins/ghost-pool/src/self_check.rs
@@ -581,20 +581,24 @@ mod tests {
 
     #[tokio::test]
     async fn ghost_pay_check_unclaimed_short_circuits() {
-        let mut cfg = NodeConfig::default();
-        cfg.ghost_pay = None;
+        let cfg = NodeConfig {
+            ghost_pay: None,
+            ..Default::default()
+        };
         let r = check_ghost_pay(&cfg).await;
         assert!(!r.claimed && !r.passed && r.reason.is_none());
     }
 
     #[tokio::test]
     async fn ghost_pay_check_failure_carries_remediation_hint() {
-        let mut cfg = NodeConfig::default();
         // ghost-pay ENABLED (claimed) but not running — the remediation scenario.
-        cfg.ghost_pay = Some(GhostPayConfig {
-            enabled: true,
+        let cfg = NodeConfig {
+            ghost_pay: Some(GhostPayConfig {
+                enabled: true,
+                ..Default::default()
+            }),
             ..Default::default()
-        });
+        };
         // 127.0.0.1:8800 almost certainly not bound in test env
         let r = check_ghost_pay(&cfg).await;
         assert!(r.claimed);

--- a/bins/ghost-pool/src/template.rs
+++ b/bins/ghost-pool/src/template.rs
@@ -4923,7 +4923,7 @@ mod tests {
 
         let mut strict = PolicyProfile::full_open();
         strict.max_tx_outputs = 5;
-        let (kept, _) = make_processor(strict).filter_transactions(&[tx.clone()]);
+        let (kept, _) = make_processor(strict).filter_transactions(std::slice::from_ref(&tx));
         assert!(
             kept.is_empty(),
             "tx exceeding max_tx_outputs must be dropped"
@@ -5038,7 +5038,7 @@ mod tests {
 
         let mut strict = PolicyProfile::full_open();
         strict.max_tx_size = 500; // vbytes; a 50-output tx is larger
-        let (kept, _) = make_processor(strict).filter_transactions(&[tx.clone()]);
+        let (kept, _) = make_processor(strict).filter_transactions(std::slice::from_ref(&tx));
         assert!(kept.is_empty(), "tx exceeding max_tx_size must be dropped");
 
         let mut loose = PolicyProfile::full_open();

--- a/bins/ghost-pool/src/template_provider.rs
+++ b/bins/ghost-pool/src/template_provider.rs
@@ -348,8 +348,8 @@ impl TemplateDistributionServer {
                     let clients = Arc::clone(&self.clients);
                     let template_processor = Arc::clone(&self.template_processor);
                     let template_id_counter = Arc::clone(&self.template_id_counter);
-                    let authority_public_key = self.config.authority_public_key.clone();
-                    let authority_secret_key = self.config.authority_secret_key.clone();
+                    let authority_public_key = self.config.authority_public_key;
+                    let authority_secret_key = self.config.authority_secret_key;
                     let cert_validity_secs = self.config.cert_validity_secs;
 
                     // The Noise handshake runs INSIDE the spawned task, never on the accept

--- a/bins/pool-sv2/src/lib/channel_manager/mining_message_handler.rs
+++ b/bins/pool-sv2/src/lib/channel_manager/mining_message_handler.rs
@@ -453,7 +453,7 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
                                 }
                                 e => {
                                     error!("error in handle_open_extended_mining_channel: {:?}", e);
-                                    return Err(PoolError::disconnect(e, downstream_id))?;
+                                    return Err(PoolError::disconnect(e, downstream_id).into());
                                 }
                             },
                         };
@@ -765,7 +765,7 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
                         messages.push((downstream_id, Mining::SubmitSharesError(error)).into());
                     }
                     Err(e) => {
-                        return Err(PoolError::disconnect(e, downstream_id))?;
+                        return Err(PoolError::disconnect(e, downstream_id).into());
                     }
                 }
 
@@ -1045,7 +1045,7 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
                         messages.push((downstream_id, Mining::SubmitSharesError(error)).into());
                     }
                     Err(e) => {
-                        return Err(PoolError::disconnect(e, downstream_id))?;
+                        return Err(PoolError::disconnect(e, downstream_id).into());
                     }
                 }
 

--- a/bins/pool-sv2/src/lib/monitoring.rs
+++ b/bins/pool-sv2/src/lib/monitoring.rs
@@ -18,7 +18,7 @@ fn downstream_to_sv2_client_info(client: &Downstream) -> Option<Sv2ClientInfo> {
             let mut extended_channels = Vec::new();
             let mut standard_channels = Vec::new();
 
-            for (_channel_id, extended_channel) in dd.extended_channels.iter() {
+            for extended_channel in dd.extended_channels.values() {
                 let channel_id = extended_channel.get_channel_id();
                 let target = extended_channel.get_target();
                 let requested_max_target = extended_channel.get_requested_max_target();

--- a/crates/ghost-mpc/src/lib.rs
+++ b/crates/ghost-mpc/src/lib.rs
@@ -106,8 +106,9 @@ pub type Groth16Params = bellperson::groth16::Parameters<blstrs::Bls12>;
 ///   * NOT in `default` features,
 ///   * never enabled by `ghost-pool`, `ghost-consensus`, or any shipping crate,
 ///   * only ever turned on by an explicit `--features mpc-test-cap` on a targeted
-///     `-p ghost-mpc` test invocation,
-/// so the production build (`cargo build -p ghost-pool --features zk-production`)
+///     `-p ghost-mpc` test invocation.
+///
+/// So the production build (`cargo build -p ghost-pool --features zk-production`)
 /// and a default `cargo build` both compile this as 101. A compile-time test
 /// (`cap_tests::test_cap_is_mainnet_value_without_feature`) locks the invariant.
 #[cfg(not(feature = "mpc-test-cap"))]


### PR DESCRIPTION
Fourth pass on #401, and the first to touch the two consensus-adjacent crates. Nine warnings, every one read by hand — **`--fix` was deliberately not run here**.

## Changes

| before | after | why it's identical |
|---|---|---|
| `filter_transactions(&[tx.clone()])` | `std::slice::from_ref(&tx)` | same one-element slice, no clone |
| `.clone()` on `[u8; 32]` | `.clone()` removed | the type is `Copy`; the call did nothing |
| `for (_channel_id, ch) in map.iter()` | `map.values()` | the key was discarded |
| `map.get("BLOCK").is_some()` | `map.contains_key("BLOCK")` | identical |
| `return Err(e)?;` | `return Err(e.into());` | see below |

## The last one is why these crates get read, not tool-fixed

Clippy flags the `return` as redundant — `?` already returns early. That reading is wrong here, and **dropping the `return` does not compile**:

```
error[E0308]: `match` arms have incompatible types
```

These sit in match arms that must produce a channel. `return …` gives the arm type `!`, which coerces to anything. `Err(e)?;` ends in a semicolon, so the arm's type becomes `()` and the arms stop agreeing. The correct fix drops the **`?`** and converts explicitly, preserving the divergence.

`cargo check` caught it, not review. That is precisely the argument for not running `--fix` across `ghost-pool` and `pool_sv2`: the mechanical reading of this lint produces code that doesn't build — and a subtler variant of the same mistake would have built and been wrong.

## Verified

312 tests pass across both crates, all targets compile, `cargo fmt --all` applied.

## Remaining on #401

Roughly 65 warning lines in these two crates, of which **19 are `result_large_err`** — the same category parked for an operator decision (box the error type, or crate-scoped `allow`; the variant sits exactly on clippy's 128-byte threshold). The rest are `field_reassign_with_default`, `sort_by_key`, complex types and two `too_many_arguments`, which need real refactors rather than substitutions.