### PR TITLE
fix(release): floor guard died on any binary with no GLIBCXX_ symbols

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -238,8 +238,13 @@ jobs:
             inspected=$((inspected + 1))
 
             syms=$(objdump -T "$bin" 2>/dev/null || true)
-            g=$(printf '%s' "$syms"  | grep -oE 'GLIBC_[0-9.]+'   | sed 's/GLIBC_//'   | sort -V | tail -1)
-            gx=$(printf '%s' "$syms" | grep -oE 'GLIBCXX_[0-9.]+' | sed 's/GLIBCXX_//' | sort -V | tail -1)
+            # `|| true` is REQUIRED on both. Under `set -e` with `pipefail`, a grep that
+            # matches nothing fails the whole substitution and kills the step — and a pure-Rust
+            # binary legitimately has NO GLIBCXX_ symbols at all. Without this the guard died on
+            # the first such binary (ghost-cli, alphabetically first in dist/) after 20ms with no
+            # output, which looks identical to a real floor violation.
+            g=$(printf '%s' "$syms"  | grep -oE 'GLIBC_[0-9.]+'   | sed 's/GLIBC_//'   | sort -V | tail -1 || true)
+            gx=$(printf '%s' "$syms" | grep -oE 'GLIBCXX_[0-9.]+' | sed 's/GLIBCXX_//' | sort -V | tail -1 || true)
             echo "  $(basename "$bin"): glibc=${g:-none} libstdc++=${gx:-none}"
 
             if [ -n "$g" ] && [ "$(printf '%s\n%s\n' "$MAX_GLIBC" "$g" | sort -V | tail -1)" != "$MAX_GLIBC" ]; then


### PR DESCRIPTION
My own bug in #563, found by **actually dispatching a release run** instead of trusting the local test.

## What happened

The dispatch run failed at the new guard after **20 ms with zero output** — no per-binary lines, no error message. Indistinguishable from a real floor violation, and it would have blocked every release.

Under `set -e` with `pipefail`, a command substitution whose pipeline ends in a grep matching **nothing** fails and kills the step:

```bash
gx=$(printf '%s' "$syms" | grep -oE 'GLIBCXX_[0-9.]+' | ... )
```

A pure-Rust binary legitimately has **no `GLIBCXX_` symbols at all** — that is the normal case, not an error. `ghost-cli` is alphabetically first in `dist/` and is pure Rust, so the guard died on the very first binary before printing anything.

## Why the local test missed it

It used **one** binary that happened to carry both symbol families. The case of a binary lacking one was never exercised — the same mistake as #555 itself: a check never run against the input that breaks it.

## Fix

`|| true` on both greps, so an absent symbol family yields `none` rather than killing the step.

## Verified under GitHub's exact shell

`bash --noprofile --norc -e -o pipefail`, against a `dist/` holding one binary with `GLIBCXX_` and one without:

```
within floor   EXIT=0   ghost-pool: glibc=2.34 libstdc++=3.4.30
                        ls:         glibc=2.34 libstdc++=none
                        inspected 2 binaries

over floor     EXIT=1   ::error::ls needs glibc 2.34, above the 2.30 floor
                        inspected 2 binaries

empty dist     EXIT=1   ::error::floor guard inspected 0 binaries — refusing to certify
```

All three paths now behave correctly with the right exit codes. I'll re-dispatch after merge to confirm against a real build — the guard has to be seen working, not assumed.

Refs #555