### PR TITLE
ci: run every integration test target, and fix the one that was red

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,77 @@ jobs:
       - name: Check for unused dependencies
         run: cargo machete
 
+  # Integration test targets.
+  #
+  # CI ran `cargo test --lib --bins` (which does not build `tests/` targets at all) plus
+  # `cargo test --test integration` (ONE named target). Between them they covered 1 of the
+  # workspace's integration test files. `cargo metadata` reports 47 such targets — a
+  # `bins/*/tests` + `crates/*/tests` glob finds only 14, because three packages sit elsewhere.
+  #
+  # `payout_ledger_e2e` had consequently been RED on `main` for an unknown period, failing with
+  # "GHOST-02: 0/8 nodes approved" — which reads like a catastrophic payout bug and was in fact a
+  # stale fixture. Nobody saw it because nothing ran it (#580).
+  #
+  # This is a SEPARATE job, not a step on `test`, deliberately: adding it there pushed that job
+  # from ~28 min past its 45-minute timeout and it was cancelled mid-run. Here it runs in
+  # parallel and cannot slow the critical path. Linux only — the same rationale the
+  # wraith-wallet step already documents.
+  #
+  # Exclusions:
+  #   ghost-mpc / mpc-xproc-harness  -> `mpc-tests` job; they need a per-package feature that a
+  #                                    workspace-wide `--tests` cannot set
+  #   integration_tests_sv2          -> 18 targets that spin up real SRI pool / template-provider
+  #                                    processes (58 `start_pool` call sites, only one
+  #                                    `#[ignore]`d). They need external services and a per-test
+  #                                    budget this job does not have, and have never run in CI.
+  #                                    Triaging them is separate work, tracked on #580.
+  integration-tests:
+    name: Integration tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+                      /opt/hostedtoolcache/CodeQL /usr/local/share/boost
+          sudo docker image prune --all --force >/dev/null 2>&1 || true
+          df -h /
+      - run: sudo apt-get update && sudo apt-get install -y $LINUX_DEPS
+      - name: Run integration tests
+        run: |
+          # bond_e2e execs the real ghost-pay binary and asserts it exists.
+          cargo build -p ghost-pay
+          cargo test $WORKSPACE_EXCLUDES --tests \
+            --exclude ghost-mpc \
+            --exclude mpc-xproc-harness \
+            --exclude integration_tests_sv2
+
+  # MPC integration harnesses.
+  #
+  # Split out of the `test` job for two reasons. They require `--features mpc-test-cap` — without
+  # it both panic deliberately, because a real run would need 101 phase-2 transforms — and a
+  # workspace-wide `--tests` cannot set a per-package feature. They also take ~5 minutes each
+  # (289 s and 303 s measured), so running them here keeps them off the main job's critical path
+  # instead of adding ~10 minutes to it.
+  #
+  # Neither had ever run in CI before #580.
+  mpc-tests:
+    name: MPC integration
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: sudo apt-get update && sudo apt-get install -y $LINUX_DEPS
+      - name: MPC lifecycle (small-cap harness)
+        run: cargo test -p ghost-mpc --test mpc_lifecycle --features mpc-test-cap
+      - name: MPC cross-process contribution flow
+        run: cargo test -p mpc-xproc-harness --test xproc --features mpc-test-cap
+
   # Build and test
   test:
     name: Test (${{ matrix.os }})
@@ -173,10 +244,6 @@ jobs:
       # gain without either surprise.
       - name: Run unit tests (feature-gated consensus modules)
         run: cargo test -p ghost-consensus --lib --features zk-consensus,mpc-ceremony
-
-      # Run integration tests
-      - name: Run integration tests
-        run: cargo test --test integration
 
       # Run wraith-wallet integration tests (separate from --lib --bins).
       # These spin up the real wraithd binary against a tempdir socket, plus

