### PR TITLE
fix(#618): stop challenging bootstrap placeholder peers

### DIFF
--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -567,10 +567,23 @@ impl PeerProvider for PeerProviderAdapter {
         // Get connected peers (seen in last 60 seconds)
         let connected = self.peers.get_connected_peers(60);
 
-        // Filter out the excluded node (ourselves) and peers without valid addresses
+        // Filter out the excluded node (ourselves) and peers without valid addresses.
+        //
+        // #618: also skip bootstrap placeholders. `connect_peer` registers a seed under an
+        // address-derived stub id until its real identity arrives on the first health ping,
+        // and such an entry satisfied both filters above. Selecting one produced a verdict
+        // attributed to a node_id that exists nowhere: only the port is rewritten when a
+        // challenge is sent, so the host is a real node, it answered with a genuine proof,
+        // and the result was filed against the stub. Measured on vm1: 11,754 ledger rows,
+        // 11,510 passing, across ghostpay, policy and stratum. An unidentified peer must not
+        // be verifiable at all, so this is filtered at selection rather than at record time.
         let mut candidates: Vec<_> = connected
             .into_iter()
-            .filter(|p| &p.node_id != exclude && !p.public_address.is_empty())
+            .filter(|p| {
+                &p.node_id != exclude
+                    && !p.public_address.is_empty()
+                    && !p.is_bootstrap_placeholder()
+            })
             .map(|p| {
                 // Derive HTTP address from public_address + http_port
                 let host = extract_peer_host(&p.public_address);
@@ -11343,6 +11356,42 @@ mod tests {
     #[test]
     fn extract_peer_host_ip_with_port() {
         assert_eq!(extract_peer_host("192.168.1.1:8080"), "192.168.1.1");
+    }
+
+    #[test]
+    fn get_random_peers_skips_bootstrap_placeholders() {
+        // #618: a stub must never be offered as a verification target, while a real
+        // peer on the same host still must be. Before the fix both were selectable,
+        // and the stub's verdict was filed against a node_id that exists nowhere.
+        use ghost_consensus::peer::{placeholder_node_id, Peer, PeerManager, PeerState};
+
+        let us = [1u8; 32];
+        let mgr = std::sync::Arc::new(PeerManager::new(us, 100));
+
+        // Exactly what connect_peer mints for a not-yet-identified seed.
+        let stub_addr = "95.111.221.169:8559".to_string();
+        let mut stub = Peer::new(placeholder_node_id(&stub_addr), stub_addr.clone());
+        stub.state = PeerState::Connected;
+        let stub_id = stub.node_id;
+        mgr.upsert_peer(stub);
+
+        // A real, identified peer on a different host.
+        let real_id = [42u8; 32];
+        let mut real = Peer::new(real_id, "203.0.113.7:8555".to_string());
+        real.state = PeerState::Connected;
+        mgr.upsert_peer(real);
+
+        let adapter = PeerProviderAdapter::new(mgr, 8080);
+        let selected = adapter.get_random_peers(&us, 10);
+
+        assert!(
+            selected.iter().any(|p| p.node_id == real_id),
+            "a real identified peer must still be selectable"
+        );
+        assert!(
+            !selected.iter().any(|p| p.node_id == stub_id),
+            "a bootstrap placeholder must never be selected as a verification target"
+        );
     }
 
     #[test]

--- a/crates/ghost-consensus/src/peer.rs
+++ b/crates/ghost-consensus/src/peer.rs
@@ -67,7 +67,7 @@ fn extract_host_from_address(address: &str) -> String {
 /// derivation: `connect_peer` calls it to mint the stub, and `upsert_peer`'s
 /// same-host reconcile calls it to recognise such a stub by exact identity — so a
 /// real peer sharing a host is never mistaken for (and evicted as) a placeholder.
-pub(crate) fn placeholder_node_id(address: &str) -> NodeId {
+pub fn placeholder_node_id(address: &str) -> NodeId {
     use std::hash::{Hash, Hasher};
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
     address.hash(&mut hasher);
@@ -664,6 +664,23 @@ impl Peer {
         }
     }
 
+    /// True while this entry is still the address-derived bootstrap stub minted by
+    /// `MeshNetwork::connect_peer`, i.e. its real identity has not yet arrived on a
+    /// health ping.
+    ///
+    /// Such a peer has no verified identity, so anything that attributes a result to a
+    /// `node_id` must skip it. #618: the verification task selected these as challenge
+    /// targets. Because only the *port* is rewritten when a challenge is sent, the host
+    /// is still a real node — it answered with a genuine nonce-bound proof, which was
+    /// then filed against a `node_id` that exists nowhere (11,754 ledger rows on vm1,
+    /// across ghostpay, policy and stratum).
+    ///
+    /// Same derivation as `upsert_peer`'s same-host reconcile, so a real peer sharing a
+    /// host is never mistaken for a stub.
+    pub fn is_bootstrap_placeholder(&self) -> bool {
+        !self.public_address.is_empty() && self.node_id == placeholder_node_id(&self.public_address)
+    }
+
     /// Node ID as hex string
     pub fn node_id_hex(&self) -> String {
         hex::encode(self.node_id)
@@ -788,6 +805,51 @@ mod tests {
     // Helper: build a 16-byte miner-id hash from a single tag byte.
     fn h(tag: u8) -> [u8; 16] {
         [tag; 16]
+    }
+
+    #[test]
+    fn test_bootstrap_placeholder_is_recognised_and_real_peers_are_not() {
+        // #618: an unidentified bootstrap stub must be distinguishable from a real
+        // peer, because anything attributing a result to a node_id has to skip it.
+        // Measured live: 11,754 verification_ledger rows on vm1 were filed against
+        // ids that exist in no table, all carrying this exact shape.
+        let addr = "95.111.221.169:8559".to_string();
+
+        let stub = Peer::new(placeholder_node_id(&addr), addr.clone());
+        assert!(
+            stub.is_bootstrap_placeholder(),
+            "an address-derived stub, exactly as connect_peer mints it, must be recognised"
+        );
+
+        // A real identity on the SAME host must not be mistaken for the stub —
+        // this is the hijack-safety property the same-host reconcile relies on.
+        let real = Peer::new([7u8; 32], addr.clone());
+        assert!(
+            !real.is_bootstrap_placeholder(),
+            "a real peer sharing the stub's host must never be treated as a placeholder"
+        );
+
+        // The observed live shape: 8 bytes, the same 8 reversed, then 16 zero bytes.
+        // Asserted directly so a future change to the derivation cannot silently
+        // stop matching what is already in the ledger.
+        let id = placeholder_node_id(&addr);
+        assert_eq!(&id[16..], &[0u8; 16], "bytes 16..32 must be zero");
+        let mut mirrored = id[..8].to_vec();
+        mirrored.reverse();
+        assert_eq!(
+            &id[8..16],
+            &mirrored[..],
+            "bytes 8..15 must reverse bytes 0..7"
+        );
+
+        // An empty address must not collapse into "everything is a placeholder":
+        // peers with no address are already filtered elsewhere, and a blanket true
+        // here would silently drop real peers from selection.
+        let no_addr = Peer::new([9u8; 32], String::new());
+        assert!(
+            !no_addr.is_bootstrap_placeholder(),
+            "an empty address must not be classified as a placeholder"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #618.

`MeshNetwork::connect_peer` registers a not-yet-identified seed under an address-derived stub id until its real identity arrives on the first health ping. `PeerProviderAdapter::get_random_peers` filtered only on "not self" and "`public_address` non-empty", so a stub was selectable as a verification target.

That is not harmless noise. Only the **port** is rewritten when a challenge is sent — `transform_to_ghostpay_port` for ghostpay, `http_address` as-is for policy and archive — so the **host** is still a real node. It answers with a genuine nonce-bound epoch proof, and that valid proof is then filed against a `node_id` that exists in no table.

## Measured on the live fleet

- **11,754 `verification_ledger` rows on vm1, 11,510 passing**, across `ghostpay`, `policy` and `stratum` — about 2.3% of that node's ledger.
- Nine distinct phantom ids, all sharing one shape: 8 bytes, the same 8 reversed, then 16 zero bytes. Compiling `placeholder_node_id` verbatim and running it over the fleet's addresses reproduced **8 of the 9 exactly** (the 9th is the degenerate all-zero id) — each one a real node's IP on `:8559` (discovery) or `:8555` (share propagation).
- They are minted at startup and reconciled away about a minute later, so every newest phantom challenge sits **50-67 s after `ghost-pool` starts**. Confirmed again during today's fleet roll: vm1 restarted `12:11:22`, newest phantom `12:12:12`.
- `node_rewards` and `nodes` hold **zero** phantom rows, so nothing pays out against them. The damage is polluted verification history and inflated fleet-wide pass rates.

## The change

Filtered at **selection** rather than at record time: a peer with no verified identity should not be verifiable at all.

`Peer::is_bootstrap_placeholder` reuses the derivation `upsert_peer`'s same-host reconcile already relies on, so a real peer sharing a stub's host is still never mistaken for one. `placeholder_node_id` becomes `pub` so the check can be asserted from `bins/ghost-pool`.

## Tests

Both were **mutation-checked** rather than assumed. With the filter removed, `get_random_peers_skips_bootstrap_placeholders` fails on:

```
a bootstrap placeholder must never be selected as a verification target
```

`test_bootstrap_placeholder_is_recognised_and_real_peers_are_not` also pins the observed byte shape directly, so a future change to the derivation cannot silently stop matching what is already in the ledger, and asserts that an empty address is **not** classified as a placeholder — a blanket `true` there would quietly drop real peers from selection.

## Acceptance test after deploy

Restart a node and confirm no new phantom rows appear within the first ~2 minutes. That window is where every one of them has been produced.

Found while investigating #616, which turned out to have an unrelated cause and is now closed.
