### PR TITLE
ops: make the canary soak exercise the share-submission path

### DIFF
--- a/scripts/deploy-node.sh
+++ b/scripts/deploy-node.sh
@@ -119,6 +119,35 @@ if echo "$PRODUCTION_NODES" | grep -qw "$NODE"; then
     fi
 fi
 
+# Exercise the SHARE-SUBMISSION path against a node, synthetically.
+#
+# A canary has no miners (#461), so "healthy for 60 minutes" says nothing about the code path
+# where both of the regressions that motivated this gate actually lived: attribution, and a
+# declared difficulty that never reached the wire. A node can sit green for the whole window
+# with either bug fully present and the soak will still report satisfied — the same
+# can't-fail-shape as #459.
+#
+# The smoke suite synthesises a real SV1 client, so it works on a node with zero miners. It is
+# the only part of the soak that touches submission at all, which is why it is mandatory here
+# rather than a remembered manual step.
+#
+# Returns 0 if the submission path answered correctly.
+exercise_submission_path() {
+    local node="$1" host
+    host=$(ssh_host_for "$node") || return 1
+    [ -n "$host" ] || return 1
+
+    timeout 120 python3 "$REPO_ROOT/bins/translator-sv2/tests/sv1_handshake_smoke.py" \
+        "$host" 3333 2>&1 | sed 's/^/      /'
+    return "${PIPESTATUS[0]}"
+}
+
+# Resolve a node alias to something the smoke client can connect to. The probes run from HERE,
+# not on the node, so `localhost` is wrong — it needs the address ssh would dial.
+ssh_host_for() {
+    ssh -G "$1" 2>/dev/null | awk '/^hostname /{print $2; exit}'
+}
+
 # 4. Canary soak before production. The bugs that hurt were behavioural and only showed
 #    under real traffic over time — an hourly livelock, and attribution that looked fine
 #    until a share was actually mined and its DB row inspected.
@@ -149,7 +178,17 @@ if echo "$PRODUCTION_NODES" | grep -qw "$NODE"; then
                 continue
             fi
         fi
-        SOAKED="$c (${elapsed}m)"
+        # Re-run at the END of the window, not only at the start. A one-shot check at minute
+        # zero cannot see anything that emerges under sustained traffic — drift, a leak, a
+        # livelock, vardiff misbehaving over many ticks. The hourly OOM took hours to show.
+        info "re-checking the submission path on $c after ${elapsed}m"
+        if ! exercise_submission_path "$c"; then
+            info "ignoring soak on $c: submission path FAILS at the end of the window"
+            rm -f "$f"
+            continue
+        fi
+
+        SOAKED="$c (${elapsed}m, submission path verified)"
         break
     done
     [ -n "$SOAKED" ] || die "$BINARY @ $SHORT has not soaked ${SOAK_MINUTES}m on a canary
@@ -308,6 +347,16 @@ if echo "$CANARY_NODES" | grep -qw "$NODE"; then
     # still running this build rather than something a rollback restored underneath it.
     LIVE_HASH=$(timeout "$REMOTE_TIMEOUT" ssh "${SSH_OPTS[@]}" "$NODE" \
         "sha256sum /opt/ghost/bin/$BINARY 2>/dev/null | cut -d' ' -f1" 2>/dev/null || true)
+
+    # Do not start a clock on a build whose submission path is already broken. Waiting an hour
+    # to discover that is an hour spent proving nothing (#461).
+    info "exercising the share-submission path on $NODE before starting the clock"
+    if ! exercise_submission_path "$NODE"; then
+        die "submission-path smoke FAILED on $NODE — no soak clock started for $BINARY @ $SHORT
+       a canary cannot vouch for a build whose miners cannot handshake"
+    fi
+    info "submission path OK on $NODE"
+
     printf '%s %s\n' "$(date +%s)" "${LIVE_HASH:-}" > "$STATE_DIR/soaked-$SHA-$NODE-$BINARY"
     info "soak clock started for $BINARY @ $SHORT on $NODE (${SOAK_MINUTES}m required before production)"
 fi

