### PR TITLE
feat(mesh): advertise the stratum tier ports so farm routing can work

### DIFF
--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -2828,6 +2828,19 @@ async fn main() -> Result<()> {
         } else {
             None
         },
+        // SV1 tier listeners, so peers can route by tier (#495).
+        //
+        // Only advertised when this node actually accepts outside hashpower. A private or solo
+        // node advertising a listener would invite connections it will refuse, and the failure
+        // reads to the sender as an unreachable peer rather than a deliberate policy.
+        //
+        // The farm port is `None` unless the operator configured one. A node that advertises a
+        // farm port it does not listen on turns a routing decision into a dropped connection,
+        // so the safe direction is to say nothing.
+        advertised_hobby_port: is_public_mining.then_some(config.network.sv1_port),
+        advertised_farm_port: is_public_mining
+            .then_some(config.network.farm_port)
+            .flatten(),
         // Advertise our node-reward payout address so every peer's node registry
         // converges (payout-finalisation: without it get_all_node_ids_with_payout
         // returns {self} everywhere and the payout checkpoint can't finalise).
@@ -6364,6 +6377,11 @@ async fn main() -> Result<()> {
                 last_seen: p.last_seen,
                 max_capacity: p.max_capacity,
                 deduped_miner_count: deduped.get(&p.node_id).copied().unwrap_or(0),
+                // Gossiped SV1 tier listeners (#495). Passed through verbatim, including None:
+                // the translator must be able to tell "no farm tier" from "farm tier on 4444",
+                // and only absence keeps a peer out of farm routing.
+                hobby_port: p.hobby_port,
+                farm_port: p.farm_port,
             })
             .collect()
     });

