### PR TITLE
fix(convergence): the REQUEST must fit on the wire too — busiest windows never sent

### DIFF
--- a/bins/ghost-pool/src/convergence.rs
+++ b/bins/ghost-pool/src/convergence.rs
@@ -747,6 +747,48 @@ mod tests {
 
     /// A forged backfill must never be credited, even over the ledger path — convergence bypasses
     /// the normal share-receive gate, so it has to verify GHOST-09 itself.
+    /// A convergence REQUEST must fit on the wire too — the response bound alone is not enough.
+    ///
+    /// The request advertises every unpaid hash in its window and nothing bounded it. A busy
+    /// 30-minute bucket on the live fleet holds ~5,800 hashes, which serialises to 1.58 MB
+    /// against the 1 MB cap, so it was dropped BEFORE reaching any peer. Silently: an
+    /// undelivered request yields neither an error nor a discard count, so repair simply
+    /// stalled wherever the divergence was densest while thin buckets kept working (#558).
+    #[test]
+    fn a_max_size_request_fits_in_one_envelope() {
+        const MAX_ENVELOPE_SIZE: usize = 1_000_000;
+        const MAX_HASHES_PER_REQUEST: usize = 3_000; // mirrors main.rs
+
+        let req = LedgerConvergenceRequest {
+            since_ts: 0,
+            until_ts: i64::MAX,
+            share_hashes: (0..MAX_HASHES_PER_REQUEST)
+                .map(|i| format!("{i:064x}"))
+                .collect(),
+        };
+        let inner = serde_json::to_vec(&ConvergencePayload::LedgerRequest(req)).unwrap();
+
+        // MessageEnvelope.payload is a bare Vec<u8>, so the inner JSON expands a second time.
+        let envelope = serde_json::json!({
+            "msg_type": "ShareConvergence",
+            "sender": "00".repeat(32),
+            "timestamp": 0u64,
+            "sequence": 0u64,
+            "signature": "00".repeat(64),
+            "payload": inner,
+            "ttl": 3u8,
+        });
+        let wire = serde_json::to_vec(&envelope).unwrap();
+
+        assert!(
+            wire.len() <= MAX_ENVELOPE_SIZE,
+            "a {MAX_HASHES_PER_REQUEST}-hash request is {} bytes as an envelope against a {} \
+             cap — the transport drops it and convergence silently never happens",
+            wire.len(),
+            MAX_ENVELOPE_SIZE
+        );
+    }
+
     /// A full window-convergence response must FIT ON THE WIRE — measured through BOTH
     /// serialisation layers, not just the inner payload.
     ///

--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -3656,6 +3656,16 @@ async fn main() -> Result<()> {
             const LEDGER_RECENT_SPAN_SECS: i64 = 86_400;
             const LEDGER_RECENT_BUCKETS: i64 = LEDGER_RECENT_SPAN_SECS / LEDGER_BUCKET_SECS;
 
+            // Max share hashes in ONE request. The request advertises every unpaid hash in its
+            // window and nothing bounded it, so a busy 30-minute bucket (~5,800 hashes) built a
+            // 1.58 MB message against the 1 MB cap and was dropped BEFORE reaching a peer —
+            // silently, since an undelivered request produces neither an error nor a discard
+            // count. Repair worked in thin buckets and stalled exactly where divergence was.
+            //
+            // Measured: 3,000 hashes -> 817 KB as an envelope, 5,799 -> 1,577,942 bytes. This is
+            // the request-side twin of the response bound in #559/#561/#562.
+            const MAX_HASHES_PER_REQUEST: i64 = 3_000;
+
             let mut ticker =
                 tokio::time::interval(std::time::Duration::from_secs(CONVERGENCE_INTERVAL_SECS));
             let mut bucket: i64 = 0;
@@ -3700,23 +3710,43 @@ async fn main() -> Result<()> {
                 // #558: log the outbound sweep request. A silent client and a client whose
                 // requests are all answered "nothing to serve" produced identical logs, so
                 // there was no way to tell a broken sweep from a converged one.
-                match conv_handler.build_ledger_request(since, until) {
-                    Ok(req) => {
-                        let advertised = req.share_hashes.len();
-                        if let Ok(bytes) = conv_handler.ledger_request_bytes(since, until) {
+                // Split the window until each request fits on the wire. A window with more
+                // than MAX_HASHES_PER_REQUEST hashes is halved repeatedly; each sub-window is
+                // sent separately. Without this the busiest windows — the ones actually holding
+                // divergence — produced messages no peer ever received.
+                let mut windows: Vec<(i64, i64)> = vec![(since, until)];
+                let mut sent = 0usize;
+                while let Some((ws, wu)) = windows.pop() {
+                    let n = db_for_conv.count_unpaid_shares_in(ws, wu).unwrap_or(0);
+                    if n > MAX_HASHES_PER_REQUEST && wu - ws > 1 {
+                        let mid = ws + (wu - ws) / 2;
+                        windows.push((ws, mid));
+                        windows.push((mid, wu));
+                        continue;
+                    }
+                    if n == 0 {
+                        continue; // nothing to advertise in this slice
+                    }
+                    match conv_handler.ledger_request_bytes(ws, wu) {
+                        Ok(bytes) => {
                             tracing::debug!(
-                                bucket,
-                                since,
-                                until,
-                                advertised,
+                                since = ws,
+                                until = wu,
+                                advertised = n,
+                                bytes = bytes.len(),
                                 "GHOST-03: window convergence request sent"
                             );
                             let _ = conv_tx.send(bytes).await;
+                            sent += 1;
+                        }
+                        Err(e) => {
+                            tracing::warn!(error = %e, since = ws, until = wu,
+                                "GHOST-03: could not build window convergence request");
                         }
                     }
-                    Err(e) => {
-                        tracing::warn!(error = %e, since, until,
-                            "GHOST-03: could not build window convergence request");
+                    // Bound the fan-out from one tick so a pathological window cannot flood.
+                    if sent >= 8 {
+                        break;
                     }
                 }
             }

--- a/crates/ghost-storage/src/queries.rs
+++ b/crates/ghost-storage/src/queries.rs
@@ -463,6 +463,28 @@ impl Database {
         })
     }
 
+    /// How many unpaid share hashes a window would advertise. Cheap COUNT, used to split a
+    /// window before building a request that would not fit on the wire.
+    ///
+    /// The convergence REQUEST carries every unpaid hash in its window, and nothing bounded it.
+    /// A busy 30-minute bucket holds ~5,800 hashes, which serialises to **1.58 MB** against the
+    /// 1 MB cap — so the request was dropped before reaching any peer. Silently: an oversized
+    /// request produces no error and no discard counter, because there is no peer to count it.
+    /// Repair therefore worked only in thin buckets and stalled wherever the divergence actually
+    /// was. Mirror image of the response-side bug in #559/#561/#562 (#558).
+    pub fn count_unpaid_shares_in(&self, since_ts: i64, until_ts: i64) -> GhostResult<i64> {
+        self.with_connection(|conn| {
+            conn.query_row(
+                "SELECT COUNT(*) FROM shares
+                 WHERE paid_in_proposal_hash IS NULL AND valid = 1
+                   AND timestamp >= ?1 AND timestamp < ?2",
+                params![since_ts, until_ts],
+                |r| r.get::<_, i64>(0),
+            )
+            .map_err(|e| GhostError::Database(e.to_string()))
+        })
+    }
+
     pub fn unpaid_share_hashes_in(&self, since_ts: i64, until_ts: i64) -> GhostResult<Vec<String>> {
         self.with_connection(|conn| {
             let mut stmt = conn


### PR DESCRIPTION
Asked for coarser buckets past day 1. **Measuring first showed that would have made things worse** — and uncovered why repair stalled at all.

## The bug

The convergence **request** advertises every unpaid share hash in its window. Nothing bounded it. Measured on the live fleet, a busy 30-minute bucket holds **~5,800 hashes**:

```
 3,000 hashes  inner=  204,067  envelope=   816,614   ok
 5,799 hashes  inner=  394,399  envelope= 1,577,942   OVER the 1 MB cap
```

So the busiest windows built messages that were **dropped before reaching any peer** — and silently, because an undelivered request produces neither an error nor a discard count. There is no peer to count it.

Repair worked in thin buckets and stalled exactly where divergence was densest. On vm7, 07-25 still holds **5,372 missing shares while inside the sweep window**, untouched, as backfill fell from ~2,300 shares/hour to ~50 per 30 min with **zero errors logged**.

## Why not coarser buckets

| bucket | peak hashes | request size |
|---|---:|---:|
| 30 min (current) | 5,799 | 1.58 MB — **over** |
| 1 h | 9,324 | ~2.5 MB |
| 6 h (proposed) | **30,255** | **~8 MB** |

Coarsening would have made *every* request in the busy region undeliverable instead of just some. The instinct — reach old data faster — was right; the arithmetic said do it a different way.

## The fix

Split windows by **count**, not time. Any window over `MAX_HASHES_PER_REQUEST` (3,000 — measured at 817 KB as an envelope) is halved repeatedly until each slice fits, and each slice is sent separately. Empty slices are skipped; fan-out from one tick is capped at 8 so a pathological window cannot flood the mesh.

This reaches old data quickly *and* fixes the currently-undeliverable busy windows.

## What this says about the earlier fixes

This is the **request-side twin** of the response bound in #559/#561/#562. I bounded responses by bytes three times over and never once checked that requests carry the same constraint — the same blind spot, on the other side of the exchange.

The new test asserts a max-size request fits in one envelope, measured through **both** serialisation layers, so it cannot regress unnoticed.

`cargo test -p ghost-pool --lib` 311 passed · `cargo test -p ghost-storage --lib` 181 passed · clippy `-D warnings` and fmt clean.

Refs #558, #548