### PR TITLE
perf(storage): give reads their own connections instead of queueing behind the writer

### DIFF
--- a/crates/ghost-storage/src/database.rs
+++ b/crates/ghost-storage/src/database.rs
@@ -192,6 +192,18 @@ pub struct Database {
 struct DatabaseInner {
     /// Primary connection (write)
     write_conn: Mutex<Connection>,
+    /// Read-only connections (#537).
+    ///
+    /// The database runs in WAL mode, which permits any number of concurrent readers
+    /// alongside one writer. Routing every read through `write_conn` therefore serialises
+    /// work SQLite is happy to do in parallel, and — because the guard is a `parking_lot`
+    /// mutex, which does not yield — each waiter blocks the whole tokio worker thread it is
+    /// running on rather than just its own task.
+    ///
+    /// Empty for in-memory databases: each `open_in_memory` is a SEPARATE database, so a
+    /// second connection would see an empty schema rather than the same data. Callers fall
+    /// back to `write_conn`, which is always correct, just serialised.
+    read_conns: Vec<Mutex<Connection>>,
     /// Database path
     path: String,
     /// Whether this is an in-memory database
@@ -390,6 +402,7 @@ impl Database {
         let db = Self {
             inner: Arc::new(DatabaseInner {
                 write_conn: Mutex::new(conn),
+                read_conns: Self::open_read_pool(&path_str, None),
                 path: path_str,
                 in_memory: false,
                 encryption_key: RwLock::new(None),
@@ -413,6 +426,8 @@ impl Database {
         let db = Self {
             inner: Arc::new(DatabaseInner {
                 write_conn: Mutex::new(conn),
+                // In-memory databases cannot be shared across connections.
+                read_conns: Vec::new(),
                 path: ":memory:".to_string(),
                 in_memory: true,
                 encryption_key: RwLock::new(None),
@@ -473,6 +488,7 @@ impl Database {
         let db = Self {
             inner: Arc::new(DatabaseInner {
                 write_conn: Mutex::new(conn),
+                read_conns: Self::open_read_pool(&path_str, Some(*key)),
                 path: path_str,
                 in_memory: false,
                 encryption_key: RwLock::new(Some(*key)),
@@ -652,6 +668,71 @@ impl Database {
             GhostError::Database(format!("Failed to register reverse_hex function: {}", e))
         })?;
         Ok(())
+    }
+
+    /// Number of read-only connections opened alongside the writer (#537).
+    ///
+    /// Nodes are 2-CPU boxes, so this is about removing needless serialisation rather than
+    /// exploiting parallelism: four readers let the 30-second convergence scan, the payout
+    /// ledger read and an inbound `/health` proceed together instead of queueing behind one
+    /// another on a lock that blocks its worker thread.
+    const READ_POOL_SIZE: usize = 4;
+
+    /// Open the read-only connection pool for a file-backed database.
+    ///
+    /// Returns an EMPTY pool on any failure — callers fall back to the write connection, which
+    /// is always correct and merely serialised. A node must never fail to start because an
+    /// optimisation could not be applied.
+    fn open_read_pool(path: &str, key: Option<[u8; 32]>) -> Vec<Mutex<Connection>> {
+        let mut pool = Vec::new();
+        for _ in 0..Self::READ_POOL_SIZE {
+            let conn = match Connection::open_with_flags(
+                path,
+                OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_FULL_MUTEX,
+            ) {
+                Ok(c) => c,
+                Err(e) => {
+                    tracing::warn!(error = %e, "read pool: could not open connection — reads will use the writer");
+                    break;
+                }
+            };
+            // SQLCipher: the key must be applied before any other statement.
+            if let Some(k) = key {
+                if let Err(e) = conn.pragma_update(None, "key", format!("x'{}'", hex::encode(k))) {
+                    tracing::warn!(error = %e, "read pool: PRAGMA key failed — reads will use the writer");
+                    break;
+                }
+            }
+            if let Err(e) = Self::register_functions(&conn) {
+                tracing::warn!(error = %e, "read pool: could not register functions — reads will use the writer");
+                break;
+            }
+            // Readers must never wait on a writer's lock; WAL means they do not have to.
+            let _ = conn.busy_timeout(std::time::Duration::from_secs(5));
+            pool.push(Mutex::new(conn));
+        }
+        pool
+    }
+
+    /// Execute a read-only function, preferring a pooled reader over the write connection.
+    ///
+    /// Falls back to the writer when every reader is busy, when the pool is empty (in-memory
+    /// databases), or when the pool could not be opened — so behaviour is never worse than
+    /// before, only less serialised.
+    ///
+    /// ONLY for statements that read. A write issued here fails: the connections are opened
+    /// `SQLITE_OPEN_READ_ONLY`, so a stray `INSERT` surfaces as an error rather than silently
+    /// landing somewhere unexpected.
+    pub fn with_read_connection<F, T>(&self, f: F) -> GhostResult<T>
+    where
+        F: FnOnce(&Connection) -> GhostResult<T>,
+    {
+        for slot in &self.inner.read_conns {
+            if let Some(conn) = slot.try_lock() {
+                return f(&conn);
+            }
+        }
+        self.with_connection(f)
     }
 
     /// Execute a function with the database connection
@@ -1593,6 +1674,57 @@ impl DatabaseStats {
 
 #[cfg(test)]
 mod tests {
+
+    /// A pooled read must proceed while the WRITE connection is held. That is the entire
+    /// point of #537: reads used to queue behind the writer on a `parking_lot` mutex, which
+    /// does not yield, so each waiter blocked a whole tokio worker thread rather than a task.
+    #[test]
+    fn read_proceeds_while_write_connection_is_held() {
+        let mut path = std::env::temp_dir();
+        path.push(format!("ghost-readpool-{}.db", std::process::id()));
+        let _ = std::fs::remove_file(&path);
+
+        let db = Database::open(&path).expect("open");
+        assert!(
+            !db.inner.read_conns.is_empty(),
+            "a file-backed database must open a read pool"
+        );
+
+        // Hold the writer for the duration, exactly as a long write would.
+        let held = db.inner.write_conn.lock();
+
+        // A pooled read must NOT need that lock.
+        let n: i64 = db
+            .with_read_connection(|c| {
+                c.query_row("SELECT COUNT(*) FROM sqlite_master", [], |r| r.get(0))
+                    .map_err(|e| GhostError::Database(e.to_string()))
+            })
+            .expect("read must succeed while the writer is held");
+        assert!(n > 0, "schema should be present after migrations");
+
+        drop(held);
+        drop(db);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// In-memory databases get no pool — each `open_in_memory` is a distinct database, so a
+    /// second connection would see an empty schema. Reads must fall back to the writer and
+    /// still be correct.
+    #[test]
+    fn in_memory_falls_back_to_the_write_connection() {
+        let db = Database::in_memory().expect("open");
+        assert!(
+            db.inner.read_conns.is_empty(),
+            "in-memory must not open a pool against a different database"
+        );
+        let n: i64 = db
+            .with_read_connection(|c| {
+                c.query_row("SELECT COUNT(*) FROM sqlite_master", [], |r| r.get(0))
+                    .map_err(|e| GhostError::Database(e.to_string()))
+            })
+            .expect("fallback read must work");
+        assert!(n > 0, "in-memory schema must be visible via the fallback");
+    }
     use super::*;
     use std::sync::atomic::{AtomicU32, Ordering};
 

--- a/crates/ghost-storage/src/queries.rs
+++ b/crates/ghost-storage/src/queries.rs
@@ -452,7 +452,7 @@ impl Database {
     /// grows for as long as nothing settles and a fixed window slides past holes before they are
     /// repaired — see the sweep in `main.rs` and #558.
     pub fn oldest_unpaid_share_timestamp(&self) -> GhostResult<Option<i64>> {
-        self.with_connection(|conn| {
+        self.with_read_connection(|conn| {
             conn.query_row(
                 "SELECT MIN(timestamp) FROM shares
                  WHERE paid_in_proposal_hash IS NULL AND valid = 1",
@@ -473,7 +473,7 @@ impl Database {
     /// Repair therefore worked only in thin buckets and stalled wherever the divergence actually
     /// was. Mirror image of the response-side bug in #559/#561/#562 (#558).
     pub fn count_unpaid_shares_in(&self, since_ts: i64, until_ts: i64) -> GhostResult<i64> {
-        self.with_connection(|conn| {
+        self.with_read_connection(|conn| {
             conn.query_row(
                 "SELECT COUNT(*) FROM shares
                  WHERE paid_in_proposal_hash IS NULL AND valid = 1
@@ -486,7 +486,7 @@ impl Database {
     }
 
     pub fn unpaid_share_hashes_in(&self, since_ts: i64, until_ts: i64) -> GhostResult<Vec<String>> {
-        self.with_connection(|conn| {
+        self.with_read_connection(|conn| {
             let mut stmt = conn
                 .prepare(
                     "SELECT share_hash FROM shares
@@ -525,7 +525,7 @@ impl Database {
         limit: usize,
         max_bytes: usize,
     ) -> GhostResult<(Vec<Vec<u8>>, usize, bool)> {
-        self.with_connection(|conn| {
+        self.with_read_connection(|conn| {
             let mut stmt = conn
                 .prepare(
                     "SELECT share_hash, proof FROM shares
@@ -1323,7 +1323,7 @@ impl Database {
         // below — integer addition is order-independent, so every node computes a
         // byte-identical per-address total. Float summation here was the residual
         // divergence that kept the checkpoint from finalising exactly.
-        let raw: Vec<(String, i64, String)> = self.with_connection(|conn| {
+        let raw: Vec<(String, i64, String)> = self.with_read_connection(|conn| {
             let mut stmt = conn
                 .prepare(
                     "SELECT s.miner_id, SUM(CAST(ROUND(s.work * 1000000) AS INTEGER)) AS micro_work, m.payout_address
@@ -8404,7 +8404,7 @@ impl Database {
     /// Returns the LOWEST gap so repeated calls walk the range forward deterministically rather
     /// than re-requesting the same window. A node with no checkpoints has no interior gap.
     pub fn lowest_l2_checkpoint_gap(&self) -> GhostResult<Option<(u64, u64)>> {
-        self.with_connection(|conn| {
+        self.with_read_connection(|conn| {
             // The first height whose successor is absent, paired with the next height present
             // above it. Bounded by the stored range, so a node that is merely behind the tip
             // (no interior hole) yields None rather than the whole future.


### PR DESCRIPTION
Partial fix for #537.

The database runs in **WAL mode** — verified on the live node, `PRAGMA journal_mode` returns `wal` — which permits any number of concurrent readers alongside one writer. Every read nevertheless went through the single `write_conn`, so SQLite was being stopped from doing work it is perfectly happy to do in parallel.

The guard is the part that hurts:

```rust
let conn = self.inner.write_conn.lock();   // parking_lot — does NOT yield
f(&conn)
```

`parking_lot` does not yield, so a task waiting on it **blocks the whole tokio worker thread** rather than just its own task. With N workers, N concurrent database callers park every worker and nothing else is polled — not inbound HTTP, not RPC completions, not timers. That is exactly the signature the canaries show: **unresponsive at low CPU**.

## What this adds

Four read-only connections alongside the writer, and `with_read_connection`, which takes the first free reader and **falls back to the writer** when all are busy, when the pool is empty, or when it could not be opened. Behaviour is never worse than before, only less serialised — and a node can never fail to start because an optimisation was unavailable.

- **In-memory databases get no pool**, deliberately: each `open_in_memory` is a *separate* database, so a second connection would see an empty schema. They fall back to the writer, which is correct.
- Connections open `SQLITE_OPEN_READ_ONLY`, so a write accidentally routed here **fails loudly** rather than landing somewhere unexpected.

## Which reads moved

The six in the 30-second convergence and payout loop that compete with `/health`:

```
count_unpaid_shares_in        unpaid_share_hashes_in
unpaid_proofs_missing_from    oldest_unpaid_share_timestamp
lowest_l2_checkpoint_gap      get_top_unpaid_addresses
```

The other **~237 call sites in `queries.rs` are untouched**. Reclassifying them needs read-your-writes and transaction-boundary review per query, and doing that in bulk during an active incident is how the last four fixes each turned out incomplete.

## Scope, stated plainly

#537 also asks for `spawn_blocking` around async database access — **this does not address that**. And the issue itself notes causation for the observed stalls is unproven. This removes a real and unnecessary serialisation; it is **not** a claim to have fixed the canaries.

## Test

`read_proceeds_while_write_connection_is_held` holds the write connection and asserts a pooled read still completes — the exact property the change exists for. Plus a fallback test for in-memory.

`cargo test -p ghost-storage --lib` 184 passed · `cargo test -p ghost-pool --lib` 311 passed · clippy `-D warnings` and fmt clean.

Refs #537, #554