### PR TITLE
fix(l2): tree sync never asked for interior gaps — only ever chased the tip

### DIFF
--- a/crates/ghost-consensus/src/nullifier_route_handler.rs
+++ b/crates/ghost-consensus/src/nullifier_route_handler.rs
@@ -1909,11 +1909,38 @@ impl NullifierRouteHandler {
             }
         }
 
-        let current_height = self.epoch_manager.current_height();
+        // Ask for the lowest INTERIOR hole if we have one, otherwise for the tip.
+        //
+        // This only ever requested `current_height`, so it chased the few blocks it was behind
+        // at the FRONT and never asked for holes inside its own range. The canaries sat on
+        // frozen interior gaps — vm5 1,216 checkpoints in 64 contiguous runs, vm7 446, vm6 244 —
+        // that no amount of syncing could close, because nothing looked for them. Sync kept
+        // reporting "Tree sync complete — root matches peer" the whole time, which is true of
+        // the tip and says nothing about the holes (#535).
+        //
+        // Serving `from_height` walks forward from there, so requesting the gap start pulls the
+        // missing run. Taking the LOWEST gap each time makes repeated calls walk the range
+        // forward deterministically instead of re-requesting the same window.
+        let tip_height = self.epoch_manager.current_height();
+        let from_height = match self.db.lowest_l2_checkpoint_gap() {
+            Ok(Some((gap_start, gap_end))) => {
+                info!(
+                    gap_start,
+                    gap_end, tip_height, "L2 tree sync targeting an interior checkpoint gap"
+                );
+                gap_start
+            }
+            Ok(None) => tip_height,
+            Err(e) => {
+                // Never let a gap-query failure stop the tip from syncing.
+                warn!(error = %e, "could not check for interior checkpoint gaps — syncing tip");
+                tip_height
+            }
+        };
 
         let request = L2TreeSyncRequest {
             requesting_node: self.our_id,
-            from_height: current_height,
+            from_height,
             timestamp: chrono::Utc::now().timestamp_millis() as u64,
         };
 
@@ -1922,10 +1949,7 @@ impl NullifierRouteHandler {
                 .map_err(|e| GhostError::Serialization(e.to_string()))?;
             broadcast(MessageType::L2TreeSync, payload)?;
             *self.last_sync_request_sent.write() = Some(Instant::now());
-            info!(
-                from_height = current_height,
-                "Requested L2 tree sync from peers"
-            );
+            info!(from_height, tip_height, "Requested L2 tree sync from peers");
         }
 
         Ok(())

--- a/crates/ghost-storage/src/queries.rs
+++ b/crates/ghost-storage/src/queries.rs
@@ -8363,6 +8363,36 @@ impl Database {
     }
 
     /// Get L2 checkpoint at a specific height
