### PR TITLE
chore(release): v1.11.21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -828,7 +828,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-ghost-tests"
-version = "1.11.20"
+version = "1.11.21"
 dependencies = [
  "bitcoin",
  "chrono",
@@ -889,7 +889,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin_core_sv2"
-version = "1.11.20"
+version = "1.11.21"
 dependencies = [
  "async-channel 1.9.0",
  "bitcoin-capnp-types",
@@ -3160,7 +3160,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-accounting"
-version = "1.11.20"
+version = "1.11.21"
 dependencies = [
  "bitcoin",
  "ghost-common",
@@ -3169,7 +3169,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-buds"
-version = "1.11.20"
+version = "1.11.21"
 dependencies = [
  "bitcoin",
  "ghost-common",
@@ -3179,7 +3179,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-cli"
-version = "1.11.20"
+version = "1.11.21"
 dependencies = [
  "anyhow",
  "clap",
@@ -3194,7 +3194,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-common"
-version = "1.11.20"
+version = "1.11.21"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -3224,7 +3224,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-consensus"
-version = "1.11.20"
+version = "1.11.21"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3254,7 +3254,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-glyph"
-version = "1.11.20"
+version = "1.11.21"
 dependencies = [
  "sha2 0.10.9",
  "thiserror 1.0.69",
@@ -3262,7 +3262,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-gsp"
-version = "1.11.20"
+version = "1.11.21"
 dependencies = [
  "axum 0.7.9",
  "bitcoin",
@@ -3317,7 +3317,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-gsp-proto"
-version = "1.11.20"
+version = "1.11.21"
 dependencies = [
  "bitcoin",
  "chrono",
@@ -3333,7 +3333,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-keys"
-version = "1.11.20"
+version = "1.11.21"
 dependencies = [
  "bech32",
  "chacha20poly1305",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-locks"
-version = "1.11.20"
+version = "1.11.21"
 dependencies = [
  "bitcoin",
  "getrandom 0.2.17",
@@ -3394,7 +3394,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-pay"
-version = "1.11.20"
+version = "1.11.21"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3440,7 +3440,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-policy"
-version = "1.11.20"
+version = "1.11.21"
 dependencies = [
  "bitcoin",
  "ghost-buds",
@@ -3451,7 +3451,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-pool"
-version = "1.11.20"
+version = "1.11.21"
 dependencies = [
  "anyhow",
  "async-channel 2.5.0",
@@ -3504,7 +3504,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-reaper"
-version = "1.11.20"
+version = "1.11.21"
 dependencies = [
  "bitcoin",
  "hex",
@@ -3515,7 +3515,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-reconciliation"
-version = "1.11.20"
+version = "1.11.21"
 dependencies = [
  "bitcoin",
  "chrono",
@@ -3532,7 +3532,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-registry"
-version = "1.11.20"
+version = "1.11.21"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -3562,7 +3562,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-setup"
-version = "1.11.20"
+version = "1.11.21"
 dependencies = [
  "clap",
  "dirs 5.0.1",
@@ -3571,7 +3571,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-storage"
-version = "1.11.20"
+version = "1.11.21"
 dependencies = [
  "base64 0.22.1",
  "chacha20poly1305",
@@ -3590,7 +3590,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-tap-core"
-version = "1.11.20"
+version = "1.11.21"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3629,7 +3629,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-tap-desktop"
-version = "1.11.20"
+version = "1.11.21"
 dependencies = [
  "dirs 6.0.0",
  "getrandom 0.2.17",
@@ -3655,7 +3655,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-tap-integration"
-version = "1.11.20"
+version = "1.11.21"
 dependencies = [
  "ghost-gsp-proto",
  "ghost-tap-core",
@@ -3668,7 +3668,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-verification"
-version = "1.11.20"
+version = "1.11.21"
 dependencies = [
  "axum 0.7.9",
  "base64 0.22.1",
@@ -4662,7 +4662,7 @@ dependencies = [
 
 [[package]]
 name = "jd_client_sv2"
-version = "1.11.20"
+version = "1.11.21"
 dependencies = [
  "async-channel 1.9.0",
  "bitcoin_core_sv2",
@@ -4678,7 +4678,7 @@ dependencies = [
 
 [[package]]
 name = "jd_server_sv2"
-version = "1.11.20"
+version = "1.11.21"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -6231,7 +6231,7 @@ dependencies = [
 
 [[package]]
 name = "pool_sv2"
-version = "1.11.20"
+version = "1.11.21"
 dependencies = [
  "async-channel 1.9.0",
  "bitcoin_core_sv2",
@@ -7989,7 +7989,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stratum-apps"
-version = "1.11.20"
+version = "1.11.21"
 dependencies = [
  "async-channel 1.9.0",
  "axum 0.8.9",
@@ -9252,7 +9252,7 @@ dependencies = [
 
 [[package]]
 name = "translator_sv2"
-version = "1.11.20"
+version = "1.11.21"
 dependencies = [
  "async-channel 1.9.0",
  "clap",
@@ -10602,7 +10602,7 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "wraith-coordinator"
-version = "1.11.20"
+version = "1.11.21"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -10636,7 +10636,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-protocol"
-version = "1.11.20"
+version = "1.11.21"
 dependencies = [
  "bitcoin",
  "getrandom 0.2.17",
@@ -10655,7 +10655,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-cli"
-version = "1.11.20"
+version = "1.11.21"
 dependencies = [
  "clap",
  "clap_complete",
@@ -10669,7 +10669,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-core"
-version = "1.11.20"
+version = "1.11.21"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -10706,7 +10706,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-daemon"
-version = "1.11.20"
+version = "1.11.21"
 dependencies = [
  "async-trait",
  "axum 0.7.9",
@@ -10732,7 +10732,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-gui"
-version = "1.11.20"
+version = "1.11.21"
 dependencies = [
  "interprocess",
  "serde",
@@ -10747,7 +10747,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-ipc"
-version = "1.11.20"
+version = "1.11.21"
 dependencies = [
  "interprocess",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ exclude = ["vendor/stratum"]
 # Use scripts/build-all-wallets.sh to build all wallet types.
 
 [workspace.package]
-version = "1.11.20"
+version = "1.11.21"
 edition = "2021"
 rust-version = "1.88"
 authors = ["Bitcoin Ghost Team"]

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1643,7 +1643,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-accounting"
-version = "1.11.20"
+version = "1.11.21"
 dependencies = [
  "bitcoin",
  "ghost-common",
@@ -1652,7 +1652,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-buds"
-version = "1.11.20"
+version = "1.11.21"
 dependencies = [
  "bitcoin",
  "ghost-common",
@@ -1662,7 +1662,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-common"
-version = "1.11.20"
+version = "1.11.21"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -1691,7 +1691,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-consensus"
-version = "1.11.20"
+version = "1.11.21"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1739,7 +1739,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-glyph"
-version = "1.11.20"
+version = "1.11.21"
 dependencies = [
  "sha2 0.10.9",
  "thiserror 1.0.69",
@@ -1747,7 +1747,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-gsp-proto"
-version = "1.11.20"
+version = "1.11.21"
 dependencies = [
  "bitcoin",
  "chrono",
@@ -1762,7 +1762,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-locks"
-version = "1.11.20"
+version = "1.11.21"
 dependencies = [
  "bitcoin",
  "getrandom 0.2.17",
@@ -1800,7 +1800,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-policy"
-version = "1.11.20"
+version = "1.11.21"
 dependencies = [
  "bitcoin",
  "ghost-buds",
@@ -1811,7 +1811,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-pool"
-version = "1.11.20"
+version = "1.11.21"
 dependencies = [
  "anyhow",
  "async-channel 2.5.0",
@@ -1862,7 +1862,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-reaper"
-version = "1.11.20"
+version = "1.11.21"
 dependencies = [
  "bitcoin",
  "serde",
@@ -1872,7 +1872,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-reconciliation"
-version = "1.11.20"
+version = "1.11.21"
 dependencies = [
  "bitcoin",
  "chrono",
@@ -1889,7 +1889,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-storage"
-version = "1.11.20"
+version = "1.11.21"
 dependencies = [
  "base64 0.22.1",
  "chacha20poly1305",
@@ -1908,7 +1908,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-verification"
-version = "1.11.20"
+version = "1.11.21"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3896,7 +3896,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stratum-apps"
-version = "1.11.20"
+version = "1.11.21"
 dependencies = [
  "async-channel 1.9.0",
  "bs58",
@@ -5185,7 +5185,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-coordinator"
-version = "1.11.20"
+version = "1.11.21"
 dependencies = [
  "anyhow",
  "axum",
@@ -5213,7 +5213,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-protocol"
-version = "1.11.20"
+version = "1.11.21"
 dependencies = [
  "bitcoin",
  "getrandom 0.2.17",


### PR DESCRIPTION
Version bump for the release. **Closes a live drift**: the binaries already running on all 8 nodes were built from this, so `main` currently claims 1.11.20 while every node reports 1.11.21 — the same ambiguity that made the v1.11.18 roll hard to reason about.

Merge this, then tag `v1.11.21`.

## What is in the release, by area

### Mesh / consensus

| file | what changed |
|---|---|
| `ghost-consensus/nullifier_route_handler.rs` | Tree sync responses carry `requesting_node`, so a node stops processing answers to everyone else's questions. Responses are broadcast — with N nodes that was N(N-1) handler runs for (N-1) real answers, each recomputing a Merkle root. Measured ~175 processed per node per 10 min against ~25 sent, and that surplus is what starved the runtime until the API stopped being served. (#531) |
| `ghost-consensus/message_validator.rs` | A message is judged stale from the raw bytes, ahead of the depth walk and the parse. A node that had fallen behind used to fully parse each message only to discard it for having waited — the backlog feeding itself. (#529) |
| `ghost-consensus/peer.rs` | A health ping reporting no capabilities no longer erases known ones. `NodeCapabilities` is all bools, so "not reported" and "all false" are identical on the wire, and believing the empty claim made `public_mining` flap fleet-wide. Also holds gossiped SV1 tier ports. (#518, #495) |
| `ghost-common/types.rs` | Health ping carries `hobby_port` / `farm_port`, so the tier-aware load balancer stops being inert. (#495) |

### SV2 / security

| file | what changed |
|---|---|
| `ghost-common/constants.rs` | `SV2_AUTHORITY_PUBLIC_KEY` deleted. It matched no node on the fleet and its secret half is public (upstream SRI test fixture), so every node advertised a key that steered SV2 miners away from the real pool and towards anyone holding that secret. A node that cannot determine its own key now says `null`. (#516) |
| `install-node.sh`, `rotate-sv2-authority.sh` | Both record the node's real authority key; rotation rolls `pool.toml` back with everything else on failure. |

### Payouts

| file | what changed |
|---|---|
| `ghost-verification/server.rs`, `ghost-pool/validation.rs` | Payout address taken from the **first** dot. `bc1qAAA.farm1.rig1` previously yielded `bc1qAAA.farm1` — not a Bitcoin address — and disagreed with `pool_sv2`, which already split on the first dot. Zero multi-dot miners in production, so nothing is repaired retroactively. (#481) |

### Storage

| file | what changed |
|---|---|
| `ghost-storage/migrations.rs` | Migration 47 (`mesh_node_list_checkpoints`), cherry-picked from `pool-hardening` so vm6/vm8 — already at 47 from a branch build — converge rather than silently skipping main's own 47 later. A database **ahead** of the binary now warns instead of passing silently. (#523) |

### Node API

| file | what changed |
|---|---|
| `ghost-verification/maxconnections.rs` | GET/POST `maxconnections`, with real inbound headroom and refusal of values above what available memory supports. The fleet's 50 left ~40 inbound, nodes sat full, and crawlers dropped them from public listings. (#499) |

### CI / tests

| file | what changed |
|---|---|
| `.github/workflows/ci.yml` | Runs the feature-gated consensus tests. **72 tests**, including every test for the L2 tree-sync code, had never been compiled by `cargo test`. (#530) |
| `scripts/deploy-node.sh` | The canary soak exercises the share-submission path at both ends of the window, and prefers the canary that actually has miners. (#461) |
| `tests/integration-sv2/` | Mock and sniffer listeners bind before spawning, closing the race that hung CI for 5h38m under `llvm-cov`. (#408) |

## Verified on the fleet before tagging

All 8 nodes on 1.11.21 · production answering `/health` in under a millisecond · mesh quorum held · stale-message rejections down from ~2,000 per 5 minutes to **0**.

## Known, not fixed by this release

Three canaries intermittently stall their HTTP API (#535) — node function is unaffected (mesh, stratum and consensus all healthy throughout). #537 identifies a plausible mechanism: every database operation blocks a tokio worker on one global `parking_lot` mutex. Neither is a regression from this release; both predate it.