### PR TITLE
feat(node): expose maxconnections, its real inbound headroom, and a memory-bounded limit

### DIFF
--- a/crates/ghost-verification/src/lib.rs
+++ b/crates/ghost-verification/src/lib.rs
@@ -49,6 +49,7 @@ pub mod config;
 pub mod handlers;
 pub mod journal;
 pub mod log_buffer;
+pub mod maxconnections;
 pub mod pool_series;
 pub mod qualification;
 pub mod routes;

--- a/crates/ghost-verification/src/maxconnections.rs
+++ b/crates/ghost-verification/src/maxconnections.rs
@@ -1,0 +1,310 @@
+//! Reading and changing ghostd's `maxconnections` (#499).
+//!
+//! This is not a cosmetic setting. Core reserves the outbound slots out of `maxconnections`, so
+//! a node configured at 50 has roughly 40 inbound to give. A settled node sits at ~39 of them,
+//! is therefore **full**, and Core then refuses new peers — including crawlers, which record it
+//! unreachable and drop it from public listings. The whole fleet vanished from node listings
+//! that way while every node was healthy and externally reachable (#497, #498).
+//!
+//! Nothing surfaced that. An operator saw a healthy node with no indication it was turning peers
+//! away, and no way to change it without SSH.
+
+use std::path::PathBuf;
+
+/// Outbound slots Core holds back from `maxconnections`: 8 full-relay + 2 block-relay-only.
+///
+/// These are Core's documented defaults (`MAX_OUTBOUND_FULL_RELAY_CONNECTIONS` and
+/// `MAX_BLOCK_RELAY_ONLY_CONNECTIONS`). Feeler connections are short-lived and not counted here.
+/// The inbound capacity an operator actually has is `maxconnections` MINUS this, which is the
+/// number that matters and the one nothing was showing.
+pub const RESERVED_OUTBOUND: u32 = 10;
+
+/// Fraction of inbound capacity at which a node is close enough to full to warn about.
+///
+/// Being full is silent — it does not degrade, it just stops accepting, and the node disappears
+/// from other people's view of the network while looking perfectly healthy from the inside.
+pub const NEAR_CEILING_FRACTION: f64 = 0.85;
+
+/// Memory allowance per peer used to bound the recommended maximum, in MB.
+///
+/// Core's per-peer ceilings are `maxreceivebuffer` (5 MB) plus `maxsendbuffer` (1 MB); steady
+/// state is far below that, often under 1 MB. 4 MB sits between typical and worst case
+/// deliberately: sizing for the typical figure is what lets a node get killed under load, and
+/// sizing for the ceiling gives a bound so low it is useless.
+///
+/// It is a judgement, not a measurement, so the API returns it alongside the number it produced
+/// rather than presenting the bound as fact.
+pub const PER_PEER_MB: u64 = 4;
+
+/// Memory left for everything that is not peer connections, in MB.
+pub const HEADROOM_MB: u64 = 512;
+
+/// Core's own default when `maxconnections` is absent from the config.
+pub const CORE_DEFAULT: u32 = 125;
+
+/// Refuse anything above this regardless of available memory — past here the file-descriptor
+/// limit and Core's own behaviour matter more than RAM, and we are no longer the right judge.
+pub const HARD_MAX: u32 = 500;
+
+/// Path to ghostd's config file. `GHOST_BITCOIN_CONF` overrides it, which is also how tests
+/// point at a temporary file instead of the real one.
+pub fn conf_path() -> PathBuf {
+    std::env::var("GHOST_BITCOIN_CONF")
+        .unwrap_or_else(|_| "/etc/bitcoin/bitcoin.conf".to_string())
+        .into()
+}
+
+/// What the config file says, and whether it says it more than once.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Configured {
+    /// The effective value, or `None` when the file does not set it (Core then uses its default).
+    pub value: Option<u32>,
+    /// Every value found, in file order. More than one entry means the file is ambiguous.
+    pub all_values: Vec<u32>,
+}
+
+impl Configured {
+    /// A file that sets `maxconnections` more than once is ambiguous, and we will not write to it.
+    ///
+    /// Which occurrence Core honours is a detail of its settings layer, not something worth
+    /// guessing at from here — and a writer that guesses could silently move a value the operator
+    /// believes is set to something else entirely.
+    pub fn is_ambiguous(&self) -> bool {
+        self.all_values.len() > 1
+    }
+
+    /// The value in force: what the file sets, else Core's default.
+    pub fn effective(&self) -> u32 {
+        self.value.unwrap_or(CORE_DEFAULT)
+    }
+}
+
+/// Parse `maxconnections` out of a config file's text.
+///
+/// Comments and `[section]` headers are ignored, as is leading whitespace. Core does not accept
+/// trailing comments on a value line, so neither do we.
+pub fn parse(contents: &str) -> Configured {
+    let mut all_values = Vec::new();
+    for line in contents.lines() {
+        let line = line.trim();
+        if line.starts_with('#') || line.starts_with('[') {
+            continue;
+        }
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        if key.trim() != "maxconnections" {
+            continue;
+        }
+        if let Ok(n) = value.trim().parse::<u32>() {
+            all_values.push(n);
+        }
+    }
+    Configured {
+        value: all_values.last().copied(),
+        all_values,
+    }
+}
+
+/// Read the configured value from disk. A missing file reads as "not set", not an error — a node
+/// can legitimately run on Core's defaults.
+pub fn read_configured() -> std::io::Result<Configured> {
+    match std::fs::read_to_string(conf_path()) {
+        Ok(contents) => Ok(parse(&contents)),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Configured {
+            value: None,
+            all_values: Vec::new(),
+        }),
+        Err(e) => Err(e),
+    }
+}
+
+/// Inbound slots available at a given `maxconnections`.
+pub fn inbound_capacity(maxconnections: u32) -> u32 {
+    maxconnections.saturating_sub(RESERVED_OUTBOUND)
+}
+
+/// MemAvailable in MB, or `None` when `/proc/meminfo` cannot be read or lacks the field.
+///
+/// MemAvailable, not MemTotal: what matters is what this node can still allocate alongside
+/// everything already resident. vm6 has ~1376 MB available against a ghostd RSS of ~1441 MB —
+/// sizing that node off MemTotal would recommend a number it cannot survive (#417, #418).
+pub fn mem_available_mb() -> Option<u64> {
+    let meminfo = std::fs::read_to_string("/proc/meminfo").ok()?;
+    for line in meminfo.lines() {
+        if let Some(rest) = line.strip_prefix("MemAvailable:") {
+            let kb: u64 = rest.trim().trim_end_matches("kB").trim().parse().ok()?;
+            return Some(kb / 1024);
+        }
+    }
+    None
+}
+
+/// The largest `maxconnections` this node's available memory supports.
+///
+/// `None` when memory cannot be determined — the caller must then decline to recommend rather
+/// than substitute a guess, because a fabricated ceiling is worse than an absent one.
+pub fn recommended_max(mem_available_mb: Option<u64>) -> Option<u32> {
+    let available = mem_available_mb?;
+    let for_peers = available.saturating_sub(HEADROOM_MB);
+    let peers = (for_peers / PER_PEER_MB) as u32;
+    // Never recommend below Core's own reserve — a value under that leaves no inbound capacity
+    // at all and is not a meaningful setting.
+    Some(peers.clamp(RESERVED_OUTBOUND + 1, HARD_MAX))
+}
+
+/// Rewrite `maxconnections` in a config file's text, returning the new text.
+///
+/// Replaces the existing setting in place, preserving everything around it, or appends it when
+/// absent. Refuses an ambiguous file rather than picking an occurrence to edit.
+pub fn rewrite(contents: &str, new_value: u32) -> Result<String, String> {
+    let configured = parse(contents);
+    if configured.is_ambiguous() {
+        return Err(format!(
+            "config sets maxconnections {} times ({:?}); refusing to guess which one is in force \
+             — remove the duplicates first",
+            configured.all_values.len(),
+            configured.all_values
+        ));
+    }
+
+    if configured.value.is_none() {
+        // Append, keeping exactly one trailing newline.
+        let mut out = contents.trim_end().to_string();
+        if !out.is_empty() {
+            out.push('\n');
+        }
+        out.push_str(&format!("maxconnections={new_value}\n"));
+        return Ok(out);
+    }
+
+    let mut out = String::with_capacity(contents.len() + 16);
+    // Preserve whether the original ended with a newline; rewriting a line must not silently
+    // add or remove one.
+    let ends_with_newline = contents.ends_with('\n');
+    let mut lines = contents.lines().peekable();
+    while let Some(line) = lines.next() {
+        let trimmed = line.trim();
+        let is_setting = !trimmed.starts_with('#')
+            && !trimmed.starts_with('[')
+            && trimmed.split_once('=').is_some_and(|(k, v)| {
+                k.trim() == "maxconnections" && v.trim().parse::<u32>().is_ok()
+            });
+        if is_setting {
+            out.push_str(&format!("maxconnections={new_value}"));
+        } else {
+            out.push_str(line);
+        }
+        if lines.peek().is_some() || ends_with_newline {
+            out.push('\n');
+        }
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_a_plain_setting() {
+        let c = parse("server=1\nmaxconnections=125\ntxindex=1\n");
+        assert_eq!(c.value, Some(125));
+        assert!(!c.is_ambiguous());
+        assert_eq!(c.effective(), 125);
+    }
+
+    #[test]
+    fn an_absent_setting_reads_as_cores_default_not_as_zero() {
+        let c = parse("server=1\ntxindex=1\n");
+        assert_eq!(c.value, None);
+        assert_eq!(
+            c.effective(),
+            CORE_DEFAULT,
+            "a node with no setting runs on Core's default, not on nothing"
+        );
+    }
+
+    #[test]
+    fn comments_and_sections_are_not_settings() {
+        let c = parse("# maxconnections=999\n[main]\nmaxconnections=50\n");
+        assert_eq!(
+            c.all_values,
+            vec![50],
+            "a commented-out value is not in force"
+        );
+    }
+
+    /// A file that sets it twice is ambiguous, and we refuse to write rather than pick.
+    #[test]
+    fn a_duplicated_setting_is_refused_not_guessed() {
+        let text = "maxconnections=50\nserver=1\nmaxconnections=125\n";
+        let c = parse(text);
+        assert!(c.is_ambiguous());
+        let err = rewrite(text, 200).unwrap_err();
+        assert!(err.contains("refusing to guess"), "got: {err}");
+    }
+
+    #[test]
+    fn rewriting_preserves_every_other_line_and_its_position() {
+        let before = "# ghostd config\nserver=1\nmaxconnections=50\nrpcuser=x\n";
+        let after = rewrite(before, 125).unwrap();
+        assert_eq!(
+            after,
+            "# ghostd config\nserver=1\nmaxconnections=125\nrpcuser=x\n"
+        );
+    }
+
+    #[test]
+    fn appends_when_the_setting_is_absent() {
+        let after = rewrite("server=1\ntxindex=1\n", 125).unwrap();
+        assert_eq!(after, "server=1\ntxindex=1\nmaxconnections=125\n");
+        assert_eq!(parse(&after).value, Some(125));
+    }
+
+    /// A file with no trailing newline must not gain one silently, and vice versa.
+    #[test]
+    fn rewriting_preserves_the_trailing_newline_exactly() {
+        assert_eq!(
+            rewrite("maxconnections=50", 125).unwrap(),
+            "maxconnections=125"
+        );
+        assert_eq!(
+            rewrite("maxconnections=50\n", 125).unwrap(),
+            "maxconnections=125\n"
+        );
+    }
+
+    /// The number that actually matters: inbound capacity, not the headline setting.
+    #[test]
+    fn inbound_capacity_is_the_setting_minus_cores_outbound_reserve() {
+        // The exact case from #497: 50 configured looks generous and leaves 40 inbound,
+        // which a settled node fills.
+        assert_eq!(inbound_capacity(50), 40);
+        assert_eq!(inbound_capacity(125), 115);
+        // Never negative.
+        assert_eq!(inbound_capacity(5), 0);
+    }
+
+    #[test]
+    fn the_recommendation_is_bounded_by_available_memory() {
+        // 4 GB available: (4096 - 512) / 4 = 896, clamped to the hard max.
+        assert_eq!(recommended_max(Some(4096)), Some(HARD_MAX));
+        // 1376 MB — vm6's real figure: (1376 - 512) / 4 = 216.
+        assert_eq!(recommended_max(Some(1376)), Some(216));
+        // A tight node gets a correspondingly small number: (600 - 512) / 4 = 22.
+        assert_eq!(recommended_max(Some(600)), Some(22));
+        // And once headroom eats nearly everything, the floor holds rather than
+        // recommending a value with no inbound capacity at all: (520 - 512) / 4 = 2 -> 11.
+        assert_eq!(recommended_max(Some(520)), Some(RESERVED_OUTBOUND + 1));
+        // Below the headroom reserve entirely, the floor still holds.
+        assert_eq!(recommended_max(Some(100)), Some(RESERVED_OUTBOUND + 1));
+    }
+
+    /// Unknown memory must produce no recommendation at all. A fabricated ceiling is worse
+    /// than an absent one, because it looks like it was measured.
+    #[test]
+    fn no_memory_reading_means_no_recommendation() {
+        assert_eq!(recommended_max(None), None);
+    }
+}

--- a/crates/ghost-verification/src/routes.rs
+++ b/crates/ghost-verification/src/routes.rs
@@ -516,6 +516,13 @@ pub fn create_router(state: Arc<VerificationState>) -> Router {
             get(api_ghostpay_payout_history_handler),
         )
         .route("/api/v1/config/full", get(api_config_full_handler))
+        // maxconnections (#499). Both verbs are on the internal tier: the POST mutates node
+        // config, and the GET exposes the node's peer-slot headroom — useful to an operator,
+        // and equally useful to someone deciding how few connections it takes to fill it.
+        .route(
+            "/api/v1/config/maxconnections",
+            get(api_config_maxconnections_handler).post(api_config_maxconnections_post_handler),
+        )
         .route("/api/v1/config/alerts", get(api_config_alerts_handler))
         // Admin endpoints for testing
         .route("/admin/test-consensus", post(admin_test_consensus_handler))
@@ -4874,6 +4881,229 @@ async fn api_watchdog_status_handler(
             .as_secs(),
         "uptime_secs": health.uptime_secs
     }))
