### PR TITLE
chore(clippy): clear ghost-consensus and ghost-storage to zero

### DIFF
--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -37,6 +37,7 @@
 
 use anyhow::Result;
 use clap::Parser;
+use ghost_storage::queries::VerificationProofInsert;
 use std::path::PathBuf;
 use std::sync::{Arc, OnceLock};
 use tokio::sync::broadcast;
@@ -8627,15 +8628,17 @@ async fn main() -> Result<()> {
             // qualification still governs the verdict.
             match serde_json::to_vec(&msg) {
                 Ok(blob) => {
-                    if let Err(e) = db_for_verification.insert_verification_proof(
-                        &hex::encode(msg.challenger_id),
-                        &hex::encode(msg.target_node_id),
-                        broadcast.capability.as_str(),
-                        msg.passed,
-                        msg.timestamp,
-                        &blob,
-                        msg.round_height.map(|h| h as i64),
-                    ) {
+                    if let Err(e) =
+                        db_for_verification.insert_verification_proof(VerificationProofInsert {
+                            challenger_id: &hex::encode(msg.challenger_id),
+                            target_node_id: &hex::encode(msg.target_node_id),
+                            capability: broadcast.capability.as_str(),
+                            passed: msg.passed,
+                            timestamp: msg.timestamp,
+                            proof: &blob,
+                            round_height: msg.round_height.map(|h| h as i64),
+                        })
+                    {
                         warn!(error = %e, "Failed to persist own verification proof to ledger");
                     }
                 }

--- a/crates/ghost-consensus/src/nullifier_route_handler.rs
+++ b/crates/ghost-consensus/src/nullifier_route_handler.rs
@@ -1503,10 +1503,11 @@ impl NullifierRouteHandler {
             m.consensus_rounds_total.inc();
             let votes = m.consensus_votes_total.get();
             let rounds = m.consensus_rounds_total.get();
-            if rounds > 0 {
-                // Participation = votes / rounds * 100 (each round we should cast 1 vote)
-                let pct = ((votes * 100) / rounds).min(100);
-                m.consensus_participation_percent.set(pct as i64);
+            // Participation = votes / rounds * 100 (each round we should cast 1 vote).
+            // `checked_div` rather than a `rounds > 0` guard: same result, and it cannot be
+            // reintroduced as a divide-by-zero if the guard is ever moved.
+            if let Some(pct) = (votes * 100).checked_div(rounds) {
+                m.consensus_participation_percent.set(pct.min(100) as i64);
             }
         }
         debug!(height, tx_count, "Checkpoint finalized");

--- a/crates/ghost-consensus/src/peer.rs
+++ b/crates/ghost-consensus/src/peer.rs
@@ -1031,9 +1031,11 @@ mod tests {
         let pid = [11u8; 32];
         mgr.upsert_peer(Peer::new(pid, "10.0.0.11:8080".to_string()));
 
-        let mut caps = NodeCapabilities::default();
-        caps.public_mining = true;
-        caps.reaper = true;
+        let caps = NodeCapabilities {
+            public_mining: true,
+            reaper: true,
+            ..Default::default()
+        };
         mgr.update_health_metrics(&pid, 5, caps, None, 0);
         assert!(mgr.get_peer(&pid).unwrap().capabilities.public_mining);
 
@@ -1059,15 +1061,19 @@ mod tests {
         let pid = [12u8; 32];
         mgr.upsert_peer(Peer::new(pid, "10.0.0.12:8080".to_string()));
 
-        let mut caps = NodeCapabilities::default();
-        caps.public_mining = true;
-        caps.reaper = true;
+        let caps = NodeCapabilities {
+            public_mining: true,
+            reaper: true,
+            ..Default::default()
+        };
         mgr.update_health_metrics(&pid, 1, caps, None, 0);
 
         // Operator turns public mining off but the node still runs the reaper: a real claim,
         // not an empty one, so it must be believed.
-        let mut narrowed = NodeCapabilities::default();
-        narrowed.reaper = true;
+        let narrowed = NodeCapabilities {
+            reaper: true,
+            ..Default::default()
+        };
         mgr.update_health_metrics(&pid, 1, narrowed, None, 0);
 
         let got = mgr.get_peer(&pid).unwrap();

--- a/crates/ghost-consensus/src/verification_handler.rs
+++ b/crates/ghost-consensus/src/verification_handler.rs
@@ -601,7 +601,7 @@ impl VerificationResultHandler {
         if let Some(ref peers) = self.peers {
             if peers.get_peer(&msg.challenger_id).is_none() {
                 // Peer not in memory — fall back to DB (nodes table persisted from health pings)
-                let challenger_hex = hex::encode(&msg.challenger_id);
+                let challenger_hex = hex::encode(msg.challenger_id);
                 let known_in_db = self.db.get_node(&challenger_hex).ok().flatten().is_some();
                 if !known_in_db {
                     warn!(

--- a/crates/ghost-consensus/src/verification_handler.rs
+++ b/crates/ghost-consensus/src/verification_handler.rs
@@ -27,6 +27,7 @@
 
 use async_trait::async_trait;
 use chrono::Utc;
+use ghost_storage::queries::VerificationProofInsert;
 use std::sync::Arc;
 use tracing::{debug, warn};
 
@@ -455,15 +456,15 @@ impl VerificationResultHandler {
         let challenger_hex = hex::encode(msg.challenger_id);
         let target_hex = hex::encode(msg.target_node_id);
         self.db
-            .insert_verification_proof(
-                &challenger_hex,
-                &target_hex,
-                msg.capability.as_str(),
-                msg.passed,
-                msg.timestamp,
-                blob,
-                msg.round_height.map(|h| h as i64),
-            )
+            .insert_verification_proof(VerificationProofInsert {
+                challenger_id: &challenger_hex,
+                target_node_id: &target_hex,
+                capability: msg.capability.as_str(),
+                passed: msg.passed,
+                timestamp: msg.timestamp,
+                proof: blob,
+                round_height: msg.round_height.map(|h| h as i64),
+            })
             .unwrap_or(false)
     }
 
@@ -640,15 +641,15 @@ impl VerificationResultHandler {
         // MAJORITY applied at qualification: a colluding minority can neither fabricate a PASS nor
         // a FAIL. Re-derivation is still applied below as a live filter on the legacy
         // `*_challenges` tables (the pre-gate qualification path), where freshness holds.
-        if let Err(e) = self.db.insert_verification_proof(
-            &challenger_hex,
-            &target_hex,
-            msg.capability.as_str(),
-            msg.passed,
-            msg.timestamp,
-            &envelope.payload,
-            msg.round_height.map(|h| h as i64),
-        ) {
+        if let Err(e) = self.db.insert_verification_proof(VerificationProofInsert {
+            challenger_id: &challenger_hex,
+            target_node_id: &target_hex,
+            capability: msg.capability.as_str(),
+            passed: msg.passed,
+            timestamp: msg.timestamp,
+            proof: &envelope.payload,
+            round_height: msg.round_height.map(|h| h as i64),
+        }) {
             warn!(error = %e, "Failed to persist verification proof to convergence ledger");
         }
 

--- a/crates/ghost-storage/src/database.rs
+++ b/crates/ghost-storage/src/database.rs
@@ -1628,6 +1628,10 @@ mod tests {
         assert!(stats.page_count > 0);
     }
 
+    // Both sides ARE constants — that is the point. This guards the constant against being
+    // lowered, so it must not be "fixed" by making it dynamic or deleted for being trivially
+    // true. It fails only when someone changes VACUUM_MIN_RECLAIMABLE_BYTES.
+    #[allow(clippy::assertions_on_constants)]
     #[test]
     fn vacuum_threshold_is_large_enough_to_matter() {
         // The threshold exists so a rebuild only happens when it recovers meaningful disk.

--- a/crates/ghost-storage/src/migrations.rs
+++ b/crates/ghost-storage/src/migrations.rs
@@ -2601,7 +2601,10 @@ mod tests {
         }
     }
 
-    fn read_singleton(conn: &Connection) -> Option<(i64, Vec<u8>, i64, Option<Vec<u8>>)> {
+    /// contribution_count, current_params_hash, is_ossified, ceremony_id
+    type CeremonySingleton = (i64, Vec<u8>, i64, Option<Vec<u8>>);
+
+    fn read_singleton(conn: &Connection) -> Option<CeremonySingleton> {
         conn.query_row(
             "SELECT contribution_count, current_params_hash, is_ossified, ceremony_id
              FROM mpc_ceremony WHERE id = 1",

--- a/crates/ghost-storage/src/queries.rs
+++ b/crates/ghost-storage/src/queries.rs
@@ -30,6 +30,11 @@ use ghost_common::error::{GhostError, GhostResult};
 use crate::database::Database;
 use crate::models::*;
 
+/// Row shape for `mpc_contributions` lookups: elder position, contributor node id, previous
+/// params hash, contribution proof, epoch, created-at. Named so the query below reads as a
+/// row rather than a six-tuple.
+type MpcContributionRow = (i64, String, Vec<u8>, Vec<u8>, i64, i64);
+
 // =============================================================================
 // M-15: BLOB SIZE VALIDATION
 // =============================================================================
@@ -4989,7 +4994,30 @@ impl Database {
             Ok(conn.last_insert_rowid())
         })
     }
+}
 
+/// Arguments for [`Database::insert_verification_proof`].
+///
+/// A struct rather than eight positional parameters because `challenger_id` and
+/// `target_node_id` are adjacent `&str`s: transposing them compiles, stores a verification
+/// record against the wrong node, and every peer keys and grades that record identically —
+/// so the mistake would converge across the mesh rather than showing up as a local anomaly.
+/// Named fields make the call sites say which node is which.
+pub struct VerificationProofInsert<'a> {
+    /// Node that issued the challenge.
+    pub challenger_id: &'a str,
+    /// Node being verified.
+    pub target_node_id: &'a str,
+    pub capability: &'a str,
+    /// The recipient's derived verdict, not the challenger's claim.
+    pub passed: bool,
+    /// The CHALLENGE's own timestamp from the signed message, never `now()`.
+    pub timestamp: i64,
+    pub proof: &'a [u8],
+    pub round_height: Option<i64>,
+}
+
+impl Database {
     /// Persist a signed verification result into the verification ledger (schema v42).
     ///
     /// Idempotent: the PRIMARY KEY `(challenger, target, capability, timestamp)` means a
@@ -5000,16 +5028,16 @@ impl Database {
     /// and `passed` is the recipient's derived verdict — so every node keys and grades the
     /// same record identically, which is what convergence and deterministic node-reward
     /// qualification depend on. See `ghost-web/docs/node-reward-convergence.md`.
-    pub fn insert_verification_proof(
-        &self,
-        challenger_id: &str,
-        target_node_id: &str,
-        capability: &str,
-        passed: bool,
-        timestamp: i64,
-        proof: &[u8],
-        round_height: Option<i64>,
-    ) -> GhostResult<bool> {
+    pub fn insert_verification_proof(&self, p: VerificationProofInsert<'_>) -> GhostResult<bool> {
+        let VerificationProofInsert {
+            challenger_id,
+            target_node_id,
+            capability,
+            passed,
+            timestamp,
+            proof,
+            round_height,
+        } = p;
         if challenger_id.len() > MAX_CHALLENGE_ID_SIZE
             || target_node_id.len() > MAX_CHALLENGE_ID_SIZE
         {
@@ -6658,7 +6686,7 @@ impl Database {
         new_params_hash: &[u8; 32],
     ) -> GhostResult<Option<MpcContributionRecord>> {
         self.with_connection(|conn| {
-            let result: Option<(i64, String, Vec<u8>, Vec<u8>, i64, i64)> = conn
+            let result: Option<MpcContributionRow> = conn
                 .query_row(
                     "SELECT elder_position, contributor_node_id, prev_params_hash,
                             contribution_proof, epoch, created_at
@@ -11491,8 +11519,8 @@ mod tests {
             .expect("Insert should succeed");
 
         let mut pixels2 = vec![1u8; 256];
-        for i in 0..256 {
-            pixels2[i] = ((i + 1) % 26) as u8;
+        for (i, px) in pixels2.iter_mut().enumerate() {
+            *px = ((i + 1) % 26) as u8;
         }
         let bh2 = test_bitmap_hash(&pixels2);
         let cm2 = test_commitment(&pixels2, "ghost1bob");
@@ -12053,39 +12081,39 @@ mod tests {
 
         // A new (challenger, target, capability, timestamp) record is stored.
         assert!(db
-            .insert_verification_proof(
-                "challengerA",
-                "targetB",
-                "archive",
-                true,
-                1_000,
-                &blob,
-                None
-            )
+            .insert_verification_proof(VerificationProofInsert {
+                challenger_id: "challengerA",
+                target_node_id: "targetB",
+                capability: "archive",
+                passed: true,
+                timestamp: 1_000,
+                proof: &blob,
+                round_height: None,
+            })
             .expect("insert"));
         // Re-delivery of the SAME key is a no-op — the dedup the *_challenges tables lacked.
         assert!(!db
-            .insert_verification_proof(
-                "challengerA",
-                "targetB",
-                "archive",
-                true,
-                1_000,
-                &blob,
-                None
-            )
+            .insert_verification_proof(VerificationProofInsert {
+                challenger_id: "challengerA",
+                target_node_id: "targetB",
+                capability: "archive",
+                passed: true,
+                timestamp: 1_000,
+                proof: &blob,
+                round_height: None,
+            })
             .expect("insert dup"));
         // A different timestamp is a distinct record.
         assert!(db
-            .insert_verification_proof(
-                "challengerA",
-                "targetB",
-                "archive",
-                false,
-                2_000,
-                &blob,
-                None
-            )
+            .insert_verification_proof(VerificationProofInsert {
+                challenger_id: "challengerA",
+                target_node_id: "targetB",
+                capability: "archive",
+                passed: false,
+                timestamp: 2_000,
+                proof: &blob,
+                round_height: None,
+            })
             .expect("insert 2"));
 
         // Windowed read serves only in-range records (the convergence responder relies on this).
@@ -12113,10 +12141,26 @@ mod tests {
         let day = 86_400i64;
 
         // One row well inside retention, one well past it.
-        db.insert_verification_proof("cA", "tB", "policy", true, now - 2 * day, &blob, None)
-            .expect("recent");
-        db.insert_verification_proof("cA", "tB", "policy", true, now - 40 * day, &blob, None)
-            .expect("old");
+        db.insert_verification_proof(VerificationProofInsert {
+            challenger_id: "cA",
+            target_node_id: "tB",
+            capability: "policy",
+            passed: true,
+            timestamp: now - 2 * day,
+            proof: &blob,
+            round_height: None,
+        })
+        .expect("recent");
+        db.insert_verification_proof(VerificationProofInsert {
+            challenger_id: "cA",
+            target_node_id: "tB",
+            capability: "policy",
+            passed: true,
+            timestamp: now - 40 * day,
+            proof: &blob,
+            round_height: None,
+        })
+        .expect("old");
 
         let deleted = db.prune_old_verification_ledger(30).expect("prune");
         assert_eq!(
@@ -12132,12 +12176,36 @@ mod tests {
     fn verification_convergence_serves_only_missing() {
         let db = Database::in_memory().expect("create in-memory db");
         let blob = |n: u8| vec![n; 8];
-        db.insert_verification_proof("cA", "tB", "archive", true, 100, &blob(1), None)
-            .unwrap();
-        db.insert_verification_proof("cA", "tB", "policy", true, 200, &blob(2), None)
-            .unwrap();
-        db.insert_verification_proof("cC", "tB", "archive", false, 300, &blob(3), None)
-            .unwrap();
+        db.insert_verification_proof(VerificationProofInsert {
+            challenger_id: "cA",
+            target_node_id: "tB",
+            capability: "archive",
+            passed: true,
+            timestamp: 100,
+            proof: &blob(1),
+            round_height: None,
+        })
+        .unwrap();
+        db.insert_verification_proof(VerificationProofInsert {
+            challenger_id: "cA",
+            target_node_id: "tB",
+            capability: "policy",
+            passed: true,
+            timestamp: 200,
+            proof: &blob(2),
+            round_height: None,
+        })
+        .unwrap();
+        db.insert_verification_proof(VerificationProofInsert {
+            challenger_id: "cC",
+            target_node_id: "tB",
+            capability: "archive",
+            passed: false,
+            timestamp: 300,
+            proof: &blob(3),
+            round_height: None,
+        })
+        .unwrap();
 
         let keys = db.verification_keys_in(0, 1_000).expect("keys");
         assert_eq!(keys.len(), 3, "all three records' keys are advertised");

--- a/crates/ghost-verification/src/qualification.rs
+++ b/crates/ghost-verification/src/qualification.rs
@@ -30,7 +30,7 @@ use std::sync::Arc;
 use tracing::{info, warn};
 
 use ghost_common::types::{NodeCapabilities, NodeId};
-use ghost_storage::Database;
+use ghost_storage::{queries::VerificationProofInsert, Database};
 
 /// Seconds in a day
 const SECONDS_PER_DAY: i64 = 86_400;
@@ -1443,8 +1443,16 @@ mod tests {
     ) {
         for i in 0..n {
             let challenger = hex_id(first_challenger + i);
-            db.insert_verification_proof(&challenger, target, "archive", passed, ts, b"p", None)
-                .unwrap();
+            db.insert_verification_proof(VerificationProofInsert {
+                challenger_id: &challenger,
+                target_node_id: target,
+                capability: "archive",
+                passed: passed,
+                timestamp: ts,
+                proof: b"p",
+                round_height: None,
+            })
+            .unwrap();
         }
     }
 
@@ -1524,26 +1532,26 @@ mod tests {
 
         // 4 distinct challengers pass, 1 distinct challenger fails.
         for i in 0..4u8 {
-            db.insert_verification_proof(
-                &hex_id(0x30 + i),
-                &target,
-                "stratum",
-                true,
-                cutoff - 100,
-                b"p",
-                None,
-            )
+            db.insert_verification_proof(VerificationProofInsert {
+                challenger_id: &hex_id(0x30 + i),
+                target_node_id: &target,
+                capability: "stratum",
+                passed: true,
+                timestamp: cutoff - 100,
+                proof: b"p",
+                round_height: None,
+            })
             .unwrap();
         }
-        db.insert_verification_proof(
-            &hex_id(0x40),
-            &target,
-            "stratum",
-            false,
-            cutoff - 100,
-            b"p",
-            None,
-        )
+        db.insert_verification_proof(VerificationProofInsert {
+            challenger_id: &hex_id(0x40),
+            target_node_id: &target,
+            capability: "stratum",
+            passed: false,
+            timestamp: cutoff - 100,
+            proof: b"p",
+            round_height: None,
+        })
         .unwrap();
 
         let provider = QualifiedCapabilityProvider::new(db);
@@ -1629,8 +1637,16 @@ mod tests {
         ];
         for (c, a) in chs.iter().zip(clustered.iter()) {
             register_voter(&db, c, a);
-            db.insert_verification_proof(c, &target, "archive", true, cutoff - 100, b"p", None)
-                .unwrap();
+            db.insert_verification_proof(VerificationProofInsert {
+                challenger_id: c,
+                target_node_id: &target,
+                capability: "archive",
+                passed: true,
+                timestamp: cutoff - 100,
+                proof: b"p",
+                round_height: None,
+            })
+            .unwrap();
         }
         let provider = QualifiedCapabilityProvider::new(Arc::clone(&db));
         assert!(
@@ -1667,20 +1683,28 @@ mod tests {
         ];
         for (c, a) in passers.iter() {
             register_voter(&db, c, a);
-            db.insert_verification_proof(c, &target, "stratum", true, cutoff - 100, b"p", None)
-                .unwrap();
+            db.insert_verification_proof(VerificationProofInsert {
+                challenger_id: c,
+                target_node_id: &target,
+                capability: "stratum",
+                passed: true,
+                timestamp: cutoff - 100,
+                proof: b"p",
+                round_height: None,
+            })
+            .unwrap();
         }
         // One voter-set griefer on its own subnet signs a FAIL.
         register_voter(&db, &hex_id(0x25), "10.5.0.1:3333");
-        db.insert_verification_proof(
-            &hex_id(0x25),
-            &target,
-            "stratum",
-            false,
-            cutoff - 100,
-            b"p",
-            None,
-        )
+        db.insert_verification_proof(VerificationProofInsert {
+            challenger_id: &hex_id(0x25),
+            target_node_id: &target,
+            capability: "stratum",
+            passed: false,
+            timestamp: cutoff - 100,
+            proof: b"p",
+            round_height: None,
+        })
         .unwrap();
 
         let provider = QualifiedCapabilityProvider::new(Arc::clone(&db));
@@ -1748,15 +1772,15 @@ mod tests {
 
         for &rh in &[100u64, 200, 300, 400, 500] {
             for ch in assigned_for(&pool, &target, rh) {
-                db.insert_verification_proof(
-                    &ch,
-                    &target,
-                    "archive",
-                    true,
-                    cutoff - 100,
-                    b"p",
-                    Some(rh as i64),
-                )
+                db.insert_verification_proof(VerificationProofInsert {
+                    challenger_id: &ch,
+                    target_node_id: &target,
+                    capability: "archive",
+                    passed: true,
+                    timestamp: cutoff - 100,
+                    proof: b"p",
+                    round_height: Some(rh as i64),
+                })
                 .unwrap();
             }
         }
@@ -1790,15 +1814,15 @@ mod tests {
                 if id == &target || assigned.contains(id) {
                     continue; // insert ONLY from challengers not drawn this round
                 }
-                db.insert_verification_proof(
-                    id,
-                    &target,
-                    "archive",
-                    true,
-                    cutoff - 100,
-                    b"p",
-                    Some(rh as i64),
-                )
+                db.insert_verification_proof(VerificationProofInsert {
+                    challenger_id: id,
+                    target_node_id: &target,
+                    capability: "archive",
+                    passed: true,
+                    timestamp: cutoff - 100,
+                    proof: b"p",
+                    round_height: Some(rh as i64),
+                })
                 .unwrap();
             }
         }


### PR DESCRIPTION
Refs #401.

## Scale correction

The issue title says 221 warnings. The real workspace figure when I started this was **57** — earlier passes had already cleared most of them. Both crates named here are now at **zero**.

## Three of these were mine

The capability-flap tests I added in #534 built a struct with `Default::default()` and then field-assigned it. Worth naming why I did not catch them at the time: that module is behind `zk-consensus`, so the clippy run on that branch **never compiled it** — the same feature-gate blind spot as #530.

## The one that is a safety fix, not lint appeasement

`insert_verification_proof` took 8 positional parameters, two of which are adjacent `&str`s:

```rust
challenger_id: &str,
target_node_id: &str,
```

Transposing those compiles cleanly, stores the verification record against the wrong node, and — because every peer keys and grades that record identically for convergence — the mistake would **converge across the mesh** rather than showing up as a local anomaly. It is now a named-field struct, so all 19 call sites state which node is which.

## The one I deliberately did not "fix"

`database.rs` has an assertion clippy calls constant:

```rust
assert!(Database::VACUUM_MIN_RECLAIMABLE_BYTES >= 64 * 1024 * 1024, ...)
```

Both sides *are* constants — that is the point. It guards the threshold against being lowered, which would reintroduce the hourly VACUUM rebuild it was written to stop. Deleting it as trivially true, or making it dynamic to satisfy the lint, throws the guard away. Annotated with the reasoning instead.

## The rest

- `checked_div` in place of a `rounds > 0` guard around a division — same result, but the divide-by-zero cannot return if the guard is moved
- needless borrow in `hex::encode`
- two six-tuples given named row types
- one loop-index rewritten as an iterator

## Method

Fixed by hand, not `cargo clippy --fix`. On this codebase `--fix` has already produced code that compiled but was wrong — it rewrote a match arm's `return Err(e)?` into a form with a different arm type — and consensus and storage are not where to rediscover that.

## Verification

341 `ghost-consensus` (with `zk-consensus,mpc-ceremony`), 178 `ghost-storage`, 249 `ghost-verification`. Workspace compiles with `--all-targets`.