### PR TITLE
fix(convergence): tell the requester when a response was truncated, and drain in place

### DIFF
--- a/bins/ghost-pool/src/convergence.rs
+++ b/bins/ghost-pool/src/convergence.rs
@@ -74,6 +74,19 @@ pub struct LedgerConvergenceResponse {
     /// schema v41 and their signature no longer exists. Reported so the divergence is visible
     /// rather than silent — no protocol can reconcile these, only a one-time operation.
     pub unservable: usize,
+    /// The responder had MORE servable proofs for this window than fitted in one response.
+    ///
+    /// Without this the requester cannot distinguish a complete answer from a truncated one:
+    /// a response carrying the full 56-proof budget looks identical to one carrying everything
+    /// that was missing. It therefore treated the window as done and did not ask again until
+    /// the sweep cursor returned — one visit per rotation, so a bucket holding ~400 missing
+    /// shares needed 7 visits and 28 hours. With the flag the requester re-asks immediately
+    /// and the bucket drains in seconds (#558).
+    ///
+    /// `#[serde(default)]` for wire-compat: a peer predating this field sends `false`, which
+    /// is exactly the old behaviour — ask again next sweep.
+    #[serde(default)]
+    pub more_available: bool,
 }
 
 /// Cap on proofs served in one response, so a wide window cannot produce an enormous message.
@@ -186,7 +199,7 @@ impl ConvergenceHandler {
         req: &LedgerConvergenceRequest,
     ) -> LedgerConvergenceResponse {
         let theirs: std::collections::HashSet<String> = req.share_hashes.iter().cloned().collect();
-        let (proofs, unservable) = match &self.db {
+        let (proofs, unservable, more_available) = match &self.db {
             Some(db) => db
                 .unpaid_proofs_missing_from(
                     req.since_ts,
@@ -196,13 +209,14 @@ impl ConvergenceHandler {
                     MAX_PROOF_BYTES_PER_RESPONSE,
                 )
                 .unwrap_or_default(),
-            None => (Vec::new(), 0),
+            None => (Vec::new(), 0, false),
         };
         LedgerConvergenceResponse {
             since_ts: req.since_ts,
             until_ts: req.until_ts,
             proofs,
             unservable,
+            more_available,
         }
     }
 
@@ -516,8 +530,34 @@ impl MessageHandler for ConvergenceHandler {
                         since = resp.since_ts,
                         until = resp.until_ts,
                         applied = outcome.applied,
+                        more_available = resp.more_available,
                         "GHOST-03: backfilled unpaid-ledger shares via window convergence"
                     );
+                }
+
+                // The peer had more for this window than fitted. Ask again NOW rather than
+                // waiting for the sweep cursor to come round — that wait is one full rotation,
+                // so a bucket holding ~400 missing shares took 7 visits and 28 hours (#558).
+                //
+                // Guarded on `applied > 0`: if we applied nothing, re-asking would repeat an
+                // identical request and could loop. Progress is the condition for continuing,
+                // which also means a peer that lies about `more_available` cannot spin us.
+                if resp.more_available && outcome.applied > 0 {
+                    if let Some(send) = &self.send {
+                        match self.ledger_request_bytes(resp.since_ts, resp.until_ts) {
+                            Ok(bytes) => {
+                                debug!(
+                                    since = resp.since_ts,
+                                    until = resp.until_ts,
+                                    "GHOST-03: window has more — re-requesting immediately"
+                                );
+                                send(bytes)?;
+                            }
+                            Err(e) => {
+                                debug!(error = %e, "GHOST-03: could not build follow-up request");
+                            }
+                        }
+                    }
                 }
             }
             ConvergencePayload::Response(resp) => {
@@ -821,6 +861,7 @@ mod tests {
                 until_ts: i64::MAX,
                 proofs,
                 unservable: 0,
+                more_available: false,
             },
         ))
         .unwrap();
