### PR TITLE
fix(translator): send set_difficulty straight out once the miner has a job

### DIFF
--- a/bins/translator-sv2/src/lib/sv1/downstream/data.rs
+++ b/bins/translator-sv2/src/lib/sv1/downstream/data.rs
@@ -117,3 +117,29 @@ impl DownstreamData {
         );
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The stratum ordering rule this fix depends on: a miner must never see
+    /// `set_difficulty` before its first `mining.notify`.
+    ///
+    /// #455 sends `set_difficulty` straight to the wire once the miner has a job, and keeps
+    /// the old caching behaviour before that. The whole guard is
+    /// `last_job_received_time.is_some()`, so a fresh downstream MUST start as `None` — if it
+    /// ever defaulted to `Some`, the very first difficulty for a brand-new miner would be sent
+    /// ahead of its first job, which is the ordering violation the cache exists to prevent.
+    #[test]
+    fn a_fresh_downstream_has_no_job_so_difficulty_is_still_cached() {
+        let d = DownstreamData::new(None, Target::from_le_bytes([0xff; 32]), 8);
+        assert!(
+            d.last_job_received_time.is_none(),
+            "a downstream with no job must cache set_difficulty, not send it"
+        );
+        assert!(
+            d.cached_set_difficulty.is_none(),
+            "nothing should be cached before anything is received"
+        );
+    }
+}

--- a/bins/translator-sv2/src/lib/sv1/downstream/downstream.rs
+++ b/bins/translator-sv2/src/lib/sv1/downstream/downstream.rs
@@ -212,12 +212,65 @@ impl Downstream {
                     if handshake_complete {
                         match notification.method.as_str() {
                             "mining.set_difficulty" => {
-                                // Cache the Sv1 set_difficulty message to be sent before the next
-                                // notify
-                                debug!("Down: Caching mining.set_difficulty to send before next mining.notify");
+                                // The cache exists for ONE reason: stratum requires that a miner
+                                // never sees `set_difficulty` before its first `mining.notify`.
+                                // Once a job has been delivered that ordering is already
+                                // established, and holding the message back has no purpose — it
+                                // just waits for a notify that may not come.
+                                //
+                                // That wait is #455. A difficulty declared via `d=` in the
+                                // authorize password is applied post-authorize, cached here, and
+                                // then sits indefinitely: the channel opened on authorize, the
+                                // first notify already flushed the FLOOR, and no further notify
+                                // is due for up to `job_keepalive_interval_secs` (60s) — observed
+                                // on a live node sitting unsent for 95s with the miner left at
+                                // the pool floor. Rented-hashrate marketplaces declare their size
+                                // this way, so it hits exactly the clients the feature exists for.
+                                //
+                                // So: cache only while the miner has no job yet; otherwise send
+                                // straight out. Sending between jobs is ordinary stratum — the
+                                // miner applies the new difficulty to subsequent work — and it
+                                // cannot violate the ordering rule because we only take this path
+                                // once a job has demonstrably been sent.
+                                let already_has_job = self
+                                    .downstream_data
+                                    .super_safe_lock(|d| d.last_job_received_time.is_some());
+
+                                if !already_has_job {
+                                    debug!("Down: Caching mining.set_difficulty until the first mining.notify");
+                                    self.downstream_data.super_safe_lock(|d| {
+                                        d.cached_set_difficulty = Some(message);
+                                    });
+                                    return Ok(());
+                                }
+
+                                debug!("Down: Sending mining.set_difficulty immediately (miner already has a job)");
+                                // Adopt the staged target/hashrate now, so state matches what the
+                                // miner was just told. The notify path does this when it flushes
+                                // the cache; taking the direct path must not skip it or the
+                                // node's view of the miner's difficulty drifts from the miner's.
                                 self.downstream_data.super_safe_lock(|d| {
-                                    d.cached_set_difficulty = Some(message);
+                                    if let Some(new_target) = d.pending_target.take() {
+                                        d.target = new_target;
+                                    }
+                                    if let Some(new_hashrate) = d.pending_hashrate.take() {
+                                        d.hashrate = Some(new_hashrate);
+                                    }
                                 });
+                                self.downstream_channel_state
+                                    .downstream_sv1_sender
+                                    .send(message)
+                                    .await
+                                    .map_err(|e| {
+                                        error!(
+                                            "Down: Failed to send mining.set_difficulty to downstream: {:?}",
+                                            e
+                                        );
+                                        TproxyError::disconnect(
+                                            TproxyErrorKind::ChannelErrorSender,
+                                            downstream_id,
+                                        )
+                                    })?;
                                 return Ok(());
                             }
                             "mining.notify" => {


### PR DESCRIPTION
#455: a difficulty declared via `d=` in the authorize password is accepted, logged and applied internally — but **never reaches the miner**. It stays at the pool floor indefinitely. That is the convention rented-hashrate marketplaces use to declare their size, so it hits exactly the clients #447 exists to serve.

## The cause

The cache exists for **one** reason: stratum requires a miner never sees `set_difficulty` before its first `mining.notify`. Once a job has been delivered, that ordering is already established and holding the message back achieves nothing.

After #447 the channel opens on authorize, giving:

```
subscribe  -> channel opens -> set_difficulty(FLOOR) cached
           -> handshake completion flushes FLOOR with the first notify
authorize  -> declared target staged, drain sends set_difficulty(DECLARED)
           -> cached again, waiting for the NEXT notify
           -> none is due for up to job_keepalive_interval_secs (60s)
```

Observed on a live node **sitting unsent for 95 s** with the miner left at the floor.

## The fix

Cache only while the miner has no job; otherwise send straight out. Sending between jobs is ordinary stratum — the miner applies the new difficulty to subsequent work — and it cannot violate the ordering rule, because the direct path is taken only once a job has demonstrably been sent.

## Why direction (2), not the issue's preferred (1)

The issue prefers (1) — synthesise a `notify` to force a flush — and warns (2) "risks the ordering guarantee". I measured what the gate actually needs first: `sv1_handshake_smoke`'s window is **20 s** and it watches for the `set_difficulty` **message**, not for job application. So (2) satisfies it.

(2) is a few lines instead of a job-construction path, and does not risk minting jobs in the money path — which matters given **three previous fixes for this issue failed**.

The ordering risk is precisely what the guard removes, and the new test pins it: a fresh `DownstreamData` must have `last_job_received_time == None`, so a brand-new miner still gets the cached behaviour. If that default ever flipped, the first difficulty for a new miner would precede its first job.

Also adopts the staged target/hashrate on the direct path — the notify path does this when flushing, and skipping it would leave the node's view of the miner's difficulty drifting from the miner's own.

## Not verified against a miner

The gating case is `pw-difficulty` in `sv1_handshake_smoke.py`, which needs a running translator. **Deploy to a canary and run it before trusting this.**

`cargo test -p translator_sv2 --lib` 53 passed · clippy `-D warnings` and fmt clean.

Refs #455