### PR TITLE
fix(mesh): address tree sync responses, so a node stops processing everyone else's

### DIFF
--- a/crates/ghost-common/src/serde_hex.rs
+++ b/crates/ghost-common/src/serde_hex.rs
@@ -56,6 +56,43 @@ pub mod bytes32 {
     }
 }
 
+/// Serialize/deserialize `Option<[u8; 32]>` as hex, or null.
+///
+/// For fields added to an existing wire type: a peer that predates the field omits it and
+/// deserialises to `None`, so the receiver can tell "not sent" from a real value instead of
+/// having to invent a sentinel.
+pub mod opt_bytes32 {
+    use super::*;
+
+    pub fn serialize<S>(bytes: &Option<[u8; 32]>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match bytes {
+            Some(b) => serializer.serialize_some(&hex::encode(b)),
+            None => serializer.serialize_none(),
+        }
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<[u8; 32]>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let opt = Option::<String>::deserialize(deserializer)?;
+        let Some(s) = opt else { return Ok(None) };
+        let bytes = hex::decode(&s).map_err(serde::de::Error::custom)?;
+        if bytes.len() != 32 {
+            return Err(serde::de::Error::custom(format!(
+                "expected 32 bytes, got {}",
+                bytes.len()
+            )));
+        }
+        let mut arr = [0u8; 32];
+        arr.copy_from_slice(&bytes);
+        Ok(Some(arr))
+    }
+}
+
 /// Serialize/deserialize [u8; 64] as hex
 pub mod bytes64 {
     use super::*;

--- a/crates/ghost-consensus/src/message.rs
+++ b/crates/ghost-consensus/src/message.rs
@@ -1319,6 +1319,18 @@ pub struct L2TreeSyncResponse {
     /// Responding node ID
     #[serde(with = "ghost_common::serde_hex::bytes32")]
     pub responding_node: NodeId,
+    /// Who asked. Responses go out over the broadcast transport, so without an addressee every
+    /// node processes every response in the mesh — with N nodes that is N(N-1) handler runs for
+    /// (N-1) real answers, and each run recomputes a Merkle root. On the 8-node fleet each node
+    /// was processing ~175 responses per 10 minutes of which ~150 were answers to somebody
+    /// else's question (#517).
+    ///
+    /// `Option` + `#[serde(default)]` for wire-compat: a peer that predates this field sends
+    /// `None`, which the handler treats as "cannot tell, process it" — the old behaviour. The
+    /// amplification only disappears once both ends are upgraded, which is the honest ordering
+    /// for a mixed-version fleet.
+    #[serde(default, with = "ghost_common::serde_hex::opt_bytes32")]
+    pub requesting_node: Option<NodeId>,
     /// Checkpoint blocks (batched, max 100 per response)
     pub checkpoints: Vec<L2CheckpointBlockMessage>,
     /// Current epoch number

--- a/crates/ghost-consensus/src/message_validator.rs
+++ b/crates/ghost-consensus/src/message_validator.rs
@@ -589,6 +589,67 @@ fn check_json_depth(data: &[u8]) -> Result<(), MessageValidationError> {
     Ok(())
 }
 
+/// Extract the envelope timestamp from raw JSON without deserializing.
+///
+/// Same technique as `extract_message_type_fast`, for the same reason: so a message can be
+/// judged before paying to parse it.
+///
+/// This exists because the drift check sat *downstream* of deserialization. A node that had
+/// fallen behind would fully parse a message, discover it had waited 40 seconds, and throw it
+/// away — burning CPU on work it was about to discard, which lengthened the queue, which made
+/// the next message later still. The check could not protect anything; it converted a backlog
+/// into wasted work (#517).
+///
+/// Measured on the fleet: nodes with a clean queue answered `/health` in under a millisecond,
+/// while a node rejecting 854 stale messages in ten minutes could not answer at all.
+///
+/// Returns `None` when the timestamp cannot be read cheaply — an unreadable timestamp must fall
+/// through to the full pipeline rather than be treated as stale, or a format change would
+/// silently drop every message on the floor.
+pub fn extract_timestamp_fast(data: &[u8]) -> Option<u64> {
+    // Only the JSON format is scannable; binary envelopes fall through to full validation.
+    if data.first() != Some(&b'{') {
+        return None;
+    }
+    let data_str = std::str::from_utf8(data).ok()?;
+
+    // `"timestamp":<digits>` — the envelope's own field. Payloads may carry their own
+    // `timestamp`, so take the FIRST occurrence: serde writes envelope fields in declaration
+    // order and `timestamp` precedes `payload`.
+    let marker = r#""timestamp":"#;
+    let start = data_str.find(marker)? + marker.len();
+    let rest = &data_str[start..];
+    let digits: String = rest
+        .chars()
+        .skip_while(|c| c.is_whitespace())
+        .take_while(|c| c.is_ascii_digit())
+        .collect();
+    if digits.is_empty() {
+        return None;
+    }
+    digits.parse().ok()
+}
+
+/// Is this message too old to be worth parsing?
+///
+/// Deliberately more lenient than `validate_timestamp_with_drift`: this is a cheap pre-filter,
+/// and the authoritative check still runs afterwards on everything that survives. A message
+/// rejected here would have been rejected there anyway.
+///
+/// Only the PAST direction is checked. A future-dated timestamp is a correctness concern that
+/// belongs with the real validator, not a backlog symptom.
+pub fn is_stale_before_deser(data: &[u8], drift_ms: u64) -> bool {
+    let drift_ms = drift_ms.clamp(MIN_TIMESTAMP_DRIFT_MS, MAX_TIMESTAMP_DRIFT_LIMIT_MS);
+    match extract_timestamp_fast(data) {
+        Some(ts) => {
+            let now_ms = chrono::Utc::now().timestamp_millis() as u64;
+            now_ms > ts.saturating_add(drift_ms)
+        }
+        // Unreadable: not our call to make here.
+        None => false,
+    }
+}
+
 /// Full validation pipeline for incoming messages
 ///
 /// 1. Validate raw bytes (size, version, type)
@@ -598,6 +659,21 @@ fn check_json_depth(data: &[u8]) -> Result<(), MessageValidationError> {
 pub fn validate_and_verify(data: &[u8]) -> Result<MessageEnvelope, MessageValidationError> {
     // Step 1: Header validation (fast, no alloc)
     validate_envelope_header(data)?;
+
+    // Step 1.2: cheap staleness check, BEFORE the depth scan and the parse (#517).
+    //
+    // The authoritative drift check is in `validate_envelope` below, but it only runs after a
+    // full JSON parse. On a node that has fallen behind, that meant paying to walk and parse
+    // every message just to discard it — the backlog feeding itself. Judging it here costs one
+    // substring scan and an integer parse, and it runs ahead of `check_json_depth` so a stale
+    // message does not even pay for that O(n) pass.
+    if is_stale_before_deser(data, DEFAULT_TIMESTAMP_DRIFT_MS) {
+        let now_ms = chrono::Utc::now().timestamp_millis() as u64;
+        let drift = extract_timestamp_fast(data)
+            .map(|ts| now_ms.saturating_sub(ts))
+            .unwrap_or(0);
+        return Err(MessageValidationError::TimestampInPast(drift));
+    }
 
     // Step 1.5: JSON depth check (O(n), prevents stack overflow from deeply nested payloads)
     check_json_depth(data)?;
@@ -785,6 +861,81 @@ impl ValidationStats {
 
 #[cfg(test)]
 mod tests {
+
+    /// The whole point of #517: a stale message must be rejected WITHOUT paying to parse it.
+    ///
+    /// The drift check used to sit after deserialization, so a node that had fallen behind
+    /// fully parsed every message just to discard it — burning CPU on work it was about to
+    /// throw away, which lengthened the queue and made the next message later still.
+    #[test]
+    fn a_stale_message_is_rejected_before_deserialization() {
+        let old_ms = (chrono::Utc::now().timestamp_millis() as u64)
+            .saturating_sub(DEFAULT_TIMESTAMP_DRIFT_MS + 60_000);
+        // Deliberately UNPARSEABLE past the timestamp, and padded past MIN_ENVELOPE_SIZE so
+        // the size gate cannot be what rejects it. If this comes back TimestampInPast, nothing
+        // downstream of the cheap scan can have run — the JSON never closes.
+        let data = format!(
+            r#"{{"msg_type":"HealthPing","sender":"00","timestamp":{old_ms},"garbage{}"#,
+            "x".repeat(MIN_ENVELOPE_SIZE)
+        );
+        assert!(
+            is_stale_before_deser(data.as_bytes(), DEFAULT_TIMESTAMP_DRIFT_MS),
+            "a 90s-old message must be judged stale from the raw bytes alone"
+        );
+        let got = validate_and_verify(data.as_bytes());
+        assert!(
+            matches!(got, Err(MessageValidationError::TimestampInPast(_))),
+            "expected TimestampInPast from the pre-filter, got {got:?}"
+        );
+    }
+
+    /// A fresh message must NOT be caught by the pre-filter — otherwise the node silently stops
+    /// participating in the mesh and everything still looks healthy.
+    #[test]
+    fn a_fresh_message_passes_the_prefilter() {
+        let now_ms = chrono::Utc::now().timestamp_millis() as u64;
+        let data = format!(r#"{{"msg_type":"HealthPing","timestamp":{now_ms},"sequence":1}}"#);
+        assert!(!is_stale_before_deser(
+            data.as_bytes(),
+            DEFAULT_TIMESTAMP_DRIFT_MS
+        ));
+    }
+
+    /// An unreadable timestamp must fall THROUGH to the real validator, never be assumed stale.
+    ///
+    /// Treating "cannot read" as "too old" would turn any envelope format change into a node
+    /// that silently drops every message on the floor while reporting itself healthy.
+    #[test]
+    fn an_unreadable_timestamp_is_not_assumed_stale() {
+        assert_eq!(extract_timestamp_fast(b"not json at all"), None);
+        assert!(!is_stale_before_deser(
+            b"not json at all",
+            DEFAULT_TIMESTAMP_DRIFT_MS
+        ));
+
+        // Present but not a number.
+        let odd = br#"{"msg_type":"HealthPing","timestamp":"soon"}"#;
+        assert_eq!(extract_timestamp_fast(odd), None);
+        assert!(!is_stale_before_deser(odd, DEFAULT_TIMESTAMP_DRIFT_MS));
+
+        // Absent entirely.
+        assert!(!is_stale_before_deser(
+            br#"{"msg_type":"HealthPing"}"#,
+            DEFAULT_TIMESTAMP_DRIFT_MS
+        ));
+    }
+
+    /// The scan must read the ENVELOPE's timestamp, not one that happens to appear inside the
+    /// payload — reading a payload field would judge the message on the wrong clock.
+    #[test]
+    fn the_envelope_timestamp_is_read_not_a_payload_one() {
+        let envelope_ts = 1_700_000_000_000u64;
+        let payload_ts = 1_600_000_000_000u64;
+        let data = format!(
+            r#"{{"msg_type":"HealthPing","sender":"00","timestamp":{envelope_ts},"sequence":1,"payload":{{"timestamp":{payload_ts}}}}}"#
+        );
+        assert_eq!(extract_timestamp_fast(data.as_bytes()), Some(envelope_ts));
+    }
     use super::*;
 
     #[test]

--- a/crates/ghost-consensus/src/nullifier_route_handler.rs
+++ b/crates/ghost-consensus/src/nullifier_route_handler.rs
@@ -16,7 +16,7 @@ use std::time::Instant;
 
 use async_trait::async_trait;
 use parking_lot::RwLock;
-use tracing::{debug, info, warn};
+use tracing::{debug, info, trace, warn};
 
 use ghost_common::error::{GhostError, GhostResult};
 use ghost_common::identity;
@@ -1609,6 +1609,9 @@ impl NullifierRouteHandler {
 
         let response = L2TreeSyncResponse {
             responding_node: self.our_id,
+            // Address it. Responses go out over the broadcast transport, so without this every
+            // node in the mesh processes every response (#517).
+            requesting_node: Some(request.requesting_node),
             checkpoints: checkpoint_blocks,
             current_epoch: self.epoch_manager.current_epoch(),
             commitment_root: canonical_root,
@@ -1629,6 +1632,31 @@ impl NullifierRouteHandler {
 
     /// Handle a tree sync response (replay checkpoints to catch up)
     fn handle_tree_sync_response(&self, response: &L2TreeSyncResponse) -> GhostResult<()> {
+        // Answers to somebody else's question are not ours to process.
+        //
+        // Responses are broadcast, so before this every node ran the full handler on every
+        // response in the mesh: with N nodes, N(N-1) runs for (N-1) real answers, each
+        // recomputing a Merkle root. On the 8-node fleet that was ~175 responses processed per
+        // node per 10 minutes against ~25 actually sent — and the surplus is what starved the
+        // runtime until the HTTP listener stopped being scheduled at all (#517).
+        //
+        // Worse than the wasted CPU: the pagination path below calls `request_tree_sync()` and
+        // mutates `sync_requests` keyed on `responding_node`, so a foreign response could drive
+        // this node into re-requesting and corrupt its own tracking state.
+        //
+        // `None` means the peer predates the field — process it, as before. The amplification
+        // only clears once both ends are upgraded, which is the honest ordering here.
+        if let Some(addressee) = response.requesting_node {
+            if addressee != self.our_id {
+                trace!(
+                    responder = %hex::encode(&response.responding_node[..8]),
+                    addressee = %hex::encode(&addressee[..8]),
+                    "Ignoring tree sync response addressed to another node"
+                );
+                return Ok(());
+            }
+        }
+
         if response.checkpoints.is_empty() {
             debug!("Empty tree sync response, nothing to replay");
             // Even with no checkpoints to replay, check root convergence.
@@ -2873,9 +2901,13 @@ mod tests {
         // B needs sign_fn to verify incoming checkpoint signatures
         handler_b.set_sign_fn(Arc::new(move |msg: &[u8]| identity_b.sign(msg)));
 
-        // Build a sync response from A's persisted checkpoint data
+        // Build a sync response from A's persisted checkpoint data.
+        //
+        // The request must carry B's real id: responses are addressed to their requester (#517)
+        // and B replays this one below. The fixture previously used a placeholder that matched
+        // no node, which only worked because every node processed every response regardless.
         let request = L2TreeSyncRequest {
-            requesting_node: [0x02; 32],
+            requesting_node: handler_b.our_id,
             from_height: 0,
             timestamp: 0,
         };
@@ -3126,6 +3158,7 @@ mod tests {
         );
         let response = L2TreeSyncResponse {
             responding_node: proposer_id,
+            requesting_node: Some(handler_ok.our_id),
             checkpoints: vec![block.clone()],
             current_epoch: 5,
             commitment_root: block.new_commitment_root,
@@ -3157,10 +3190,78 @@ mod tests {
             "re-replay must not duplicate the checkpoint"
         );
 
+        // --- A response addressed to ANOTHER node must be ignored entirely (#517) ---
+        //
+        // Responses are broadcast, so before the addressee field every node ran this handler on
+        // every response in the mesh: with N nodes, N(N-1) runs for (N-1) real answers, each
+        // recomputing a Merkle root. On the 8-node fleet that was ~175 responses processed per
+        // node per 10 minutes against ~25 actually sent, and the surplus starved the runtime
+        // until the HTTP listener stopped being scheduled at all.
+        let (db_other, handler_other) = make_node();
+        let someone_else = [0xABu8; 32];
+        assert_ne!(someone_else, handler_other.our_id);
+        let foreign = L2TreeSyncResponse {
+            responding_node: proposer_id,
+            requesting_node: Some(someone_else),
+            checkpoints: vec![block.clone()],
+            current_epoch: 5,
+            commitment_root: block.new_commitment_root,
+            epochs: vec![epoch5.clone()],
+            has_more: false,
+            timestamp: 0,
+        };
+        handler_other
+            .handle_tree_sync_response(&foreign)
+            .expect("ignoring a foreign response is not an error");
+        assert!(
+            db_other.get_l2_epoch(5).unwrap().is_none(),
+            "a response addressed to another node must not be replayed at all"
+        );
+        assert_eq!(
+            db_other
+                .get_l2_checkpoints_from_height(550, 10)
+                .unwrap()
+                .len(),
+            0,
+            "no checkpoint may be persisted from somebody else's answer"
+        );
+
+        // ...and the SAME payload addressed to us IS processed, so the filter is a filter and
+        // not a blanket refusal.
+        let (db_mine, handler_mine) = make_node();
+        let mine = L2TreeSyncResponse {
+            requesting_node: Some(handler_mine.our_id),
+            ..foreign.clone()
+        };
+        handler_mine
+            .handle_tree_sync_response(&mine)
+            .expect("our own answer must still be processed");
+        assert!(
+            db_mine.get_l2_epoch(5).unwrap().is_some(),
+            "a response addressed to us must be replayed"
+        );
+
+        // A peer that predates the field sends None. That must still be processed, or upgrading
+        // one node would cut it out of sync with every older peer in the fleet.
+        let (db_legacy, handler_legacy) = make_node();
+        let _ = handler_legacy;
+        let legacy = L2TreeSyncResponse {
+            requesting_node: None,
+            ..foreign.clone()
+        };
+        handler_legacy
+            .handle_tree_sync_response(&legacy)
+            .expect("a legacy response must still be processed");
+        assert!(
+            db_legacy.get_l2_epoch(5).unwrap().is_some(),
+            "an unaddressed response from an older peer must not be dropped"
+        );
+
         // --- Case 2: epoch missing from payload -> deferred, not force-inserted ---
         let (db_defer, handler_defer) = make_node();
         let response_no_epoch = L2TreeSyncResponse {
             responding_node: proposer_id,
+            requesting_node: Some(handler_defer.our_id),
             checkpoints: vec![block.clone()],
             current_epoch: 5,
             commitment_root: block.new_commitment_root,


### PR DESCRIPTION
**Root cause of the API stalls in #517.** Stacks on #529 (which removed the feedback loop); this removes what generated the load.

## The amplification

`L2TreeSyncRequest` carries `requesting_node`. `L2TreeSyncResponse` carried only `responding_node` — **no addressee** — and responses go out over the broadcast transport. `handle_tree_sync_response` then ran on every response in the mesh with no check that it was for this node.

So one node's request produced 7 responses, and **all 8 nodes fully processed all 7** — six of every seven being answers to somebody else's question. With N nodes that is N(N-1) handler runs for (N-1) real answers, and each run recomputes a Merkle root.

Measured on the fleet: **~175 responses processed per node per 10 minutes against ~25 actually sent.**

## Why that stalls the API

Every node has 2 CPUs and therefore 2 tokio workers. On vm7 one was pinned at 80%, holding 54 of the process's 99 minutes of CPU. Connections were accepted by the kernel while no task was ever scheduled to serve them — every endpoint at once, with `systemctl` reporting `active` and 0 restarts throughout.

Worse than the wasted CPU: the pagination path calls `request_tree_sync()` and mutates `sync_requests` keyed on `responding_node`. So a foreign response could drive a node into re-requesting, and corrupt its own tracking state with a stranger's id.

## The change

`requesting_node: Option<NodeId>` on the response, populated from the request. `None` means the peer predates the field — processed as before, so upgrading one node does not cut it out of sync with older peers. The amplification clears once both ends are upgraded, which is the honest ordering for a mixed-version fleet. Adds `serde_hex::opt_bytes32` for the wire encoding.

## An existing test had to be corrected

`test_tree_sync_replays_checkpoints` built its request with a placeholder `[0x02; 32]` and replayed the response into a *different* handler. That only ever worked because every node processed every response. The fixture now uses B's real id — which is what production does, since `request_tree_sync` always sets `requesting_node: self.our_id`.

## Please read this part — the verification nearly went wrong

**This module is behind `#[cfg(feature = "zk-consensus")]`, and CI's test job runs with no features.** None of it has ever been compiled by `cargo test`.

My first version of this change **did not compile at all** and `cargo test -p ghost-consensus --lib` cheerfully reported *267 passed*. A deliberate syntax error in the file produced zero build errors. I only caught it by sabotaging one of my own assertions and noticing the suite still passed.

Everything here was therefore verified with `--features zk-consensus`:

```
cargo test -p ghost-consensus --lib                          267 tests
cargo test -p ghost-consensus --lib --features zk-consensus  317 tests   <- 50 never run in CI
```

317 pass, and I re-confirmed the new assertions actually execute by inverting one and watching it fail. Filed separately as **#530** — under CI as it stands, the regression this PR introduced into `test_tree_sync_replays_checkpoints` would have merged green.

## Expected effect

Tree-sync handler invocations should drop by roughly 7/8 on an 8-node mesh, taking the CPU that starved the runtime with them. Worth confirming on a canary before the production roll: `journalctl -u ghost-pool | grep -c 'Tree sync complete'` over a fixed window, alongside `/health` latency.

No new clippy warnings (checked with the feature enabled).