### PR TITLE
fix(ops): correct the extension config, and gate the keys that diverged

### DIFF
--- a/config/sri/pool-config.toml
+++ b/config/sri/pool-config.toml
@@ -47,7 +47,8 @@ shares_per_minute = 6.0
 share_batch_size = 10
 
 # Protocol extensions
-supported_extensions = []
+# Must SUPPORT what the translator REQUIRES (0x0002, worker-specific hashrate tracking).
+supported_extensions = [0x0002]
 required_extensions = []
 
 # Monitoring endpoint

--- a/config/sri/translator-config.toml
+++ b/config/sri/translator-config.toml
@@ -26,8 +26,13 @@ user_identity = "ghost_miner"
 aggregate_channels = false
 
 # Protocol extensions
+# Worker-Specific Hashrate Tracking (0x0002) carries the per-share worker identity that the
+# pool recombines with the channel-level address for attribution. REQUIRED here, and the pool
+# must list it under `supported_extensions` — check-stratum-config-agreement.sh enforces that
+# pairing, because a translator requiring an extension the pool does not support fails the
+# handshake, and the reverse silently drops attribution.
 supported_extensions = []
-required_extensions = []
+required_extensions = [0x0002]
 
 # Monitoring endpoint
 monitoring_address = "0.0.0.0:9092"

--- a/scripts/check-stratum-config-agreement.sh
+++ b/scripts/check-stratum-config-agreement.sh
@@ -33,6 +33,7 @@ import re, sys
 
 INSTALLER = "scripts/install-node.sh"
 REFERENCE = "config/sri/translator-config.toml"
+POOL_REFERENCE = "config/sri/pool-config.toml"
 
 # Keys that must be identical in both files.
 SHARED = [
@@ -44,6 +45,12 @@ SHARED = [
     "downstream_port",
     "max_supported_version",
     "min_supported_version",
+    # Extension negotiation. These diverged silently: the installer set
+    # required_extensions = [0x0002] on the translator while the reference config said [], so
+    # which attribution path a node took depended on which file provisioned it. Nothing
+    # reported that, because these keys were not compared (#480).
+    "supported_extensions",
+    "required_extensions",
 ]
 
 # Invariants that must hold regardless of whether the two files agree.
@@ -137,6 +144,50 @@ try:
         )
 except ValueError:
     pass
+
+# The pool must SUPPORT every extension the translator REQUIRES.
+#
+# This spans two files, so no amount of per-file agreement catches it. Both directions break
+# something, and neither breaks loudly:
+#   - translator requires what the pool does not support -> the SV2 handshake fails and the
+#     translator falls through to the next upstream.
+#   - pool supports what the translator does not require -> the TLV is never negotiated, so
+#     per-worker attribution silently stops and shares fall back to the channel identity.
+def parse_ext_list(v):
+    """`[0x0002, 0x0003]` -> {2, 3}. Returns None if it cannot be parsed."""
+    if v is None:
+        return None
+    inner = v.strip().strip("[]").strip()
+    if not inner:
+        return set()
+    out = set()
+    for item in inner.split(","):
+        item = item.strip()
+        if not item:
+            continue
+        try:
+            out.add(int(item, 16) if item.lower().startswith("0x") else int(item))
+        except ValueError:
+            return None
+    return out
+
+pool_vals, _ = values(POOL_REFERENCE)
+tran_required = parse_ext_list(b.get("required_extensions"))
+pool_supported = parse_ext_list(pool_vals.get("supported_extensions"))
+
+if tran_required is None or pool_supported is None:
+    problems.append(
+        "could not parse supported_extensions/required_extensions as a list — "
+        "the pool-supports-what-the-translator-requires invariant was NOT checked"
+    )
+else:
+    missing = tran_required - pool_supported
+    if missing:
+        problems.append(
+            f"{REFERENCE} requires extension(s) {sorted(hex(x) for x in missing)} that "
+            f"{POOL_REFERENCE} does not list under supported_extensions — the SV2 handshake "
+            f"will fail and the translator will fall through to another upstream"
+        )
 
 for k in SHARED:
     va, vb = a.get(k), b.get(k)


### PR DESCRIPTION
Closes #480.

## The divergence

| | translator | pool |
|---|---|---|
| `scripts/install-node.sh` — **what provisions nodes** | `required = [0x0002]` | `supported = [0x0002]` |
| `config/sri/*.toml` — the in-repo reference | `[]` | `[]` |

So which attribution path a node took depended on which file provisioned it. The live fleet matches the **installer** (verified on vm1–vm4), which means the in-repo reference described a configuration no node was running.

`check-stratum-config-agreement.sh` exists to stop precisely this, and couldn't see it — neither key was in its `SHARED` list. Both added: **8 keys compared before, 10 now.**

## The invariant that per-file comparison can't express

**The pool must support every extension the translator requires.** That spans two files, so no amount of file-vs-file agreement catches it — and both directions fail quietly:

- **translator requires what the pool doesn't support** → SV2 handshake fails, translator falls through to another upstream
- **pool supports what the translator doesn't require** → the TLV is never negotiated, per-worker attribution stops, and shares silently fall back to the channel identity

The second is the dangerous one here: nothing logs it. It surfaces only as attribution quietly becoming coarser, which is the kind of thing noticed weeks later when payouts look odd.

## Both checks were driven against broken state, not assumed

```
config/sri/translator-config.toml requires extension(s) ['0x2'] that
config/sri/pool-config.toml does not list under supported_extensions

required_extensions: scripts/install-node.sh = '[0x0002]' but
config/sri/translator-config.toml = '[]'
```

The second reproduces the original bug exactly — so the gate would now catch it.

## Verified

- `check-stratum-config-agreement.sh` — 10/10 keys, invariants hold
- `check-inlined-copies.sh` — 4 pairs match