### PR TITLE
ci: re-enable integration_tests_sv2 in Coverage, and make Coverage dispatchable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,12 +239,16 @@ jobs:
       - run: sudo apt-get update && sudo apt-get install -y $LINUX_DEPS
       - run: cargo check $WORKSPACE_EXCLUDES
 
-  # Coverage (optional, runs on main only)
+  # Coverage. Runs on main, and on demand via workflow_dispatch.
+  #
+  # Main-only meant this job could not be exercised before merge — so a change that made it
+  # hang was only discoverable after landing, which is exactly how #408 reached main and took
+  # a run to GitHub's 6h cap. `workflow_dispatch` makes it testable on a branch first.
   coverage:
     name: Coverage
     runs-on: ubuntu-latest
     timeout-minutes: 45
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
@@ -266,12 +270,18 @@ jobs:
         # external infrastructure (a real bitcoin-core/ghostd node, a running
         # stratum server, a live cluster) that isn't available in CI — those
         # are exercised separately, not in the coverage gate.
+        #
+        # `integration_tests_sv2` is no longer excluded. It was dropped when its
+        # sniffer test hung for 5h38m under instrumentation; the cause was mock and
+        # sniffer listeners binding inside `tokio::spawn`, so a caller could dial an
+        # address nothing was listening on yet. Fixed in #536 — this re-enables the
+        # crate so the fix is actually exercised rather than assumed (#408).
         # Block scalar (`|`), not a plain one: a plain multi-line scalar is folded
         # onto a single line joined with a space, and YAML leaves the backslash
         # alone, so the shell sees `\ ` — an escaped space — and `--lib` arrives as
         # one token with a leading space rather than as a flag.
         run: |
-          cargo llvm-cov $WORKSPACE_EXCLUDES --exclude integration_tests_sv2 \
+          cargo llvm-cov $WORKSPACE_EXCLUDES \
             --lib --bins --lcov --output-path lcov.info
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5


### PR DESCRIPTION
Closes #408 — with the confirmation the issue asked for, not by inspection.

## The result

Dispatched on this branch with `integration_tests_sv2` **included**:

```
Coverage job        00:52:55 -> 01:14:49   21m54s   success
  Generate coverage 00:54:55 -> 01:14:44   19m49s   success
```

Against the numbers in the issue:

| | Coverage job |
|---|---|
| v1.11.15 (pre-regression) | 22m26s |
| v1.11.16 | 22m20s |
| v1.11.17 (the hang) | **6h00m16s, cancelled** |
| this branch, crate re-enabled | **21m54s** |

Back to baseline under instrumentation — which is the only condition that ever reproduced it. Two independent dispatched runs, both green.

## Why this needed a workflow change first

The Coverage job was gated on the ref being `refs/heads/main`. So the job that would catch a hang **could only run after merge** — which is precisely how the original 6-hour hang reached main. It now also runs on `workflow_dispatch`.

That is the same shape as the release workflow in #540: the check that would have caught the problem could only run once the problem had shipped. Worth noticing it twice in one day.

## What was actually wrong

Not the two candidates in the issue body. `MockUpstream::start` and `Sniffer::start` both bound their listener **inside `tokio::spawn`**, so `start()` returned before anything was listening and the caller dialled an address that did not exist yet. Callers also probe a free port with a temporary `TcpListener` and drop it, leaving the port unowned in between. Invisible on a fast machine; wide open under `cargo llvm-cov`. Fixed in #536; this change is what proves it.

## Note on coverage numbers

Re-enabling the crate changes the reported coverage percentage — it is a test harness, so its own lines now count. `fail_ci_if_error: false` is unchanged, so this cannot break the build either way.