+}
+
+/// GET the node's peer-connection limit, what it is actually using, and what its memory supports.
+///
+/// The headline `maxconnections` is not the number that matters — Core reserves outbound slots
+/// out of it, so a node at 50 has 40 inbound to give and a settled node fills them. It is then
+/// full and refuses new peers, including crawlers, which is how the whole fleet disappeared from
+/// public node listings while every node was healthy (#497, #498). Nothing surfaced that, so this
+/// returns inbound capacity and utilisation rather than making an operator infer them.
+async fn api_config_maxconnections_handler(
+    State(state): State<Arc<VerificationState>>,
+) -> impl IntoResponse {
+    let configured = match crate::maxconnections::read_configured() {
+        Ok(c) => c,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({
+                    "error": format!("cannot read {}: {e}", crate::maxconnections::conf_path().display()),
+                })),
+            )
+                .into_response();
+        }
+    };
+
+    let effective = configured.effective();
+    let inbound_capacity = crate::maxconnections::inbound_capacity(effective);
+
+    // Live counts. Absent when ghostd cannot be reached — reported as null rather than 0, which
+    // would read as "no peers" instead of "we do not know".
+    let (connections, connections_in, connections_out) = match state.rpc {
+        Some(ref rpc) => {
+            match tokio::time::timeout(std::time::Duration::from_secs(5), rpc.get_network_info())
+                .await
+            {
+                Ok(Ok(info)) => (
+                    Some(info.connections),
+                    Some(info.connections_in),
+                    Some(info.connections_out),
+                ),
+                _ => (None, None, None),
+            }
+        }
+        None => (None, None, None),
+    };
+
+    let utilisation = connections_in
+        .and_then(|inb| (inbound_capacity > 0).then(|| inb as f64 / inbound_capacity as f64));
+    let near_ceiling = utilisation.map(|u| u >= crate::maxconnections::NEAR_CEILING_FRACTION);
+
+    let mem_available_mb = crate::maxconnections::mem_available_mb();
+    let recommended_max = crate::maxconnections::recommended_max(mem_available_mb);
+
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({
+            "configured": configured.value,
+            "effective": effective,
+            "is_core_default": configured.value.is_none(),
+            // More than one setting in the file means we will not write to it, so say so here
+            // rather than letting the POST be the first time anyone finds out.
+            "ambiguous": configured.is_ambiguous(),
+            "all_configured_values": configured.all_values,
+            "inbound_capacity": inbound_capacity,
+            "reserved_outbound": crate::maxconnections::RESERVED_OUTBOUND,
+            "connections": connections,
+            "connections_in": connections_in,
+            "connections_out": connections_out,
+            "inbound_utilisation": utilisation,
+            "near_ceiling": near_ceiling,
+            "recommended_max": recommended_max,
+            "hard_max": crate::maxconnections::HARD_MAX,
+            // The recommendation is a judgement, not a measurement. Return what produced it so
+            // an operator can disagree with it on the evidence rather than on faith.
+            "recommendation_basis": {
+                "mem_available_mb": mem_available_mb,
+                "per_peer_mb": crate::maxconnections::PER_PEER_MB,
+                "headroom_mb": crate::maxconnections::HEADROOM_MB,
+            },
+            "requires_restart": true,
+            "config_path": crate::maxconnections::conf_path().display().to_string(),
+        })),
+    )
+        .into_response()
+}
+
+/// Request body for changing `maxconnections`.
+#[derive(serde::Deserialize)]
+struct MaxConnectionsUpdate {
+    value: u32,
+    /// Set to accept a value above what this node's available memory supports. Without it, such
+    /// a value is refused — a control that ignores memory is worse than no control, because it
+    /// invites an operator to OOM a node from a web page.
+    #[serde(default)]
+    force: bool,
+}
+
+/// POST a new `maxconnections`, persisted to ghostd's config file.
+///
+/// It does NOT take effect until ghostd restarts, and this does not restart it: that drops the
+/// TDP template feed `pool_sv2` depends on, so pausing mining is the operator's call to make
+/// deliberately, not a side effect of saving a setting. The response says so explicitly.
+async fn api_config_maxconnections_post_handler(
+    Json(payload): Json<MaxConnectionsUpdate>,
+) -> impl IntoResponse {
+    apply_maxconnections_update(&crate::maxconnections::conf_path(), payload)
+}
+
+/// The body of the POST, with the config path passed in.
+///
+/// Separated so tests can drive it against a temporary file. Reaching it through the env var
+/// instead would mean three tests mutating one process-wide variable while the harness runs them
+/// in parallel — a race that shows up as an occasional failure and gets re-run rather than fixed.
+fn apply_maxconnections_update(
+    path: &std::path::Path,
+    payload: MaxConnectionsUpdate,
+) -> axum::response::Response {
+    let bad = |msg: String| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": msg })),
+        )
+            .into_response()
+    };
+
+    // Below the outbound reserve there is no inbound capacity at all, which is not a setting
+    // anyone means to choose.
+    if payload.value <= crate::maxconnections::RESERVED_OUTBOUND {
+        return bad(format!(
+            "{} leaves no inbound capacity — Core reserves {} outbound slots",
+            payload.value,
+            crate::maxconnections::RESERVED_OUTBOUND
+        ));
+    }
+    if payload.value > crate::maxconnections::HARD_MAX {
+        return bad(format!(
+            "{} exceeds the hard maximum of {}",
+            payload.value,
+            crate::maxconnections::HARD_MAX
+        ));
+    }
+
+    let mem_available_mb = crate::maxconnections::mem_available_mb();
+    let recommended = crate::maxconnections::recommended_max(mem_available_mb);
+    if let Some(rec) = recommended {
+        if payload.value > rec && !payload.force {
+            return bad(format!(
+                "{} is above this node's memory-derived maximum of {rec} \
+                 ({}MB available, {}MB per peer, {}MB headroom); pass force=true to override",
+                payload.value,
+                mem_available_mb.unwrap_or(0),
+                crate::maxconnections::PER_PEER_MB,
+                crate::maxconnections::HEADROOM_MB,
+            ));
+        }
+    } else if !payload.force {
+        // Unknown memory. Refusing is the safe default — we cannot say the value is survivable.
+        return bad(
+            "cannot read available memory, so this node's maximum is unknown; \
+             pass force=true to set it anyway"
+                .to_string(),
+        );
+    }
+
+    let contents = match std::fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(
+                    serde_json::json!({ "error": format!("cannot read {}: {e}", path.display()) }),
+                ),
+            )
+                .into_response();
+        }
+    };
+
+    let previous = crate::maxconnections::parse(&contents);
+    let updated = match crate::maxconnections::rewrite(&contents, payload.value) {
+        Ok(u) => u,
+        Err(e) => return bad(e),
+    };
+
+    // Write through a temporary file in the same directory and rename, so an interrupted write
+    // cannot leave ghostd with a truncated config it will refuse to start on.
+    let tmp = path.with_extension("conf.tmp");
+    if let Err(e) = std::fs::write(&tmp, &updated) {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({ "error": format!("cannot write {}: {e}", tmp.display()) })),
+        )
+            .into_response();
+    }
+    if let Err(e) = std::fs::rename(&tmp, path) {
+        let _ = std::fs::remove_file(&tmp);
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({ "error": format!("cannot replace {}: {e}", path.display()) })),
+        )
+            .into_response();
+    }
+
+    info!(
+        previous = ?previous.value,
+        new = payload.value,
+        forced = payload.force,
+        "maxconnections updated in ghostd config (restart required)"
+    );
+
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({
+            "previous": previous.value,
+            "value": payload.value,
+            "inbound_capacity": crate::maxconnections::inbound_capacity(payload.value),
+            "forced": payload.force,
+            "requires_restart": true,
+            "message": "saved to ghostd's config. It takes effect on the next ghostd restart, \
+                        which briefly interrupts mining — restart when you are ready.",
+        })),
+    )
+        .into_response()
 }
 
 /// API v1 System version handler