@@ -866,6 +907,7 @@ mod tests {
             until_ts: i64::MAX,
             proofs: vec![serde_json::to_vec(&forged).unwrap()],
             unservable: 0,
+            more_available: false,
         };
 
         assert_eq!(

--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -3678,7 +3678,18 @@ async fn main() -> Result<()> {
             // lever. 12 buckets per long tick covers 6 hours of history per minute — a full
             // horizon sweep in ~4 hours instead of 46 — and each request is bounded by
             // MAX_HASHES_PER_REQUEST, so the wire cost stays flat.
-            const LONG_BUCKETS_PER_TICK: i64 = 12;
+            //
+            // Was 12. That made the rotation 12x faster but the binding constraint was never
+            // visits-per-hour — it was proofs-per-visit, which the truncation signal now fixes
+            // directly (#558). 12 cost real capacity for nothing: vm5's `/health` went from
+            // sub-millisecond to 10.06s, having read 887 GB since restart at 36% CPU with
+            // 1,329 MB available, because each tick runs 12x the ledger queries against a
+            // 2.6 GB database on a node whose working set already exceeds RAM (#556).
+            //
+            // 4 keeps a useful improvement on the original 46-hour rotation (~11.6h) at a third
+            // of the query load. With truncation now drained in-place, rotation speed only
+            // governs how quickly a NEW hole is discovered, not how long one takes to clear.
+            const LONG_BUCKETS_PER_TICK: i64 = 4;
             /// Hard cap on requests emitted in one tick. Sized above LONG_BUCKETS_PER_TICK so a
             /// tick's buckets are never silently dropped, with room for windows that split.
             const MAX_REQUESTS_PER_TICK: usize = 24;

--- a/crates/ghost-storage/src/queries.rs
+++ b/crates/ghost-storage/src/queries.rs
@@ -524,7 +524,7 @@ impl Database {
         theirs: &std::collections::HashSet<String>,
         limit: usize,
         max_bytes: usize,
-    ) -> GhostResult<(Vec<Vec<u8>>, usize)> {
+    ) -> GhostResult<(Vec<Vec<u8>>, usize, bool)> {
         self.with_connection(|conn| {
             let mut stmt = conn
                 .prepare(
@@ -543,6 +543,11 @@ impl Database {
             let mut proofs = Vec::new();
             let mut unservable = 0usize;
             let mut bytes = 0usize;
+            // Whether either bound stopped us adding a proof we DO hold and COULD serve.
+            // Without this the caller cannot tell a complete answer from a truncated one, so it
+            // treats a full response as "window done" and does not ask again until the sweep
+            // cursor comes round — 28 hours for a dense bucket (#558).
+            let mut truncated = false;
             for row in rows {
                 let (hash, proof) = row.map_err(|e| GhostError::Database(e.to_string()))?;
                 if theirs.contains(&hash) {
@@ -552,16 +557,19 @@ impl Database {
                     Some(p) => {
                         // Stop on EITHER bound. Overshooting `max_bytes` would produce a
                         // message the transport silently drops, which is strictly worse than
-                        // serving fewer proofs — the requester simply asks again next sweep.
+                        // serving fewer proofs — but the requester must be TOLD, or it cannot
+                        // know to ask again.
                         if proofs.len() < limit && bytes + p.len() <= max_bytes {
                             bytes += p.len();
                             proofs.push(p);
+                        } else {
+                            truncated = true;
                         }
                     }
                     None => unservable += 1,
                 }
             }
-            Ok((proofs, unservable))
+            Ok((proofs, unservable, truncated))
         })
     }
 
@@ -9470,6 +9478,54 @@ mod tests {
             Some((105, 107)),
             "must report the LOWEST gap so repeated calls walk forward deterministically"
         );
+    }
+
+    /// A truncated response must SAY it was truncated.
+    ///
+    /// The responder stops adding proofs at either bound, and before #558 said nothing about
+    /// it — so a requester receiving a full budget could not tell "that is everything" from
+    /// "that is the first 56 of 400". It treated the window as done and did not ask again
+    /// until the sweep cursor returned, one visit per rotation: 28 hours to drain a dense
+    /// bucket that could drain in seconds.
+    #[test]
+    fn a_truncated_proof_response_reports_that_more_remain() {
+        let db = Database::in_memory().expect("in-memory db");
+
+        db.with_connection(|conn| {
+            conn.execute_batch(
+                "INSERT INTO shares
+                   (round_id, miner_id, difficulty, work, share_hash, timestamp, received_by, valid, proof)
+                 VALUES
+                   (1,'m',1.0,1.0,'h1',100,'n',1,X'AABB'),
+                   (1,'m',1.0,1.0,'h2',101,'n',1,X'AABB'),
+                   (1,'m',1.0,1.0,'h3',102,'n',1,X'AABB');",
+            )
+            .map_err(|e| GhostError::Database(e.to_string()))
+        })
+        .expect("seed");
+
+        let theirs = std::collections::HashSet::new();
+
+        // Budget for everything: complete answer, nothing withheld.
+        let (proofs, _unservable, more) = db
+            .unpaid_proofs_missing_from(0, 1000, &theirs, 10, 1_000_000)
+            .expect("query");
+        assert_eq!(proofs.len(), 3);
+        assert!(!more, "a complete answer must not claim more remain");
+
+        // Count bound hit — must report truncation.
+        let (proofs, _unservable, more) = db
+            .unpaid_proofs_missing_from(0, 1000, &theirs, 2, 1_000_000)
+            .expect("query");
+        assert_eq!(proofs.len(), 2);
+        assert!(more, "hitting the COUNT bound must report more remain");
+
+        // Byte bound hit — must also report truncation.
+        let (proofs, _unservable, more) = db
+            .unpaid_proofs_missing_from(0, 1000, &theirs, 10, 3)
+            .expect("query");
+        assert!(proofs.len() < 3);
+        assert!(more, "hitting the BYTE bound must report more remain");
     }
 
     /// The GHOST-03 sweep span is derived from this, so it must ignore paid and invalid shares —


### PR DESCRIPTION
The responder stops adding proofs at either bound and **said nothing about it**. A requester receiving a full 56-proof budget could not tell *"that is everything"* from *"that is the first 56 of 400"*, so it treated the window as complete and did not ask again until the sweep cursor returned — one visit per rotation.

## The cost

Measured on 07-25: missing shares **cluster in outage windows** rather than spreading evenly.

```
hour 14 -> 794     hour 16 -> 501     hour 20 -> 204
hour 15 ->  49     hour 18 -> 161     hour 21 ->  77
```

So a dense bucket holds ~400. At 56 per visit that is 7 visits, and at one visit per rotation, **28 hours to drain a single bucket** that could drain in seconds.

This is the **fifth instance of the same shape** in this issue: a truncation nobody can observe. `MAX_PROOFS_PER_RESPONSE = 2000` silently exceeding the envelope (#562/#559/#561), the request that was never size-bounded (#568), the fan-out cap dropping buckets (#569), and now the response cap.

## The fix

- `unpaid_proofs_missing_from` returns a `truncated` flag, set when either bound stops it adding a proof it holds and could serve
- `LedgerConvergenceResponse` carries `more_available`, `#[serde(default)]` so a peer predating the field sends `false` — exactly the old behaviour
- On receiving it, the requester **re-asks the same window immediately**

The re-request is guarded on `applied > 0`: if nothing was applied, asking again would repeat an identical request and could loop. Requiring *progress* also means a peer that lies about `more_available` cannot spin us.

## Also reverts part of #569 — `LONG_BUCKETS_PER_TICK` 12 → 4

**12 was the wrong lever, and I should have established the real constraint before shipping it.** The binding limit was proofs-per-visit, not visits-per-hour, so a 12× faster rotation bought little — and it cost real capacity:

```
vm5 /health   0.0007s  ->  10.06s
              887 GB read since restart, 36% CPU, 1,329 MB available
```

Each tick runs 12× the ledger queries against a 2.6 GB database on a node whose working set already exceeds RAM (#556).

4 keeps a useful improvement on the original 46 h rotation (**~11.6 h**) at a third of the query load. With truncation now drained in place, rotation speed governs only how quickly a *new* hole is discovered, not how long one takes to clear.

## Test

Asserts truncation is reported for **both** bounds, and — importantly — that a complete answer does **not** claim more remain. A flag stuck on would re-request forever.

`cargo test -p ghost-storage --lib` 183 passed · `cargo test -p ghost-pool --lib` 311 passed · clippy `-D warnings` and fmt clean.

Refs #558, #556