### PR TITLE
test(wraith): stop the idle-lock test asserting how fast CI is

### DIFF
--- a/apps/wraith-wallet/daemon/tests/wallet_lifecycle.rs
+++ b/apps/wraith-wallet/daemon/tests/wallet_lifecycle.rs
@@ -435,9 +435,18 @@ async fn shroud_max_ms_surfaces_in_daemon_env() {
     child.kill().await.ok();
 }
 
-/// Auto-lock: with WRAITHD_IDLE_LOCK_SECS=2 the daemon should lock all
-/// unlocked wallets after ~2s of no user-facing IPC activity. Health and
+/// Auto-lock: with WRAITHD_IDLE_LOCK_SECS=10 the daemon should lock all
+/// unlocked wallets after ~10s of no user-facing IPC activity. Health and
 /// DaemonEnv should NOT count as activity (would defeat the feature).
+///
+/// The threshold was 2s, which made this flaky (#502). The idle timer starts at wallet
+/// CREATION, and creation runs a passphrase KDF — so on a loaded runner the KDF alone could
+/// outlast the window, and the very next call would find the wallet already locked. The test
+/// then failed on `fresh wallet must be unlocked`, i.e. it was asserting "under two seconds of
+/// wall-clock elapsed", which is not a property the daemon controls.
+///
+/// 10s is chosen so a KDF would have to be pathologically slow to reach it, while still
+/// keeping the test's own runtime bounded.
 #[tokio::test]
 async fn idle_lock_locks_wallets_after_threshold() {
     let tmp = tempfile::tempdir().expect("tempdir");
@@ -447,7 +456,7 @@ async fn idle_lock_locks_wallets_after_threshold() {
     let mut child = Command::new(wraithd_binary())
         .env("WRAITHD_SOCKET", &socket)
         .env("WRAITHD_WALLETS_DIR", &wallets)
-        .env("WRAITHD_IDLE_LOCK_SECS", "2")
+        .env("WRAITHD_IDLE_LOCK_SECS", "10")
         .env("RUST_LOG", "warn")
         .stdout(Stdio::null())
         .stderr(Stdio::null())
@@ -492,9 +501,9 @@ async fn idle_lock_locks_wallets_after_threshold() {
     // Sleep past the idle threshold without sending any IPC traffic. Health
     // wouldn't have counted, but to keep the test deterministic we just wait.
     // Threshold = 2s, tick = min(30, 2/2) = 1s. 6s gives the auto-lock task
-    // ~4 chances to fire — generous slack for parallel-test CI hosts where
-    // the tokio scheduler doesn't always wake on the dot.
-    tokio::time::sleep(Duration::from_secs(6)).await;
+    // Must exceed the 10s threshold with slack, for parallel-test CI hosts where the tokio
+    // scheduler doesn't always wake on the dot.
+    tokio::time::sleep(Duration::from_secs(14)).await;
 
     // WalletList now: should show the wallet as locked. (The list call itself
     // re-bumps the timer, but the auto-lock has already happened.)


### PR DESCRIPTION
Closes #502.

## What was actually being asserted

`idle_lock_locks_wallets_after_threshold` failed with `fresh wallet must be unlocked` on **#498**, whose entire diff was one value in `scripts/install-node.sh` — a file that cannot reach the wraith daemon. `main` was green, macOS passed, and a rerun passed.

The idle threshold was **2 seconds**, and the idle timer starts at wallet **creation**. Creation runs a passphrase KDF. On a loaded runner the KDF alone can outlast that window, so the very next call finds the wallet already locked — correctly, since the daemon did exactly what it was told.

The assertion was therefore really *"fewer than two seconds of wall-clock elapsed on this runner"*, which is not a property the code under test controls.

## Fix

Threshold **2s → 10s**, lock wait **6s → 14s**. A KDF would have to be pathologically slow to reach 10s.

The cost is honest: the file goes from ~9s to **16.8s**. That's the price of the test meaning something, and it's one file.

## Not chosen

Making the clock injectable so the test advances time rather than sleeping. That is strictly better — no flake *and* near-zero runtime — but it needs a seam in the daemon rather than a change to the test, so it belongs in its own change rather than riding in on a flake fix.

## Verified

4 tests pass in `wallet_lifecycle`, including the one that was flaky.