@@ -14290,6 +14520,87 @@ mod tests {
         let data: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(data["total"].as_u64(), Some(1));
         assert_eq!(data["miners"].as_array().unwrap().len(), 1);
+    }
+
+    /// The POST must not let an operator set a value this node's memory cannot support.
+    ///
+    /// A control that ignores memory is worse than no control: it invites someone to OOM a node
+    /// from a web page, and vm6 is exactly the node that would go — ~1376MB available against a
+    /// ghostd RSS of ~1441MB (#417, #418). Overriding must be possible but deliberate.
+    #[test]
+    fn maxconnections_post_refuses_a_value_memory_cannot_support() {
+        use crate::maxconnections;
+
+        let dir = tempfile::tempdir().unwrap();
+        let conf = dir.path().join("bitcoin.conf");
+        std::fs::write(&conf, "server=1\nmaxconnections=50\nrpcuser=x\n").unwrap();
+        // Whatever this host reports, a value one above its own ceiling must be refused and the
+        // file left untouched. Derive the target rather than hardcoding one, so the test says the
+        // same thing on a laptop and on a 1GB VM.
+        let ceiling = maxconnections::recommended_max(maxconnections::mem_available_mb());
+        let too_big = ceiling.map(|c| c + 1).unwrap_or(maxconnections::HARD_MAX);
+
+        let resp = super::apply_maxconnections_update(
+            &conf,
+            MaxConnectionsUpdate {
+                value: too_big,
+                force: false,
+            },
+        );
+
+        // With a readable /proc/meminfo the ceiling exists and `too_big` exceeds it; without one
+        // the handler refuses for the other reason. Either way it must refuse.
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(
+            std::fs::read_to_string(&conf).unwrap(),
+            "server=1\nmaxconnections=50\nrpcuser=x\n",
+            "a refused update must not have touched the config file"
+        );
+    }
+
+    /// A value below Core's outbound reserve leaves zero inbound capacity, which is never a
+    /// setting anyone means to choose — and is the failure mode this whole endpoint exists for.
+    #[test]
+    fn maxconnections_post_refuses_a_value_with_no_inbound_capacity() {
+        let dir = tempfile::tempdir().unwrap();
+        let conf = dir.path().join("bitcoin.conf");
+        std::fs::write(&conf, "maxconnections=125\n").unwrap();
+        let resp = super::apply_maxconnections_update(
+            &conf,
+            MaxConnectionsUpdate {
+                value: crate::maxconnections::RESERVED_OUTBOUND,
+                force: true, // even forced: this is arithmetic, not a judgement call
+            },
+        );
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(
+            std::fs::read_to_string(&conf).unwrap(),
+            "maxconnections=125\n"
+        );
+    }
+
+    /// An accepted update rewrites the value in place and leaves every other line alone —
+    /// this is ghostd's config, and a setting lost here does not surface until a restart.
+    #[test]
+    fn maxconnections_post_rewrites_in_place_and_preserves_the_rest() {
+        let dir = tempfile::tempdir().unwrap();
+        let conf = dir.path().join("bitcoin.conf");
+        std::fs::write(&conf, "# ghostd\nserver=1\nmaxconnections=50\nrpcuser=x\n").unwrap();
+        // 40 is under any plausible memory ceiling, so this exercises the success path
+        // regardless of the host it runs on.
+        let resp = super::apply_maxconnections_update(
+            &conf,
+            MaxConnectionsUpdate {
+                value: 40,
+                force: false,
+            },
+        );
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            std::fs::read_to_string(&conf).unwrap(),
+            "# ghostd\nserver=1\nmaxconnections=40\nrpcuser=x\n"
+        );
     }
 
     /// `/api/v1/mining/status` exposes this node's OWN SV2 authority public key,

