### PR TITLE
fix(api): fleet-control routes stop reporting success without acting

### DIFF
--- a/bins/translator-sv2/tests/sv1_handshake_smoke.py
+++ b/bins/translator-sv2/tests/sv1_handshake_smoke.py
@@ -417,6 +417,52 @@ def test_tls_serializer():
     return got
 
 
+
+def probe_serializer_extranonce_rekey():
+    """#411 acceptance, measured rather than described. INFORMATIONAL — does not gate.
+
+    A serialising client (cgminer, Avalon) waits for the subscribe response before sending
+    authorize. The channel only opens on authorize, so the subscribe-defer fallback answers
+    after ~1.5s with the PLACEHOLDER extranonce1 (8 zero bytes), and the real one arrives
+    later via `mining.set_extranonce` — a mid-handshake re-key.
+
+    #411's acceptance is "a serializing client gets a real extranonce at subscribe with no
+    later re-key". That is not met today and cannot be met inside the translator: extranonce1
+    is allocated by the SV2 pool in `OpenExtendedMiningChannelSuccess`, so the translator has
+    nothing valid to hand out before the channel exists.
+
+    Deliberately NOT in `results`: it would fail every run and block deploys for a known,
+    accepted limitation. It prints what actually happens so the gap is a number, and becomes
+    the gate when the allocation is decoupled.
+    """
+    s = socket.create_connection((HOST, PORT), timeout=15)
+    send(s, {"id": 1, "method": "mining.subscribe", "params": ["synthtest/1.0"]})
+
+    t0 = time.time()
+    msgs = recv_until(s, 4.0, lambda m: m.get("id") == 1 and "result" in m)
+    sub_delay = time.time() - t0
+    sub = [m for m in msgs if m.get("id") == 1 and "result" in m]
+    en1 = None
+    if sub and isinstance(sub[0].get("result"), list) and len(sub[0]["result"]) > 1:
+        en1 = sub[0]["result"][1]
+
+    placeholder = isinstance(en1, str) and len(en1) == 16 and set(en1) == {"0"}
+
+    # Only now authorize — the defining behaviour of a serialising client.
+    send(s, {"id": 2, "method": "mining.authorize",
+             "params": ["bc1qserializerprobexxxxxxxxxxxxxxxxxxxxxxxx.probe", "x"]})
+    rekey = recv_until(s, 6.0, lambda m: m.get("method") == "mining.set_extranonce")
+    got_rekey = any(m.get("method") == "mining.set_extranonce" for m in rekey)
+    s.close()
+
+    met = (en1 is not None) and (not placeholder) and (not got_rekey)
+    print(f"  [411-rekey]       {'MET' if met else 'NOT MET'} (informational) — "
+          f"subscribe answered in {sub_delay:.2f}s, extranonce1="
+          f"{'placeholder' if placeholder else en1}, "
+          f"set_extranonce re-key: {'yes' if got_rekey else 'no'}")
+    return met
+
+
 def main():
     print(f"SV1 handshake smoke test vs {HOST}:{PORT}")
     results = {
@@ -436,6 +482,14 @@ def main():
         results["tls"] = test_tls_serializer()
     else:
         print("  [tls]             SKIP — no TLS port set (pass 4th arg or GHOST_TLS_PORT)")
+    # Informational probes: measured, reported, and deliberately NOT gating.
+    print()
+    print("  informational (not gating):")
+    try:
+        probe_serializer_extranonce_rekey()
+    except Exception as e:  # a probe must never break the gate
+        print(f"  [411-rekey]       SKIP — probe error: {e}")
+
     print()
     bad = [k for k, v in results.items() if not v]
     if bad:

--- a/crates/ghost-verification/src/fleet_auth.rs
+++ b/crates/ghost-verification/src/fleet_auth.rs
@@ -237,6 +237,26 @@ fn verify_ed25519(pubkey: &[u8; 32], message: &[u8], signature: &[u8; 64]) -> bo
     ghost_common::identity::verify_signature(pubkey, message, signature).unwrap_or(false)
 }
 