--- a/scripts/test-deploy-gate.sh
+++ b/scripts/test-deploy-gate.sh
@@ -30,6 +30,19 @@ REPO_ROOT="$TMP/repo"
 mkdir -p "$REPO_ROOT/scripts" "$REPO_ROOT/bins/translator-sv2/tests" "$REPO_ROOT/crates"
 cp "$SRC_ROOT/scripts/deploy-node.sh" "$REPO_ROOT/scripts/deploy-node.sh"
 : > "$REPO_ROOT/crates/.keep"
+
+# Stand-in for the SV1 smoke suite, which the soak gate now runs against a canary (#461).
+# Committed here rather than written mid-test, because creating a file later would dirty the
+# tree and trip the clean-tree gate before the case under test is reached.
+#
+# Its exit code is driven by GATE_SMOKE_EXIT so a single committed file can play both a healthy
+# and a broken submission path.
+cat > "$REPO_ROOT/bins/translator-sv2/tests/sv1_handshake_smoke.py" <<'SMOKE_STUB'
+#!/usr/bin/env python3
+import os, sys
+sys.exit(int(os.environ.get("GATE_SMOKE_EXIT", "0")))
+SMOKE_STUB
+chmod +x "$REPO_ROOT/bins/translator-sv2/tests/sv1_handshake_smoke.py"
 git -C "$REPO_ROOT" init -q
 git -C "$REPO_ROOT" add -A
 git -C "$REPO_ROOT" -c user.email=t@t -c user.name=t commit -qm "gate under test"
@@ -45,6 +58,7 @@ run_gate() {
     local node="$1" binary="$2"
     ( cd "$REPO_ROOT" \
         && GHOST_DEPLOY_REPO_ROOT="$REPO_ROOT" STATE_DIR="$TMP/state" SOAK_MINUTES=60 \
+        GATE_SMOKE_EXIT="${GATE_SMOKE_EXIT:-0}" \
         timeout 60 bash "$DEPLOY" "$node" "$binary" 2>&1 )
 }
 
@@ -106,7 +120,45 @@ out="$(run_gate ghost-vm1 translator_sv2)"
 check "a 5-minute soak does not satisfy a 60-minute requirement" "has not soaked" "$out"
 
 # ---------------------------------------------------------------------------
-# 5. Canary deploys must NOT require a soak — that is the point of a canary.
+# 5. A LONG ENOUGH soak whose submission path is broken must NOT satisfy the gate.
+#
+#    This is the #461 case. A canary has no miners, so "healthy for 60 minutes" says nothing
+#    about the path where both motivating regressions lived. Before this, the gate accepted a
+#    soak purely on elapsed time and a matching hash — a build could handshake-deadlock every
+#    miner and still be waved into production.
+# ---------------------------------------------------------------------------
+printf '%s %s\n' "$(( $(date +%s) - 7200 ))" "" \
+    > "$TMP/state/soaked-$SHA-ghost-vm5-translator_sv2"
+out="$(GATE_SMOKE_EXIT=1 run_gate ghost-vm1 translator_sv2)"
+check "a 2-hour soak with a FAILING submission path does not satisfy the gate" \
+    "has not soaked" "$out"
+
+# The refused record must also be cleared, so a later run cannot inherit the same bad vouch.
+if [ -f "$TMP/state/soaked-$SHA-ghost-vm5-translator_sv2" ]; then
+    printf "  [BAD] a soak refused for a broken submission path was left on disk\n"
+    fail=$((fail+1))
+else
+    printf "  [ok ] a refused soak record is cleared, not left to be re-read\n"
+    pass=$((pass+1))
+fi
+
+# ---------------------------------------------------------------------------
+# 6. The same soak with a PASSING submission path DOES satisfy the gate — so the
+#    check above is a real gate and not a blanket refusal.
+# ---------------------------------------------------------------------------
+printf '%s %s\n' "$(( $(date +%s) - 7200 ))" "" \
+    > "$TMP/state/soaked-$SHA-ghost-vm5-translator_sv2"
+out="$(run_gate ghost-vm1 translator_sv2)"
+if grep -qi "has not soaked" <<<"$out"; then
+    printf "  [BAD] a good soak with a passing submission path was still refused\n"
+    fail=$((fail+1))
+else
+    printf "  [ok ] a soak with a verified submission path satisfies the gate\n"
+    pass=$((pass+1))
+fi
+
+# ---------------------------------------------------------------------------
+# 7. Canary deploys must NOT require a soak — that is the point of a canary.
 #    It should get past the soak gate and fail later (on ssh or a missing binary).
 # ---------------------------------------------------------------------------
 rm -f "$TMP/state/soaked-$SHA"-*