--- a/crates/ghost-verification/src/routes.rs
+++ b/crates/ghost-verification/src/routes.rs
@@ -14586,21 +14586,49 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let conf = dir.path().join("bitcoin.conf");
         std::fs::write(&conf, "# ghostd\nserver=1\nmaxconnections=50\nrpcuser=x\n").unwrap();
-        // 40 is under any plausible memory ceiling, so this exercises the success path
-        // regardless of the host it runs on.
+        // 40 is under any plausible memory ceiling — but only a host that can MEASURE its
+        // memory accepts it unforced. macOS has no /proc/meminfo, so there the handler
+        // correctly refuses rather than claiming a value is survivable that it cannot check.
+        // Assert the real behaviour on each platform instead of assuming Linux: this test
+        // failed CI on macOS when it assumed.
+        let measurable = crate::maxconnections::mem_available_mb().is_some();
         let resp = super::apply_maxconnections_update(
             &conf,
             MaxConnectionsUpdate {
                 value: 40,
-                force: false,
+                force: !measurable,
             },
         );
 
-        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "40 is below any plausible ceiling and must be accepted (forced only where memory \
+             cannot be read)"
+        );
         assert_eq!(
             std::fs::read_to_string(&conf).unwrap(),
             "# ghostd\nserver=1\nmaxconnections=40\nrpcuser=x\n"
         );
