### PR TITLE
fix(sv2): never advertise a guessed SV2 authority key

### DIFF
--- a/crates/ghost-common/src/config.rs
+++ b/crates/ghost-common/src/config.rs
@@ -1358,14 +1358,19 @@ pub struct NetworkConfig {
     /// Ghost Shroud: random relay delay (0-5s) to prevent origin analysis
     #[serde(default)]
     pub shroud_enabled: bool,
-    /// SV2 pool authority public key advertised on `/api/v1/mining/status`.
+    /// This node's OWN SV2 authority public key, advertised on
+    /// `/api/v1/mining/status`.
     ///
-    /// SV2/Noise miners must pin the pool's authority public key to connect.
-    /// This is the `authority_public_key` that the colocated `pool_sv2` instance
-    /// publishes in its own pool config; it is identical across every node on
-    /// the public pool. Leave unset to advertise the network-wide default
-    /// (`constants::SV2_AUTHORITY_PUBLIC_KEY`); set this only when running a
-    /// bespoke authority keypair so the dashboard reports the correct value.
+    /// SV2/Noise miners pin it to authenticate the pool, and it must match the
+    /// `authority_public_key` that the colocated `pool_sv2` presents. Every node
+    /// has its own keypair — `install-node.sh` generates one per node — so there
+    /// is no network-wide value and nothing to default to.
+    ///
+    /// Left unset, the API advertises `null`. That is deliberate: a wrong pin is
+    /// worse than a missing one, because the miner cannot reach the real pool but
+    /// WOULD authenticate anyone holding the secret half of the advertised key
+    /// (#516). Keep it in step with `pool-config.toml` whenever the keypair is
+    /// rotated — `rotate-sv2-authority.sh` does this.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub sv2_authority_public_key: Option<String>,
     /// HTTP rate-limiter trusted-IP allowlist.

--- a/crates/ghost-common/src/constants.rs
+++ b/crates/ghost-common/src/constants.rs
@@ -235,18 +235,6 @@ pub const SV1_STRATUM_PORT: u16 = 3333;
 /// provider without duplicating the literal.
 pub const TDP_PORT: u16 = 8442;
 
-/// SV2 pool authority public key (the Noise static key SV2/Noise clients pin).
-///
-/// This is the network-wide authority key that every `pool_sv2` instance
-/// publishes as `authority_public_key` in its pool config — it is identical
-/// across all pool nodes, so a miner pins this single value to authenticate any
-/// node it connects to. Surfaced on `/api/v1/mining/status` so the dashboard
-/// can source it dynamically instead of hardcoding it in the frontend.
-///
-/// Operators running a bespoke authority keypair can override this per-node via
-/// `[network] sv2_authority_public_key` in `pool.toml`.
-pub const SV2_AUTHORITY_PUBLIC_KEY: &str = "9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72";
-
 /// HTTP API port (plain HTTP — used by SRI share webhook on loopback, the
 /// nginx public-API upstream, and the local dashboard).
 pub const HTTP_API_PORT: u16 = 8080;

--- a/crates/ghost-verification/src/routes.rs
+++ b/crates/ghost-verification/src/routes.rs
@@ -35,9 +35,7 @@ use std::sync::Arc;
 use tracing::{debug, error, info, warn};
 
 use ghost_buds::{BudsClassifier, BudsTier};
-use ghost_common::constants::{
-    ACTIVE_MINER_WINDOW_SECS, SV1_STRATUM_PORT, SV2_AUTHORITY_PUBLIC_KEY, SV2_STRATUM_PORT,
-};
+use ghost_common::constants::{ACTIVE_MINER_WINDOW_SECS, SV1_STRATUM_PORT, SV2_STRATUM_PORT};
 use ghost_common::rpc::MempoolFilterStats;
 
 use crate::auth::{verify_internal_auth, InternalAuth};
@@ -1853,17 +1851,23 @@ async fn api_mining_status_handler(
     let mesh_hashrate_th = state.mesh_total_hashrate().unwrap_or(total_hashrate_th);
     let local_hashrate_th = state.local_hashrate().unwrap_or(total_hashrate_th);
 
-    // SV2/Noise miners must pin the pool's authority public key to connect.
-    // Source it from the node's own pool config when the operator set a bespoke
-    // `[network] sv2_authority_public_key`; otherwise advertise the network-wide
-    // default so the dashboard can stop hardcoding it as a frontend constant.
+    // SV2/Noise miners must pin the pool's authority public key to connect, and
+    // every node has its OWN keypair — so this is read from this node's
+    // `[network] sv2_authority_public_key` and NEVER defaulted.
+    //
+    // There used to be a network-wide `SV2_AUTHORITY_PUBLIC_KEY` constant to fall
+    // back on. It stopped matching any node once per-node keypairs shipped, and a
+    // wrong pin is worse than a missing one: the miner cannot reach the real pool,
+    // but WOULD authenticate anyone holding the secret half of the advertised key.
+    // A node that does not know its own key must say so (#516).
+    //
     // (Reading full_node_config is a non-async lock, safe alongside the config
     // guard held above — no await points follow.)
-    let authority_public_key = state
+    let authority_public_key: Option<String> = state
         .full_node_config
         .as_ref()
         .and_then(|c| c.read().network.sv2_authority_public_key.clone())
-        .unwrap_or_else(|| SV2_AUTHORITY_PUBLIC_KEY.to_string());
+        .filter(|k| !k.trim().is_empty());
 
     // Source the operator's pool name and node-reward payout address from the
     // REAL persisted config (pool.toml) so the dashboard round-trips the saved
@@ -11137,9 +11141,10 @@ async fn api_settings_ghostpay_payout_address_post_handler(
     let persist = persist_full_config(&state, |cfg| match cfg.ghost_pay {
         Some(ref mut gp) => gp.payout_address = new_address.clone(),
         None => {
-            let mut gp = ghost_common::config::GhostPayConfig::default();
-            gp.payout_address = new_address.clone();
-            cfg.ghost_pay = Some(gp);
+            cfg.ghost_pay = Some(ghost_common::config::GhostPayConfig {
+                payout_address: new_address.clone(),
+                ..Default::default()
+            });
         }
     });
     if let Err((code, msg)) = persist {
@@ -14287,16 +14292,20 @@ mod tests {
         assert_eq!(data["miners"].as_array().unwrap().len(), 1);
     }
 
-    /// `/api/v1/mining/status` exposes the SV2 authority public key so the
-    /// dashboard can source it dynamically. Defaults to the network-wide
-    /// constant, and honours a per-node `[network] sv2_authority_public_key`.
+    /// `/api/v1/mining/status` exposes this node's OWN SV2 authority public key,
+    /// and `null` when it does not know it.
+    ///
+    /// It must never substitute a default. Every node has its own keypair, so a
+    /// defaulted key matches nobody — and a miner that pins a wrong key cannot
+    /// reach the real pool while still authenticating whoever holds that key's
+    /// secret half (#516).
     #[tokio::test]
     async fn test_mining_status_exposes_authority_key() {
         use ghost_common::config::NodeConfig as FullNodeConfig;
         use ghost_common::types::NodeCapabilities;
         use ghost_policy::PolicyProfile;
 
-        async fn authority(state: Arc<crate::server::VerificationState>) -> String {
+        async fn authority(state: Arc<crate::server::VerificationState>) -> serde_json::Value {
             let app = super::create_router(state);
             let response = app
                 .oneshot(
@@ -14313,13 +14322,15 @@ mod tests {
                 .await
                 .unwrap();
             let data: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
-            data["authority_public_key"]
-                .as_str()
-                .expect("authority_public_key must be present")
-                .to_string()
+            assert!(
+                data.get("authority_public_key").is_some(),
+                "the field must always be present, even when the value is null"
+            );
+            data["authority_public_key"].clone()
         }
 
-        // Default: the network-wide constant.
+        // Unconfigured: null, NOT a guess. This is the whole point of #516 — a
+        // plausible-but-wrong pin is more dangerous than an absent one.
         let default_state = Arc::new(crate::server::VerificationState::new(
             "test_node".to_string(),
             "1.0.0".to_string(),
@@ -14328,8 +14339,27 @@ mod tests {
         ));
         assert_eq!(
             authority(default_state).await,
-            SV2_AUTHORITY_PUBLIC_KEY,
-            "status must advertise the default SV2 authority key"
+            serde_json::Value::Null,
+            "a node that does not know its own authority key must advertise null"
+        );
+
+        // An empty or whitespace-only setting is "not configured", not a key.
+        let dir_blank = tempfile::tempdir().unwrap();
+        let mut blank_cfg = FullNodeConfig::default();
+        blank_cfg.network.sv2_authority_public_key = Some("   ".to_string());
+        let blank_state = Arc::new(
+            crate::server::VerificationState::new(
+                "test_node".to_string(),
+                "1.0.0".to_string(),
+                PolicyProfile::default(),
+                NodeCapabilities::default(),
+            )
+            .with_full_node_config(blank_cfg, dir_blank.path().join("pool.toml")),
+        );
+        assert_eq!(
+            authority(blank_state).await,
+            serde_json::Value::Null,
+            "a blank setting must read as unconfigured, not as an empty key"
         );
 
         // Operator override via pool.toml wins.
@@ -14346,7 +14376,11 @@ mod tests {
             )
             .with_full_node_config(cfg, path),
         );
-        assert_eq!(authority(override_state).await, "customAuthorityKey123");
+        assert_eq!(
+            authority(override_state).await,
+            serde_json::Value::String("customAuthorityKey123".to_string()),
+            "the node's own configured key must be advertised verbatim"
+        );
     }
 
     /// The self-check endpoint must serialise a FAILING snapshot so the

--- a/scripts/install-node.sh
+++ b/scripts/install-node.sh
@@ -890,6 +890,22 @@ SV2_AUTH_PUB="$(sed -n 's/^authority_public_key *= *"\(.*\)"$/\1/p' <<<"$SV2_KEY
 SV2_AUTH_SEC="$(sed -n 's/^authority_secret_key *= *"\(.*\)"$/\1/p' <<<"$SV2_KEYPAIR")"
 [[ -n "$SV2_AUTH_PUB" && -n "$SV2_AUTH_SEC" ]] || err "Could not parse the generated SV2 authority keypair."
 
+# Tell the node its OWN authority key, so /api/v1/mining/status advertises the key this
+# node's pool_sv2 actually presents. pool.toml was written earlier — before the keypair
+# existed — so it is patched here rather than templated above.
+#
+# There is no default to fall back on and there must not be one: an SV2 miner that pins a
+# wrong key cannot reach this pool, but WOULD authenticate anyone holding the secret half
+# of whatever key it was told to trust (#516). Unset, the API says `null`, which is the
+# honest answer.
+if grep -q '^sv2_authority_public_key' /etc/ghost/pool.toml; then
+  sed -i "s|^sv2_authority_public_key.*|sv2_authority_public_key = \"${SV2_AUTH_PUB}\"|" /etc/ghost/pool.toml
+else
+  sed -i "/^\[network\]/a sv2_authority_public_key = \"${SV2_AUTH_PUB}\"" /etc/ghost/pool.toml
+fi
+grep -q "^sv2_authority_public_key = \"${SV2_AUTH_PUB}\"$" /etc/ghost/pool.toml \
+  || err "Failed to record the SV2 authority public key in pool.toml."
+
 # Farm/rental tier (#410). Emitted ONLY for public_pool: a private or solo node has a
 # known set of miners and no rented hashrate to serve, so a second public listener is
 # surface it does not need. `reconcile-mining-firewall.sh` opens 4444 on the same

--- a/scripts/rotate-sv2-authority.sh
+++ b/scripts/rotate-sv2-authority.sh
@@ -22,6 +22,7 @@ set -euo pipefail
 
 POOL_CONF=/etc/ghost/pool-config.toml
 TRAN_CONF=/etc/ghost/translator-config.toml
+NODE_CONF=/etc/ghost/pool.toml
 STAMP=$(date +%Y%m%d-%H%M%S)
 SV2_PORT=34255
 POOL_READY_TIMEOUT=240
@@ -30,12 +31,18 @@ TRAN_READY_TIMEOUT=180
 restore() {
     cp -a "${POOL_CONF}.bak.${STAMP}" "$POOL_CONF"
     cp -a "${TRAN_CONF}.bak.${STAMP}" "$TRAN_CONF"
+    # pool.toml too, and ghost-pool below to reload it. A rollback that restores the
+    # SERVED key but leaves the ADVERTISED one rolled forward is the exact drift this
+    # script exists to prevent — the pool would answer on the old key while the API
+    # told miners to pin the new one.
+    cp -a "${NODE_CONF}.bak.${STAMP}" "$NODE_CONF"
     systemctl restart sri-pool || true
     for _ in $(seq 1 "$POOL_READY_TIMEOUT"); do
         ss -ltn 2>/dev/null | grep -q ":${SV2_PORT}" && break
         sleep 1
     done
     systemctl restart sri-translator || true
+    systemctl restart ghost-pool || true
 }
 
 # REFUSE if anything outside this box is connected to the SV2 port.
@@ -71,7 +78,7 @@ if [ "${EXTERNAL:-0}" -gt 0 ]; then
     echo "  WARNING: proceeding — the miners above will stay down until reconfigured." >&2
 fi
 
-for f in "$POOL_CONF" "$TRAN_CONF"; do
+for f in "$POOL_CONF" "$TRAN_CONF" "$NODE_CONF"; do
     [[ -r "$f" ]] || { echo "REFUSED: cannot read $f" >&2; exit 1; }
     cp -a "$f" "${f}.bak.${STAMP}"
 done
@@ -91,6 +98,15 @@ sed -i "s|^authority_public_key *= *\".*\"|authority_public_key = \"${NEW_PUB}\"
 sed -i "s|^authority_secret_key *= *\".*\"|authority_secret_key = \"${NEW_SEC}\"|" "$POOL_CONF"
 sed -i "s|^authority_pubkey *= *\".*\"|authority_pubkey = \"${NEW_PUB}\"|" "$TRAN_CONF"
 
+# Third file: what the node ADVERTISES on /api/v1/mining/status. Miss it and the API keeps
+# naming the old key, so the website and dashboard hand miners a pin that no longer works —
+# and the old key's secret is, by definition, the one we are rotating away from (#516).
+if grep -q '^sv2_authority_public_key' "$NODE_CONF"; then
+    sed -i "s|^sv2_authority_public_key.*|sv2_authority_public_key = \"${NEW_PUB}\"|" "$NODE_CONF"
+else
+    sed -i "/^\[network\]/a sv2_authority_public_key = \"${NEW_PUB}\"" "$NODE_CONF"
+fi
+
 # Verify the two agree BEFORE restarting anything — a mismatch here is a dead node.
 P=$(sed -n 's/^authority_public_key *= *"\(.*\)"$/\1/p' "$POOL_CONF")
 T=$(sed -n 's/^authority_pubkey *= *"\(.*\)"$/\1/p' "$TRAN_CONF")
@@ -98,6 +114,7 @@ if [[ "$P" != "$T" || "$P" != "$NEW_PUB" ]]; then
     echo "REFUSED: pool/translator keys disagree after edit — restoring" >&2
     cp -a "${POOL_CONF}.bak.${STAMP}" "$POOL_CONF"
     cp -a "${TRAN_CONF}.bak.${STAMP}" "$TRAN_CONF"
+    cp -a "${NODE_CONF}.bak.${STAMP}" "$NODE_CONF"
     exit 1
 fi
 


### PR DESCRIPTION
Closes #516. Node-side half; the website half is #519.

## What was wrong

`/api/v1/mining/status` fell back to a hardcoded `SV2_AUTHORITY_PUBLIC_KEY` when a node had no `[network] sv2_authority_public_key` set. **No node had it set**, so all 8 advertised that constant — and it matched no node's real key. vm1–vm4 had rotated away from it; vm5–vm8 never had it, because `install-node.sh` generates a keypair per node.

Its secret half is public: it is the upstream SRI test fixture, which is why the key was rotated in the first place.

## Why a default is the wrong shape here

A wrong pin is worse than a missing one. The miner cannot reach the real pool, but **would** authenticate anyone holding the secret half of whatever key it was told to trust. Silence is the honest answer, so the constant is gone and the field is `Option<String>` — a node that does not know its own key advertises `null`.

Blank and whitespace-only settings read as unconfigured rather than as an empty key, so a half-finished edit cannot produce a nonsense pin either.

## Keeping it from drifting again

Both scripts that create or change a keypair now record it:

- **`install-node.sh`** writes the generated key into `pool.toml` and fails loudly if it cannot. `pool.toml` is templated before the keypair exists, so it is patched afterwards rather than templated.
- **`rotate-sv2-authority.sh`** updates it as a **third** file alongside the pool and translator configs — and its rollback now restores `pool.toml` and restarts `ghost-pool` too. A rollback that restored the *served* key while leaving the *advertised* one rolled forward would recreate exactly the drift the script exists to prevent.

## Tests

`test_mining_status_exposes_authority_key` rewritten to pin the new contract: unconfigured → `null` (never a guess), whitespace → `null`, configured → that value verbatim, and the field is always present so consumers can distinguish "no key" from "no field".

236 `ghost-verification` tests green, 284 `ghost-common`. Also cleared the one clippy warning in `ghost-verification`, leaving the crate at zero.

## Note on fleet state

The fleet has since been consolidated onto **one shared authority keypair** across all 8 nodes, which is how SV2 is designed to work for a single-operator pool — the authority key is the pool identity, and each node certifies its own short-lived static key with it. That does not change anything here: a node must still advertise the key it actually presents, and must never guess. See #520 for the parked multi-operator design.