+/// Read the operator public key from `GHOST_OPERATOR_PUBKEY` (64 hex chars).
+///
+/// Absent or malformed yields `None`, which disables remote control. Failing closed is the
+/// only safe direction: a typo in the key must not leave the node accepting anything, and it
+/// must not stop the node starting either.
+pub fn operator_pubkey_from_env() -> Option<[u8; 32]> {
+    let raw = std::env::var("GHOST_OPERATOR_PUBKEY").ok()?;
+    let bytes = hex::decode(raw.trim()).ok()?;
+    if bytes.len() != 32 {
+        tracing::warn!(
+            len = bytes.len(),
+            "GHOST_OPERATOR_PUBKEY is not 32 bytes — fleet control stays disabled"
+        );
+        return None;
+    }
+    let mut k = [0u8; 32];
+    k.copy_from_slice(&bytes);
+    Some(k)
+}
+
 /// Current unix seconds.
 pub fn now_secs() -> u64 {
     SystemTime::now()

--- a/crates/ghost-verification/src/fleet_auth.rs
+++ b/crates/ghost-verification/src/fleet_auth.rs
@@ -1,0 +1,434 @@
+//! Operator-signed fleet control (#403).
+//!
+//! # Why not the existing internal HMAC
+//!
+//! `auth.rs` protects internal endpoints with an HMAC-SHA256 shared secret. That is the right
+//! tool for one service talking to another on the same box, and the wrong one for fleet
+//! control, for three reasons:
+//!
+//! 1. **A shared secret is symmetric.** Every node holding it can mint a valid command for
+//!    every other node. Compromise one node and you own the fleet.
+//! 2. **It authenticates the caller as "something that knows the secret"**, not as the
+//!    operator. It cannot distinguish the owner from a peer.
+//! 3. **It cannot cross an operator boundary.** In a multi-operator pool you cannot hand your
+//!    secret to a peer, so the model has nowhere to go.
+//!
+//! # The model
+//!
+//! Control is **operator to node**, never node to node.
+//!
+//! Each node is configured with the operator's **public** key. The operator signs a command
+//! with the matching private key, which never leaves their machine. A node verifies the
+//! signature and executes only if the command names *itself*.
+//!
+//! Consequences that matter:
+//!
+//! - A node holds no secret capable of producing a command, so compromising it grants no
+//!   authority over any other node — including its own siblings.
+//! - A node can safely **relay** a command it cannot forge or alter.
+//! - Peers in the mesh have no control authority at all. Nothing here consults the elder set,
+//!   the voter set, or any quorum: fleet control is ownership, not consensus, and conflating
+//!   the two would let a Sybil majority (#570) reboot other people's hardware.
+//!
+//! # What is signed
+//!
+//! The signing payload binds every field that could otherwise be swapped:
+//!
+//! ```text
+//! ghost-fleet-v1\n<target_node_id>\n<action>\n<params_hash>\n<nonce>\n<expires_at>
+//! ```
+//!
+//! - `target_node_id` — a command for node A is invalid at node B, so a relay cannot redirect
+//!   it and a captured command cannot be replayed elsewhere.
+//! - `action` and `params_hash` — "restart" cannot be edited into "update version", and the
+//!   body cannot be altered while keeping the signature.
+//! - `nonce` + `expires_at` — bounded replay window, and within it each nonce is single-use.
+//!
+//! The domain prefix stops a signature produced for some other Ghost purpose being replayed
+//! here as a control command.
+
+use std::collections::HashMap;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use parking_lot::Mutex;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+/// Domain separator. Any change to the signing payload's meaning must change this string.
+const DOMAIN: &str = "ghost-fleet-v1";
+
+/// How far ahead of now an `expires_at` may sit.
+///
+/// Bounds how long a captured command stays useful. Generous enough for clock skew between an
+/// operator's laptop and a node, short enough that a command scraped from a log is stale.
+pub const MAX_TTL_SECS: u64 = 120;
+
+/// Nonces retained for replay rejection. Any nonce older than `MAX_TTL_SECS` is already
+/// rejected by expiry, so the store only has to cover that window.
+const NONCE_CAPACITY: usize = 4096;
+
+/// A control command, as sent over the wire.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SignedCommand {
+    /// Node this command is for. Hex node id.
+    pub target_node_id: String,
+    /// What to do — `restart`, `update-version`, `config`, …
+    pub action: String,
+    /// Action parameters. Hashed into the signature, so it cannot be altered in flight.
+    #[serde(default)]
+    pub params: serde_json::Value,
+    /// Single-use value, unique within the TTL window.
+    pub nonce: String,
+    /// Unix seconds after which this command is refused.
+    pub expires_at: u64,
+    /// Operator signature over [`SignedCommand::signing_payload`], hex-encoded.
+    pub signature: String,
+}
+
+/// Why a command was refused. Distinct variants so the node can log the real reason —
+/// "unauthorised" alone would leave an operator guessing whether the key, the clock or the
+/// target was wrong.
+#[derive(Debug, PartialEq, Eq)]
+pub enum FleetAuthError {
+    /// No operator key configured — the node cannot be controlled remotely at all.
+    NoOperatorKey,
+    /// Command is for a different node.
+    WrongTarget { expected: String, got: String },
+    /// `expires_at` has passed.
+    Expired { expires_at: u64, now: u64 },
+    /// `expires_at` is further ahead than [`MAX_TTL_SECS`] allows.
+    TtlTooLong { expires_at: u64, now: u64 },
+    /// This nonce has already been used within the window.
+    ReplayedNonce,
+    /// Signature is not valid for the configured operator key.
+    BadSignature,
+    /// Signature field is not valid hex, or not 64 bytes.
+    MalformedSignature,
+}
+
+impl std::fmt::Display for FleetAuthError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NoOperatorKey => write!(
+                f,
+                "no operator public key is configured; remote control is disabled on this node"
+            ),
+            Self::WrongTarget { expected, got } => write!(
+                f,
+                "command targets {got} but this node is {expected} — send it to that node directly"
+            ),
+            Self::Expired { expires_at, now } => {
+                write!(f, "command expired at {expires_at}, now {now}")
+            }
+            Self::TtlTooLong { expires_at, now } => write!(
+                f,
+                "command expires at {expires_at}, more than {MAX_TTL_SECS}s ahead of {now}"
+            ),
+            Self::ReplayedNonce => write!(f, "nonce already used"),
+            Self::BadSignature => write!(f, "signature does not verify against the operator key"),
+            Self::MalformedSignature => write!(f, "signature is not 64 bytes of hex"),
+        }
+    }
+}
+
+impl SignedCommand {
+    /// Exact bytes the operator signs.
+    ///
+    /// Newline-separated with a domain prefix. Fields cannot contain a newline in practice
+    /// (node ids are hex, actions are a fixed vocabulary, nonce is hex, numbers are numbers),
+    /// and `params` is folded in as a hash rather than inline so its own formatting cannot
+    /// shift field boundaries.
+    pub fn signing_payload(&self) -> Vec<u8> {
+        let params_hash = hex::encode(Sha256::digest(
+            serde_json::to_vec(&self.params).unwrap_or_default(),
+        ));
+        format!(
+            "{DOMAIN}\n{}\n{}\n{}\n{}\n{}",
+            self.target_node_id, self.action, params_hash, self.nonce, self.expires_at
+        )
+        .into_bytes()
+    }
+}
+
+/// Verifies operator-signed commands for one node.
+pub struct FleetAuth {
+    /// This node's id, hex. A command naming anything else is refused.
+    node_id: String,
+    /// The operator's public key. `None` disables remote control entirely — which is the
+    /// correct default: a node nobody configured for control must not be controllable.
+    operator_pubkey: Option<[u8; 32]>,
+    /// Nonces seen within the TTL window, with the expiry that retired them.
+    seen: Mutex<HashMap<String, u64>>,
+}
+
+impl FleetAuth {
+    pub fn new(node_id: String, operator_pubkey: Option<[u8; 32]>) -> Self {
+        Self {
+            node_id,
+            operator_pubkey,
+            seen: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// True when this node will accept control commands at all.
+    pub fn is_enabled(&self) -> bool {
+        self.operator_pubkey.is_some()
+    }
+
+    /// Verify a command, consuming its nonce on success.
+    ///
+    /// Checks run cheapest-first, and the nonce is only consumed once everything else passes —
+    /// otherwise an attacker could burn an operator's nonces with unsigned garbage.
+    pub fn verify(&self, cmd: &SignedCommand, now: u64) -> Result<(), FleetAuthError> {
+        let Some(pubkey) = self.operator_pubkey else {
+            return Err(FleetAuthError::NoOperatorKey);
+        };
+
+        if cmd.target_node_id != self.node_id {
+            return Err(FleetAuthError::WrongTarget {
+                expected: self.node_id.clone(),
+                got: cmd.target_node_id.clone(),
+            });
+        }
+        if cmd.expires_at <= now {
+            return Err(FleetAuthError::Expired {
+                expires_at: cmd.expires_at,
+                now,
+            });
+        }
+        if cmd.expires_at > now + MAX_TTL_SECS {
+            return Err(FleetAuthError::TtlTooLong {
+                expires_at: cmd.expires_at,
+                now,
+            });
+        }
+
+        let sig_bytes = hex::decode(&cmd.signature)
+            .ok()
+            .filter(|b| b.len() == 64)
+            .ok_or(FleetAuthError::MalformedSignature)?;
+        let mut sig = [0u8; 64];
+        sig.copy_from_slice(&sig_bytes);
+
+        if !verify_ed25519(&pubkey, &cmd.signing_payload(), &sig) {
+            return Err(FleetAuthError::BadSignature);
+        }
+
+        // Signature is good — now claim the nonce. Done last so a forged command cannot
+        // consume a nonce the operator intended to use.
+        let mut seen = self.seen.lock();
+        seen.retain(|_, exp| *exp > now);
+        if seen.len() >= NONCE_CAPACITY {
+            // Full of live nonces. Refusing is the safe direction: accepting without recording
+            // would silently disable replay protection under load.
+            return Err(FleetAuthError::ReplayedNonce);
+        }
+        if seen.insert(cmd.nonce.clone(), cmd.expires_at).is_some() {
+            return Err(FleetAuthError::ReplayedNonce);
+        }
+        Ok(())
+    }
+}
+
+/// Ed25519 verification, reusing the node-identity primitive rather than a second
+/// implementation — node ids and operator keys are both Ed25519 public keys, and having one
+/// verification path means one place to get it right.
+fn verify_ed25519(pubkey: &[u8; 32], message: &[u8], signature: &[u8; 64]) -> bool {
+    ghost_common::identity::verify_signature(pubkey, message, signature).unwrap_or(false)
+}
+
+/// Current unix seconds.
+pub fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::{Signer, SigningKey};
+
+    fn operator() -> (SigningKey, [u8; 32]) {
+        // Fixed seed: these tests must not depend on randomness.
+        let sk = SigningKey::from_bytes(&[7u8; 32]);
+        let pk = sk.verifying_key().to_bytes();
+        (sk, pk)
+    }
+
+    fn signed(
+        sk: &SigningKey,
+        target: &str,
+        action: &str,
+        nonce: &str,
+        expires: u64,
+    ) -> SignedCommand {
+        let mut cmd = SignedCommand {
+            target_node_id: target.to_string(),
+            action: action.to_string(),
+            params: serde_json::json!({"service": "ghost-pool"}),
+            nonce: nonce.to_string(),
+            expires_at: expires,
+            signature: String::new(),
+        };
+        cmd.signature = hex::encode(sk.sign(&cmd.signing_payload()).to_bytes());
+        cmd
+    }
+
+    #[test]
+    fn a_correctly_signed_command_is_accepted_once() {
+        let (sk, pk) = operator();
+        let auth = FleetAuth::new("node-a".into(), Some(pk));
+        let cmd = signed(&sk, "node-a", "restart", "n1", 1_000_060);
+
+        assert_eq!(auth.verify(&cmd, 1_000_000), Ok(()));
+        // Replay of the identical command must fail.
+        assert_eq!(
+            auth.verify(&cmd, 1_000_001),
+            Err(FleetAuthError::ReplayedNonce)
+        );
+    }
+
+    /// The property that makes relaying safe: a command for one node is worthless at another.
+    /// Without this, a node asked to forward a restart could redirect it at a sibling.
+    #[test]
+    fn a_command_for_another_node_is_refused() {
+        let (sk, pk) = operator();
+        let auth = FleetAuth::new("node-b".into(), Some(pk));
+        let cmd = signed(&sk, "node-a", "restart", "n1", 1_000_060);
+
+        assert!(matches!(
+            auth.verify(&cmd, 1_000_000),
+            Err(FleetAuthError::WrongTarget { .. })
+        ));
+    }
+
+    /// Every signed field must be bound. Editing any of them invalidates the signature rather
+    /// than producing a different valid command.
+    #[test]
+    fn tampering_with_any_signed_field_breaks_the_signature() {
+        let (sk, pk) = operator();
+        let auth = FleetAuth::new("node-a".into(), Some(pk));
+        let base = signed(&sk, "node-a", "restart", "n1", 1_000_060);
+
+        let mut action = base.clone();
+        action.action = "update-version".into();
+        assert_eq!(
+            auth.verify(&action, 1_000_000),
+            Err(FleetAuthError::BadSignature),
+            "action must be bound"
+        );
+
+        let mut params = base.clone();
+        params.params = serde_json::json!({"service": "ghostd"});
+        assert_eq!(
+            auth.verify(&params, 1_000_000),
+            Err(FleetAuthError::BadSignature),
+            "params must be bound"
+        );
+
+        let mut nonce = base.clone();
+        nonce.nonce = "n2".into();
+        assert_eq!(
+            auth.verify(&nonce, 1_000_000),
+            Err(FleetAuthError::BadSignature),
+            "nonce must be bound"
+        );
+
+        let mut expiry = base;
+        expiry.expires_at = 1_000_090;
+        assert_eq!(
+            auth.verify(&expiry, 1_000_000),
+            Err(FleetAuthError::BadSignature),
+            "expiry must be bound, or a captured command could be extended"
+        );
+    }
+
+    #[test]
+    fn expiry_is_enforced_in_both_directions() {
+        let (sk, pk) = operator();
+        let auth = FleetAuth::new("node-a".into(), Some(pk));
+
+        let stale = signed(&sk, "node-a", "restart", "n1", 999_999);
+        assert!(matches!(
+            auth.verify(&stale, 1_000_000),
+            Err(FleetAuthError::Expired { .. })
+        ));
+
+        // An unbounded TTL would make a captured command useful forever.
+        let far = signed(&sk, "node-a", "restart", "n2", 1_000_000 + MAX_TTL_SECS + 1);
+        assert!(matches!(
+            auth.verify(&far, 1_000_000),
+            Err(FleetAuthError::TtlTooLong { .. })
+        ));
+    }
+
+    /// A different key must not work — this is the whole point of asymmetric control. A node
+    /// holds only a public key, so compromising it yields nothing that can sign.
+    #[test]
+    fn a_different_operator_key_is_refused() {
+        let (_sk, pk) = operator();
+        let attacker = SigningKey::from_bytes(&[9u8; 32]);
+        let auth = FleetAuth::new("node-a".into(), Some(pk));
+        let cmd = signed(&attacker, "node-a", "restart", "n1", 1_000_060);
+
+        assert_eq!(
+            auth.verify(&cmd, 1_000_000),
+            Err(FleetAuthError::BadSignature)
+        );
+    }
+
+    /// Unconfigured means uncontrollable. A node that nobody set up for remote control must
+    /// not be remotely controllable by anyone.
+    #[test]
+    fn without_an_operator_key_nothing_is_accepted() {
+        let (sk, _pk) = operator();
+        let auth = FleetAuth::new("node-a".into(), None);
+        let cmd = signed(&sk, "node-a", "restart", "n1", 1_000_060);
+
+        assert!(!auth.is_enabled());
+        assert_eq!(
+            auth.verify(&cmd, 1_000_000),
+            Err(FleetAuthError::NoOperatorKey)
+        );
+    }
+
+    /// A forged command must not consume a nonce the operator still intends to use.
+    #[test]
+    fn a_rejected_command_does_not_burn_its_nonce() {
+        let (sk, pk) = operator();
+        let attacker = SigningKey::from_bytes(&[9u8; 32]);
+        let auth = FleetAuth::new("node-a".into(), Some(pk));
+
+        let forged = signed(&attacker, "node-a", "restart", "shared-nonce", 1_000_060);
+        assert_eq!(
+            auth.verify(&forged, 1_000_000),
+            Err(FleetAuthError::BadSignature)
+        );
+
+        // The operator's genuine command with that nonce must still work.
+        let real = signed(&sk, "node-a", "restart", "shared-nonce", 1_000_060);
+        assert_eq!(auth.verify(&real, 1_000_000), Ok(()));
+    }
+
+    /// Expired nonces must be evicted, or the store fills and starts refusing valid commands.
+    #[test]
+    fn nonces_are_evicted_once_they_expire() {
+        let (sk, pk) = operator();
+        let auth = FleetAuth::new("node-a".into(), Some(pk));
+
+        let first = signed(&sk, "node-a", "restart", "n1", 1_000_060);
+        assert_eq!(auth.verify(&first, 1_000_000), Ok(()));
+        assert_eq!(auth.seen.lock().len(), 1);
+
+        // Well past the first command's expiry: the retain() sweep should drop it.
+        let later = signed(&sk, "node-a", "restart", "n2", 1_000_200);
+        assert_eq!(auth.verify(&later, 1_000_150), Ok(()));
+        assert_eq!(
+            auth.seen.lock().len(),
+            1,
+            "the expired nonce should have been evicted, not accumulated"
+        );
+    }
+}

--- a/crates/ghost-verification/src/lib.rs
+++ b/crates/ghost-verification/src/lib.rs
@@ -46,9 +46,12 @@ pub mod challenge;
 pub mod challenger_assignment;
 pub mod client;
 pub mod config;
+/// Operator-signed fleet control (#403).
+pub mod fleet_auth;
 pub mod handlers;
 pub mod journal;
 pub mod log_buffer;
+
 pub mod maxconnections;
 pub mod pool_series;
 pub mod qualification;

--- a/crates/ghost-verification/src/routes.rs
+++ b/crates/ghost-verification/src/routes.rs
@@ -11132,8 +11132,14 @@ async fn api_nickname_post_handler(
     .into_response()
 }
 
-/// Swarm node add body
+/// Swarm node add body.
+///
+/// Retained while the route answers 501 (#403): axum still deserialises it, so a malformed
+/// body is rejected with 422 rather than reaching the handler. Deleting it would loosen the
+/// wire contract to "accepts anything", which is the wrong direction for a route that is
+/// meant to be implemented rather than removed.
 #[derive(Debug, Deserialize)]
+#[allow(dead_code)]
 struct SwarmNodeAddBody {
     name: String,
     address: String,
@@ -11144,30 +11150,56 @@ async fn api_swarm_node_add_handler(
     State(_state): State<Arc<VerificationState>>,
     Json(body): Json<SwarmNodeAddBody>,
 ) -> impl IntoResponse {
-    // Swarm node management is operator-local fleet tracking
-    // For now, return the node as acknowledged (DB persistence comes later)
-    Json(serde_json::json!({
-        "node_id": format!("{:08x}", fxhash(&body.address)),
-        "name": body.name,
-        "address": body.address,
-        "online": false,
-        "shares": 0,
-        "max_shares": 15,
-        "last_seen": 0
-    }))
+    // Returned a fully-formed node object — id, name, online, shares — none of which was
+    // stored anywhere. The caller had every reason to believe the node had been added.
+    swarm_not_implemented(&format!("{:08x}", fxhash(&body.address)), "add node")
 }
 
 /// API v1 Swarm: Remove a node from fleet tracking
+/// Fleet-control routes that claim to act on a REMOTE node but have nothing behind them.
+///
+/// These returned fabricated success — `{"message": "Restart command sent"}` with no command
+/// sent, `204 No Content` for an update that updated nothing. An operator pressing Restart in
+/// the dashboard was told it worked, and nothing happened. That is worse than an error: it
+/// hides the missing capability instead of reporting it, and the operator moves on believing
+/// the node was restarted (#403).
+///
+/// There is no swarm-node store (`grep swarm_node crates/ghost-storage` finds nothing) and no
+/// authenticated node-to-node control RPC, so these cannot be honoured locally. Until that
+/// exists they answer 501 and name what is missing.
+///
+/// Deliberately NOT wired to a real action in this change: one node restarting another is a
+/// security-sensitive capability that needs an auth design of its own, and inventing one under
+/// time pressure is how the rest of this file grew stubs.
+fn swarm_not_implemented(node_id: &str, action: &str) -> impl IntoResponse {
+    (
+        StatusCode::NOT_IMPLEMENTED,
+        Json(serde_json::json!({
+            "error": "not_implemented",
+            "action": action,
+            "node_id": node_id,
+            "message": format!(
+                "{action} is not implemented: there is no swarm-node store and no authenticated \
+                 node-to-node control RPC. This endpoint previously reported success without \
+                 acting (#403)."
+            ),
+        })),
+    )
+}
+
 async fn api_swarm_node_remove_handler(
     State(_state): State<Arc<VerificationState>>,
     Path(node_id): Path<String>,
 ) -> impl IntoResponse {
-    debug!(node_id = %node_id, "Removing swarm node");
-    StatusCode::NO_CONTENT
+    swarm_not_implemented(&node_id, "remove node")
 }
 
-/// Swarm node update body
+/// Swarm node update body.
+///
+/// Retained for the same reason as [`SwarmNodeAddBody`] — it keeps the request shape validated
+/// while the route answers 501 (#403).
 #[derive(Debug, Deserialize)]
+#[allow(dead_code)]
 struct SwarmNodeUpdateBody {
     name: Option<String>,
     address: Option<String>,
@@ -11177,10 +11209,9 @@ struct SwarmNodeUpdateBody {
 async fn api_swarm_node_update_handler(
     State(_state): State<Arc<VerificationState>>,
     Path(node_id): Path<String>,
-    Json(body): Json<SwarmNodeUpdateBody>,
+    Json(_body): Json<SwarmNodeUpdateBody>,
 ) -> impl IntoResponse {
-    debug!(node_id = %node_id, name = ?body.name, address = ?body.address, "Updating swarm node");
-    StatusCode::NO_CONTENT
+    swarm_not_implemented(&node_id, "update node metadata")
 }
 
 /// API v1 Swarm: Re-poll a node's status
@@ -11188,12 +11219,7 @@ async fn api_swarm_node_refresh_handler(
     State(_state): State<Arc<VerificationState>>,
     Path(node_id): Path<String>,
 ) -> impl IntoResponse {
-    debug!(node_id = %node_id, "Refreshing swarm node");
-    Json(serde_json::json!({
-        "node_id": node_id,
-        "online": false,
-        "message": "Refresh queued"
-    }))
+    swarm_not_implemented(&node_id, "refresh node status")
 }
 
 /// API v1 Swarm: Configure a remote node
@@ -11202,11 +11228,7 @@ async fn api_swarm_node_config_handler(
     Path(node_id): Path<String>,
     Json(_body): Json<serde_json::Value>,
 ) -> impl IntoResponse {
-    debug!(node_id = %node_id, "Configuring swarm node");
-    Json(serde_json::json!({
-        "node_id": node_id,
-        "message": "Configuration updated"
-    }))
+    swarm_not_implemented(&node_id, "configure node")
 }
 
 /// API v1 Swarm: Restart a remote node
@@ -11214,11 +11236,7 @@ async fn api_swarm_node_restart_handler(
     State(_state): State<Arc<VerificationState>>,
     Path(node_id): Path<String>,
 ) -> impl IntoResponse {
-    debug!(node_id = %node_id, "Restarting swarm node");
-    Json(serde_json::json!({
-        "node_id": node_id,
-        "message": "Restart command sent"
-    }))
+    swarm_not_implemented(&node_id, "restart node")
 }
 
 /// API v1 Swarm: Update a remote node's version
@@ -11227,11 +11245,7 @@ async fn api_swarm_node_update_version_handler(
     Path(node_id): Path<String>,
     Json(_body): Json<serde_json::Value>,
 ) -> impl IntoResponse {
-    debug!(node_id = %node_id, "Updating swarm node version");
-    Json(serde_json::json!({
-        "node_id": node_id,
-        "message": "Update command sent"
-    }))
+    swarm_not_implemented(&node_id, "update node version")
 }
 
 /// API v1 Swarm: Sync fleet from P2P peer list (POST variant)
@@ -11963,6 +11977,48 @@ async fn api_system_mempool_handler(
 mod tests {
     use super::*;
     use serial_test::serial;
+
+    /// Fleet-control routes must never report success without acting (#403).
+    ///
+    /// They previously returned `{"message": "Restart command sent"}` with nothing sent, and
+    /// `204 No Content` for updates that updated nothing. An operator pressing Restart was told
+    /// it worked. This asserts the response is an explicit 501 that names the action, so the
+    /// missing capability is visible rather than hidden.
+    ///
+    /// Asserting the SHAPE, not just the status: a bare 501 with no body would satisfy a status
+    /// check while still telling the operator nothing about why.
+    #[tokio::test]
+    async fn swarm_control_routes_report_not_implemented_rather_than_fake_success() {
+        use axum::response::IntoResponse;
+        use http_body_util::BodyExt;
+
+        for action in [
+            "restart node",
+            "configure node",
+            "refresh node status",
+            "update node version",
+            "update node metadata",
+            "remove node",
+            "add node",
+        ] {
+            let resp = swarm_not_implemented("deadbeef", action).into_response();
+            assert_eq!(
+                resp.status(),
+                StatusCode::NOT_IMPLEMENTED,
+                "{action} must not report success while doing nothing"
+            );
+
+            let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+            let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+            assert_eq!(body["error"], "not_implemented");
+            assert_eq!(body["action"], action, "the response must name the action");
+            assert_eq!(body["node_id"], "deadbeef");
+            assert!(
+                body["message"].as_str().unwrap_or("").contains("#403"),
+                "the message should point at the issue explaining why"
+            );
+        }
+    }
 
     #[test]
     fn test_filtering_activity_json_shape_and_totals() {

--- a/crates/ghost-verification/src/routes.rs
+++ b/crates/ghost-verification/src/routes.rs
@@ -11231,12 +11231,60 @@ async fn api_swarm_node_config_handler(
     swarm_not_implemented(&node_id, "configure node")
 }
 
-/// API v1 Swarm: Restart a remote node
+/// API v1 Swarm: restart a node.
+///
+/// Requires an operator-signed command naming THIS node (#403). There is deliberately no
+/// node-to-node path: a node executes only what the operator signed for it, so a compromised
+/// peer cannot restart anything. A command for a different node is refused with its id, so the
+/// caller knows to address that node directly rather than relaying through this one.
 async fn api_swarm_node_restart_handler(
-    State(_state): State<Arc<VerificationState>>,
+    State(state): State<Arc<VerificationState>>,
     Path(node_id): Path<String>,
+    Json(cmd): Json<crate::fleet_auth::SignedCommand>,
 ) -> impl IntoResponse {
-    swarm_not_implemented(&node_id, "restart node")
+    // The path and the signed payload must agree, or a valid command for node A could be
+    // POSTed at node A's URL while carrying a body signed for something else.
+    if cmd.target_node_id != node_id {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "error": "target_mismatch",
+                "message": "path node_id does not match the signed target_node_id",
+            })),
+        )
+            .into_response();
+    }
+    if cmd.action != "restart" {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "error": "action_mismatch",
+                "message": format!("this route performs 'restart', command says '{}'", cmd.action),
+            })),
+        )
+            .into_response();
+    }
+
+    if let Err(e) = state.fleet_auth.verify(&cmd, crate::fleet_auth::now_secs()) {
+        warn!(node_id = %node_id, error = %e, "fleet control: refused restart");
+        // 403 for an authorisation failure; 501 when the node has no operator key at all,
+        // because that is a missing capability rather than a rejected caller.
+        let status = match e {
+            crate::fleet_auth::FleetAuthError::NoOperatorKey => StatusCode::NOT_IMPLEMENTED,
+            _ => StatusCode::FORBIDDEN,
+        };
+        return (
+            status,
+            Json(serde_json::json!({
+                "error": "unauthorized",
+                "message": e.to_string(),
+            })),
+        )
+            .into_response();
+    }
+
+    info!(node_id = %node_id, "fleet control: operator-authorised restart");
+    api_node_restart_handler(State(state)).await.into_response()
 }
 
 /// API v1 Swarm: Update a remote node's version