+
+        // Where memory is unreadable, the same update WITHOUT force must be refused — else
+        // that branch would go silently untested on exactly the platform that exercises it.
+        if !measurable {
+            std::fs::write(&conf, "# ghostd\nserver=1\nmaxconnections=50\nrpcuser=x\n").unwrap();
+            let refused = super::apply_maxconnections_update(
+                &conf,
+                MaxConnectionsUpdate {
+                    value: 40,
+                    force: false,
+                },
+            );
+            assert_eq!(refused.status(), StatusCode::BAD_REQUEST);
+            assert_eq!(
+                std::fs::read_to_string(&conf).unwrap(),
+                "# ghostd\nserver=1\nmaxconnections=50\nrpcuser=x\n",
+                "a refused update must not have touched the file"
+            );
+        }
     }
 
     /// `/api/v1/mining/status` exposes this node's OWN SV2 authority public key,


### PR DESCRIPTION
Refs #499 — the API half. Dashboard UI is a follow-up.

## Why this is not a cosmetic setting

Core reserves the outbound slots **out of** `maxconnections`. The fleet's 50 therefore left ~40 inbound, a settled node sat at ~39, and the node was **full** — refusing new peers, including the crawlers that then recorded it unreachable and dropped it from public listings. Every node was healthy and externally reachable throughout (#497, #498).

