### PR TITLE
chore(clippy): silence result_large_err where boxing would be the worse code

### DIFF
--- a/bins/jd-client-sv2/src/lib/mod.rs
+++ b/bins/jd-client-sv2/src/lib/mod.rs
@@ -1,4 +1,7 @@
 #![allow(rustdoc::all)] // imported SV2 crate: relax strict rustdoc policy (SRI upstream doc style)
+#![allow(clippy::result_large_err)] // Err variant sits AT clippy's 128-byte threshold, not past
+                                    // it. Boxing would change signatures across a crate imported from SRI upstream, so the churn is
+                                    // paid twice: once now, and again at every upstream sync. Revisit if the variant grows.
 use std::{
     sync::{
         atomic::{AtomicBool, Ordering},

--- a/bins/pool-sv2/src/lib/mod.rs
+++ b/bins/pool-sv2/src/lib/mod.rs
@@ -1,4 +1,7 @@
 #![allow(rustdoc::all)] // imported SV2 crate: relax strict rustdoc policy (SRI upstream doc style)
+#![allow(clippy::result_large_err)] // Err variant sits AT clippy's 128-byte threshold, not past
+                                    // it. Boxing would change signatures across a crate imported from SRI upstream, so the churn is
+                                    // paid twice: once now, and again at every upstream sync. Revisit if the variant grows.
 use std::{
     sync::{
         atomic::{AtomicBool, Ordering},

--- a/bins/wraith-coordinator/src/api/blind_sig.rs
+++ b/bins/wraith-coordinator/src/api/blind_sig.rs
@@ -65,6 +65,11 @@ fn error(status: StatusCode, code: &'static str, detail: String) -> Response {
 /// Validate the common preconditions for both endpoints — session
 /// exists, in `Locked` state, ghost_id enrolled — and return the
 /// caller-friendly error response when any precondition fails.
+// `Err = axum::http::Response` is the idiomatic axum early-return: the helper hands back the
+// exact response the caller should send. Boxing it to satisfy result_large_err would make
+// every call site unwrap a Box to return a Response, which is worse code for 128 bytes on a
+// path that is already building an HTTP response.
+#[allow(clippy::result_large_err)]
 fn check_session(
     state: &CoordinatorState,
     session_id: &str,

--- a/bins/wraith-coordinator/src/api/session_inputs.rs
+++ b/bins/wraith-coordinator/src/api/session_inputs.rs
@@ -313,6 +313,11 @@ pub async fn post(
 /// for the conditions the caller can't recover from (Mix round with no
 /// fee address configured — the round can't be built later, so we fail
 /// the input now).
+// `Err = axum::http::Response` is the idiomatic axum early-return: the helper hands back the
+// exact response the caller should send. Boxing it to satisfy result_large_err would make
+// every call site unwrap a Box to return a Response, which is worse code for 128 bytes on a
+// path that is already building an HTTP response.
+#[allow(clippy::result_large_err)]
 fn minimum_participant_input(
     session: &LiteSession,
     state: &CoordinatorState,


### PR DESCRIPTION
Your call on #401's largest single item. All **34** occurrences cleared, without changing a single signature.

## Two crates, two different reasons — deliberately not one blanket allow

**`pool_sv2` (17) and `jd_client_sv2` (15) — crate-level allow.**
The `Err` variant sits *at* clippy's 128-byte threshold, not past it. Both crates are imported from SRI upstream, so boxing changes signatures in vendored code and the churn is paid twice: now, and again at every upstream sync. The allow sits directly beneath the existing `#![allow(rustdoc::all)]`, which is on those crates for the same reason and sets the precedent.

**`wraith-coordinator` (2) — function-level allows.**
This is *our* code, so the vendored rationale doesn't apply and I didn't reuse it. There the `Err` type is **`axum::http::Response`** — handing back the exact response the caller should send is the idiomatic axum early-return. Boxing it would force every call site to unwrap a `Box` to produce a `Response`: worse code, on a path already building an HTTP response, to save 128 bytes.

Scoped to the two functions rather than the crate, so a genuinely oversized error appearing elsewhere in the coordinator still gets flagged.

## Effect

Workspace **88 → 54** warning lines. Remaining is `ghost-pool` 19, `ghost-storage` 6, `pool_sv2` 4, and a long tail of 1–3 per crate — all `field_reassign_with_default`, `sort_by`, complex types, and two `too_many_arguments`.

Note five of `ghost-pool`'s are the `sort_by` calls in `payout.rs`/`shares.rs` that I've deliberately left alone: `sort_by_key` is provably equivalent, but `payout.rs:204` orders nodes immediately before hashing them into the **ledger root**, so that one wants a human and a ledger-root test rather than a lint sweep.