### PR TITLE
fix(translator): refuse usernames that cannot be paid

### DIFF
--- a/bins/translator-sv2/src/lib/sv1/sv1_server/downstream_message_handler.rs
+++ b/bins/translator-sv2/src/lib/sv1/sv1_server/downstream_message_handler.rs
@@ -97,10 +97,12 @@ impl IsServer<'static> for Sv1Server {
         // A trailing `.d=<difficulty>` is stripped here so the rest of the checks — and the
         // payout address / worker attribution downstream — see the plain `<address>.<worker>`.
         let (name, username_difficulty) = super::split_username_difficulty(request.name.as_str());
-        if !name.contains('.') {
+        if let Err(rejection) = super::check_username_attributable(name) {
             warn!(
-                "Down: Rejecting mining.authorize from downstream {} — username '{}' has no '.' separator; expected `<bitcoin_address>.<worker_name>`",
-                downstream_id, name
+                "Down: Rejecting mining.authorize from downstream {} — username '{}' has a missing or empty {} half; expected `<bitcoin_address>.<worker_name>`. Shares from this username could not be attributed and would earn nothing (#479).",
+                downstream_id,
+                name,
+                rejection.half()
             );
             return false;
         }

--- a/bins/translator-sv2/src/lib/sv1/sv1_server/mod.rs
+++ b/bins/translator-sv2/src/lib/sv1/sv1_server/mod.rs
@@ -176,6 +176,57 @@ pub(super) fn extract_worker_name(name: &str) -> &str {
     name.rsplit_once('.').map(|(_, w)| w).unwrap_or(name)
 }
 
+/// Why an SV1 username cannot be attributed to a payout target.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum UsernameRejection {
+    /// No `.` at all — `<address>` with no worker.
+    NoSeparator,
+    /// `bc1q….` — the worker half is empty, so the per-share TLV is omitted.
+    EmptyWorker,
+    /// `.worker` — the address half is empty, so there is no payout target.
+    EmptyAddress,
+}
+
+impl UsernameRejection {
+    pub(super) fn half(self) -> &'static str {
+        match self {
+            Self::NoSeparator => "separator",
+            Self::EmptyWorker => "worker",
+            Self::EmptyAddress => "address",
+        }
+    }
+}
+
+/// Check that an SV1 username can actually be paid.
+///
+/// Both halves of `<address>.<worker>` must be present and non-empty. The `.`-only check is
+/// not sufficient, and the failure is silent rather than loud:
+///
+/// - `bc1q….` yields an empty worker, so `extract_worker_name` returns `""` and the per-share
+///   TLV is omitted entirely. A pool with extension 0x0002 negotiated as *required* — which the
+///   live fleet has — then marks every such share unattributable and skips the payout webhook,
+///   while still answering `SubmitSharesSuccess`. The miner sees a healthy accept rate and is
+///   credited for none of it.
+/// - `.worker` yields an empty address, so there is no payout target even though the worker
+///   name looks well-formed.
+///
+/// `mining.authorize` is the only layer that can tell the miner. Below it, every component
+/// reports success. See #479.
+///
+/// Callers pass the name with any `.d=<difficulty>` directive already stripped.
+pub(super) fn check_username_attributable(name: &str) -> Result<(), UsernameRejection> {
+    let Some((address, worker)) = name.rsplit_once('.') else {
+        return Err(UsernameRejection::NoSeparator);
+    };
+    if worker.is_empty() {
+        return Err(UsernameRejection::EmptyWorker);
+    }
+    if address.is_empty() {
+        return Err(UsernameRejection::EmptyAddress);
+    }
+    Ok(())
+}
+
 /// Truncates a string to [`MAX_USER_IDENTITY_BYTES`], respecting UTF-8 character boundaries.
 ///
 /// If the input string exceeds the limit, it is truncated at the last valid UTF-8 character