+    /// The lowest INTERIOR gap in the stored L2 checkpoint range, as `(gap_start, gap_end)`
+    /// inclusive, or `None` if the range is contiguous.
+    ///
+    /// Tree sync only ever requested `from_height = current_height` — the TIP — so it chased the
+    /// few blocks it was behind at the front and never asked for holes inside its own range. The
+    /// canaries sat on frozen interior gaps (vm5 1,216, vm7 446, vm6 244) that no amount of
+    /// syncing could close, because nothing looked for them (#535).
+    ///
+    /// Returns the LOWEST gap so repeated calls walk the range forward deterministically rather
+    /// than re-requesting the same window. A node with no checkpoints has no interior gap.
+    pub fn lowest_l2_checkpoint_gap(&self) -> GhostResult<Option<(u64, u64)>> {
+        self.with_connection(|conn| {
+            // The first height whose successor is absent, paired with the next height present
+            // above it. Bounded by the stored range, so a node that is merely behind the tip
+            // (no interior hole) yields None rather than the whole future.
+            conn.query_row(
+                "SELECT c.height + 1, (SELECT MIN(n.height) FROM l2_checkpoints n WHERE n.height > c.height) - 1
+                 FROM l2_checkpoints c
+                 WHERE c.height < (SELECT MAX(height) FROM l2_checkpoints)
+                   AND NOT EXISTS (SELECT 1 FROM l2_checkpoints x WHERE x.height = c.height + 1)
+                 ORDER BY c.height
+                 LIMIT 1",
+                [],
+                |r| Ok((r.get::<_, i64>(0)? as u64, r.get::<_, i64>(1)? as u64)),
+            )
+            .optional()
+            .map_err(|e| GhostError::Database(e.to_string()))
+        })
+    }
+
     pub fn get_l2_checkpoint(&self, height: u64) -> GhostResult<Option<L2CheckpointRecord>> {
         self.with_connection(|conn| {
             let result = conn
@@ -9364,6 +9394,61 @@ pub fn resolve_bond_row(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Interior gaps must be found; a node merely BEHIND the tip must not report one.
+    /// This is #535: sync chased the tip and never asked for holes inside its own range.
+    #[test]
+    fn lowest_l2_checkpoint_gap_finds_interior_holes_only() {
+        let db = Database::in_memory().expect("in-memory db");
+        assert_eq!(db.lowest_l2_checkpoint_gap().unwrap(), None, "empty ledger");
+
+        let insert = |hs: &[u64]| -> String {
+            let vals = hs
+                .iter()
+                .map(|h| format!("({h},0,X'00',0,'p',1,X'00')"))
+                .collect::<Vec<_>>()
+                .join(",");
+            format!(
+                "INSERT INTO l2_checkpoints
+                   (height, epoch, commitment_root, tx_count, proposer_id, active_node_count, block_data)
+                 VALUES {vals};"
+            )
+        };
+
+        // Contiguous 100..=104 — being behind the tip is NOT an interior gap.
+        // The parent epoch must exist first: a trigger enforces
+        // l2_checkpoints.epoch -> l2_epochs.epoch.
+        db.with_connection(|c| {
+            c.execute_batch(
+                "INSERT INTO l2_epochs (epoch, start_height, initial_root) VALUES (0, 0, X'00');",
+            )
+            .map_err(|e| GhostError::Database(e.to_string()))
+        })
+        .expect("seed epoch");
+        db.with_connection(|c| {
+            c.execute_batch(&insert(&[100, 101, 102, 103, 104]))
+                .map_err(|e| GhostError::Database(e.to_string()))
+        })
+        .expect("seed contiguous");
+        assert_eq!(
+            db.lowest_l2_checkpoint_gap().unwrap(),
+            None,
+            "a contiguous range has no interior gap however far behind the tip it is"
+        );
+
+        // Punch holes: 105..=107 missing (108 present), 109 missing (110 present).
+        db.with_connection(|c| {
+            c.execute_batch(&insert(&[108, 110]))
+                .map_err(|e| GhostError::Database(e.to_string()))
+        })
+        .expect("seed holes");
+
+        assert_eq!(
+            db.lowest_l2_checkpoint_gap().unwrap(),
+            Some((105, 107)),
+            "must report the LOWEST gap so repeated calls walk forward deterministically"
+        );
+    }
 
     /// The GHOST-03 sweep span is derived from this, so it must ignore paid and invalid shares —
     /// and return None on an empty ledger rather than 0, which would make the span the epoch.

--- a/ghost-web/docs/index.html
+++ b/ghost-web/docs/index.html
@@ -336,7 +336,7 @@
         <div class="dn-group-title">External</div>
         <ul>
           <li><a href="https://github.com/bitcoin-ghost" target="_blank" rel="noopener">GitHub →</a></li>
-          <li><a href="https://github.com/bitcoin-ghost/ghost/blob/main/docs/SPECIFICATION.md" target="_blank" rel="noopener">Full spec →</a></li>
+          <li><a href="https://github.com/bitcoin-ghost/ghost/tree/main/ghost-web/docs" target="_blank" rel="noopener">Docs source →</a></li>
         </ul>
       </aside>
 


### PR DESCRIPTION
#535 reported gap recovery as *"requests, receives, replays, and the hole survives"*. Close, but wrong in the way that mattered: **the holes are never requested at all.**

```rust
let current_height = self.epoch_manager.current_height();
let request = L2TreeSyncRequest { from_height: current_height, .. };
```

`from_height` is the node's **maximum** height. So sync fetches the handful of blocks it is behind at the *front*, succeeds, and reports success — which is true of the tip and says nothing about holes inside the stored range.

Live on vm5, taken this morning:

```
Behind on checkpoint height, requesting tree sync   our_height=907723 gap=5
Requested L2 tree sync from peers                   from_height=907723
Replaying tree sync response  checkpoints=7
Tree sync complete — root matches peer          ← reported while 1,216 holes remain
```

The interior gaps are **frozen at exactly the values in the issue** — vm5 1,216 · vm7 446 · vm6 244 · vm8 31 — unchanged since it was filed. Nothing was looking for them.

## The fix

`lowest_l2_checkpoint_gap()` returns the lowest interior hole as inclusive `(start, end)`, or `None` when the range is contiguous. Being merely *behind the tip* is deliberately **not** a gap — otherwise every node would report one permanently.

**Verified against the live vm5 database** before wiring anything up:

```
743375|743407
743409|743414
743417|743418
743420|743432
743635|743644
   -> 64 gap runs total
```

vm5's 1,216 missing checkpoints are **64 contiguous runs** — 64 targeted requests, not an unbounded chase.

`request_tree_sync` now asks for the lowest gap when one exists, the tip otherwise. Serving walks forward from `from_height`, so requesting the gap start pulls the missing run; always taking the *lowest* gap makes repeated calls walk the range forward deterministically instead of re-requesting one window. A gap-query error falls back to the tip, so a storage problem can never stop normal sync.

## Scope

This makes the holes **reachable**, which they were not. It does **not** retroactively repair the canaries by itself, and whether they close is something to verify on the fleet rather than assume — the same discipline that turned up the real cause here.

Related: #554 and #556 are the other half of why vm5 is slow; this removes one source of the endless work, not all of it.

## Tests

`lowest_l2_checkpoint_gap_finds_interior_holes_only` — contiguous range yields `None` however far behind the tip; punched holes yield the lowest run. (The fixture needed the parent `l2_epochs` row: a trigger enforces `l2_checkpoints.epoch -> l2_epochs.epoch`, which is worth knowing for the sync path too.)

`cargo test -p ghost-storage --lib` 182 passed · `cargo test -p ghost-consensus --lib` 272 passed · clippy `-D warnings` and fmt clean.

Refs #535