Nothing surfaced any of that. An operator saw a healthy node with no indication it was turning peers away, and no way to change it without SSH. So this returns **inbound capacity and utilisation**, not just the headline number an operator would have to know to reinterpret.

## `GET /api/v1/config/maxconnections`

Configured value · whether it is merely Core's default · live `connections` / `_in` / `_out` · inbound capacity · utilisation · a `near_ceiling` flag at 85% · the memory-derived maximum · whether the file is ambiguous.

Live counts are `null` when ghostd is unreachable, never `0` — "no peers" and "we don't know" are different answers.

## `POST /api/v1/config/maxconnections`

Refuses, in order:

- **at or below the outbound reserve** — leaves zero inbound capacity; never a setting anyone means to choose. Refused even with `force`, because it is arithmetic rather than a judgement call
- **above the memory-derived maximum**, unless `force: true`. A control that ignores memory is worse than no control — it invites someone to OOM a node from a web page, and vm6 is precisely the node that would go (~1376MB available against a ghostd RSS of ~1441MB, #417/#418)
- **anything at all when memory cannot be read**, unless forced. We cannot claim a value is survivable when we cannot measure

The recommendation is a judgement, not a measurement, so the response carries what produced it — `mem_available_mb`, `per_peer_mb`, `headroom_mb` — for an operator to disagree with on evidence rather than on faith. `MemAvailable` rather than `MemTotal`, since what matters is what the node can still allocate alongside what is already resident.

## Safety of the write

- temp file + rename, so an interrupted write cannot leave ghostd with a truncated config it refuses to start on
- a file setting `maxconnections` more than once is **refused**, not edited by guess. Which occurrence Core honours is its business, and a writer that guesses could silently move a value the operator believes is set
- rewrites in place, preserving every other line and the trailing-newline convention
- **does not restart ghostd.** That drops the TDP template feed `pool_sv2` depends on, so pausing mining stays a deliberate operator action. The response says so rather than implying the change took effect

Both verbs sit on the internal HMAC tier: the POST mutates node config, and the GET reports how few connections it takes to fill this node.

## Tests

13, covering: parsing (comments, sections, absent-means-Core-default), ambiguity refusal, in-place rewrite preserving surrounding lines and the trailing newline, inbound capacity including the exact #497 case (50 → 40), the memory bound and its floor, and no-memory-means-no-recommendation.

The three handler tests drive the write path against a temp file rather than through the env var. Three tests mutating one process-wide variable while the harness runs them in parallel is a race that surfaces as an occasional failure and gets re-run instead of fixed — so the shared state is gone rather than serialised.

Parser checked against the real fleet configs: vm1/vm4 one setting at 125, vm6 one at 50, none ambiguous. 249 crate tests pass; no new clippy warnings.

## Not in this PR

The dashboard UI, and the near-ceiling alert. The API returns everything both need.