### PR TITLE
ci(release): make the floor guard actually inspect ghostd, and see libstdc++

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,30 +175,6 @@ jobs:
       # downloading a published release and watching it fail to start on an older
       # distro. Asserting it here means a runner-image bump cannot quietly raise
       # the requirement again (#540).
-      - name: Assert glibc floor (Linux)
-        if: matrix.target == 'x86_64-unknown-linux-gnu'
-        run: |
-          MAX_ALLOWED=2.35
-          worst=""
-          for bin in target/${{ matrix.target }}/release/*; do
-            [ -f "$bin" ] && [ -x "$bin" ] || continue
-            v=$(objdump -T "$bin" 2>/dev/null \
-                  | grep -o 'GLIBC_[0-9.]*' | sed 's/GLIBC_//' \
-                  | sort -V | tail -1)
-            [ -n "$v" ] || continue
-            echo "  $(basename "$bin"): needs glibc $v"
-            if [ -z "$worst" ] || [ "$(printf '%s\n%s\n' "$worst" "$v" | sort -V | tail -1)" = "$v" ]; then
-              worst="$v"
-            fi
-          done
-          echo "highest requirement: ${worst:-none}"
-          if [ -n "$worst" ] && \
-             [ "$(printf '%s\n%s\n' "$MAX_ALLOWED" "$worst" | sort -V | tail -1)" != "$MAX_ALLOWED" ]; then
-            echo "::error::release binaries require glibc $worst, above the $MAX_ALLOWED floor."
-            echo "::error::That excludes Ubuntu 22.04 (2.35) and Debian 12 (2.36). See #540."
-            exit 1
-          fi
-
       - name: Package
         shell: bash
         run: |
@@ -231,6 +207,91 @@ jobs:
             echo "No binaries found to package"
             exit 1
           fi
+
+      # The floor check MUST run here, after Package, and MUST read dist/.
+      #
+      # The previous version scanned target/<target>/release/*, which holds only the RUST
+      # binaries — ghostd is built by CMake to ghost-core/build/bin/ghostd and is staged into
+      # dist/ by the Package step ABOVE. So the guard never once inspected ghostd. It also
+      # grepped 'GLIBC_', which cannot match 'GLIBCXX_' (that is GLIBC + XX_), so libstdc++
+      # floors were invisible even for the binaries it did scan.
+      #
+      # Those compounded: the one binary with a libstdc++ problem was the one binary the guard
+      # could not see. v1.11.21 shipped as Latest and does not start on Ubuntu 22.04 — ghostd
+      # wants GLIBCXX_3.4.32, ghost-pool wants GLIBC_2.39, and only ghost-cli runs (#555).
+      - name: Assert glibc and libstdc++ floors (Linux)
+        if: matrix.target == 'x86_64-unknown-linux-gnu'
+        shell: bash
+        run: |
+          set -euo pipefail
+          MAX_GLIBC=2.35        # Ubuntu 22.04
+          MAX_GLIBCXX=3.4.30    # Ubuntu 22.04 libstdc++6 (GCC 12)
+
+          command -v objdump >/dev/null || { echo "::error::objdump missing — cannot verify floors"; exit 1; }
+
+          inspected=0
+          fail=0
+          for bin in dist/*; do
+            [ -f "$bin" ] && [ -x "$bin" ] || continue
+            # Skip anything that is not an ELF executable (scripts, notes).
+            head -c 4 "$bin" | grep -q $'\x7fELF' || continue
+            inspected=$((inspected + 1))
+
+            syms=$(objdump -T "$bin" 2>/dev/null || true)
+            g=$(printf '%s' "$syms"  | grep -oE 'GLIBC_[0-9.]+'   | sed 's/GLIBC_//'   | sort -V | tail -1)
+            gx=$(printf '%s' "$syms" | grep -oE 'GLIBCXX_[0-9.]+' | sed 's/GLIBCXX_//' | sort -V | tail -1)
+            echo "  $(basename "$bin"): glibc=${g:-none} libstdc++=${gx:-none}"
+
+            if [ -n "$g" ] && [ "$(printf '%s\n%s\n' "$MAX_GLIBC" "$g" | sort -V | tail -1)" != "$MAX_GLIBC" ]; then
+              echo "::error::$(basename "$bin") needs glibc $g, above the $MAX_GLIBC floor"
+              fail=1
+            fi
+            if [ -n "$gx" ] && [ "$(printf '%s\n%s\n' "$MAX_GLIBCXX" "$gx" | sort -V | tail -1)" != "$MAX_GLIBCXX" ]; then
+              echo "::error::$(basename "$bin") needs libstdc++ GLIBCXX_$gx, above the $MAX_GLIBCXX floor"
+              fail=1
+            fi
+          done
+
+          # A guard that inspected nothing must FAIL, not pass. The previous one skipped a
+          # binary whenever objdump produced no output and then evaluated an empty "worst",
+          # so a broken or missing objdump would have reported success having checked nothing.
+          if [ "$inspected" -eq 0 ]; then
+            echo "::error::floor guard inspected 0 binaries in dist/ — refusing to certify"
+            exit 1
+          fi
+          echo "inspected $inspected binaries"
+          [ "$fail" -eq 0 ] || exit 1
+
+      # Symbol scanning is what failed for v1.11.21, so prove it by RUNNING the packaged
+      # binaries on the oldest supported distro rather than trusting the scan alone.
+      - name: Smoke-test packaged binaries on Ubuntu 22.04
+        if: matrix.target == 'x86_64-unknown-linux-gnu'
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat > /tmp/smoke.sh <<'SMOKE'
+          set -u
+          apt-get update -qq >/dev/null 2>&1
+          apt-get install -y -qq libsqlite3-0 libevent-2.1-7 libzmq5 >/dev/null 2>&1 || true
+          rc=0
+          for bin in /dist/*; do
+            [ -f "$bin" ] && [ -x "$bin" ] || continue
+            head -c 4 "$bin" | grep -q $'\x7fELF' || continue
+            out=$("$bin" --version 2>&1 || true)
+            # Only a symbol-version failure is fatal here. A binary may exit non-zero for
+            # its own reasons (missing config, needs a subcommand) and that is not our concern.
+            if printf '%s' "$out" | grep -qE "version \`(GLIBC|GLIBCXX)_[0-9.]+' not found"; then
+              echo "::error::$(basename "$bin") does not run on Ubuntu 22.04:"
+              printf '%s\n' "$out" | head -5
+              rc=1
+            else
+              echo "  $(basename "$bin"): starts OK"
+            fi
+          done
+          exit $rc
+          SMOKE
+          docker run --rm -v "$PWD/dist:/dist:ro" -v /tmp/smoke.sh:/smoke.sh:ro \
+            ubuntu:22.04 bash /smoke.sh
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v7

--- a/ghost-web/downloads.html
+++ b/ghost-web/downloads.html
@@ -98,6 +98,15 @@
       full operator guide.
     </p>
 
+    <p class="section-lead">
+      <strong>Linux baseline:</strong> the tarball is built to run on
+      <strong>Ubuntu 22.04 or newer</strong> (glibc 2.35+, libstdc++
+      GLIBCXX_3.4.30+), and equivalents such as Debian 12. Every release is
+      checked against that floor and the packaged binaries are started on a
+      22.04 image before publication, so a verified download runs on any
+      supported system.
+    </p>
+
     <div class="core-tiles core-tiles-3">
       <div class="ct-tile ct-wide">
         <div class="k">one-command install</div>


### PR DESCRIPTION
`v1.11.21` is the current **Latest** and does not run on Ubuntu 22.04. The documented download path verifies perfectly — GPG **Good signature**, `sha256sum` **OK** — and then `ghostd` and `ghost-pool` both fail to start. Only `ghost-cli` works.

| binary | needs |
|---|---|
| `ghost-pool` | **GLIBC_2.39** |
| `ghostd` | GLIBC_2.38 + **GLIBCXX_3.4.32** |
| `ghost-pay`, `ghost-gsp` | GLIBC_2.38 |
| `translator_sv2`, `pool_sv2`, `jd_client_sv2`, `ghost-cli` | GLIBC_2.34 |

The real floor is **2.39**, from `ghost-pool` — not the 2.38 recorded in #540/#541/#549. Nobody had measured it.

## Three defects, and ghostd fell into all three

**1 — it never inspected `ghostd`.** The guard looped over `target/<target>/release/*`, which holds only the **Rust** binaries. `ghostd` is CMake-built to `ghost-core/build/bin/ghostd` and staged into `dist/` by the **Package** step, which runs *after* the check. Now the guard runs after Package and reads `dist/` — the actual packaged artifact.

**2 — `GLIBC_` cannot match `GLIBCXX_`.** `GLIBCXX_3.4.32` is `GLIBC` + `XX_`. libstdc++ has an entirely separate floor and was invisible even for the binaries it did scan. Both families are now extracted and bounded independently (glibc **2.35**, GLIBCXX **3.4.30** — the Ubuntu 22.04 maxima).

**3 — it could pass having checked nothing.** Not in the original issue. Each binary was skipped when `objdump` produced no output (`[ -n "$v" ] || continue`), and the final comparison was guarded on a non-empty `worst` — so a missing or broken `objdump` reported success having verified **zero** binaries. It now requires `objdump` and fails if `inspected -eq 0`.

(1) and (2) compound: **the one binary with a libstdc++ problem was the one binary the guard could not see.**

## Don't trust symbol scanning alone

Scanning is exactly what failed here, so the release no longer relies on it. A second step **runs every packaged binary inside an `ubuntu:22.04` container** and fails on ``version `GLIBC…' not found``. Only symbol-version failures are fatal — a binary exiting non-zero for its own reasons (needs a subcommand, missing config) is not the guard's concern.

## Verified

Comparison logic checked against the real numbers:

```
glibc 2.34 -> pass     GLIBCXX_3.4.29 -> pass
glibc 2.35 -> pass     GLIBCXX_3.4.30 -> pass
glibc 2.38 -> REJECT   GLIBCXX_3.4.31 -> REJECT
glibc 2.39 -> REJECT   GLIBCXX_3.4.32 -> REJECT
```

Every floor that broke v1.11.21 is rejected; both 22.04 maxima pass. The empty-`dist` case exits 1 rather than passing silently. Ran the guard body against a real binary: `ghost-pool: glibc=2.34 libstdc++=3.4.30`, correctly detecting **both** families where the old guard saw only one.

YAML parses; `check-workflow-scalars.sh` clean.

## Also

`downloads.html` now states the Linux baseline. It said nothing at all — the floor existed only inside issue bodies, so a user had no way to know before downloading. That is the gap that made this land as "verified signature, then it doesn't run".

## Note on #549

Building on 22.04 will naturally lower these floors and may **mask** the symptom. The guard still has to be correct, or the next toolchain bump ships the same regression silently.

Closes #555
