### PR TITLE
ci: actually run the feature-gated consensus tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,28 @@ jobs:
       - name: Run unit tests
         run: cargo test $WORKSPACE_EXCLUDES --lib --bins
 
+      # Feature-gated modules, which the run above does NOT compile (#530).
+      #
+      # `ghost-consensus` has `default = []` and gates two modules behind features:
+      #
+      #   #[cfg(feature = "zk-consensus")]  pub mod nullifier_route_handler;   <- L2 tree sync
+      #   #[cfg(feature = "mpc-ceremony")]  pub mod mpc_handler;
+      #
+      # so plain `cargo test -p ghost-consensus` reports 267 passed while 72 tests are not even
+      # compiled — including every test for the L2 tree-sync and nullifier-routing code that is
+      # live on all 8 production nodes. A change to that module could be syntactically invalid
+      # and still show a green suite; that is not hypothetical, it happened while fixing #517.
+      #
+      # The clippy job already uses `--all-features`, so this code IS type-checked. Only its
+      # tests were missing, which is why nothing ever went red.
+      #
+      # NOT `--all-features`, deliberately. That would also switch on `ghost-verification`'s
+      # `allow-insecure` (changing what the security tests actually assert) and `zk-production`
+      # (which needs trusted-setup params a runner does not have). Naming the features keeps the
+      # gain without either surprise.
+      - name: Run unit tests (feature-gated consensus modules)
+        run: cargo test -p ghost-consensus --lib --features zk-consensus,mpc-ceremony
+
       # Run integration tests
       - name: Run integration tests
         run: cargo test --test integration


### PR DESCRIPTION
Closes #530.

## 72 tests CI has never run

`ghost-consensus` has `default = []` and gates two modules behind features:

```rust
#[cfg(feature = "zk-consensus")]  pub mod nullifier_route_handler;   // L2 tree sync
#[cfg(feature = "mpc-ceremony")]  pub mod mpc_handler;
```

CI's test job passes no features:

```
cargo test -p ghost-consensus --lib                              267 tests
cargo test -p ghost-consensus --lib --features zk-consensus,...  339 tests
```

The missing 72 include **every test for the L2 tree-sync and nullifier-routing code that runs on all 8 production nodes**.

## How it surfaced

Not hypothetically. While fixing #517 I edited that module, ran `cargo test -p ghost-consensus --lib`, and saw *267 passed*. The file had not been compiled at all — a deliberate syntax error in it produced **zero** build errors. I only noticed because I sabotaged one of my own assertions and the suite still went green.

The change I was making introduced a real regression in `test_tree_sync_replays_checkpoints`. Locally invisible; under CI as it stands it would have merged green.

The clippy job already uses `--all-features`, so this code *is* type-checked. Only its tests were absent — which is exactly why nothing ever went red and nobody noticed.

## Why not `--all-features`

Tempting, and wrong here. It would also switch on:

- `ghost-verification`'s **`allow-insecure`** — changing what the security tests actually assert
- **`zk-production`** — which needs trusted-setup params a runner does not have

Naming the two features gets the coverage without either surprise. If someone later wants the blanket flag, those two need handling first.

`ghost-pool` carries the same gates but gains no tests from them (71 either way), so it is left alone rather than adding a slow step for nothing.

## Verified

339 tests pass locally with both features enabled.