### PR TITLE
fix(web): replace the dead 'Full spec' link on /docs/

### DIFF
--- a/ghost-web/docs/index.html
+++ b/ghost-web/docs/index.html
@@ -336,7 +336,7 @@
         <div class="dn-group-title">External</div>
         <ul>
           <li><a href="https://github.com/bitcoin-ghost" target="_blank" rel="noopener">GitHub →</a></li>
-          <li><a href="https://github.com/bitcoin-ghost/ghost/blob/main/docs/SPECIFICATION.md" target="_blank" rel="noopener">Full spec →</a></li>
+          <li><a href="https://github.com/bitcoin-ghost/ghost/tree/main/ghost-web/docs" target="_blank" rel="noopener">Docs source →</a></li>
         </ul>
       </aside>
 


### PR DESCRIPTION
The External section of the `/docs/` sidebar linked to `docs/SPECIFICATION.md`, which **404s** — the file does not exist in the repo and never has. `docs/` contains only `SECURITY_AUDIT_2026-06.md`.

It sat in the **persistent nav**, so it was on screen for every document a reader opened, and "Full spec" is what a reviewer clicks first.

## Why it wasn't just repointed

#560 flagged that the target needed a decision, and it did: **there is no single specification document**, because the docs page *is* the spec — 31 documents served from `ghost-web/docs/` (`consensus`, `mpc`, `zk`, `haze`, `ghost-pool`, `elder-system`, …), every one of them already listed in the sidebar directly above this link.

Repointing at any individual document would have replaced a 404 with something that isn't a full spec, which is worse — a broken link is at least obvious.

## Fix

```diff
-<a href="…/blob/main/docs/SPECIFICATION.md">Full spec →</a>
+<a href="…/tree/main/ghost-web/docs">Docs source →</a>
```

Points at a directory that exists, labelled for what it actually is: the source of the documents on the page.

## Verified

- `ghost-web/docs/` exists in-repo with 31 `.md` files
- Scanned every other `github.com/bitcoin-ghost/ghost/blob/main/…` link on the page — `LICENSE` is the only other one, and it resolves

Closes #560