### PR TITLE
fix(deploy): point at a command that exists when there is no test record

### DIFF
--- a/scripts/deploy-node.sh
+++ b/scripts/deploy-node.sh
@@ -99,9 +99,19 @@ if echo "$PRODUCTION_NODES" | grep -qw "$NODE"; then
 fi
 
 # 3. Tests must have passed for THIS commit. Not for something near it.
+#
+#    The remedy this used to print — `deploy-node.sh --record-tests` — does not exist and never
+#    did; this script takes `<node> <binary> [--canary]` and nothing else, so following the
+#    instruction produced a usage error. `scripts/record-tests.sh` is what writes the marker.
+#
+#    Worth stating the per-SHA part explicitly, because merging is where it bites: testing a
+#    branch records the BRANCH commit, and the merge commit is a different SHA with a different
+#    tree whenever main has moved underneath it. Two independently-tested branches merged into
+#    main produce a combination neither run covered.
 MARKER="$STATE_DIR/tested-$SHA"
 [ -f "$MARKER" ] || die "no passing test record for $SHORT
-       run: scripts/deploy-node.sh --record-tests   (after a green suite)"
+       run: scripts/record-tests.sh   (records HEAD; re-run it after a merge — the merge
+       commit is a different SHA, and its tree is what actually ships)"
 
 # 3b. The commit must still be what main says, not merely something main once contained.
 #


### PR DESCRIPTION
`deploy-node.sh` refuses to deploy a commit with no test record, and tells you how to fix it:

```
run: scripts/deploy-node.sh --record-tests   (after a green suite)
```

That command does not exist and never did. The script takes `<node> <binary> [--canary]` and nothing else, so following its own instruction produces:

```
REFUSED: usage: deploy-node.sh <node> <binary> [--canary]
```

The real mechanism is `scripts/record-tests.sh`, which runs the gates and, only if they all pass, records the current `HEAD` as deployable.

Verified in both directions: the old suggestion errors, and the new one names a script that exists, is executable, and is what actually writes the marker.

The message now also states the per-SHA part out loud, because that is where it bites. The record is keyed by the full commit sha, so a branch tested before merging does **not** carry over to the merge commit — which is the point of the gate, but is easy to misread as a bug when a suite you just watched go green still refuses to deploy. It cost a wasted step today.

No behavioural change to the gate itself; this only corrects what it tells you to do.
