### PR TITLE
feat(dashboard): show live inbound usage and warn at the connection ceiling

### DIFF
--- a/crates/ghost-verification/src/maxconnections.rs
+++ b/crates/ghost-verification/src/maxconnections.rs
@@ -11,13 +11,20 @@
 
 use std::path::PathBuf;
 
-/// Outbound slots Core holds back from `maxconnections`: 8 full-relay + 2 block-relay-only.
+/// Outbound slots Core holds back from `maxconnections`: 8 full-relay + 2 block-relay-only
+/// + 1 feeler.
 ///
-/// These are Core's documented defaults (`MAX_OUTBOUND_FULL_RELAY_CONNECTIONS` and
-/// `MAX_BLOCK_RELAY_ONLY_CONNECTIONS`). Feeler connections are short-lived and not counted here.
+/// These are Core's documented defaults (`MAX_OUTBOUND_FULL_RELAY_CONNECTIONS`,
+/// `MAX_BLOCK_RELAY_ONLY_CONNECTIONS`) plus the single feeler slot, which Core includes in the
+/// outbound reserve even though an individual feeler connection is short-lived.
+///
+/// This was 10 — the feeler was omitted — which overstated inbound capacity by one. The live
+/// fleet settles it: on 2026-07-30 vm4 reported `connections_out=11` while vm1-vm3 reported 10,
+/// the difference being whether a feeler happened to be open at that instant. The reserve is 11.
+///
 /// The inbound capacity an operator actually has is `maxconnections` MINUS this, which is the
 /// number that matters and the one nothing was showing.
-pub const RESERVED_OUTBOUND: u32 = 10;
+pub const RESERVED_OUTBOUND: u32 = 11;
 
 /// Fraction of inbound capacity at which a node is close enough to full to warn about.
 ///