@@ -370,7 +421,55 @@ mod username_difficulty_tests {
     /// Where the pool has extension 0x0002 negotiated as *required* — which the live fleet does
     /// (`required_extensions = [0x0002]` in the installed translator config) — such a share is
     /// marked unattributable and earns nothing, while the miner still gets `SubmitSharesSuccess`.
-    /// `mining.authorize` accepts this shape today because it only checks for a `.`.
+    ///
+    /// `mining.authorize` now REJECTS this shape (#479), so it should be unreachable in
+    /// practice. This still pins the underlying behaviour, because the rejection is the only
+    /// thing standing between it and a miner silently earning nothing — if that guard is ever
+    /// relaxed, this is what comes back.
+    /// The shapes `mining.authorize` must refuse, and the ones it must keep accepting.
+    ///
+    /// The refusals are the point of #479: each one produces a miner that submits shares,
+    /// receives `SubmitSharesSuccess` for every one of them, and is paid for none — because
+    /// the pool cannot derive an attribution target and every layer below authorize reports
+    /// success anyway.
+    #[test]
+    fn usernames_that_cannot_be_paid_are_refused() {
+        use UsernameRejection::*;
+
+        // Accepted: a normal address.worker, and multi-dot worker names.
+        for ok in [
+            &format!("{ADDR}.rig1")[..],
+            &format!("{ADDR}.farm1.rig1")[..],
+            "x.y",
+        ] {
+            assert_eq!(
+                check_username_attributable(ok),
+                Ok(()),
+                "{ok} should be accepted"
+            );
+        }
+
+        // Refused: empty worker — TLV omitted, shares unattributable, earns nothing.
+        assert_eq!(
+            check_username_attributable(&format!("{ADDR}.")),
+            Err(EmptyWorker)
+        );
+        // Refused: empty address — no payout target, however good the worker name looks.
+        assert_eq!(check_username_attributable(".rig1"), Err(EmptyAddress));
+        // Refused: no separator at all, which was already the case before #479.
+        assert_eq!(check_username_attributable(ADDR), Err(NoSeparator));
+        assert_eq!(check_username_attributable(""), Err(NoSeparator));
+    }
+
+    /// A `.d=` directive is stripped before the check, so declaring a difficulty must not
+    /// turn a payable username into a refused one.
+    #[test]
+    fn a_difficulty_directive_does_not_make_a_username_unpayable() {
+        let username = format!("{ADDR}.rig1.d=9300000");
+        let (stripped, _) = split_username_difficulty(&username);
+        assert_eq!(check_username_attributable(stripped), Ok(()));
+    }
+
     #[test]
     fn an_empty_worker_segment_yields_no_tlv_identity() {
         assert_eq!(extract_worker_name(&format!("{ADDR}.")), "");


### PR DESCRIPTION
Closes #479.

## The failure

`mining.authorize` only checked that the username contained a `.`, so **`bc1q….`** was accepted. That shape earns nothing and reports nothing:

1. `extract_worker_name` returns `""`
2. so the per-share TLV is omitted entirely
3. so a pool with extension `0x0002` negotiated as **required** — which the live fleet has — marks every such share unattributable and skips the payout webhook
4. and still answers **`SubmitSharesSuccess`**

The miner sees a healthy accepted-share rate and is credited for none of it, indefinitely, with no error surfaced at any layer.

`.worker` is the mirror case: the address half is empty, so there is no payout target however well-formed the worker name looks.

`mining.authorize` is the **only** place this can be caught. Everything below it reports success — that is exactly why the failure is silent rather than loud.

## The change

The check moves into `check_username_attributable`, a pure function returning *which* half is at fault, so the log tells the operator what to fix rather than merely that something was wrong.

It's extracted rather than inlined because the inline version could not be tested — `handle_authorize` requires a whole `Sv1Server`. Now it's four lines of table-driven test.

## No production impact

```sql
SELECT COUNT(*) FROM miners WHERE miner_id LIKE '%.';   -- vm3: 0, vm4: 0
```

Nobody is currently in this state, which is what makes now the right time to close it — as a guard rather than a migration.

## Tests

- `usernames_that_cannot_be_paid_are_refused` — accepts `addr.rig1`, `addr.farm1.rig1`, `x.y`; refuses `addr.`, `.rig1`, bare address, empty
- `a_difficulty_directive_does_not_make_a_username_unpayable` — `.d=` is stripped before the check, so declaring a difficulty must not turn a payable username into a refused one
- 48 tests pass; `translator_sv2` remains clippy-clean

Also corrects the doc on `an_empty_worker_segment_yields_no_tlv_identity`, which stated that authorize accepts this shape — true when written, false now.