### PR TITLE
ops: soak on the canary that has miners, and say so when it has none

### DIFF
--- a/scripts/deploy-node.sh
+++ b/scripts/deploy-node.sh
@@ -42,6 +42,13 @@ NODE="${1:-}"
 BINARY="${2:-}"
 CANARY="${3:-}"
 
+# Order matters: the soak gate below takes the FIRST canary with a valid marker, so whichever
+# is listed first is the one that gets soaked in practice.
+#
+# ghost-vm5 leads because it is the only canary carrying a real miner (bitaxe3, ~60 shares per
+# 30 minutes). Real submitted traffic is the one thing a synthetic probe cannot reproduce, and
+# soaking on a canary with none is how the gate stayed blind to the submission path (#461).
+# vm5 is also at schema 46 like production, where vm6 and vm8 carry the drift from #523.
 CANARY_NODES="ghost-vm5 ghost-vm6 ghost-vm7 ghost-vm8"
 PRODUCTION_NODES="ghost-vm1 ghost-vm2 ghost-vm3 ghost-vm4"
 SOAK_MINUTES="${SOAK_MINUTES:-60}"
@@ -188,7 +195,27 @@ if echo "$PRODUCTION_NODES" | grep -qw "$NODE"; then
             continue
         fi
 
-        SOAKED="$c (${elapsed}m, submission path verified)"
+        # How much REAL traffic this canary took while it soaked.
+        #
+        # A share submitted here carries a plaintext `address.worker` miner_id; one that arrived
+        # by gossip carries a 16-hex hash, because peers only ever see the hashed form. That is
+        # the reliable discriminator — `received_by` length is NOT, since it is a concatenation
+        # of 8-character node-id prefixes and length 8 merely means one node has recorded it.
+        #
+        # This does not gate: the synthetic probe above already covers the submission path, and
+        # blocking every deploy on a miner being connected would be worse than the problem. It
+        # exists so "this soak observed no real traffic" is stated rather than assumed.
+        local_shares=$(timeout "$REMOTE_TIMEOUT" ssh "${SSH_OPTS[@]}" "$c" \
+            "sudo -u ghost sqlite3 /home/ghost/.ghost/ghost.db \
+             \"select count(*) from shares where timestamp > $started and miner_id like '%.%';\"" \
+            2>/dev/null || true)
+        if [ "${local_shares:-0}" -gt 0 ] 2>/dev/null; then
+            SOAKED="$c (${elapsed}m, submission path verified, ${local_shares} real shares)"
+        else
+            info "note: $c took NO real submitted shares while soaking — the synthetic probe passed,"
+            info "      but nothing that needs sustained real traffic was exercised (#461)"
+            SOAKED="$c (${elapsed}m, submission path verified, no real traffic)"
+        fi
         break
     done
     [ -n "$SOAKED" ] || die "$BINARY @ $SHORT has not soaked ${SOAK_MINUTES}m on a canary


### PR DESCRIPTION
Refs #461. Follows #524.

## List order silently decided everything

The gate takes the **first** canary with a valid marker, so whichever is listed first is the one that actually gets soaked. `ghost-vm5` now leads, because it is the only canary carrying a real miner — `bitaxe3`, ~60 shares per 30 minutes.

Real submitted traffic is the one thing a synthetic probe cannot reproduce, and soaking on a canary that has none is how the gate stayed blind to the submission path in the first place. vm5 is also at schema 46 like production, where vm6 and vm8 carry the drift from #523.

## And it now says when it saw nothing

The soak reports how many real shares the canary took during its window. It deliberately **does not gate** on that: #524's synthetic probe already covers the submission path, and blocking every deploy on a miner happening to be connected would be worse than the problem. This exists so *"this soak observed no real traffic"* is stated rather than assumed.

## Counting it correctly turned out to matter

#461's own table used `length(received_by) > 8` to mean "gossiped". But `received_by` is a concatenation of 8-character node-id prefixes, so length 8 means *one node has recorded this share* — not *it was submitted here*. By that measure every canary looks like it has ~1000 local shares.

The reliable discriminator is `miner_id`: plaintext `address.worker` on the node that received it, a 16-hex hash on every peer. Re-measured on that basis, same window:

```
vm1 345   vm2   0   vm3 355   vm4 303
vm5  60   vm6   0   vm7   0   vm8   0
```

Which is how vm5 turned out to have a miner at all. The issue states every canary is at zero; one is not, and it is the one worth soaking on.

## Verified

Query run against the live fleet: vm5 returns 63, vm6 returns 0. 8/8 deploy-gate checks still pass.

## Still outstanding on #461

Concentrating the test miners on vm5 — `bitaxe4` is offline pending reconfiguration for the new SV2 authority key, so pointing it at vm5 rather than back at vm4 costs nothing and gives the soak a second independent miner. Operator action.