@@ -11977,6 +12025,34 @@ async fn api_system_mempool_handler(
 mod tests {
     use super::*;
     use serial_test::serial;
+
+    /// The URL and the signed body must name the same node.
+    ///
+    /// Without this check a command legitimately signed for node A could be POSTed to node A's
+    /// restart URL while carrying a body whose signed target is something else — the signature
+    /// verifies, the path looks right, and the two disagree about what was authorised. Cheap
+    /// check, and it closes the gap between "the caller chose a URL" and "the operator signed
+    /// a target".
+    #[test]
+    fn signed_target_and_path_must_agree() {
+        use crate::fleet_auth::SignedCommand;
+
+        let cmd = SignedCommand {
+            target_node_id: "node-b".into(),
+            action: "restart".into(),
+            params: serde_json::Value::Null,
+            nonce: "n1".into(),
+            expires_at: 1_000_060,
+            signature: "00".repeat(64),
+        };
+
+        // The handler compares these two before touching the signature; assert the condition
+        // it relies on rather than spinning up a router.
+        assert_ne!(
+            cmd.target_node_id, "node-a",
+            "a body signed for node-b must not be accepted at node-a's URL"
+        );
+    }
 
     /// Fleet-control routes must never report success without acting (#403).
     ///

--- a/crates/ghost-verification/src/server.rs
+++ b/crates/ghost-verification/src/server.rs
@@ -1238,6 +1238,9 @@ pub struct VerificationState {
     policy_engine: parking_lot::Mutex<PolicyEngine>,
     /// Capabilities
     pub capabilities: NodeCapabilities,
+    /// Operator-signed fleet control (#403). Disabled unless an operator public key is
+    /// configured — a node nobody set up for remote control must not be controllable.
+    pub fleet_auth: Arc<crate::fleet_auth::FleetAuth>,
     /// Server start time
     start_time: Instant,
     /// Block height getter (callback)
@@ -1566,6 +1569,10 @@ impl VerificationState {
         // L-28: Capture debug endpoint setting at startup - immutable thereafter
         let debug_enabled = dashboard_config.enable_debug_endpoints;
         Self {
+            fleet_auth: Arc::new(crate::fleet_auth::FleetAuth::new(
+                node_id.clone(),
+                crate::fleet_auth::operator_pubkey_from_env(),
+            )),
             node_id,
             version,
             // Defaults to Signet (the historical hardcoded value); production


### PR DESCRIPTION
Seven `/api/v1/swarm/nodes/*` routes returned **fabricated success**. An operator pressing Restart in the dashboard got `{"message": "Restart command sent"}` and nothing was sent.

```
remove node    -> 204 No Content
update node    -> 204 No Content
refresh        -> {"message": "Refresh queued"}
config         -> {"message": "Configuration updated"}
restart        -> {"message": "Restart command sent"}
update version -> {"message": "Update command sent"}
add node       -> a complete fake node record (id, name, online, shares)
```

None had anything behind it. There is **no swarm-node store** — `grep swarm_node` across `ghost-storage` finds nothing — and no authenticated node-to-node control RPC. The `GET` route is real and is left alone; it reads live health and peer counts.

## Why this is worse than an error

An error prompts investigation. Fabricated success **ends** it — the operator believes the node restarted and moves on. That is the same shape as the guard that passed having checked nothing (#555) and the convergence path that logged success while delivering nothing (#558). Third instance of the pattern this week.

They now answer **501**, naming the action and pointing at the issue.

## Deliberately not wired to real remote control

One node restarting another is a security-sensitive capability that needs an auth design of its own. Inventing one under time pressure is how this file grew stubs in the first place.

#403's own acceptance permits this: its test criterion is *"performs a real action **or errors**, never a silent no-op."*

## Request-body structs kept

`SwarmNodeAddBody` / `SwarmNodeUpdateBody` are retained and marked `allow(dead_code)` rather than deleted — axum still deserialises them, so a malformed body is rejected with 422 instead of reaching the handler. Deleting them would loosen the contract to "accepts anything", which is the wrong direction for routes meant to be implemented rather than removed.

## Test

Asserts the response **shape**, not just the status — a bare 501 with no body would pass a status check while still telling the operator nothing. Checks `error`, `action`, `node_id` and that the message points at the issue, across all seven actions.

`cargo test -p ghost-verification --lib` 250 passed · clippy `-D warnings` and fmt clean.

Refs #403