--- a/bins/ghost-pool/tests/payout_ledger_e2e.rs
+++ b/bins/ghost-pool/tests/payout_ledger_e2e.rs
@@ -109,8 +109,23 @@ struct Node {
 /// If the scenario were future-dated, the re-derived `now` would fall BEFORE the shares and
 /// exclude everything — the tests would still go red, but for a reason that cannot happen in
 /// production, and the real race would go untested.
+///
+/// It must ALSO stay inside `PRE_GATE_FRESHNESS_SECS` (1800, `payout.rs`), which validators
+/// apply to the proposal timestamp. This was `- 3_600`, chosen before that rule existed, so
+/// every validator rejected the proposal outright:
+///
+/// ```text
+/// node rejected the payout: pre-gate proposal timestamp ... not within 1800s of now ...
+/// GHOST-02: 0/8 nodes approved, quorum needs 6
+/// ```
+///
+/// which reads like a catastrophic payout failure and is purely a stale fixture. It went
+/// unnoticed because CI never ran this target (#580).
+///
+/// 600 s keeps a real gap for the race under test while leaving 3x headroom on the freshness
+/// bound, so a slow runner cannot drift the test into rejection.
 fn block_found_at() -> i64 {
-    chrono::Utc::now().timestamp() - 3_600
+    chrono::Utc::now().timestamp() - 600
 }
 
 fn regtest_rpc() -> Option<Arc<BitcoinRpc>> {


### PR DESCRIPTION
## CI covered 1 of the workspace's integration test targets

`cargo test --lib --bins` does not build `tests/` targets at all, and `cargo test --test integration`
names a single one. Between them they ran **one** integration test file.

`payout_ledger_e2e` had consequently been **red on `main`** for an unknown period, failing with:

```
node rejected the payout: pre-gate proposal timestamp ... not within 1800s of now ...
GHOST-02: 0/8 nodes approved, quorum needs 6 — the fleet would reject its own
payout and the coinbase would fall back to paying pool_payout_address
```

That reads like a catastrophic failure on the path that runs when the pool **wins a block** — and per
#556 the fleet has not won one since 2026-06-02, so production has not exercised it in two months.

### It is a stale fixture, not a live defect

`block_found_at()` stamped the proposal at `now - 3_600`, while `PRE_GATE_FRESHNESS_SECS = 1800`
(`payout.rs`) rejects anything older than 30 minutes. The fixture predates that rule; production
proposals are stamped fresh. Verified it is **not** gate-related by re-running above
`PAYOUT_TOLERANCE_V2_HEIGHT` — still failed. Now `600` s, which keeps the gap the race test needs
with 3× headroom so a slow runner cannot drift into rejection. **All 5 tests pass.**

### Triage

`cargo metadata` reports **47** integration test targets, not the 14 a `bins/*/tests` +
`crates/*/tests` glob finds — three packages sit elsewhere. Of the 14 in those trees:

| status | targets |
|---|---|
| green as-is | `empty_template_e2e`, `fleet_rehearsal`, `mesh_onboarding_fanout`, `mpc_mesh_dispatch`, `identity_tls_handshake`, `gossip`, `router` |
| green once invoked correctly | `mpc_lifecycle` + `xproc` (need `--features mpc-test-cap`; 289 s / 303 s), `bond_e2e` (execs the real `ghost-pay` binary) |
| `#[ignore]`d no-ops | 3 × `ghost-reaper` backtests |
| **actually red** | `payout_ledger_e2e` — fixed here |

### Scope

- **`integration_tests_sv2` (18 targets) is excluded deliberately.** They spin up real SRI pool /
  template-provider processes — 58 `start_pool` call sites, only one `#[ignore]`d — so they need
  external services and a per-test budget this job does not have. They have never run in CI either;
  triaging them is separate work, noted on #580.
- `cluster_chaos` and `load_tests` are fully `#[ignore]`d and harmless.
- The two MPC harnesses get their own **parallel** `mpc-tests` job: a workspace-wide `--tests` cannot
  set a per-package feature, and at ~5 minutes each they would add ~10 minutes to the main job's
  critical path.
- `--lib --bins` is kept. The new step re-runs those unit tests as a side effect of `--tests` — costs
  time, loses no coverage. Excluding the MPC packages there does not drop their unit tests, because
  `--lib --bins` already ran them.

### Verification

The exact scoped command was run locally to completion: **green, RC=0**, no failures.
`cargo fmt --check` clean.

Refs #580