@@ -278,12 +285,15 @@ mod tests {
     /// The number that actually matters: inbound capacity, not the headline setting.
     #[test]
     fn inbound_capacity_is_the_setting_minus_cores_outbound_reserve() {
-        // The exact case from #497: 50 configured looks generous and leaves 40 inbound,
-        // which a settled node fills.
-        assert_eq!(inbound_capacity(50), 40);
-        assert_eq!(inbound_capacity(125), 115);
-        // Never negative.
+        // The exact case from #497: 50 configured looks generous but leaves only 39 inbound,
+        // which a settled node fills — and a full node silently stops accepting peers.
+        assert_eq!(inbound_capacity(50), 39);
+        // 125 is the current fleet setting. vm1/vm2/vm3 sat at 114 inbound on 2026-07-30,
+        // i.e. exactly full against this capacity (#572).
+        assert_eq!(inbound_capacity(125), 114);
+        // Never negative, even below the reserve.
         assert_eq!(inbound_capacity(5), 0);
+        assert_eq!(inbound_capacity(RESERVED_OUTBOUND), 0);
     }
 
     #[test]

--- a/dashboard/src/app/(dashboard)/settings/daemon/page.tsx
+++ b/dashboard/src/app/(dashboard)/settings/daemon/page.tsx
@@ -8,6 +8,7 @@ import { Badge } from "@/components/ui/Badge";
 import { Toggle } from "@/components/ui/Toggle";
 import { ConfirmDialog } from "@/components/ui/Dialog";
 import { SectionErrorBoundary } from "@/components/ui/SectionErrorBoundary";
+import { getMaxConnections, type MaxConnectionsStatus } from "@/lib/api/config";
 import { useToast } from "@/components/ui/Toast";
 import {
   useDaemonSettings,
@@ -145,6 +146,8 @@ function FieldRow({
 // Only the total (`-maxconnections`) is tunable; inbound capacity is whatever is
 // left after the reserved outbound. This control sets the total and shows the
 // fixed-outbound / variable-inbound split as a two-tone bar.
+// 8 full-relay + 2 block-relay-only + 1 feeler. Matches RESERVED_OUTBOUND in
+// crates/ghost-verification/src/maxconnections.rs — the two must not drift.
 const OUTBOUND_RESERVED = 11;
 const MAXCONN_DEFAULT = 125; // ghostd DEFAULT_MAX_PEER_CONNECTIONS
 const MAXCONN_SLIDER_MIN = 11;
@@ -154,10 +157,12 @@ function PeerConnectionsField({
   value,
   onChange,
   disabled,
+  live,
 }: {
   value: string;
   onChange: (v: string) => void;
   disabled?: boolean;
+  live?: MaxConnectionsStatus | null;
 }) {
   const isDefault = value.trim() === "";
   const parsed = parseInt(value, 10);
@@ -239,6 +244,47 @@ function PeerConnectionsField({
           </button>
         )}
       </div>
+
+      {/* Live inbound usage (#499). The configured total says nothing about whether the
+          node is actually full; a node at its inbound ceiling stops accepting peers
+          silently and drops out of public crawler listings (#497, #498, #572). */}
+      {live && live.connections_in != null && (
+        <div
+          className={
+            "rounded-md px-3 py-2 text-xs " +
+            (live.near_ceiling
+              ? "bg-[color:var(--warn-bg,rgba(200,120,0,0.12))] text-[color:var(--warn,#c87800)]"
+              : "text-[color:var(--dim)]")
+          }
+        >
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+            <span>
+              In use <b>{live.connections_in}</b> / {live.inbound_capacity} inbound
+              {live.inbound_utilisation != null && (
+                <> ({Math.round(live.inbound_utilisation * 100)}%)</>
+              )}
+            </span>
+            <span>
+              Outbound {live.connections_out ?? "-"} of {live.reserved_outbound} reserved
+            </span>
+          </div>
+          {live.near_ceiling && (
+            <div className="mt-1">
+              This node is at or near its inbound ceiling and is refusing new peers. Crawlers
+              that cannot connect record it unreachable and drop it from public listings.
+              {live.recommended_max != null && (
+                <> Memory on this node supports up to <b>{live.recommended_max}</b>.</>
+              )}
+            </div>
+          )}
+          {live.ambiguous && (
+            <div className="mt-1">
+              <code>maxconnections</code> is set more than once in <code>bitcoin.conf</code>;
+              this control will not overwrite an ambiguous file.
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }
@@ -279,6 +325,28 @@ export default function DaemonSettingsPage() {
 
   const [form, setForm] = useState<FormState>(EMPTY_FORM);
   const [confirmOpen, setConfirmOpen] = useState(false);
+  // Live peer-connection state (#499). Polled rather than read from the config, because the
+  // question "is this node full?" cannot be answered by the configured value alone.
+  const [maxConn, setMaxConn] = useState<MaxConnectionsStatus | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = () =>
+      getMaxConnections()
+        .then((r) => {
+          if (!cancelled) setMaxConn(r);
+        })
+        .catch(() => {
+          // Non-fatal: the widget simply shows no live figures.
+          if (!cancelled) setMaxConn(null);
+        });
+    load();
+    const t = setInterval(load, 30_000);
+    return () => {
+      cancelled = true;
+      clearInterval(t);
+    };
+  }, []);
 
   // Seed the form once the current settings load / change.
   const loaded = data?.settings;
@@ -398,6 +466,7 @@ export default function DaemonSettingsPage() {
               <PeerConnectionsField
                 value={form.maxConnections}
                 onChange={(v) => patch({ maxConnections: v })}
+                live={maxConn}
               />
               <FieldRow
                 label="Max upload target / 24h"

--- a/dashboard/src/lib/api/config.ts
+++ b/dashboard/src/lib/api/config.ts
@@ -2,6 +2,32 @@
 import { fetchApi } from './client';
 import type { NodeConfig, FullNodeConfig, L2PruningConfig } from '@/types/api';
 
+/// Live peer-connection state (#499).
+///
+/// `maxconnections` on its own is not the number that matters: ghostd reserves 11 outbound
+/// slots (8 full-relay + 2 block-relay-only + 1 feeler) out of the total, so inbound capacity
+/// is the setting minus that. A node at its inbound ceiling silently stops accepting peers —
+/// crawlers then record it unreachable and drop it from public listings, which is what #497
+/// and #498 were, and what #572 is again at the higher limit.
+export interface MaxConnectionsStatus {
+  configured: number | null;      // value in bitcoin.conf, null = not set
+  effective: number;              // configured, or ghostd's default
+  is_core_default: boolean;
+  ambiguous: boolean;             // set more than once in the file — we refuse to write
+  inbound_capacity: number;       // effective - reserved_outbound
+  reserved_outbound: number;
+  connections: number | null;     // live, from getnetworkinfo
+  connections_in: number | null;
+  connections_out: number | null;
+  inbound_utilisation: number | null;  // connections_in / inbound_capacity, 0..1
+  near_ceiling: boolean | null;        // at/above the warn fraction
+  recommended_max: number | null;      // memory-derived ceiling for this node
+}
+
+export async function getMaxConnections(): Promise<MaxConnectionsStatus> {
+  return fetchApi<MaxConnectionsStatus>('/api/v1/config/maxconnections');
+}
+
 export async function getConfig(): Promise<NodeConfig> {
   return fetchApi<NodeConfig>('/api/v1/config');
 }


### PR DESCRIPTION
#499 asks for three things. **The backend already had all of them** — `GET /api/v1/config/maxconnections` computes inbound capacity, live connection counts, utilisation, a `near_ceiling` flag and a memory-derived recommended maximum.

**The dashboard never called it.** The daemon page drew a two-tone bar computed purely from the configured number, so it showed what the operator had typed and nothing about whether the node was actually full.

That is the acceptance criterion that matters. A node at its inbound ceiling stops accepting peers **silently** — it does not degrade, it just disappears from other people's view of the network while looking perfectly healthy from the inside. That is what #497 and #498 were.

## What this adds

Wires the page to the endpoint (30 s poll) and renders, beneath the existing bar:

- live in/out counts against **real** inbound capacity
- utilisation percentage
- at or above the warn fraction, an explicit warning naming the consequence, plus the memory-supported maximum for that node
- the "ambiguous config" case, where `maxconnections` is set more than once and the backend refuses to write

Fetch failure is non-fatal — the widget falls back to the static bar rather than breaking the settings page.

## Also: `RESERVED_OUTBOUND` 10 → 11

Core reserves 8 full-relay + 2 block-relay-only + **1 feeler**. The Rust constant omitted the feeler and overstated inbound capacity by one, while the dashboard already used 11 — two sources of truth disagreeing.

The live fleet settles it: on 2026-07-30 **vm4 reported `connections_out=11`** while vm1–vm3 reported 10, the difference being whether a feeler happened to be open at that instant.

The test now encodes measured reality instead of the old arithmetic:

```rust
assert_eq!(inbound_capacity(125), 114);   // exactly where vm1/vm2/vm3 are sitting — full
```

That saturation is filed separately as **#572**; this change is what makes it visible without SSH.

## Not verified in a browser

Dashboard dependencies are not installed in this worktree, so there is **no typecheck or render** behind this. I checked the TS interface field-by-field against the handler's JSON keys (all 12 present, none would be `undefined`) and verified JSX brace balance — but it wants a real build before it ships.

`cargo test -p ghost-verification --lib` 249 passed · clippy `-D warnings` and fmt clean.

Refs #499, #572, #497, #498