### PR TITLE
fix(payout): split the payout address on the FIRST dot, everywhere

### DIFF
--- a/bins/ghost-pool/src/validation.rs
+++ b/bins/ghost-pool/src/validation.rs
@@ -292,7 +292,8 @@ impl ValidatedCredentials {
         let _password = validate_password(password)?;
 
         // Parse username into address.worker
-        let (address, worker) = if let Some(dot_pos) = username.rfind('.') {
+        // FIRST dot, matching parse_user_identity and pool_sv2's PayoutMode (#481).
+        let (address, worker) = if let Some(dot_pos) = username.find('.') {
             let addr = &username[..dot_pos];
             let worker = &username[dot_pos + 1..];
             (addr, worker)

--- a/bins/translator-sv2/src/lib/sv1/sv1_server/mod.rs
+++ b/bins/translator-sv2/src/lib/sv1/sv1_server/mod.rs
@@ -173,7 +173,9 @@ pub(super) fn parse_suggest_difficulty(msg: &Message) -> Option<f64> {
 /// share is marked unattributable and silently earns nothing, while the miner still receives
 /// `SubmitSharesSuccess`. `mining.authorize` does not currently reject that shape.
 pub(super) fn extract_worker_name(name: &str) -> &str {
-    name.rsplit_once('.').map(|(_, w)| w).unwrap_or(name)
+    // FIRST dot: the worker is everything after it, so `addr.farm1.rig1` keeps `farm1.rig1`
+    // rather than collapsing to `rig1` (#481).
+    name.split_once('.').map(|(_, w)| w).unwrap_or(name)
 }
 
 /// Why an SV1 username cannot be attributed to a payout target.
@@ -215,7 +217,7 @@ impl UsernameRejection {
 ///
 /// Callers pass the name with any `.d=<difficulty>` directive already stripped.
 pub(super) fn check_username_attributable(name: &str) -> Result<(), UsernameRejection> {
-    let Some((address, worker)) = name.rsplit_once('.') else {
+    let Some((address, worker)) = name.split_once('.') else {
         return Err(UsernameRejection::NoSeparator);
     };
     if worker.is_empty() {
@@ -459,6 +461,33 @@ mod username_difficulty_tests {
         // Refused: no separator at all, which was already the case before #479.
         assert_eq!(check_username_attributable(ADDR), Err(NoSeparator));
         assert_eq!(check_username_attributable(""), Err(NoSeparator));
+    }
+
+    /// The address/worker split is on the FIRST dot, so a multi-dot worker survives intact.
+    ///
+    /// `bc1qAAA.farm1.rig1` and `bc1qAAA.farm2.rig1` used to collapse to the same identity,
+    /// because the worker was taken from the LAST dot and both yielded `rig1`. Worse, the
+    /// consumer took the address from everything BEFORE the last dot — `bc1qAAA.farm1` — which
+    /// is not a valid Bitcoin address at all (#481).
+    #[test]
+    fn a_multi_dot_worker_keeps_its_full_name() {
+        let a = format!("{ADDR}.farm1.rig1");
+        let b = format!("{ADDR}.farm2.rig1");
+        assert_eq!(extract_worker_name(&a), "farm1.rig1");
+        assert_eq!(extract_worker_name(&b), "farm2.rig1");
+        assert_ne!(
+            extract_worker_name(&a),
+            extract_worker_name(&b),
+            "two rigs under different farms must not collapse to one identity"
+        );
+    }
+
+    /// Single-dot usernames — every miner in production — are completely unaffected, because
+    /// the first and last dot are the same dot.
+    #[test]
+    fn a_single_dot_username_is_unchanged_by_the_convention() {
+        assert_eq!(extract_worker_name(&format!("{ADDR}.rig1")), "rig1");
+        assert_eq!(check_username_attributable(&format!("{ADDR}.rig1")), Ok(()));
     }
 
     /// A `.d=` directive is stripped before the check, so declaring a difficulty must not

--- a/crates/ghost-verification/src/routes.rs
+++ b/crates/ghost-verification/src/routes.rs
@@ -2856,7 +2856,7 @@ async fn api_miners_by_address_handler(
             // Extract the worker suffix from `address.worker` for display
             let worker = m
                 .miner_id
-                .rsplit_once('.')
+                .split_once('.')
                 .map(|(_, w)| w.to_string())
                 .unwrap_or_else(|| "".to_string());
             serde_json::json!({
@@ -3516,7 +3516,7 @@ pub fn internal_hex_to_display_hex(internal_hex: &str) -> String {
 }
 
 fn is_system_miner(miner_id: &str) -> bool {
-    let worker = miner_id.rsplit_once('.').map(|(_, w)| w).unwrap_or("");
+    let worker = miner_id.split_once('.').map(|(_, w)| w).unwrap_or("");
     let lower = worker.to_ascii_lowercase();
     lower.contains("translator") || lower == "proxy"
 }

--- a/crates/ghost-verification/src/server.rs
+++ b/crates/ghost-verification/src/server.rs
@@ -961,9 +961,13 @@ pub struct L2TreeStateInfo {
 /// Format: <payout_address>.<worker_name>
 /// Returns (payout_address, worker_name) or (user_identity, "default") if no dot found.
 fn parse_user_identity(user_identity: &str) -> (String, String) {
-    if let Some(last_dot) = user_identity.rfind('.') {
-        let address = &user_identity[..last_dot];
-        let worker = &user_identity[last_dot + 1..];
+    // Address is everything before the FIRST dot; the worker is the rest (#481). `a.b.c` is
+    // addr=a, worker=b.c — the public-pool convention, and what pool_sv2's PayoutMode and
+    // build_webhook_user_identity already assumed. Splitting on the LAST dot yielded
+    // addr="a.b" for multi-dot names, which is not a valid Bitcoin address.
+    if let Some(first_dot) = user_identity.find('.') {
+        let address = &user_identity[..first_dot];
+        let worker = &user_identity[first_dot + 1..];
         (address.to_string(), worker.to_string())
     } else {
         // No dot found - treat entire string as address with default worker
@@ -3144,6 +3148,36 @@ mod tests {
     use super::*;
     use ghost_common::types::NodeCapabilities;
     use ghost_policy::PolicyProfile;
+
+    /// The payout address is everything before the FIRST dot.
+    ///
+    /// This is the half of #481 that was actually broken. Splitting on the LAST dot gave
+    /// `bc1qAAA.farm1` as the payout address for `bc1qAAA.farm1.rig1` — not a valid Bitcoin
+    /// address, and disagreeing with pool_sv2, which already derived the address from the
+    /// first dot in both `PayoutMode::try_from` and `build_webhook_user_identity`.
+    #[test]
+    fn payout_address_is_taken_from_the_first_dot() {
+        // Multi-dot: the address must be the address, and the worker keeps its full name.
+        let (addr, worker) = parse_user_identity("bc1qAAA.farm1.rig1");
+        assert_eq!(
+            addr, "bc1qAAA",
+            "the address must not absorb part of the worker name"
+        );
+        assert_eq!(worker, "farm1.rig1");
+
+        // Two rigs under different farms stay distinct.
+        let (_, w1) = parse_user_identity("bc1qAAA.farm1.rig1");
+        let (_, w2) = parse_user_identity("bc1qAAA.farm2.rig1");
+        assert_ne!(w1, w2);
+
+        // Single dot — every miner in production — is unchanged.
+        let (addr, worker) = parse_user_identity("bc1qAAA.rig1");
+        assert_eq!((addr.as_str(), worker.as_str()), ("bc1qAAA", "rig1"));
+
+        // No dot at all keeps the documented fallback.
+        let (addr, worker) = parse_user_identity("bc1qAAA");
+        assert_eq!((addr.as_str(), worker.as_str()), ("bc1qAAA", "default"));
+    }
 
     fn test_secret() -> [u8; 32] {
         let mut secret = [0u8; 32];


### PR DESCRIPTION
Closes #481.

## The bug is worse than I filed it

I filed #481 as lost per-rig granularity — `bc1qAAA.farm1.rig1` and `bc1qAAA.farm2.rig1` collapsing to the same worker — with the money still going to the right place. The money was **not** going to the right place.

`parse_user_identity` took the address from everything **before the last dot**:

```
bc1qAAA.farm1.rig1  ->  address = "bc1qAAA.farm1"   <- not a Bitcoin address
                        worker  = "rig1"
```

Meanwhile `pool_sv2` had already been splitting on the **first** dot in both `PayoutMode::try_from` (`utils.rs:157`) and `build_webhook_user_identity` (`mining_message_handler.rs:50`). So the two crates disagreed with each other in production about who gets paid. That is the actual defect; the granularity loss is a symptom of the same split.

## What changed

Nine identity-splitting sites exist, not the three the issue described. Six moved to the first dot, two were already correct, one must stay on the last dot:

| site | before | after |
|---|---|---|
| `pool_sv2` `utils.rs:157` (`PayoutMode`) | first | unchanged — already correct |
| `pool_sv2` `mining_message_handler.rs:50` | first | unchanged — already correct |
| `ghost-verification` `server.rs:964` (`parse_user_identity`) | last | **first** |
| `ghost-pool` `validation.rs:295` (`ThreadSafeUsername::parse`) | last | **first** |
| `translator` `mod.rs:176` (`extract_worker_name`) | last | **first** |
| `translator` `mod.rs:218` (`check_username_attributable`) | last | **first** |
| `ghost-verification` `routes.rs` x2 (display only) | last | **first** |
| `translator` `mod.rs:124` (`split_username_difficulty`) | last | **unchanged — must not change** |

`split_username_difficulty` strips a trailing `.d=<difficulty>` directive. Last-dot is correct there and first-dot would corrupt every username carrying one. `rsplit_once` now appears exactly once in the workspace, at that function, which makes the exception self-documenting.

## Blast radius: none

Single-dot usernames are bit-for-bit unaffected — with one dot, the first dot *is* the last dot. I checked production before changing anything: **zero multi-dot `miner_id`s** on vm3 and vm4. Nothing is being repaired retroactively, and no migration is needed. The change is purely forward-looking: it makes `farm.rig` naming safe to adopt, which #403's swarm work will want.

## Tests

New tests pin both halves of the convention and the exception:

- `payout_address_is_taken_from_the_first_dot` (`server.rs`) — multi-dot gives `bc1qAAA` not `bc1qAAA.farm1`; two farms stay distinct; single-dot unchanged; no-dot keeps the `default` fallback.
- `a_multi_dot_worker_keeps_its_full_name` (translator) — asserts the two rigs do **not** collapse.
- `a_single_dot_username_is_unchanged_by_the_convention` (translator) — the production case, including attributability.

The existing `.d=` tests already cover the exception and still pass unmodified, which is the check that mattered most here.

Verified locally: 305 `ghost-pool`, 236 `ghost-verification`, 50 `translator_sv2`, 7 `pool_sv2` — all green.