### PR TITLE
chore(release): v1.11.22

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -828,7 +828,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-ghost-tests"
-version = "1.11.21"
+version = "1.11.22"
 dependencies = [
  "bitcoin",
  "chrono",
@@ -889,7 +889,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin_core_sv2"
-version = "1.11.21"
+version = "1.11.22"
 dependencies = [
  "async-channel 1.9.0",
  "bitcoin-capnp-types",
@@ -3160,7 +3160,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-accounting"
-version = "1.11.21"
+version = "1.11.22"
 dependencies = [
  "bitcoin",
  "ghost-common",
@@ -3169,7 +3169,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-buds"
-version = "1.11.21"
+version = "1.11.22"
 dependencies = [
  "bitcoin",
  "ghost-common",
@@ -3179,7 +3179,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-cli"
-version = "1.11.21"
+version = "1.11.22"
 dependencies = [
  "anyhow",
  "clap",
@@ -3194,7 +3194,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-common"
-version = "1.11.21"
+version = "1.11.22"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -3224,7 +3224,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-consensus"
-version = "1.11.21"
+version = "1.11.22"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3254,7 +3254,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-glyph"
-version = "1.11.21"
+version = "1.11.22"
 dependencies = [
  "sha2 0.10.9",
  "thiserror 1.0.69",
@@ -3262,7 +3262,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-gsp"
-version = "1.11.21"
+version = "1.11.22"
 dependencies = [
  "axum 0.7.9",
  "bitcoin",
@@ -3317,7 +3317,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-gsp-proto"
-version = "1.11.21"
+version = "1.11.22"
 dependencies = [
  "bitcoin",
  "chrono",
@@ -3333,7 +3333,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-keys"
-version = "1.11.21"
+version = "1.11.22"
 dependencies = [
  "bech32",
  "chacha20poly1305",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-locks"
-version = "1.11.21"
+version = "1.11.22"
 dependencies = [
  "bitcoin",
  "getrandom 0.2.17",
@@ -3394,7 +3394,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-pay"
-version = "1.11.21"
+version = "1.11.22"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3440,7 +3440,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-policy"
-version = "1.11.21"
+version = "1.11.22"
 dependencies = [
  "bitcoin",
  "ghost-buds",
@@ -3451,7 +3451,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-pool"
-version = "1.11.21"
+version = "1.11.22"
 dependencies = [
  "anyhow",
  "async-channel 2.5.0",
@@ -3504,7 +3504,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-reaper"
-version = "1.11.21"
+version = "1.11.22"
 dependencies = [
  "bitcoin",
  "hex",
@@ -3515,7 +3515,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-reconciliation"
-version = "1.11.21"
+version = "1.11.22"
 dependencies = [
  "bitcoin",
  "chrono",
@@ -3532,7 +3532,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-registry"
-version = "1.11.21"
+version = "1.11.22"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -3562,7 +3562,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-setup"
-version = "1.11.21"
+version = "1.11.22"
 dependencies = [
  "clap",
  "dirs 5.0.1",
@@ -3571,7 +3571,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-storage"
-version = "1.11.21"
+version = "1.11.22"
 dependencies = [
  "base64 0.22.1",
  "chacha20poly1305",
@@ -3590,7 +3590,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-tap-core"
-version = "1.11.21"
+version = "1.11.22"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3629,7 +3629,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-tap-desktop"
-version = "1.11.21"
+version = "1.11.22"
 dependencies = [
  "dirs 6.0.0",
  "getrandom 0.2.17",
@@ -3655,7 +3655,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-tap-integration"
-version = "1.11.21"
+version = "1.11.22"
 dependencies = [
  "ghost-gsp-proto",
  "ghost-tap-core",
@@ -3668,7 +3668,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-verification"
-version = "1.11.21"
+version = "1.11.22"
 dependencies = [
  "axum 0.7.9",
  "base64 0.22.1",
@@ -4662,7 +4662,7 @@ dependencies = [
 
 [[package]]
 name = "jd_client_sv2"
-version = "1.11.21"
+version = "1.11.22"
 dependencies = [
  "async-channel 1.9.0",
  "bitcoin_core_sv2",
@@ -4678,7 +4678,7 @@ dependencies = [
 
 [[package]]
 name = "jd_server_sv2"
-version = "1.11.21"
+version = "1.11.22"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -6231,7 +6231,7 @@ dependencies = [
 
 [[package]]
 name = "pool_sv2"
-version = "1.11.21"
+version = "1.11.22"
 dependencies = [
  "async-channel 1.9.0",
  "bitcoin_core_sv2",
@@ -7989,7 +7989,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stratum-apps"
-version = "1.11.21"
+version = "1.11.22"
 dependencies = [
  "async-channel 1.9.0",
  "axum 0.8.9",
@@ -9252,7 +9252,7 @@ dependencies = [
 
 [[package]]
 name = "translator_sv2"
-version = "1.11.21"
+version = "1.11.22"
 dependencies = [
  "async-channel 1.9.0",
  "clap",
@@ -10602,7 +10602,7 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "wraith-coordinator"
-version = "1.11.21"
+version = "1.11.22"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -10636,7 +10636,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-protocol"
-version = "1.11.21"
+version = "1.11.22"
 dependencies = [
  "bitcoin",
  "getrandom 0.2.17",
@@ -10655,7 +10655,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-cli"
-version = "1.11.21"
+version = "1.11.22"
 dependencies = [
  "clap",
  "clap_complete",
@@ -10669,7 +10669,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-core"
-version = "1.11.21"
+version = "1.11.22"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -10706,7 +10706,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-daemon"
-version = "1.11.21"
+version = "1.11.22"
 dependencies = [
  "async-trait",
  "axum 0.7.9",
@@ -10732,7 +10732,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-gui"
-version = "1.11.21"
+version = "1.11.22"
 dependencies = [
  "interprocess",
  "serde",
@@ -10747,7 +10747,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-wallet-ipc"
-version = "1.11.21"
+version = "1.11.22"
 dependencies = [
  "interprocess",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ exclude = ["vendor/stratum"]
 # Use scripts/build-all-wallets.sh to build all wallet types.
 
 [workspace.package]
-version = "1.11.21"
+version = "1.11.22"
 edition = "2021"
 rust-version = "1.88"
 authors = ["Bitcoin Ghost Team"]

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1643,7 +1643,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-accounting"
-version = "1.11.21"
+version = "1.11.22"
 dependencies = [
  "bitcoin",
  "ghost-common",
@@ -1652,7 +1652,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-buds"
-version = "1.11.21"
+version = "1.11.22"
 dependencies = [
  "bitcoin",
  "ghost-common",
@@ -1662,7 +1662,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-common"
-version = "1.11.21"
+version = "1.11.22"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -1691,7 +1691,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-consensus"
-version = "1.11.21"
+version = "1.11.22"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1739,7 +1739,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-glyph"
-version = "1.11.21"
+version = "1.11.22"
 dependencies = [
  "sha2 0.10.9",
  "thiserror 1.0.69",
@@ -1747,7 +1747,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-gsp-proto"
-version = "1.11.21"
+version = "1.11.22"
 dependencies = [
  "bitcoin",
  "chrono",
@@ -1762,7 +1762,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-locks"
-version = "1.11.21"
+version = "1.11.22"
 dependencies = [
  "bitcoin",
  "getrandom 0.2.17",
@@ -1800,7 +1800,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-policy"
-version = "1.11.21"
+version = "1.11.22"
 dependencies = [
  "bitcoin",
  "ghost-buds",
@@ -1811,7 +1811,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-pool"
-version = "1.11.21"
+version = "1.11.22"
 dependencies = [
  "anyhow",
  "async-channel 2.5.0",
@@ -1862,7 +1862,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-reaper"
-version = "1.11.21"
+version = "1.11.22"
 dependencies = [
  "bitcoin",
  "serde",
@@ -1872,7 +1872,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-reconciliation"
-version = "1.11.21"
+version = "1.11.22"
 dependencies = [
  "bitcoin",
  "chrono",
@@ -1889,7 +1889,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-storage"
-version = "1.11.21"
+version = "1.11.22"
 dependencies = [
  "base64 0.22.1",
  "chacha20poly1305",
@@ -1908,7 +1908,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-verification"
-version = "1.11.21"
+version = "1.11.22"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3896,7 +3896,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stratum-apps"
-version = "1.11.21"
+version = "1.11.22"
 dependencies = [
  "async-channel 1.9.0",
  "bs58",
@@ -5185,7 +5185,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-coordinator"
-version = "1.11.21"
+version = "1.11.22"
 dependencies = [
  "anyhow",
  "axum",
@@ -5213,7 +5213,7 @@ dependencies = [
 
 [[package]]
 name = "wraith-protocol"
-version = "1.11.21"
+version = "1.11.22"
 dependencies = [
  "bitcoin",
  "getrandom 0.2.17",


### PR DESCRIPTION
Version bump only — `Cargo.toml` 1.11.21 → 1.11.22 plus the two lockfile refreshes it requires. Independent of #551; either can merge first.

## What this release ships

| PR | | status |
|---|---|---|
| #550 | Payout reject log names *which* of the four checks failed; convergence-stall alarm on every node at 18 blocks (`warn`) / 60 (`error`). No consensus change. | **merged** |
| #552 | Linux release build works again — Cap'n Proto ≥ 1.0 from source. **This is what makes the release cuttable at all**; v1.11.22 was tagged once, failed here, tag deleted (#549). | **merged** |
| #551 | Payout tolerance floored at 0.2% of **total** pool work, so a dust address can no longer veto the fleet. **Consensus change, gated at 960_106.** | in CI |

## ⚠️ Consensus gate

`PAYOUT_TOLERANCE_V2_HEIGHT = 960_106`. **Every node must be on this build before that height** — a node still on the old rule rejects proposals its peers accept.

At the measured block interval that lands near **14:00 BST on 2026-07-29**, but arrival is Poisson: treat the window as **~12:30–14:30**. Rollout target is noon. If it slips, move the gate and rebuild rather than deploy into a mixed window.

Note the failure mode is milder than it first looks: if the gate fires with *no* node upgraded, every node still uses the old rule — that is the status quo, not a split. The only real exposure is a mixed window *during* the roll, which is minutes.

## Lockfiles

The fuzz workspace pins workspace crates by version, so `check-fuzz-targets` fails under `--locked` after a bump — CI names the fix explicitly (`cd fuzz && cargo update --workspace`). The root lockfile needs the same.

## Context

Payout checkpointing stalled from 2026-07-25 02:38 (height 959488) — 580+ blocks, 2.66M unpaid shares back to 06-02. Investigation in #548.

Related work landing separately: #557 adds the covering index that cleared today's vm5/vm6 API outage (55.57 s → 4.04 s on the unpaid-ledger scan; `/health` 45 s timeout → 1.9 ms). Not in this release — already applied by hand to all eight nodes.