### PR TITLE
fix(#621): warn once per cooldown, not once per vote, on quorum-without-proposal

### DIFF
--- a/crates/ghost-consensus/src/nullifier_route_handler.rs
+++ b/crates/ghost-consensus/src/nullifier_route_handler.rs
@@ -1287,19 +1287,33 @@ impl NullifierRouteHandler {
             // apply commitments or compute the canonical root, which would cause this
             // node's tree to diverge from nodes that do have the proposal.
             if proposal.is_none() {
-                warn!(
-                    height,
-                    "Checkpoint reached quorum but proposal data missing — requesting tree sync"
-                );
                 // Unmark as finalized so tree sync can replay this height
-                let mut votes = self.votes.write();
-                if let Some(state) = votes.get_mut(&height) {
-                    state.finalized = false;
+                {
+                    let mut votes = self.votes.write();
+                    if let Some(state) = votes.get_mut(&height) {
+                        state.finalized = false;
+                    }
                 }
                 // Self-heal: the proposer that finalized has the checkpoint data.
                 // Request tree sync so we can replay it locally.
-                if let Err(e) = self.request_tree_sync() {
-                    warn!(error = %e, "Failed to request tree sync after quorum-without-proposal");
+                //
+                // #621: warn only when a request actually goes out. A node that cannot
+                // advance hits this path continuously — vm1 and vm4 logged it ~35x/minute
+                // for the same height (743626, 692 times in 20 minutes), which together
+                // with the suppression line was 49% of vm1's total log output. The
+                // condition still deserves a WARN, but once per cooldown, not per vote.
+                match self.request_tree_sync() {
+                    Ok(true) => warn!(
+                        height,
+                        "Checkpoint reached quorum but proposal data missing — requested tree sync"
+                    ),
+                    Ok(false) => debug!(
+                        height,
+                        "Checkpoint reached quorum but proposal data missing — sync already pending"
+                    ),
+                    Err(e) => {
+                        warn!(error = %e, "Failed to request tree sync after quorum-without-proposal")
+                    }
                 }
                 return Ok(false);
             }
@@ -1892,7 +1906,11 @@ impl NullifierRouteHandler {
 
     /// Request tree sync from peers (called on startup or when behind).
     /// Client-side cooldown prevents spamming peers who rate-limit at 60s.
-    pub fn request_tree_sync(&self) -> GhostResult<()> {
+    ///
+    /// Returns `true` if a request was actually broadcast, `false` if the cooldown
+    /// suppressed it. Callers use this to avoid logging once per *attempt* when the
+    /// attempt did nothing — a node that is behind can call this many times a second.
+    pub fn request_tree_sync(&self) -> GhostResult<bool> {
         // Client-side dedup: don't re-request within the cooldown window.
         // Peers rate-limit at SYNC_REQUEST_COOLDOWN_SECS, so sending more
         // often just wastes bandwidth and delays the first accepted response.
@@ -1900,11 +1918,14 @@ impl NullifierRouteHandler {
             let last = self.last_sync_request_sent.read();
             if let Some(last_time) = *last {
                 if last_time.elapsed().as_secs() < SYNC_REQUEST_COOLDOWN_SECS {
-                    info!(
+                    // #621: debug, not info. This says "I correctly did nothing", and on a
+                    // node that cannot advance it fired ~35x/minute — 24% of vm1's entire
+                    // log volume, on a node with the least disk headroom in the fleet.
+                    debug!(
                         remaining_secs = SYNC_REQUEST_COOLDOWN_SECS - last_time.elapsed().as_secs(),
                         "Tree sync request suppressed (client-side cooldown)"
                     );
-                    return Ok(());
+                    return Ok(false);
                 }
             }
         }
@@ -1950,9 +1971,12 @@ impl NullifierRouteHandler {
             broadcast(MessageType::L2TreeSync, payload)?;
             *self.last_sync_request_sent.write() = Some(Instant::now());
             info!(from_height, tip_height, "Requested L2 tree sync from peers");
+            return Ok(true);
         }
 
-        Ok(())
+        // No broadcast function wired up — nothing was sent, so say so rather than
+        // reporting a request that never left the node.
+        Ok(false)
     }
 
     /// Handle note gap request — peer is missing notes after tree sync, respond with
@@ -2797,6 +2821,46 @@ mod tests {
     }
 
     /// Test tree sync request rate limiting
+    #[test]
+    fn test_request_tree_sync_reports_whether_it_actually_sent() {
+        // #621: callers log based on this return value, so "suppressed by cooldown" must be
+        // distinguishable from "sent". Before this, a node that could not advance warned
+        // once per incoming vote — vm1 logged the same height 692 times in 20 minutes,
+        // and the two lines together were 49% of its output.
+        let (_db, _epoch_mgr, handler) = setup();
+
+        let sent = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let counter = sent.clone();
+        handler.set_broadcast_fn(Arc::new(move |_ty, _payload| {
+            counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok(())
+        }));
+
+        assert!(
+            handler.request_tree_sync().unwrap(),
+            "the first request must report that it was sent"
+        );
+        assert_eq!(
+            sent.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "exactly one broadcast so far"
+        );
+
+        // Every subsequent call inside the cooldown must report false AND must not
+        // broadcast. Looping proves the caller can hammer it without either effect.
+        for i in 0..25 {
+            assert!(
+                !handler.request_tree_sync().unwrap(),
+                "call {i} within the cooldown must report suppressed"
+            );
+        }
+        assert_eq!(
+            sent.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "25 further calls must not put another request on the wire"
+        );
+    }
+
     #[test]
     fn test_tree_sync_request_rate_limiting() {
         let (_db, _epoch_mgr, handler) = setup();

--- a/scripts/record-tests.sh
+++ b/scripts/record-tests.sh
@@ -118,6 +118,33 @@ if grep -qE "FAILED" <<<"$test_out"; then
     exit 1
 fi
 
+# Feature-gated consensus modules. `--lib --bins` above does NOT compile these, because
+# ghost-consensus has `default = []` and gates two modules behind features:
+#
+#   #[cfg(feature = "zk-consensus")]  pub mod nullifier_route_handler;   <- L2 tree sync
+#   #[cfg(feature = "mpc-ceremony")]  pub mod mpc_handler;
+#
+# Without them the run reports ~286 tests while ~71 more are not even compiled — including
+# every test for the L2 tree-sync and nullifier-routing code that is live on all 8 production
+# nodes. CI has run these since #530; this gate did not, so a commit could fail CI's
+# feature-gated job and still be recorded here as deployable. Mirrors ci.yml exactly.
+#
+# NOT `--all-features`, deliberately, for the same reasons ci.yml gives: that would also enable
+# ghost-verification's `allow-insecure` (changing what the security tests assert) and
+# `zk-production` (which needs trusted-setup params).
+echo "==> tests (feature-gated consensus modules)"
+feat_out="$(cargo test -p ghost-consensus --lib --features zk-consensus,mpc-ceremony 2>&1)" || {
+    echo "$feat_out" | grep -E "FAILED|^error|panicked at|assertion|left ==|right ==|left:|right:" \
+        | head -40 >&2
+    echo "FAILED: feature-gated consensus tests" >&2; exit 1; }
+grep -E "^test result" <<<"$feat_out" | tail -2
+if grep -qE "FAILED" <<<"$feat_out"; then
+    echo "$feat_out" | grep -E "FAILED|panicked at|assertion|left ==|right ==|left:|right:" \
+        | head -40 >&2
+    echo "FAILED: feature-gated consensus test failures" >&2
+    exit 1
+fi
+
 SHA="$(git rev-parse HEAD)"
 date +%s > "${STATE_DIR}/tested-${SHA}"
 echo "OK: recorded $(git rev-parse --short HEAD) as tested — deploy-node.sh will now accept it"


### PR DESCRIPTION
Addresses the log-volume half of #621. **It does not fix the underlying stall** — vm1 and vm4 still cannot advance past L2 height 743426. This stops that condition flooding the journal while it is diagnosed.

## The problem

A node that cannot advance hits the C-7 "reached quorum but no proposal data" path on **every incoming vote**. Measured on vm1: the same height (743626) logged **692 times in 20 minutes**, and together with the matching cooldown line these two messages were **49% of the node's entire log output** — on the node with the least disk headroom in the fleet (84%, 13G free).

```
385  Tree sync request suppressed (client-side cooldown) remaining_secs=<n>
336  Checkpoint reached quorum but proposal data missing — requesting tree sync height=743626
```

Neither line said anything new after the first one. The suppression line in particular reports that the function *correctly did nothing*.

## The change

`request_tree_sync` now returns whether a request actually went out, so callers can tell "asked a peer" from "the cooldown swallowed it":

- the suppression line drops from `info!` to `debug!`
- the C-7 warning fires only when a request is genuinely broadcast, and drops to `debug!` when one is already pending

The condition still warns — **once per 60 s cooldown instead of once per vote** — so a genuinely stuck node stays visible. That is the property worth keeping: this should get quieter, not silent.

All seven existing call sites use `let _ =` or `if let Err(e)`, so widening `GhostResult<()>` to `GhostResult<bool>` required no changes at any of them.

## Second, unrelated-looking but found on the way: the deploy gate was weaker than CI

`ghost-consensus` has `default = []` and gates `nullifier_route_handler` behind `zk-consensus`. So `cargo test -p ghost-consensus` compiles **286** tests while **71 more are not built at all** — every test for the L2 tree-sync and nullifier-routing code that runs on all 8 production nodes.

`ci.yml` has covered this since #530 with an explicit `--features zk-consensus,mpc-ceremony` job. **`record-tests.sh` did not**, so a commit could fail CI's feature-gated job and still be recorded locally as deployable — and `deploy-node.sh` trusts that record. This PR adds the same run to the gate, matching ci.yml's feature list exactly (deliberately not `--all-features`, for the reasons ci.yml already documents).

I noticed this because my new test silently did not run: `cargo test` reported `0 passed` while the test was plainly in the file.

Full suite with the features enabled: **357 passed, 0 failed**.

## Tests

Mutation-checked. Making the cooldown branch return `Ok(true)` — i.e. claiming it sent when it did not — fails:

```
test_request_tree_sync_reports_whether_it_actually_sent
```

The test also asserts that 25 further calls inside the cooldown put nothing on the wire, so the change cannot quietly turn the cooldown itself off.