@@ -128,4 +180,4 @@ if [ "$fail" -ne 0 ]; then
     echo "*** $fail of $((pass+fail)) deploy-gate checks FAILED — the gate is not refusing what it must ***"
     exit 1
 fi
-echo "All $pass deploy-gate checks passed: the gate refuses untested, unsoaked, wrong-binary and short soaks."
+echo "All $pass deploy-gate checks passed: the gate refuses untested, unsoaked, wrong-binary, short, and submission-path-broken soaks."


### PR DESCRIPTION
Refs #461 (option 1 — the half that needs no operator decision).

## The gap

The soak gates every production deploy, and it was blind to the one code path both motivating regressions lived on.

No canary has miners. Shares over 30 minutes, split by local submission vs gossip:

| node | local | gossiped |
|---|---|---|
| ghost-vm3 | **87** | 487 |
| ghost-vm4 | **488** | 87 |
| every other node | **0** | ~570 |

`CANARY_NODES="ghost-vm5 ghost-vm6 ghost-vm7 ghost-vm8"` — all zeros. So the soak was measuring uptime and gossip, never submission. A canary could sit healthy for the full 60 minutes with attribution broken, or with a declared difficulty never reaching the wire, and the gate would report the soak satisfied. That is the same can't-fail shape as #459.

## What changed

The SV1 smoke suite synthesises a real client, so it runs against a node with zero miners. It is now run at **both** ends of the window:

- **Before the clock starts** — no point spending an hour on a build whose miners cannot handshake.
- **Again when the marker is consumed** — a check at minute zero cannot see what only emerges under sustained traffic: drift, a leak, a livelock, vardiff over many ticks. The hourly OOM took hours to appear.

A soak whose end-of-window check fails has its marker **deleted**, not just skipped, so a later run cannot inherit the same bad vouch — the same reasoning as the rollback-detection path directly above it.

## Verified against a real canary

Against ghost-vm6, all 10 cases pass — including the two that cover the exact regressions this exists for:

```
[pw-difficulty]   PASS — asked for 1,000,000, pool set 1,000,000.0 on the first set_difficulty at 0.1s
[suggest-diff]    PASS — asked for 1,000,000, pool set 1,000,000.0 on the first set_difficulty at 0.1s
[attribution]     PASS — authorized …y492.attribtest as True, per-miner extranonce1=0001000400…
[serializer]      PASS — subscribe answered in 1.57s (no deadlock)
```

## Gate self-test

`test-deploy-gate.sh` grows two cases, and 8/8 now pass:

- a 2-hour soak with a **failing** submission path is refused, **and** its record is cleared
- the same soak with a **passing** one is accepted

The second matters as much as the first. Without it the new check could be a blanket refusal and still look green.

One harness detail worth noting: the smoke stub is committed into the hermetic repo at setup rather than written mid-test. Creating a file later dirties the working tree, and the clean-tree gate then fires before the case under test is reached — which is exactly how the first version of these tests passed for the wrong reason.

## What this does not fix

The one-shot limitation is reduced, not removed. A synthetic probe still cannot observe behaviour that needs sustained *real* load. #461's option 2 — pointing a real miner at a canary — is the only thing that makes the soak mean what it claims, and it needs an operator decision because it moves a miner.

`bitaxe4` is currently offline pending reconfiguration for the new SV2 authority key. If it is going to be reconfigured by hand anyway, pointing it at a canary instead of vm4 would close this at no extra cost. Leaving that for the operator.