### PR TITLE
fix(convergence): sweep the whole unpaid horizon, not a fixed 7 days

### DIFF
--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -3619,6 +3619,7 @@ async fn main() -> Result<()> {
         let conv_handler = Arc::clone(&convergence_handler);
         let rm_for_conv = Arc::clone(&round_manager);
         let conv_tx = conv_tx.clone();
+        let db_for_conv = Arc::clone(&db);
         tokio::spawn(async move {
             const CONVERGENCE_INTERVAL_SECS: u64 = 30;
 
@@ -3633,19 +3634,33 @@ async fn main() -> Result<()> {
             // rotating back through `LEDGER_SWEEP_SPAN_SECS`. Bucketing keeps each advertisement
             // a sane size; the rotation covers the whole span.
             const LEDGER_BUCKET_SECS: i64 = 1_800; // 30 min per advertisement
-                                                   // Sweep the trailing 7 days, matching the verification-ledger sweep
-                                                   // (VLEDGER_SWEEP_SPAN_SECS). At 24h a proof-present share dropped in gossip
-                                                   // that was not reconciled within a day aged out of the rotation and stayed
-                                                   // divergent forever — even though its proof exists and it is fully servable.
-                                                   // The unpaid-share horizon spans well past 24h (shares accumulate until a
-                                                   // payout settles), so the sweep must too, or the payout ledger can never
-                                                   // reach the byte-identical totals the checkpoint requires.
-            const LEDGER_SWEEP_SPAN_SECS: i64 = 7 * 86_400; // sweep the last 7 days
-            const LEDGER_BUCKETS: i64 = LEDGER_SWEEP_SPAN_SECS / LEDGER_BUCKET_SECS;
+
+            // The span must cover the UNPAID HORIZON, not a fixed number of days.
+            //
+            // It was 7 days, and that was still too short. The window SLIDES, so a hole ages out
+            // of it whether or not it was repaired first — measured on 2026-07-30, vm7 had 6,121
+            // shares frozen on 07-20, 3,552 on 07-21, and 4,321 on 07-22 that had aged out
+            // MID-REPAIR (that day was 4,397 and had come down by only 76 before the boundary
+            // passed it). Meanwhile 07-25, still inside the window, went 17,862 -> 9,404. So the
+            // mechanism works and simply loses the race against its own boundary.
+            //
+            // The payout ledger compares EVERY unpaid share, and nothing has settled since
+            // 2026-06-02 (won_blocks = 0, see #556), so the horizon is ~2 months and growing. A
+            // fixed span can never track that. Derive it from the oldest unpaid share instead,
+            // with a cap so a pathological backlog cannot make the rotation unbounded.
+            const LEDGER_SPAN_MIN_SECS: i64 = 7 * 86_400;
+            const LEDGER_SPAN_MAX_SECS: i64 = 90 * 86_400;
+            // Fast lane: recent holes must not wait for a full long rotation. Every other tick
+            // sweeps within the last day, so a fresh drop is still repaired within ~24 min while
+            // the long rotation guarantees everything is eventually reached.
+            const LEDGER_RECENT_SPAN_SECS: i64 = 86_400;
+            const LEDGER_RECENT_BUCKETS: i64 = LEDGER_RECENT_SPAN_SECS / LEDGER_BUCKET_SECS;
 
             let mut ticker =
                 tokio::time::interval(std::time::Duration::from_secs(CONVERGENCE_INTERVAL_SECS));
             let mut bucket: i64 = 0;
+            let mut recent_bucket: i64 = 0;
+            let mut long_lane = true;
 
             loop {
                 ticker.tick().await;
@@ -3657,11 +3672,30 @@ async fn main() -> Result<()> {
                 }
 
                 // Repair one window of the unpaid ledger (the slow path that actually keeps the
-                // ledgers converged). A full sweep of the span takes LEDGER_BUCKETS ticks.
+                // ledgers converged), alternating between the long rotation over the whole
+                // unpaid horizon and a fast lane over the last day.
                 let now = chrono::Utc::now().timestamp();
-                let until = now - bucket * LEDGER_BUCKET_SECS;
-                let since = until - LEDGER_BUCKET_SECS;
-                bucket = (bucket + 1) % LEDGER_BUCKETS;
+
+                // Span tracks the oldest unpaid share, clamped. Cheap query, and it must be
+                // re-read rather than cached: the horizon grows for as long as nothing settles.
+                let span = db_for_conv
+                    .oldest_unpaid_share_timestamp()
+                    .ok()
+                    .flatten()
+                    .map(|oldest| (now - oldest).clamp(LEDGER_SPAN_MIN_SECS, LEDGER_SPAN_MAX_SECS))
+                    .unwrap_or(LEDGER_SPAN_MIN_SECS);
+                let long_buckets = (span / LEDGER_BUCKET_SECS).max(1);
+
+                let (since, until) = if long_lane {
+                    let until = now - bucket * LEDGER_BUCKET_SECS;
+                    bucket = (bucket + 1) % long_buckets;
+                    (until - LEDGER_BUCKET_SECS, until)
+                } else {
+                    let until = now - recent_bucket * LEDGER_BUCKET_SECS;
+                    recent_bucket = (recent_bucket + 1) % LEDGER_RECENT_BUCKETS;
+                    (until - LEDGER_BUCKET_SECS, until)
+                };
+                long_lane = !long_lane;
 
                 // #558: log the outbound sweep request. A silent client and a client whose
                 // requests are all answered "nothing to serve" produced identical logs, so

--- a/crates/ghost-storage/src/queries.rs
+++ b/crates/ghost-storage/src/queries.rs
@@ -446,6 +446,23 @@ impl Database {
     /// This is what a node ADVERTISES during ledger convergence. Peers reply with the proofs
     /// for anything they hold that is absent from this list. Scoped to unpaid shares because
     /// those are precisely the ones a payout will be computed from.
+    /// Timestamp of the OLDEST unpaid share, or `None` if the ledger is empty.
+    ///
+    /// The GHOST-03 sweep span is derived from this rather than fixed, because the unpaid horizon
+    /// grows for as long as nothing settles and a fixed window slides past holes before they are
+    /// repaired — see the sweep in `main.rs` and #558.
+    pub fn oldest_unpaid_share_timestamp(&self) -> GhostResult<Option<i64>> {
+        self.with_connection(|conn| {
+            conn.query_row(
+                "SELECT MIN(timestamp) FROM shares
+                 WHERE paid_in_proposal_hash IS NULL AND valid = 1",
+                [],
+                |r| r.get::<_, Option<i64>>(0),
+            )
+            .map_err(|e| GhostError::Database(e.to_string()))
+        })
+    }
+
     pub fn unpaid_share_hashes_in(&self, since_ts: i64, until_ts: i64) -> GhostResult<Vec<String>> {
         self.with_connection(|conn| {
             let mut stmt = conn
@@ -9347,6 +9364,33 @@ pub fn resolve_bond_row(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The GHOST-03 sweep span is derived from this, so it must ignore paid and invalid shares —
+    /// and return None on an empty ledger rather than 0, which would make the span the epoch.
+    #[test]
+    fn oldest_unpaid_share_timestamp_ignores_paid_and_invalid() {
+        let db = Database::in_memory().expect("in-memory db");
+        assert_eq!(db.oldest_unpaid_share_timestamp().unwrap(), None);
+
+        db.with_connection(|conn| {
+            conn.execute_batch(
+                "INSERT INTO shares
+                   (round_id, miner_id, difficulty, work, share_hash, timestamp, received_by, valid, paid_in_proposal_hash)
+                 VALUES
+                   (1,'m',1.0,1.0,'h_unpaid_old', 1000,'n',1,NULL),
+                   (1,'m',1.0,1.0,'h_paid_older',  500,'n',1,X'AA'),
+                   (1,'m',1.0,1.0,'h_invalid',     400,'n',0,NULL);",
+            )
+            .map_err(|e| GhostError::Database(e.to_string()))
+        })
+        .expect("seed shares");
+
+        assert_eq!(
+            db.oldest_unpaid_share_timestamp().unwrap(),
+            Some(1000),
+            "must skip the PAID share at 500 and the INVALID one at 400"
+        );
+    }
 
     /// `get_blocks_found_count` reflects only real settled WINS (`won_blocks`), is
     /// idempotent per height, and is not inflated by payout proposals.


### PR DESCRIPTION
The 7-day sweep span **slides**, so a hole ages out of it whether or not it was repaired first.

## Confirmed on the live fleet

Per-day unpaid-share gaps, vm7 vs vm1, measured 2026-07-30 03:32 (boundary 07-23 03:32):

| date | gap | status | evidence |
|---|---:|---|---|
| 07-20 | 6,121 | **frozen** | unchanged across 17 h of observation |
| 07-21 | 3,552 | **frozen** | unchanged |
| 07-22 | 4,321 | **aged out mid-repair** | was 4,397 — came down 76, then the boundary passed it |
| 07-23 | 2,469 | ageing out now | boundary falls mid-day |
| 07-25 | 9,404 | in window | **was 17,862** — repairing correctly ✓ |
| 07-27…29 | 3,827 | in window | closing |

The mechanism works and simply loses the race against its own boundary. **~14,000 shares on vm7 are already permanently unreachable, and the figure grows daily.**

This is why the share gaps kept closing while the two payout-gating addresses stalled — `bc1q9z`'s work spread sat at **0.42 against a 0.11 tolerance for 73 minutes without moving**.

## Why a fixed span can't work here

The payout ledger compares **every** unpaid share, and nothing has settled since **2026-06-02** (`won_blocks = 0`, see #556). The horizon is ~2 months and growing, so no constant tracks it.

The span is now derived from `oldest_unpaid_share_timestamp()`, clamped to **[7, 90] days**, and re-read each tick — the horizon grows for as long as nothing settles, so caching it would reintroduce the same drift.

## Two lanes, so recent holes don't regress

A longer rotation means any single bucket waits longer for its turn, which would slow repair of *fresh* drops. So the sweep alternates:

- **long lane** — one bucket of the full-horizon rotation
- **fast lane** — one bucket of the trailing 24 h

A fresh drop is still repaired within ~24 min, while everything is eventually reached.

## Tests

`oldest_unpaid_share_timestamp_ignores_paid_and_invalid` — skips paid and invalid shares, and returns `None` rather than `0` on an empty ledger (`0` would make the span the entire epoch).

`cargo test -p ghost-storage --lib` 181 passed · `cargo test -p ghost-pool --lib` 310 passed · clippy `-D warnings` and fmt clean.

## Note

This does not retroactively rescue the ~14,000 already-frozen shares by itself — but once the span covers them they become reachable again, which is the point. Whether the two gating addresses then fall inside tolerance is the thing to verify after deploy, not assume.

Refs #558, #548