--- a/crates/ghost-common/src/config.rs
+++ b/crates/ghost-common/src/config.rs
@@ -1270,6 +1270,17 @@ pub struct NetworkConfig {
     pub sv2_port: u16,
     /// SV1 Stratum port (translator)
     pub sv1_port: u16,
+    /// This node's SV1 **farm/rental** listener, gossiped so peers can route farm traffic here
+    /// (#495). `None` = this node runs no farm tier and must never be sent farm connections.
+    ///
+    /// It duplicates the translator's `[farm_tier] port`, because the two live in different
+    /// processes: `translator_sv2` owns the listener, `ghost-pool` owns the gossip. Duplication
+    /// is the lesser evil against ghost-pool reading another service's config file, but it can
+    /// drift — and a node advertising a farm port it does not listen on turns a routing decision
+    /// into a dropped connection. `scripts/check-stratum-config-agreement.sh` holds the two in
+    /// step, in the same spirit as the extension-key invariant added for #480.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub farm_port: Option<u16>,
     /// HTTP API port (plain HTTP — SRI webhook, nginx upstream, dashboard).
     pub http_port: u16,
     /// HTTPS port for the inter-peer verification mesh.
@@ -1406,6 +1417,7 @@ impl Default for NetworkConfig {
             public_address: None,
             sv2_port: SV2_STRATUM_PORT,
             sv1_port: SV1_STRATUM_PORT,
+            farm_port: None,
             http_port: HTTP_API_PORT,
             verification_https_port: crate::constants::VERIFICATION_HTTPS_PORT,
             p2p: P2PPortConfig::default(),

--- a/crates/ghost-common/src/types.rs
+++ b/crates/ghost-common/src/types.rs
@@ -475,6 +475,26 @@ pub struct HealthPing {
     /// empty Vec, and newer nodes simply ignore peers that omit it.
     #[serde(default)]
     pub best_records: Vec<WindowBestRecord>,
+    /// This node's SV1 **hobby** stratum listener, and its **farm** listener when it runs one.
+    ///
+    /// The load balancer became tier-aware in #494 but nothing advertised which listeners a node
+    /// actually runs, so no peer was ever a farm-routing candidate and the busiest node could not
+    /// shed a farm miner. This is the half that switches it on (#495).
+    ///
+    /// Deliberately NOT in `NodeCapabilities`: every field there feeds `total_shares()` for the
+    /// 5-4-3-2-1 scoring model, and a port number would corrupt the score.
+    ///
+    /// `None` on a peer that predates this field. The consumer treats absent-hobby as "serves the
+    /// default 3333", which is what every node did before the farm tier existed, and absent-farm
+    /// as "not a farm target" — assuming a farm port is how a farm miner lands on a hobby floor,
+    /// so absence disqualifies rather than defaults. A partial rollout therefore degrades to
+    /// "no farm routing", never to misrouting.
+    #[serde(default)]
+    pub hobby_port: Option<u16>,
+    /// See `hobby_port`. `None` means either "no farm tier" or "too old to say", and both must be
+    /// treated identically: not a farm routing target.
+    #[serde(default)]
+    pub farm_port: Option<u16>,
     /// If this node has opted in as a Wraith coordinator
     /// (`capabilities.coordinator`), the reachable endpoint a wallet should dial
     /// to mix with it: a public `host:port` or a `.onion`. This is a DELIBERATE,
@@ -1167,6 +1187,8 @@ mod tests {
             active_miner_id_hashes: vec![[1u8; 16], [2u8; 16]],
             local_hashrate_th: 4.0,
             max_capacity: 0,
+            hobby_port: None,
+            farm_port: None,
             best_records: vec![WindowBestRecord {
                 window: "day".to_string(),
                 share_hash: "0".repeat(8) + &"f".repeat(56),

--- a/crates/ghost-consensus/src/health_handler.rs
+++ b/crates/ghost-consensus/src/health_handler.rs
@@ -872,6 +872,10 @@ impl HealthPingHandler {
         // Hardware-derived capacity used by the LB for utilisation routing.
         self.peers
             .update_max_capacity(&envelope.sender, ping.max_capacity);
+        // SV1 tier listeners, so the translator's load balancer can route farm traffic to a peer
+        // that actually runs a farm listener (#495).
+        self.peers
+            .update_tier_ports(&envelope.sender, ping.hobby_port, ping.farm_port);
         // Swarm-page telemetry: L1 height, trailing-7-day uptime %, this peer's
         // own peer count, and Ghost Pay L2 height. Older peers omit the Option
         // fields (→ None) and report block_height 0, all handled inside the

--- a/crates/ghost-consensus/src/mesh.rs
+++ b/crates/ghost-consensus/src/mesh.rs
@@ -98,6 +98,12 @@ pub struct MeshConfig {
     /// `.onion`. `None` for nodes that haven't opted in — they advertise no
     /// endpoint and so are never elected.
     pub advertised_coordinator_endpoint: Option<String>,
+    /// SV1 hobby and farm listeners advertised to peers so the load balancer can route by tier
+    /// (#495). Both `None` until the operator configures them; a peer that advertises neither is
+    /// still a valid hobby target on the default port, but never a farm target.
+    pub advertised_hobby_port: Option<u16>,
+    /// See `advertised_hobby_port`.
+    pub advertised_farm_port: Option<u16>,
     /// This node's node-reward payout address, advertised in health pings so every
     /// peer learns it (see `HealthPing::payout_address`). Read from local config;
     /// `None` when no payout address is configured.
@@ -166,6 +172,8 @@ impl Default for MeshConfig {
             max_seen_messages: 100_000, // Cap at 100k messages (~3.2MB with 32-byte IDs)
             capabilities: ghost_common::types::NodeCapabilities::default(),
             advertised_coordinator_endpoint: None,
+            advertised_hobby_port: None,
+            advertised_farm_port: None,
             advertised_payout_address: None,
             // C-1: Enable Noise by default for secure-by-default operation
             noise_enabled: true,
@@ -3041,6 +3049,9 @@ impl MeshNetwork {
                 active_miner_id_hashes,
                 local_hashrate_th,
                 max_capacity: self.max_capacity.load(Ordering::Relaxed),
+                // Static, operator-chosen listeners read from config, never mutated at runtime.
+                hobby_port: self.config.advertised_hobby_port,
+                farm_port: self.config.advertised_farm_port,
                 best_records,
                 // Static, operator-chosen advertisement (read from config, never
                 // mutated at runtime), so reading from self.config is fine.

--- a/crates/ghost-consensus/src/peer.rs
+++ b/crates/ghost-consensus/src/peer.rs
@@ -201,6 +201,14 @@ impl PeerManager {
             if merged.coordinator_endpoint.is_none() {
                 merged.coordinator_endpoint = existing.coordinator_endpoint.clone();
             }
+            // Same reasoning as the fields above: a bare re-announce carries no tier ports, and
+            // blanking them would drop the peer out of farm routing until its next full ping.
+            if merged.hobby_port.is_none() {
+                merged.hobby_port = existing.hobby_port;
+            }
+            if merged.farm_port.is_none() {
+                merged.farm_port = existing.farm_port;
+            }
             if merged.coordinator_sessions == 0 {
                 merged.coordinator_sessions = existing.coordinator_sessions;
             }
@@ -402,6 +410,27 @@ impl PeerManager {
     /// Update a peer's hardware-derived `max_capacity` (advertised in their
     /// most recent health ping). Used by the load balancer to compute
     /// utilisation for routing decisions.
+    /// Record the SV1 tier listeners a peer advertised in its health ping (#495).
+    ///
+    /// A ping that omits them leaves the cached values alone. Absence on the wire means "this
+    /// build does not say", not "this node has no listeners", and clearing on every such ping
+    /// would make farm routing flap for the whole mixed-version window.
+    pub fn update_tier_ports(
+        &self,
+        node_id: &NodeId,
+        hobby_port: Option<u16>,
+        farm_port: Option<u16>,
+    ) {
+        if let Some(peer) = self.peers.write().get_mut(node_id) {
+            if hobby_port.is_some() {
+                peer.hobby_port = hobby_port;
+            }
+            if farm_port.is_some() {
+                peer.farm_port = farm_port;
+            }
+        }
+    }
+
     pub fn update_max_capacity(&self, node_id: &NodeId, max_capacity: u32) {
         if let Some(peer) = self.peers.write().get_mut(node_id) {
             peer.max_capacity = max_capacity;
@@ -538,6 +567,11 @@ pub struct Peer {
     /// (legacy or pre-update node) — treated as "unknown" and excluded
     /// from utilisation-based routing.
     pub max_capacity: u32,
+    /// The peer's advertised SV1 tier listeners (#495). `None` = not advertised; for the farm
+    /// port that must be read as "not a farm target", never as a default.
+    pub hobby_port: Option<u16>,
+    /// See `hobby_port`.
+    pub farm_port: Option<u16>,
     /// This peer's best (rarest) valid share per records window, from its most
     /// recent health ping. Merged with the local DB best (and every other
     /// peer's) so the `/api/v1/pool/records` endpoint returns the mesh-wide
@@ -590,6 +624,8 @@ impl Peer {
             active_miner_id_hashes: Vec::new(),
             local_hashrate_th: 0.0,
             max_capacity: 0,
+            hobby_port: None,
+            farm_port: None,
             best_records: Vec::new(),
             coordinator_endpoint: None,
             coordinator_sessions: 0,
@@ -950,6 +986,52 @@ mod tests {
             mgr.get_peer(&pid).unwrap().active_miner_id_hashes,
             vec![[9u8; 16]],
             "a real ping update must still overwrite"
+        );
+    }
+
+    /// A health ping that omits the tier ports must not blank what the peer already told us.
+    ///
+    /// Absence on the wire means "this build does not say", not "this node has no listeners".
+    /// Clearing on every such ping would drop peers in and out of farm routing for the whole
+    /// mixed-version window — the same flap the other gossiped fields are guarded against (#495).
+    #[test]
+    fn a_ping_without_tier_ports_does_not_erase_known_ones() {
+        let mgr = PeerManager::new([0xFFu8; 32], 100);
+        let pid = [9u8; 32];
+        mgr.upsert_peer(Peer::new(pid, "10.0.0.9:8080".to_string()));
+
+        mgr.update_tier_ports(&pid, Some(3333), Some(4444));
+        let got = mgr.get_peer(&pid).expect("peer");
+        assert_eq!((got.hobby_port, got.farm_port), (Some(3333), Some(4444)));
+
+        // An older build's ping carries neither.
+        mgr.update_tier_ports(&pid, None, None);
+        let got = mgr.get_peer(&pid).expect("peer");
+        assert_eq!(
+            (got.hobby_port, got.farm_port),
+            (Some(3333), Some(4444)),
+            "a ping that says nothing about ports must leave the known ones alone"
+        );
+
+        // A node that genuinely moves its farm listener still updates.
+        mgr.update_tier_ports(&pid, None, Some(4455));
+        assert_eq!(mgr.get_peer(&pid).unwrap().farm_port, Some(4455));
+    }
+
+    /// A peer that has never advertised a farm port must stay `None` — the translator reads that
+    /// as "not a farm target", and a default here is how a farm miner lands on a hobby floor.
+    #[test]
+    fn an_unadvertised_farm_port_stays_absent_rather_than_defaulting() {
+        let mgr = PeerManager::new([0xFFu8; 32], 100);
+        let pid = [10u8; 32];
+        mgr.upsert_peer(Peer::new(pid, "10.0.0.10:8080".to_string()));
+
+        mgr.update_tier_ports(&pid, Some(3333), None);
+        let got = mgr.get_peer(&pid).expect("peer");
+        assert_eq!(got.hobby_port, Some(3333));
+        assert_eq!(
+            got.farm_port, None,
+            "a peer running no farm tier must never be presented as a farm target"
         );
     }
 

--- a/crates/ghost-verification/src/server.rs
+++ b/crates/ghost-verification/src/server.rs
@@ -1095,6 +1095,16 @@ pub struct PoolPeerInfo {
     /// miner that fails over between nodes.
     #[serde(default)]
     pub deduped_miner_count: u32,
+    /// The peer's SV1 hobby listener, or `None` if it does not advertise one. The translator
+    /// treats absence as "serves the default 3333", which is what every node did before the farm
+    /// tier existed (#495).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hobby_port: Option<u16>,
+    /// The peer's SV1 farm listener. `None` means "no farm tier" OR "too old to say", and both
+    /// disqualify it as a farm routing target — assuming a port is how a farm miner ends up on a
+    /// hobby floor.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub farm_port: Option<u16>,
 }
 
 /// One mesh node as surfaced by the public `/api/v1/pool/mesh-nodes`

--- a/scripts/check-stratum-config-agreement.sh
+++ b/scripts/check-stratum-config-agreement.sh
@@ -29,7 +29,7 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 
 python3 - <<'PY'
-import re, sys
+import os, re, sys
 
 INSTALLER = "scripts/install-node.sh"
 REFERENCE = "config/sri/translator-config.toml"
@@ -211,6 +211,74 @@ for k, check in INVARIANTS.items():
         ok, why = check(v)
         if not ok:
             problems.append(f"{k} = {v} in {path} — {why}")
+
+# ---------------------------------------------------------------------------
+# Cross-file: the farm port ghost-pool GOSSIPS must equal the one the translator LISTENS on.
+#
+# translator_sv2 owns the listener (`[farm_tier] port`); ghost-pool owns the advertisement
+# (`[network] farm_port` in pool.toml), because they are different processes and ghost-pool
+# must not read another service's config file. So the value is duplicated, and duplication
+# drifts.
+#
+# Drift here is not cosmetic: a node advertising a farm port it does not listen on turns a
+# routing decision into a dropped connection, and the sender reads that as an unreachable peer
+# rather than a misconfiguration (#495).
+farm_listen = None
+in_farm = False
+for line in open(REFERENCE, encoding="utf-8"):
+    t = line.strip()
+    if t.startswith("["):
+        in_farm = t == "[farm_tier]"
+        continue
+    if in_farm and t.startswith("port"):
+        m = re.match(r"port\s*=\s*(\d+)", t)
+        if m:
+            farm_listen = int(m.group(1))
+        break
+
+farm_advertise = None
+for line in open("config/sri/pool.toml", encoding="utf-8") if os.path.exists("config/sri/pool.toml") else []:
+    m = re.match(r"\s*farm_port\s*=\s*(\d+)", line)
+    if m:
+        farm_advertise = int(m.group(1))
+        break
+
+# The installer writes both files, so it is the copy that actually reaches a node.
+installer_src = open(INSTALLER, encoding="utf-8").read()
+inst_farm_listen = None
+m = re.search(r"\[farm_tier\]\s*\nport\s*=\s*(\d+)", installer_src)
+if m:
+    inst_farm_listen = int(m.group(1))
+inst_farm_advertise = None
+m = re.search(r"^\s*farm_port\s*=\s*(\d+)", installer_src, re.M)
+if m:
+    inst_farm_advertise = int(m.group(1))
+
+if inst_farm_listen is not None and inst_farm_advertise is None:
+    problems.append(
+        f"{INSTALLER} configures a farm listener on {inst_farm_listen} but never sets "
+        "[network] farm_port in pool.toml — the node listens and never tells anyone, "
+        "so farm routing stays inert (#495)"
+    )
+elif (
+    inst_farm_listen is not None
+    and inst_farm_advertise is not None
+    and inst_farm_listen != inst_farm_advertise
+):
+    problems.append(
+        f"{INSTALLER} listens for farm traffic on {inst_farm_listen} but advertises "
+        f"{inst_farm_advertise} — peers would route farm connections to a closed port"
+    )
+
+if (
+    farm_listen is not None
+    and farm_advertise is not None
+    and farm_listen != farm_advertise
+):
+    problems.append(
+        f"{REFERENCE} listens for farm traffic on {farm_listen} but config/sri/pool.toml "
+        f"advertises {farm_advertise}"
+    )
 
 if problems:
     print("Stratum config sources disagree, or an invariant is broken:\n", file=sys.stderr)

--- a/scripts/install-node.sh
+++ b/scripts/install-node.sh
@@ -704,6 +704,19 @@ log "Writing /etc/ghost/pool.toml"
 # ghost-pool REQUIRES: a miner password for both, plus the operator's solo
 # payout address for private_solo (99% subsidy + all fees route there).
 MINING_BLOCK="mining_mode = \"${MINING_MODE}\""
+# Tell peers about the farm listener, on exactly the nodes that run one.
+#
+# The listener itself is the translator's ([farm_tier] port, emitted below for public_pool
+# only); this is ghost-pool's advertisement of it. They are separate processes, so the port is
+# duplicated — `scripts/check-stratum-config-agreement.sh` keeps the two in step, because a node
+# advertising a port it does not listen on turns a routing decision into a dropped connection.
+#
+# Without this the listener is open and nobody is told, which is why farm routing has been inert
+# since #494 shipped (#495).
+if [[ "$MINING_MODE" == "public_pool" ]]; then
+  MINING_BLOCK="${MINING_BLOCK}
+farm_port = 4444"
+fi
 case "$MINING_MODE" in
   private_pool)
     MINING_BLOCK="${MINING_BLOCK}


### PR DESCRIPTION
Closes #495. Unblocks #472 / #494.

## The inert half

The load balancer became tier-aware in #494, but **no node advertised which stratum listeners it runs**. So a peer was never a farm-routing candidate, and the busiest node could not shed a farm miner. #494 shipped inert by design; this switches it on.

`hobby_port` and `farm_port` are gossiped on the health ping as `Option<u16>`. Deliberately **not** in `NodeCapabilities` — every field there feeds `total_shares()` for the 5-4-3-2-1 model, and a port number would corrupt the score.

The consumer already existed: `PeerInfo` in the translator's `load_balancer` deserialises both with `#[serde(default)]` and treats an absent farm port as "not a farm target". So a partial rollout degrades to *no farm routing*, never to misrouting — a property now asserted rather than relied on by accident.

## Absence is preserved in three places, deliberately

- A ping that **omits** the ports leaves the cached values alone, matching how every other gossiped field is guarded. Absence on the wire means "this build does not say", not "this node has no listeners", and clearing on each such ping would flap peers in and out of farm routing for the whole mixed-version window
- A bare **re-announce** likewise does not blank them
- An **unadvertised** farm port stays `None` rather than defaulting — assuming a port is exactly how a farm miner ends up on a hobby floor

Ports are advertised only where the node actually accepts outside hashpower. A private or solo node advertising a listener invites connections it will refuse, and the sender reads that as an unreachable peer rather than deliberate policy.

## The duplication, and the gate that found a live bug

The farm port has to exist twice: `translator_sv2` owns the listener (`[farm_tier] port`), `ghost-pool` owns the advertisement (`[network] farm_port`), and they are separate processes — ghost-pool must not read another service's config file. Duplication drifts, and drift here is not cosmetic: a node advertising a port it does not listen on turns a routing decision into a dropped connection.

So `check-stratum-config-agreement.sh` now holds the two in step, in the same spirit as the extension-key invariant added for #480.

**It immediately found the live defect it was written for:**

```
scripts/install-node.sh configures a farm listener on 4444 but never sets
[network] farm_port in pool.toml — the node listens and never tells anyone,
so farm routing stays inert (#495)
```

Every public node provisioned by the installer is in that state today. Fixed in the same change.

The gate is verified to **fail on drift** rather than being inert — deliberately skewing the installer to 4455 produces:

```
listens for farm traffic on 4444 but advertises 4455 — peers would route
farm connections to a closed port
```

## Tests

Two new, both about the safety direction rather than the happy path:

- a ping without tier ports does not erase known ones (and a genuine port change still applies)
- an unadvertised farm port stays absent rather than defaulting

785 tests across `ghost-consensus`, `ghost-common` and `ghost-verification` pass. The translator's 10 load-balancer tests are untouched and still green.

## Rollout

Per the issue: ship the advertisement everywhere, confirm every node reports both ports, and only then treat farm routing as live. The fail-safe direction means a partial fleet simply does no farm routing in the meantime.