### PR TITLE
fix(translator): survive an impossible state instead of killing every miner

### DIFF
--- a/bins/translator-sv2/src/lib/utils.rs
+++ b/bins/translator-sv2/src/lib/utils.rs
@@ -171,7 +171,18 @@ impl AtomicAggregatedState {
             0 => AggregatedState::NoChannel,
             1 => AggregatedState::Pending,
             2 => AggregatedState::Connected,
-            v => panic!("Invalid UpstreamState value: {v}"),
+            // Unreachable unless something wrote this atomic directly: `set` only ever stores
+            // a discriminant. It used to `panic!`, which in the translator takes the process
+            // down and disconnects every miner on the node — a poor trade for an invariant
+            // violation we can survive. Report it loudly and fall back to the state that makes
+            // the caller re-establish rather than assume a channel it may not have.
+            v => {
+                tracing::error!(
+                    value = v,
+                    "UpstreamState holds an invalid discriminant; treating as NoChannel"
+                );
+                AggregatedState::NoChannel
+            }
         }
     }
 
@@ -198,5 +209,37 @@ mod tests {
         assert_eq!(proxy_extranonce_prefix_len(8, 4), 4);
         assert_eq!(proxy_extranonce_prefix_len(10, 6), 4);
         assert_eq!(proxy_extranonce_prefix_len(4, 4), 0);
+    }
+}
+
+#[cfg(test)]
+mod upstream_state_tests {
+    use super::*;
+
+    /// An invalid discriminant must be reported and survived, not fatal.
+    ///
+    /// This is unreachable through `set`, which only ever stores an enum discriminant — but it
+    /// used to `panic!`, and a panic here takes the translator down and disconnects every miner
+    /// on the node. Surviving an impossible state costs nothing; crashing on it costs the
+    /// whole node.
+    #[test]
+    fn an_invalid_discriminant_is_survived_rather_than_fatal() {
+        let s = AtomicAggregatedState::new(AggregatedState::NoChannel);
+        s.inner.store(200, Ordering::SeqCst);
+        assert_eq!(s.get(), AggregatedState::NoChannel);
+    }
+
+    /// And the ordinary values still round-trip.
+    #[test]
+    fn valid_states_round_trip() {
+        let s = AtomicAggregatedState::new(AggregatedState::NoChannel);
+        for st in [
+            AggregatedState::NoChannel,
+            AggregatedState::Pending,
+            AggregatedState::Connected,
+        ] {
+            s.set(st);
+            assert_eq!(s.get(), st);
+        }
     }
 }


### PR DESCRIPTION
From the private board, **SEC-9**. Partial — and the analysis matters as much as the fix.

## What changed

`AtomicAggregatedState::get()` panicked on a discriminant outside `0..=2`. A panic in the translator takes the process down and **disconnects every miner on the node**, which is a poor trade for an invariant violation the caller can survive.

It now logs at ERROR and returns `NoChannel` — the state that makes the caller re-establish, rather than assume a channel it may not have.

## Being precise about the risk

SEC-9 describes this class as *"potential remote DoS on malformed input"*. **This one is not reachable from the wire.** The atomic is only ever written by `set`, which stores an enum discriminant. It is an internal invariant, and this change is about blast radius, not an exploit.

## The other three sites named in SEC-9 are NOT bugs

SEC-9 also points at `mining_message_handler.rs` (now lines 195, 318 and 1088 after other edits), all the same shape:

```rust
Target::from_le_bytes(msg.max_target.inner_as_ref().try_into().unwrap())
```

That `unwrap` cannot fail on decoded input. `max_target` and `maximum_target` are typed `U256`, and in the codec:

```rust
pub type U256<'a> = Inner<'a, true, 32, 0, 0>;
//                              ^^^^  ^^
//                              fixed  32 bytes
```

so a decoded `U256` is always exactly 32 bytes and the conversion to `[u8; 32]` always succeeds. A wrong-length field cannot get past the decoder to reach them.

I nearly concluded this from the wrong evidence: there is a `resize(32, 0)` with a comment saying "unwrap never panic" in that file, but it sits in `from_gen`, a quickcheck generator — it says nothing about the wire path. The type alias is the real proof.

**If** there is a decode-path panic for undersized frames it would be inside the vendored codec (`from_bytes_unchecked` is exactly the shape that would do it), which is a different fix in a different crate and should not be filed as ours.

## Suggested update to SEC-9

Narrow it: three of the four cited sites are safe by construction, and the fourth is an internal invariant rather than a remote DoS. Whether the vendored codec validates length before `from_bytes_unchecked` is a separate question worth its own look.

52 `translator_sv2` tests pass; the crate reports zero clippy warnings.