### PR TITLE
chore(clippy): clear the workspace to zero and make clippy blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,19 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: sudo apt-get update && sudo apt-get install -y $LINUX_DEPS
       # L-01: Removed needless_borrows_for_generic_args and useless_vec allows
-      - run: cargo clippy $WORKSPACE_EXCLUDES --all-targets --all-features -- -W clippy::all -A clippy::derivable_impls -A clippy::clone_on_copy -A clippy::match_like_matches_macro -A clippy::manual_flatten -A clippy::redundant_slicing -A clippy::skip_while_next
+      #
+      # BLOCKING as of #401: `-D warnings`, not `-W`. The workspace carries zero clippy
+      # warnings in its own code, so anything new is a regression introduced by the change
+      # under review — which is the only moment it is cheap to fix.
+      #
+      # The six `-A` entries are pre-existing style choices, not new exemptions.
+      #
+      # One warning remains and is deliberately NOT covered: cargo reports that
+      # proc-macro-error2 v2.0.1 contains code a future rustc will reject. It arrives via
+      # ghost-cli -> tabled 0.20 -> tabled_derive, 2.0.1 is the latest published version, and
+      # it is a cargo future-incompat NOTE rather than a rustc lint — so it does not fail this
+      # gate and cannot be fixed here. It needs tabled to drop the dependency upstream.
+      - run: cargo clippy $WORKSPACE_EXCLUDES --all-targets --all-features -- -D warnings -A clippy::derivable_impls -A clippy::clone_on_copy -A clippy::match_like_matches_macro -A clippy::manual_flatten -A clippy::redundant_slicing -A clippy::skip_while_next
 
   # Unused-dependency gate: fails if a crate declares a dependency it does not use.
   # Pairs with the per-crate `#![deny(unreachable_pub)]` ratchet — together they stop

--- a/apps/ghost-tap/core/src/transaction/signer.rs
+++ b/apps/ghost-tap/core/src/transaction/signer.rs
@@ -763,9 +763,9 @@ mod tests {
         signed.raw_tx = hex::encode(&raw_bytes);
 
         // Should either return Ok(false) or Err (invalid DER)
-        match verify_transaction(&signed, &tx) {
-            Ok(valid) => assert!(!valid, "tampered signature must not verify"),
-            Err(_) => {} // also acceptable (parse error from bad DER)
+        // Err is equally acceptable — a tampered signature can fail DER parsing outright.
+        if let Ok(valid) = verify_transaction(&signed, &tx) {
+            assert!(!valid, "tampered signature must not verify");
         }
     }
 

--- a/apps/ghost-tap/tests/integration/src/lib.rs
+++ b/apps/ghost-tap/tests/integration/src/lib.rs
@@ -105,7 +105,7 @@ mod transaction_tests {
         assert!(result.is_ok());
         let tx = result.unwrap();
         assert_eq!(tx.inputs.len(), 1);
-        assert!(tx.outputs.len() >= 1);
+        assert!(!tx.outputs.is_empty());
     }
 }
 

--- a/apps/ghost-tap/tests/integration/src/live_tests.rs
+++ b/apps/ghost-tap/tests/integration/src/live_tests.rs
@@ -12,6 +12,10 @@
 //! ```
 
 #![cfg(feature = "live-tests")]
+// Every helper below is used only from the `#[tokio::test]` functions in this file, which the
+// LIB target does not compile — so a lib-only build reports them dead. They are not: removing
+// them breaks the live tests the moment anyone runs them with `--features live-tests`.
+#![allow(dead_code)]
 
 use ghost_tap_core::network::ghost_pay::ShieldRequest;
 use std::env;

--- a/apps/ghost-tap/tests/integration/src/live_tests.rs
+++ b/apps/ghost-tap/tests/integration/src/live_tests.rs
@@ -15,7 +15,7 @@
 // Every helper below is used only from the `#[tokio::test]` functions in this file, which the
 // LIB target does not compile — so a lib-only build reports them dead. They are not: removing
 // them breaks the live tests the moment anyone runs them with `--features live-tests`.
-#![allow(dead_code)]
+#![allow(dead_code, unused_imports)]
 
 use ghost_tap_core::network::ghost_pay::ShieldRequest;
 use std::env;

--- a/apps/wraith-wallet/core/src/psbt.rs
+++ b/apps/wraith-wallet/core/src/psbt.rs
@@ -818,8 +818,8 @@ pub fn bump_fee(
     let n_inputs = unsigned.input.len() as u64;
     let n_outputs = unsigned.output.len() as u64;
     let est_vbytes = 11 + n_inputs * 58 + n_outputs * 31;
-    let old_rate = if est_vbytes > 0 {
-        old_fee / est_vbytes
+    let old_rate = if let Some(r) = old_fee.checked_div(est_vbytes) {
+        r
     } else {
         0
     };

--- a/apps/wraith-wallet/core/src/psbt.rs
+++ b/apps/wraith-wallet/core/src/psbt.rs
@@ -818,11 +818,9 @@ pub fn bump_fee(
     let n_inputs = unsigned.input.len() as u64;
     let n_outputs = unsigned.output.len() as u64;
     let est_vbytes = 11 + n_inputs * 58 + n_outputs * 31;
-    let old_rate = if let Some(r) = old_fee.checked_div(est_vbytes) {
-        r
-    } else {
-        0
-    };
+    // est_vbytes is a sum of positive terms so it cannot be zero, but divide defensively:
+    // a zero here would panic rather than merely mis-price the bump.
+    let old_rate = old_fee.checked_div(est_vbytes).unwrap_or_default();
     if new_fee_rate_sats_per_vb <= old_rate {
         return Err(BumpError::NotIncreasing {
             new_rate: new_fee_rate_sats_per_vb,

--- a/apps/wraith-wallet/core/src/psbt.rs
+++ b/apps/wraith-wallet/core/src/psbt.rs
@@ -585,7 +585,7 @@ pub fn create_psbt(
     // as few inputs as possible — keeps fee predictable and avoids
     // slicing tiny coins for big sends.
     let mut sorted: Vec<&AvailableUtxo> = available.iter().collect();
-    sorted.sort_by(|a, b| b.value_sats.cmp(&a.value_sats));
+    sorted.sort_by_key(|u| std::cmp::Reverse(u.value_sats));
 
     let recipient_spk = recipient.script_pubkey();
     let change_spk = change_address.script_pubkey();

--- a/bins/ghost-pool/src/alert_monitors.rs
+++ b/bins/ghost-pool/src/alert_monitors.rs
@@ -649,6 +649,10 @@ mod tests {
         assert!(evaluate_mempool_congestion(u64::MAX, 0, MEMPOOL_CONGESTION_HIGH_PCT).is_none());
     }
 
+    // Both sides are constants deliberately: this guards the hysteresis band against being
+    // inverted or collapsed by a future edit. It fails only when someone changes those
+    // constants, which is the entire point — do not "fix" it by making it dynamic.
+    #[allow(clippy::assertions_on_constants)]
     #[test]
     fn congestion_rearm_is_below_high() {
         // Sanity: hysteresis band is non-empty and ordered.

--- a/bins/ghost-pool/src/capacity.rs
+++ b/bins/ghost-pool/src/capacity.rs
@@ -149,7 +149,6 @@ fn detect_ram_mb() -> u64 {
             for line in contents.lines() {
                 if let Some(rest) = line.strip_prefix("MemTotal:") {
                     let kb: u64 = rest
-                        .trim()
                         .split_whitespace()
                         .next()
                         .and_then(|s| s.parse().ok())
@@ -178,7 +177,7 @@ fn detect_fd_limit() -> u64 {
     };
     let rc = unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, &mut rlim) };
     if rc == 0 && rlim.rlim_cur > 0 {
-        rlim.rlim_cur as u64
+        rlim.rlim_cur
     } else {
         FALLBACK_FD_LIMIT
     }

--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -9591,11 +9591,13 @@ mod tests {
     #[test]
     fn test_finalize_gate_enabled_with_ghost_pay() {
         // A node running ghost-pay sets enabled = true → notify is wired.
-        let mut config = NodeConfig::default();
-        config.ghost_pay = Some(GhostPayConfig {
-            enabled: true,
-            ..GhostPayConfig::default()
-        });
+        let config = NodeConfig {
+            ghost_pay: Some(GhostPayConfig {
+                enabled: true,
+                ..GhostPayConfig::default()
+            }),
+            ..Default::default()
+        };
         assert!(
             config.ghost_pay_enabled(),
             "a ghost-pay node must attempt the finalize notify"

--- a/bins/ghost-pool/src/payout.rs
+++ b/bins/ghost-pool/src/payout.rs
@@ -201,7 +201,7 @@ pub fn compute_ledger_root(
     let mut m = miners.to_vec();
     m.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
     let mut n = nodes.to_vec();
-    n.sort_by(|a, b| a.0.cmp(&b.0));
+    n.sort_by_key(|x| x.0);
 
     let mut h = Sha256::new();
     h.update(LEDGER_ROOT_DOMAIN);
@@ -250,7 +250,7 @@ pub fn ledger_root_diag(
     let mdig = mh.finalize();
 
     let mut n = nodes.to_vec();
-    n.sort_by(|a, b| a.0.cmp(&b.0));
+    n.sort_by_key(|x| x.0);
     let mut nh = Sha256::new();
     for (node_id, shares) in &n {
         nh.update(&node_id[..]);
@@ -1460,7 +1460,7 @@ impl PayoutProposalCreator {
 
         // Sort by work descending, take top N (using scaled integer comparison)
         let mut sorted = scaled_work;
-        sorted.sort_by(|a, b| b.1.cmp(&a.1));
+        sorted.sort_by_key(|x| std::cmp::Reverse(x.1));
         sorted.truncate(self.config.max_miner_outputs);
 
         // Recalculate total work for top miners

--- a/bins/ghost-pool/src/payout.rs
+++ b/bins/ghost-pool/src/payout.rs
@@ -310,6 +310,10 @@ pub fn resolve_payout_cutoff(db: &ghost_storage::Database, tip_height: u64) -> O
     }
 }
 
+/// The two halves of an adopted payout split: miner payouts as `(address, work)` and node
+/// shares as `(node_id, share_count)` — the same pair `compute_ledger_root` hashes.
+pub type AdoptedPayout = (Vec<(String, u128)>, Vec<(NodeId, i32)>);
+
 /// Option (c) adopt-CONSUMPTION: the BFT-finalised checkpoint's ADOPTED payout lists at
 /// or before `tip_height` — `(miner_payouts: (address, WORK_SCALE-quantised work),
 /// node_shares: (node_id, 5-4-3-2-1 shares))`.
@@ -325,10 +329,7 @@ pub fn resolve_payout_cutoff(db: &ghost_storage::Database, tip_height: u64) -> O
 /// `None` when no checkpoint has finalised at or before `tip_height` (the brief window at
 /// first activation) — the caller then builds NO split (treasury-only fallback, safe:
 /// there is nothing for validators to disagree on).
-pub fn read_adopted_payout(
-    db: &ghost_storage::Database,
-    tip_height: u64,
-) -> Option<(Vec<(String, u128)>, Vec<(NodeId, i32)>)> {
+pub fn read_adopted_payout(db: &ghost_storage::Database, tip_height: u64) -> Option<AdoptedPayout> {
     match db.get_payout_ledger_checkpoint_at_or_before(tip_height) {
         Ok(Some(cp)) => Some((cp.miner_payouts, cp.node_shares)),
         Ok(None) => None,

--- a/bins/ghost-pool/src/payout.rs
+++ b/bins/ghost-pool/src/payout.rs
@@ -3963,9 +3963,8 @@ mod tests {
 
         // One whale miner with 99% of work, 99 tiny miners with 1% total
         let mut miner_work: Vec<u128> = vec![99_000u128]; // whale
-        for _ in 0..99 {
-            miner_work.push(10u128); // tiny miners: 10 each = 990 total
-        }
+                                                          // tiny miners: 10 each = 990 total
+        miner_work.extend(std::iter::repeat_n(10u128, 99));
         let total_work: u128 = miner_work.iter().sum();
         assert_eq!(total_work, 99_990);
 

--- a/bins/ghost-pool/src/self_check.rs
+++ b/bins/ghost-pool/src/self_check.rs
@@ -610,8 +610,10 @@ mod tests {
         // Enabled alert config, drift event on, channels default-disabled so no
         // network I/O — we only assert the trigger reached the dispatcher.
         let dispatcher = Arc::new(AlertDispatcher::new("node".into(), || {
-            let mut c = AlertsConfig::default();
-            c.enabled = true;
+            let mut c = AlertsConfig {
+                enabled: true,
+                ..Default::default()
+            };
             c.events.capability_drift = true;
             c
         }));
@@ -647,8 +649,11 @@ mod tests {
         // v1.10.20: a present-but-disabled `[ghost_pay]` block must NOT claim the
         // capability (gate on `enabled`, not mere block presence) — otherwise
         // pool-only nodes advertise GhostPay and peers waste probes on port 8800.
-        let mut cfg = NodeConfig::default();
-        cfg.ghost_pay = Some(GhostPayConfig::default()); // default enabled = false
+        // default enabled = false, which is the point of this case
+        let cfg = NodeConfig {
+            ghost_pay: Some(GhostPayConfig::default()),
+            ..Default::default()
+        };
         let r = check_ghost_pay(&cfg).await;
         assert!(!r.claimed && !r.passed && r.reason.is_none());
     }

--- a/bins/ghost-pool/src/self_check.rs
+++ b/bins/ghost-pool/src/self_check.rs
@@ -288,10 +288,7 @@ fn check_archive(config: &NodeConfig) -> CapabilityCheck {
     let configured = config.storage.db_path.as_path();
     let probe_path = data_probe_path(config);
     let free = free_bytes(&probe_path);
-    let passed = match free {
-        Some(b) if b >= ARCHIVE_MIN_FREE_BYTES => true,
-        _ => false,
-    };
+    let passed = matches!(free, Some(b) if b >= ARCHIVE_MIN_FREE_BYTES);
     let reason = match free {
         None => Some(format!(
             "could not stat data_dir {} (probed {})",

--- a/bins/ghost-pool/src/template.rs
+++ b/bins/ghost-pool/src/template.rs
@@ -4978,7 +4978,7 @@ mod tests {
 
         let mut strict = PolicyProfile::full_open();
         strict.max_op_return_size = 40;
-        let (kept, _) = make_processor(strict).filter_transactions(&[ttx.clone()]);
+        let (kept, _) = make_processor(strict).filter_transactions(std::slice::from_ref(&ttx));
         assert!(kept.is_empty(), "oversized OP_RETURN must be dropped");
 
         let mut loose = PolicyProfile::full_open();
@@ -5021,7 +5021,7 @@ mod tests {
 
         let mut strict = PolicyProfile::full_open();
         strict.max_witness_per_input = 500;
-        let (kept, _) = make_processor(strict).filter_transactions(&[ttx.clone()]);
+        let (kept, _) = make_processor(strict).filter_transactions(std::slice::from_ref(&ttx));
         assert!(kept.is_empty(), "oversized witness must be dropped");
 
         let mut loose = PolicyProfile::full_open();
@@ -5113,7 +5113,7 @@ mod tests {
         // allow_inscriptions = false → dropped by policy (reaper disabled).
         let mut strict = PolicyProfile::full_open();
         strict.allow_inscriptions = false;
-        let (kept, _) = make_processor(strict).filter_transactions(&[ttx.clone()]);
+        let (kept, _) = make_processor(strict).filter_transactions(std::slice::from_ref(&ttx));
         assert!(
             kept.is_empty(),
             "inscription must be dropped when disallowed"

--- a/bins/ghost-pool/tests/fleet_rehearsal.rs
+++ b/bins/ghost-pool/tests/fleet_rehearsal.rs
@@ -139,7 +139,7 @@ fn seed_divergent(db: &Database, node: usize, now: i64) {
 
     for (i, (hash, m, round, work, ts)) in all_shares(now).into_iter().enumerate() {
         // Drop ~5% — a different slice on each node, as real gossip loss would.
-        if (i + node * 7) % 20 == 0 {
+        if (i + node * 7).is_multiple_of(20) {
             continue;
         }
         db.insert_share(&ShareRecord {

--- a/bins/jd-client-sv2/src/lib/channel_manager/template_message_handler.rs
+++ b/bins/jd-client-sv2/src/lib/channel_manager/template_message_handler.rs
@@ -467,6 +467,14 @@ impl HandleTemplateDistributionMessagesFromServerAsync for ChannelManager {
             if let Some(ref mut upstream_channel) = channel_manager_data.upstream_channel {
                 _ = upstream_channel.on_chain_tip_update(msg.clone().into());
 
+                // clippy::unnecessary_unwrap wants the `is_some()` checks folded into `if let`.
+                // Do not: the token must only be popped when BOTH are present. Moving the
+                // binding inside would pop and mark `token_consumed` before checking
+                // `job_factory`, leaking an allocation token whenever the factory is absent.
+                // Edition 2021 has no let-chains, and taking `job_factory.as_mut()` first
+                // borrows `channel_manager_data` for the `allocate_tokens.pop_front()` below.
+                // The two `expect`s are guarded on the line above and cannot fire.
+                #[allow(clippy::unnecessary_unwrap)]
                 if get_jd_mode() == JdMode::CoinbaseOnly
                     && channel_manager_data.job_factory.is_some()
                     && future_template.is_some()

--- a/bins/jd-client-sv2/src/lib/channel_manager/upstream_message_handler.rs
+++ b/bins/jd-client-sv2/src/lib/channel_manager/upstream_message_handler.rs
@@ -166,6 +166,11 @@ impl HandleMiningMessagesFromServerAsync for ChannelManager {
                     debug!("Applied last_new_prev_hash to new extended channel");
                 }
 
+                // Same as the template handler: the token must only be popped when ALL three
+                // are present, so the `is_some()` guards cannot be folded into `if let`
+                // bindings without leaking an allocation token when one is absent. Edition
+                // 2021, so no let-chains. The `expect`s are guarded directly above.
+                #[allow(clippy::unnecessary_unwrap)]
                 let set_custom_job = if get_jd_mode() == JdMode::CoinbaseOnly
                     && data.job_factory.is_some()
                     && data.last_future_template.is_some()

--- a/bins/pool-sv2/src/lib/channel_manager/mining_message_handler.rs
+++ b/bins/pool-sv2/src/lib/channel_manager/mining_message_handler.rs
@@ -453,7 +453,7 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
                                 }
                                 e => {
                                     error!("error in handle_open_extended_mining_channel: {:?}", e);
-                                    return Err(PoolError::disconnect(e, downstream_id).into());
+                                    return Err(PoolError::disconnect(e, downstream_id));
                                 }
                             },
                         };
@@ -765,7 +765,7 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
                         messages.push((downstream_id, Mining::SubmitSharesError(error)).into());
                     }
                     Err(e) => {
-                        return Err(PoolError::disconnect(e, downstream_id).into());
+                        return Err(PoolError::disconnect(e, downstream_id));
                     }
                 }
 
@@ -1045,7 +1045,7 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
                         messages.push((downstream_id, Mining::SubmitSharesError(error)).into());
                     }
                     Err(e) => {
-                        return Err(PoolError::disconnect(e, downstream_id).into());
+                        return Err(PoolError::disconnect(e, downstream_id));
                     }
                 }
 

--- a/bins/pool-sv2/src/lib/monitoring.rs
+++ b/bins/pool-sv2/src/lib/monitoring.rs
@@ -46,7 +46,7 @@ fn downstream_to_sv2_client_info(client: &Downstream) -> Option<Sv2ClientInfo> {
                 });
             }
 
-            for (_channel_id, standard_channel) in dd.standard_channels.iter() {
+            for standard_channel in dd.standard_channels.values() {
                 let channel_id = standard_channel.get_channel_id();
                 let target = standard_channel.get_target();
                 let requested_max_target = standard_channel.get_requested_max_target();

--- a/bins/wraith-coordinator/src/api/session_outputs.rs
+++ b/bins/wraith-coordinator/src/api/session_outputs.rs
@@ -270,17 +270,20 @@ pub async fn post(
             .unwrap_or_default();
         let mut entropy = [0u8; 32];
         getrandom::getrandom(&mut entropy).expect("OS CSPRNG failed during round assembly");
+        let round_ctx = crate::assembly::RoundContext {
+            session_id: &session_id,
+            tier: session.tier,
+            session_type: session.session_type,
+            network: state.network,
+            coordinator_fee_address: state.coordinator_fee_address.as_deref(),
+            inputs: &inputs_snapshot,
+            outputs: &outputs_snapshot,
+            entropy: &entropy,
+        };
         match try_assemble_if_ready(
-            &session_id,
-            session.tier,
-            session.session_type,
+            round_ctx,
             session.state.clone(),
-            state.network,
-            state.coordinator_fee_address.as_deref(),
-            &inputs_snapshot,
-            &outputs_snapshot,
             enrolled_count as usize,
-            &entropy,
             now,
         ) {
             Some(Ok(assembled)) => {

--- a/bins/wraith-coordinator/src/assembly.rs
+++ b/bins/wraith-coordinator/src/assembly.rs
@@ -61,16 +61,37 @@ pub type AssembledRoundStore = Mutex<HashMap<String, AssembledRound>>;
 /// Build the assembled round from an arrival-order pairing of inputs
 /// and outputs. Pure function over the data — no shared state — so
 /// it's trivial to unit-test.
-pub fn assemble_round(
-    session_id: &str,
-    tier: wraith_protocol::LiteTier,
-    session_type: SessionType,
-    network: Network,
-    coordinator_fee_address: Option<&str>,
-    inputs: &[AcceptedInputs],
-    outputs: &[AcceptedOutput],
-    entropy: &[u8; 32],
-) -> Result<AssembledRound, AssembleError> {
+/// What a round needs to be assembled.
+///
+/// A struct rather than eight-then-eleven positional parameters. The list is mostly borrowed
+/// slices and newtypes that do not distinguish themselves at a call site — `inputs` and
+/// `outputs` are both `&[Accepted...]`, and `session_id` sits next to two enums — so the
+/// positional form is easy to get subtly wrong and impossible to read back.
+///
+/// `try_assemble_if_ready` takes the same context plus the readiness inputs, so both share this.
+#[derive(Clone, Copy)]
+pub struct RoundContext<'a> {
+    pub session_id: &'a str,
+    pub tier: wraith_protocol::LiteTier,
+    pub session_type: SessionType,
+    pub network: Network,
+    pub coordinator_fee_address: Option<&'a str>,
+    pub inputs: &'a [AcceptedInputs],
+    pub outputs: &'a [AcceptedOutput],
+    pub entropy: &'a [u8; 32],
+}
+
+pub fn assemble_round(ctx: RoundContext<'_>) -> Result<AssembledRound, AssembleError> {
+    let RoundContext {
+        session_id,
+        tier,
+        session_type,
+        network,
+        coordinator_fee_address,
+        inputs,
+        outputs,
+        entropy,
+    } = ctx;
     if inputs.len() != outputs.len() {
         return Err(AssembleError::CountMismatch {
             inputs: inputs.len(),
@@ -183,35 +204,20 @@ impl AssembleError {
 /// Returns `Some(Result<assembled, error>)` if assembly was attempted
 /// (success or failure), `None` if not yet ready.
 pub fn try_assemble_if_ready(
-    session_id: &str,
-    tier: wraith_protocol::LiteTier,
-    session_type: SessionType,
+    ctx: RoundContext<'_>,
     state: LiteSessionState,
-    network: Network,
-    coordinator_fee_address: Option<&str>,
-    inputs: &[AcceptedInputs],
-    outputs: &[AcceptedOutput],
     enrolled_count: usize,
-    entropy: &[u8; 32],
     now: u64,
 ) -> Option<Result<AssembledRound, AssembleError>> {
+    let session_id = ctx.session_id;
+    let (inputs, outputs) = (ctx.inputs, ctx.outputs);
     if !matches!(state, LiteSessionState::Signing) {
         return None;
     }
     if inputs.len() != enrolled_count || outputs.len() != enrolled_count {
         return None;
     }
-    let result = assemble_round(
-        session_id,
-        tier,
-        session_type,
-        network,
-        coordinator_fee_address,
-        inputs,
-        outputs,
-        entropy,
-    )
-    .map(|mut a| {
+    let result = assemble_round(ctx).map(|mut a| {
         a.assembled_at = now;
         a
     });

--- a/crates/ghost-accounting/src/shares.rs
+++ b/crates/ghost-accounting/src/shares.rs
@@ -247,7 +247,7 @@ impl RoundShares {
             .iter()
             .map(|(id, info)| (*id, info.shares_received))
             .collect();
-        nodes.sort_by(|a, b| b.1.cmp(&a.1));
+        nodes.sort_by_key(|x| std::cmp::Reverse(x.1));
 
         // Collect top 100 node IDs
         let top_100_ids: Vec<NodeId> = nodes.iter().take(100).map(|(id, _)| *id).collect();
@@ -327,7 +327,7 @@ impl RoundShares {
             .map(|(id, work)| (id.as_str(), *work))
             .collect();
 
-        miners.sort_by(|a, b| b.1.cmp(&a.1));
+        miners.sort_by_key(|x| std::cmp::Reverse(x.1));
         miners.truncate(n);
         miners
     }

--- a/crates/ghost-common/src/config.rs
+++ b/crates/ghost-common/src/config.rs
@@ -2819,9 +2819,12 @@ mod tests {
         .unwrap();
         assert!(core.enabled);
 
-        let mut config = NodeConfig::default();
-        config.ghost_pay = Some(pool_only);
+        let mut config = NodeConfig {
+            ghost_pay: Some(pool_only),
+            ..Default::default()
+        };
         assert!(!config.ghost_pay_enabled());
+        // The reassignment is the test: same node, block swapped for an enabled one.
         config.ghost_pay = Some(core);
         assert!(config.ghost_pay_enabled());
     }

--- a/crates/ghost-glyph/src/glyph.rs
+++ b/crates/ghost-glyph/src/glyph.rs
@@ -106,8 +106,8 @@ mod tests {
 
     fn test_pixels() -> [u8; GLYPH_SIZE] {
         let mut pixels = [0u8; GLYPH_SIZE];
-        for i in 0..GLYPH_SIZE {
-            pixels[i] = (i % PALETTE_SIZE) as u8;
+        for (i, px) in pixels.iter_mut().enumerate() {
+            *px = (i % PALETTE_SIZE) as u8;
         }
         pixels
     }

--- a/crates/ghost-gsp/src/api/rest.rs
+++ b/crates/ghost-gsp/src/api/rest.rs
@@ -367,11 +367,8 @@ pub async fn admin_inject_candidate_tx(
         block_height: req.block_height,
     };
 
-    let n = match state.silent_payments_tx.send(msg) {
-        Ok(n) => n,
-        // No subscribers yet — that's fine, just nobody to notify.
-        Err(_) => 0,
-    };
+    // No subscribers yet is fine — nobody to notify, so zero.
+    let n = state.silent_payments_tx.send(msg).unwrap_or_default();
     info!(subscribers = n, "admin: candidate-tx injected");
     Json(InjectCandidateTxResponse {
         success: true,

--- a/crates/ghost-gsp/src/state/subscriptions.rs
+++ b/crates/ghost-gsp/src/state/subscriptions.rs
@@ -44,8 +44,14 @@ pub enum SubscriptionType {
 }
 
 impl SubscriptionType {
-    /// Parse from string
-    pub fn from_str(s: &str) -> Option<Self> {
+    /// Parse a subscription name, case-insensitively.
+    ///
+    /// Named `from_name` rather than `from_str`: the latter shadows
+    /// `std::str::FromStr::from_str`, so a caller with the trait in scope could reach a
+    /// different method than they meant. Implementing `FromStr` properly is not the answer
+    /// either — it returns `Result`, and an unknown subscription name is an ordinary `None`
+    /// here, not an error worth a type.
+    pub fn from_name(s: &str) -> Option<Self> {
         match s.to_lowercase().as_str() {
             "balance" => Some(SubscriptionType::Balance),
             "payments" => Some(SubscriptionType::Payments),
@@ -99,7 +105,7 @@ impl SubscriptionManager {
 
     /// Add a subscription for a wallet
     pub fn subscribe(&self, wallet_id: &WalletId, subscription: &str) {
-        if let Some(sub_type) = SubscriptionType::from_str(subscription) {
+        if let Some(sub_type) = SubscriptionType::from_name(subscription) {
             let mut subs = self.subscriptions.write();
             subs.entry(wallet_id.to_string())
                 .or_default()
@@ -109,7 +115,7 @@ impl SubscriptionManager {
 
     /// Remove a subscription for a wallet
     pub fn unsubscribe(&self, wallet_id: &WalletId, subscription: &str) {
-        if let Some(sub_type) = SubscriptionType::from_str(subscription) {
+        if let Some(sub_type) = SubscriptionType::from_name(subscription) {
             let mut subs = self.subscriptions.write();
             if let Some(wallet_subs) = subs.get_mut(&wallet_id.to_string()) {
                 wallet_subs.remove(&sub_type);

--- a/crates/ghost-keys/src/ghost_id.rs
+++ b/crates/ghost-keys/src/ghost_id.rs
@@ -330,7 +330,7 @@ impl fmt::Display for GhostId {
                 // of exposing internal error details. This ensures Display never
                 // panics and always produces a usable (if degraded) representation.
                 let bytes = self.to_bytes();
-                write!(f, "ghost-invalid:{}", &hex::encode(&bytes[..16]))
+                write!(f, "ghost-invalid:{}", hex::encode(&bytes[..16]))
             }
         }
     }

--- a/crates/ghost-verification/src/qualification.rs
+++ b/crates/ghost-verification/src/qualification.rs
@@ -30,7 +30,7 @@ use std::sync::Arc;
 use tracing::{info, warn};
 
 use ghost_common::types::{NodeCapabilities, NodeId};
-use ghost_storage::{queries::VerificationProofInsert, Database};
+use ghost_storage::Database;
 
 /// Seconds in a day
 const SECONDS_PER_DAY: i64 = 86_400;
@@ -1093,6 +1093,9 @@ impl QualificationStats {
 #[cfg(test)]
 mod tests {
     use super::*;
+    // Only the tests construct verification proofs; keeping this here rather than at module
+    // level is what stops the lib build reporting it unused.
+    use ghost_storage::queries::VerificationProofInsert;
 
     #[test]
     fn test_default_config() {

--- a/crates/ghost-verification/src/qualification.rs
+++ b/crates/ghost-verification/src/qualification.rs
@@ -1450,7 +1450,7 @@ mod tests {
                 challenger_id: &challenger,
                 target_node_id: target,
                 capability: "archive",
-                passed: passed,
+                passed,
                 timestamp: ts,
                 proof: b"p",
                 round_height: None,

--- a/crates/mpc-xproc-harness/tests/xproc.rs
+++ b/crates/mpc-xproc-harness/tests/xproc.rs
@@ -353,8 +353,8 @@ fn cross_process_contribution_flow() {
 
         // ---- (2) VOTERS (separate processes) FETCH by hash + real verify ------
         let mut approvals = 0u32;
-        for v in 1..COMMITTEE {
-            let r = nodes[v].send(json!({
+        for node in nodes.iter_mut().take(COMMITTEE).skip(1) {
+            let r = node.send(json!({
                 "cmd": "fetch_verify",
                 "url": contributor_url,
                 "new_hash": new_hash,
@@ -378,7 +378,7 @@ fn cross_process_contribution_flow() {
             approvals += 1;
             println!(
                 "  [{}] fetched {} bytes via ?new_hash=, verify_ok=true",
-                nodes[v].name, r["size"]
+                node.name, r["size"]
             );
         }
         // The contributor holds valid params it generated -> counts as an approval.

--- a/tests/cluster_chaos_mod/phase17_restore_configs.rs
+++ b/tests/cluster_chaos_mod/phase17_restore_configs.rs
@@ -6,6 +6,9 @@
 
 use std::time::Duration;
 
+/// One config setting to restore: (file, key, value).
+type ConfigSetting = (&'static str, &'static str, &'static str);
+
 use super::client::ClusterClient;
 use super::config::ClusterConfig;
 use super::ssh::SshController;
@@ -47,7 +50,7 @@ async fn restore_01_restore_all_configs() {
     // If a backup exists, restore from it. Otherwise, force-patch the expected
     // original values — the backup may have been lost due to SSH timeouts in a
     // prior run, leaving the config in a modified state.
-    let original_values: &[(&str, &[(&str, &str, &str)])] = &[
+    let original_values: &[(&str, &[ConfigSetting])] = &[
         (
             "VM2",
             &[

--- a/tests/integration_tests/adversarial.rs
+++ b/tests/integration_tests/adversarial.rs
@@ -118,16 +118,13 @@ fn test_930_deeply_nested_json_rejected() {
     let ok_json = "{\"a\":".repeat(MAX_JSON_DEPTH) + "1" + &"}".repeat(MAX_JSON_DEPTH);
     let ok_data = ok_json.as_bytes();
     let result = validate_and_verify(ok_data);
-    match result {
-        Err(MessageValidationError::ExcessiveNesting(_)) => {
-            panic!(
-                "{}-level nesting should NOT trigger ExcessiveNesting",
-                MAX_JSON_DEPTH
-            );
-        }
-        // Any other error (TooSmall, DeserializationFailed, etc.) is acceptable
-        // -- we only care that the depth check itself passes.
-        _ => {}
+    // Any other error (TooSmall, DeserializationFailed, etc.) is acceptable — we only care
+    // that the depth check itself passes.
+    if let Err(MessageValidationError::ExcessiveNesting(_)) = result {
+        panic!(
+            "{}-level nesting should NOT trigger ExcessiveNesting",
+            MAX_JSON_DEPTH
+        );
     }
 }
 

--- a/tests/integration_tests/consensus.rs
+++ b/tests/integration_tests/consensus.rs
@@ -421,7 +421,7 @@ fn test_elder_priority() {
         .collect();
 
     // Sort by tenure (descending) and mark top 5 as elders
-    nodes.sort_by(|a, b| b.tenure_days.cmp(&a.tenure_days));
+    nodes.sort_by_key(|n| std::cmp::Reverse(n.tenure_days));
     for node in nodes.iter_mut().take(5) {
         node.is_elder = true;
     }

--- a/tests/integration_tests/discovery_security.rs
+++ b/tests/integration_tests/discovery_security.rs
@@ -18,8 +18,8 @@ fn make_node_id(discriminator: u8) -> [u8; 32] {
     let mut id = [0u8; 32];
     id[0] = discriminator;
     // Fill remaining bytes for uniqueness
-    for i in 1..32 {
-        id[i] = discriminator.wrapping_add(i as u8);
+    for (i, byte) in id.iter_mut().enumerate().skip(1) {
+        *byte = discriminator.wrapping_add(i as u8);
     }
     id
 }


### PR DESCRIPTION
Closes #401.

## Scale

The issue title says 221 warnings. The real workspace figure when I started this session was **57** — earlier passes had already cleared most of it. It is now **zero in our own code**, and `-D warnings` is on.

## Two that would have broken things if I had obeyed the lint

**jd-client, both handlers.** `clippy::unnecessary_unwrap` wanted the `is_some()` guards folded into `if let`. That is wrong here: the allocation token must only be popped when **all** the guarded values are present. Moving the binding inside pops the token and sets `token_consumed` *before* `job_factory` is checked, leaking a token whenever the factory is absent. Edition 2021 has no let-chains, and binding `job_factory.as_mut()` first holds a mutable borrow across the `pop_front()` below. Annotated with that reasoning; the `expect`s are guarded on the line directly above.

**Two constant assertions** — `alert_monitors.rs` (`REARM < HIGH`) and `database.rs` (`VACUUM_MIN_RECLAIMABLE_BYTES >= 64 MB`). Both sides are constants deliberately: they guard those constants against being lowered or inverted. Deleting them as trivially true, or making them dynamic to satisfy the lint, throws the guard away. Annotated.

## Two "unused" items that were not

- `VerificationProofInsert` — I removed it as unused and the build failed immediately. Used by four *test* call sites; now scoped inside the test module.
- `live_tests.rs` — `TEST_COUNTER`, `ghost_pay_url`, `test_key`, `to_hex` and a `ShieldRequest` import are referenced 2–9 times each, but only from `#[tokio::test]` functions the lib target does not compile. Annotated, not deleted — they are load-bearing under `--features live-tests`.

## Where a refactor was genuinely worth it

- **`insert_verification_proof`** had 8 positional args, two of them adjacent `&str`s (`challenger_id`, `target_node_id`). Transposing them compiles, files the record against the wrong node, and — because every peer grades that record identically for convergence — the error *converges across the mesh*. Now a named-field struct across 19 call sites.
- **`assemble_round` / `try_assemble_if_ready`** (8 and 11 params) had exactly one call site each, and the former's params are a strict subset of the latter's, so one `RoundContext` serves both.

## Care taken on consensus-critical code

`compute_ledger_root`'s doc says its canonical sort order is part of the contract. `NodeId` is `[u8; 32]` and therefore `Copy`, so `sort_by_key` is the identical comparison with no allocation — and all four ledger-root tests pass, including `ledger_root_is_deterministic_and_order_independent`, which is precisely the test that would catch a changed ordering.

Everything was fixed by hand. `cargo clippy --fix` has already produced compiling-but-wrong code on this repo once, and consensus and storage are not where to rediscover that.

## Making it blocking

Verified locally with the exact CI invocation before flipping `-W` to `-D`. The six `-A` entries are pre-existing style choices carried over unchanged — no new exemptions were bought to make this pass.

**One warning remains and is deliberately not covered.** Cargo reports that `proc-macro-error2 v2.0.1` contains code a future rustc will reject, reached via `ghost-cli → tabled 0.20 → tabled_derive`. 2.0.1 is the latest published version, so there is nothing to bump to, and it is a cargo future-incompat *note* rather than a rustc lint — so it does not fail the gate. It needs `tabled` to drop the dependency upstream. That is recorded in the workflow comment so the next person does not mistake it for something they broke.

## Tests

305 ghost-pool · 284 ghost-common · 178 ghost-storage · 341 ghost-consensus (with `zk-consensus,mpc-ceremony`) · 249 ghost-verification · 69 ghost-gsp · 68 wraith-wallet-core · 14 wraith-coordinator — all passing, and the whole workspace compiles with `--all-targets`.