### PR TITLE
feat(discovery): land the signed mesh node-list checkpoint + miner shim (#599)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3366,6 +3366,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghost-miner-proxy"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "ghost-common",
+ "ghost-consensus",
+ "hex",
+ "reqwest 0.12.28",
+ "rustls",
+ "serde",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "ghost-mpc"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,8 @@ members = [
     "bins/ghost-gsp",
     # Wraith coordinator (Wraith Lite v1, single-round atomic CoinJoin)
     "bins/wraith-coordinator",
-    # Registry service for load balancing
+    # Decentralised mining-discovery shim (miner-side; verifies the signed node-list checkpoint)
+    "bins/ghost-miner-proxy",
     # Headless setup CLI
     "bins/ghost-setup",
     # Mobile Apps

--- a/bins/ghost-miner-proxy/Cargo.toml
+++ b/bins/ghost-miner-proxy/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "ghost-miner-proxy"
+version = "0.1.0"
+edition = "2021"
+description = "Decentralised mining discovery shim — verifies the signed Ghost node-list checkpoint and stratum-proxies a miner to a live pool node"
+license = "MIT"
+repository = "https://github.com/bitcoin-ghost"
+
+[[bin]]
+name = "ghost-miner-proxy"
+path = "src/main.rs"
+doc = false
+
+[dependencies]
+# Workspace crates: the checkpoint wire types + hashes, and the signature primitive.
+ghost-consensus = { path = "../../crates/ghost-consensus" }
+ghost-common = { path = "../../crates/ghost-common" }
+
+# Async runtime + networking (TCP proxy).
+tokio = { version = "1.0", features = ["full"] }
+
+# HTTP client to fetch the signed checkpoint, and its TLS provider.
+reqwest = { workspace = true }
+rustls = { workspace = true }
+
+# CLI
+clap = { version = "4.0", features = ["derive"] }
+
+# (de)serialisation of the checkpoint blob (reqwest handles the JSON transport itself)
+serde = { version = "1.0", features = ["derive"] }
+hex = "0.4"
+
+# Errors + logging
+anyhow = "1.0"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/bins/ghost-miner-proxy/src/checkpoint.rs
+++ b/bins/ghost-miner-proxy/src/checkpoint.rs
@@ -1,0 +1,415 @@
+//! Verify a signed Ghost node-list checkpoint against a trusted signer set, and advance the
+//! trusted set along the signed forward chain.
+//!
+//! This is the security core of the shim. It performs the SAME checks a pool node's
+//! `apply_synced_checkpoint` does, but rooted in the shim's OWN trusted signer set — the
+//! baked-in genesis MPC elders, advanced by verified deltas — rather than a node's live voter
+//! set. So a miner discovers pool nodes without trusting DNS, the website, or the serving node:
+//! only a ≥67% supermajority of the already-trusted signers can move the set forward or attest
+//! a node list.
+
+use std::collections::HashSet;
+
+use anyhow::{bail, Context, Result};
+
+use ghost_common::identity::verify_signature;
+use ghost_common::types::NodeId;
+use ghost_consensus::{
+    mesh_node_list_root, mesh_signer_set_root, MeshNodeEntry, MeshNodeListCheckpointMessage,
+    MeshNodeListCheckpointVoteMessage, SignerSetDelta,
+};
+
+const BFT_THRESHOLD_PERCENT: u64 = 67;
+
+/// Approvals required: ceil of 67% of `n` trusted signers.
+fn quorum_for(n: usize) -> usize {
+    (n as u64 * BFT_THRESHOLD_PERCENT).div_ceil(100) as usize
+}
+
+/// The signed checkpoint blob as served by `GET /api/v1/pool/mesh-node-list-checkpoint`.
+#[derive(Debug, Clone, serde::Deserialize)]
+pub(crate) struct CheckpointBlob {
+    pub height: u64,
+    pub cutoff_ts: i64,
+    pub nodes: Vec<BlobNode>,
+    pub list_root: String,
+    pub signer_set_root: String,
+    #[serde(default)]
+    pub signer_set_delta: BlobDelta,
+    pub active_node_count: u32,
+    pub proposer: String,
+    pub proposer_signature: String,
+    #[serde(default)]
+    pub approvals: Vec<BlobApproval>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+pub(crate) struct BlobNode {
+    pub node_id: String,
+    pub host: String,
+    pub sv1_port: u16,
+    pub sv2_port: u16,
+}
+
+#[derive(Debug, Clone, Default, serde::Deserialize)]
+pub(crate) struct BlobDelta {
+    #[serde(default)]
+    pub added: Vec<String>,
+    #[serde(default)]
+    pub removed: Vec<String>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+pub(crate) struct BlobApproval {
+    pub voter: String,
+    pub signature: String,
+}
+
+/// A verified pool node a miner can be routed to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct VerifiedNode {
+    pub host: String,
+    pub sv1_port: u16,
+    pub sv2_port: u16,
+}
+
+fn hex32(s: &str) -> Result<[u8; 32]> {
+    let b = hex::decode(s).context("invalid hex")?;
+    if b.len() != 32 {
+        bail!("expected 32 bytes, got {}", b.len());
+    }
+    let mut a = [0u8; 32];
+    a.copy_from_slice(&b);
+    Ok(a)
+}
+
+fn hex64(s: &str) -> Result<[u8; 64]> {
+    let b = hex::decode(s).context("invalid hex")?;
+    if b.len() != 64 {
+        bail!("expected 64 bytes, got {}", b.len());
+    }
+    let mut a = [0u8; 64];
+    a.copy_from_slice(&b);
+    Ok(a)
+}
+
+/// Verify `blob` against `trusted` (the shim's current trusted signer set) and, on success,
+/// ADVANCE `trusted` to the checkpoint's signer set and return the verified node list.
+///
+/// All of these must hold:
+/// 1. `list_root == mesh_node_list_root(nodes)` — the node list matches its declared root.
+/// 2. The proposer is a member of the trusted set and its signature over the checkpoint hash
+///    verifies.
+/// 3. At least 67% of the TRUSTED (prior) set signed an approve-vote over the checkpoint hash
+///    (decision C: a delta/list is attested by a supermajority of the already-trusted signers,
+///    so an attacker cannot inject signers and self-certify).
+/// 4. Applying the signed delta to the trusted set yields a set whose root equals the signed
+///    `signer_set_root`.
+///
+/// On success `trusted` becomes that new set. On any failure `trusted` is left unchanged.
+pub(crate) fn verify_and_advance(
+    blob: &CheckpointBlob,
+    trusted: &mut Vec<NodeId>,
+) -> Result<Vec<VerifiedNode>> {
+    let trusted_set: HashSet<NodeId> = trusted.iter().copied().collect();
+    if trusted_set.is_empty() {
+        bail!("empty trusted signer set (need a genesis anchor)");
+    }
+
+    // (1) Node list ↔ list_root.
+    let entries: Vec<MeshNodeEntry> = blob
+        .nodes
+        .iter()
+        .map(|n| {
+            Ok(MeshNodeEntry {
+                node_id: hex32(&n.node_id)?,
+                host: n.host.clone(),
+                sv1_port: n.sv1_port,
+                sv2_port: n.sv2_port,
+            })
+        })
+        .collect::<Result<_>>()?;
+    let list_root = hex32(&blob.list_root)?;
+    if mesh_node_list_root(&entries) != list_root {
+        bail!("list_root does not match the node list");
+    }
+
+    // Parse the remaining signed fields and reconstruct the checkpoint hash (timestamp is not
+    // part of it, so 0 is fine).
+    let signer_set_root = hex32(&blob.signer_set_root)?;
+    let added: Vec<NodeId> = blob
+        .signer_set_delta
+        .added
+        .iter()
+        .map(|s| hex32(s))
+        .collect::<Result<_>>()?;
+    let removed: Vec<NodeId> = blob
+        .signer_set_delta
+        .removed
+        .iter()
+        .map(|s| hex32(s))
+        .collect::<Result<_>>()?;
+    let proposer = hex32(&blob.proposer)?;
+    let proposer_signature = hex64(&blob.proposer_signature)?;
+    let msg = MeshNodeListCheckpointMessage {
+        height: blob.height,
+        cutoff_ts: blob.cutoff_ts,
+        nodes: entries.clone(),
+        list_root,
+        signer_set_delta: SignerSetDelta {
+            added: added.clone(),
+            removed: removed.clone(),
+        },
+        signer_set_root,
+        active_node_count: blob.active_node_count,
+        proposer,
+        proposer_signature,
+        timestamp: 0,
+    };
+    let hash = msg.checkpoint_hash();
+
+    // (2) Proposer must be trusted and its signature valid.
+    if !trusted_set.contains(&proposer) {
+        bail!("proposer is not in the trusted signer set");
+    }
+    if !verify_signature(&proposer, &hash, &proposer_signature).unwrap_or(false) {
+        bail!("proposer signature invalid");
+    }
+
+    // (3) ≥67% of the trusted (prior) set signed a valid approve-vote over the hash.
+    let needed = quorum_for(trusted.len());
+    let mut seen = HashSet::new();
+    let mut valid = 0usize;
+    for ap in &blob.approvals {
+        let Ok(voter) = hex32(&ap.voter) else {
+            continue;
+        };
+        if !trusted_set.contains(&voter) || !seen.insert(voter) {
+            continue;
+        }
+        let Ok(sig) = hex64(&ap.signature) else {
+            continue;
+        };
+        let vote = MeshNodeListCheckpointVoteMessage {
+            height: blob.height,
+            checkpoint_hash: hash,
+            voter,
+            approve: true,
+            signature: sig,
+            timestamp: 0,
+        };
+        if verify_signature(&voter, &vote.signing_message(), &sig).unwrap_or(false) {
+            valid += 1;
+        }
+    }
+    if valid < needed {
+        bail!("insufficient quorum: {valid}/{needed} of the trusted signer set approved");
+    }
+
+    // (4) Applying the delta must yield the signed signer-set root.
+    let mut new_set = trusted_set.clone();
+    for r in &removed {
+        new_set.remove(r);
+    }
+    for a in &added {
+        new_set.insert(*a);
+    }
+    let mut new_vec: Vec<NodeId> = new_set.into_iter().collect();
+    new_vec.sort_unstable();
+    if mesh_signer_set_root(&new_vec) != signer_set_root {
+        bail!("signer_set_root does not match the applied delta");
+    }
+
+    // Adopt.
+    *trusted = new_vec;
+    Ok(entries
+        .into_iter()
+        .map(|e| VerifiedNode {
+            host: e.host,
+            sv1_port: e.sv1_port,
+            sv2_port: e.sv2_port,
+        })
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ghost_common::identity::NodeIdentity;
+
+    fn entry(id: u8, host: &str) -> MeshNodeEntry {
+        MeshNodeEntry {
+            node_id: [id; 32],
+            host: host.into(),
+            sv1_port: 3333,
+            sv2_port: 34255,
+        }
+    }
+
+    /// Build a valid signed blob. `signers` = identities of the PRIOR trusted set (the voters);
+    /// `new_signer_set` = the resulting signer set (delta computed prior→new). Proposer =
+    /// `prior[height % n]`; every signer casts an approve vote.
+    fn build_blob(
+        signers: &[NodeIdentity],
+        nodes: &[MeshNodeEntry],
+        new_signer_set: &[NodeId],
+        height: u64,
+    ) -> CheckpointBlob {
+        let mut prior: Vec<NodeId> = signers.iter().map(|i| i.node_id()).collect();
+        prior.sort_unstable();
+        let prior_set: HashSet<NodeId> = prior.iter().copied().collect();
+        let new_set: HashSet<NodeId> = new_signer_set.iter().copied().collect();
+        let mut added: Vec<NodeId> = new_set.difference(&prior_set).copied().collect();
+        let mut removed: Vec<NodeId> = prior_set.difference(&new_set).copied().collect();
+        added.sort_unstable();
+        removed.sort_unstable();
+
+        let list_root = mesh_node_list_root(nodes);
+        let signer_set_root = mesh_signer_set_root(new_signer_set);
+        let proposer_id = prior[(height as usize) % prior.len()];
+        let msg = MeshNodeListCheckpointMessage {
+            height,
+            cutoff_ts: 1_784_000_000,
+            nodes: nodes.to_vec(),
+            list_root,
+            signer_set_delta: SignerSetDelta {
+                added: added.clone(),
+                removed: removed.clone(),
+            },
+            signer_set_root,
+            active_node_count: prior.len() as u32,
+            proposer: proposer_id,
+            proposer_signature: [0u8; 64],
+            timestamp: 0,
+        };
+        let hash = msg.checkpoint_hash();
+        let proposer_ident = signers.iter().find(|i| i.node_id() == proposer_id).unwrap();
+        let proposer_sig = proposer_ident.sign(&hash);
+        let approvals: Vec<BlobApproval> = signers
+            .iter()
+            .map(|i| {
+                let vote = MeshNodeListCheckpointVoteMessage {
+                    height,
+                    checkpoint_hash: hash,
+                    voter: i.node_id(),
+                    approve: true,
+                    signature: [0u8; 64],
+                    timestamp: 0,
+                };
+                BlobApproval {
+                    voter: hex::encode(i.node_id()),
+                    signature: hex::encode(i.sign(&vote.signing_message())),
+                }
+            })
+            .collect();
+        CheckpointBlob {
+            height,
+            cutoff_ts: 1_784_000_000,
+            nodes: nodes
+                .iter()
+                .map(|e| BlobNode {
+                    node_id: hex::encode(e.node_id),
+                    host: e.host.clone(),
+                    sv1_port: e.sv1_port,
+                    sv2_port: e.sv2_port,
+                })
+                .collect(),
+            list_root: hex::encode(list_root),
+            signer_set_root: hex::encode(signer_set_root),
+            signer_set_delta: BlobDelta {
+                added: added.iter().map(hex::encode).collect(),
+                removed: removed.iter().map(hex::encode).collect(),
+            },
+            active_node_count: prior.len() as u32,
+            proposer: hex::encode(proposer_id),
+            proposer_signature: hex::encode(proposer_sig),
+            approvals,
+        }
+    }
+
+    fn signer_ids(signers: &[NodeIdentity]) -> Vec<NodeId> {
+        let mut v: Vec<NodeId> = signers.iter().map(|i| i.node_id()).collect();
+        v.sort_unstable();
+        v
+    }
+
+    #[test]
+    fn valid_checkpoint_verifies_and_returns_nodes() {
+        let signers: Vec<NodeIdentity> = (0..4).map(|_| NodeIdentity::generate()).collect();
+        let trusted = signer_ids(&signers);
+        let nodes = vec![entry(200, "203.0.113.1"), entry(201, "203.0.113.2")];
+        let blob = build_blob(&signers, &nodes, &trusted, 100);
+        let mut t = trusted.clone();
+        let out = verify_and_advance(&blob, &mut t).expect("valid");
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0].host, "203.0.113.1");
+        assert_eq!(out[0].sv1_port, 3333);
+        assert_eq!(t, trusted, "stable signer set unchanged");
+    }
+
+    #[test]
+    fn membership_change_advances_trusted_set() {
+        let signers: Vec<NodeIdentity> = (0..4).map(|_| NodeIdentity::generate()).collect();
+        let prior = signer_ids(&signers);
+        let newcomer = [42u8; 32];
+        let mut new_set = prior.clone();
+        new_set.push(newcomer);
+        new_set.sort_unstable();
+        let nodes = vec![entry(200, "h")];
+        let blob = build_blob(&signers, &nodes, &new_set, 100);
+        let mut trusted = prior.clone();
+        verify_and_advance(&blob, &mut trusted).expect("valid membership change");
+        assert!(
+            trusted.contains(&newcomer),
+            "trusted advanced to include newcomer"
+        );
+        assert_eq!(trusted.len(), 5);
+    }
+
+    #[test]
+    fn tampered_proposer_signature_rejected() {
+        let signers: Vec<NodeIdentity> = (0..4).map(|_| NodeIdentity::generate()).collect();
+        let trusted = signer_ids(&signers);
+        let nodes = vec![entry(200, "h")];
+        let mut blob = build_blob(&signers, &nodes, &trusted, 100);
+        let mut sig = hex::decode(&blob.proposer_signature).unwrap();
+        sig[0] ^= 0xff;
+        blob.proposer_signature = hex::encode(sig);
+        let mut t = trusted.clone();
+        assert!(verify_and_advance(&blob, &mut t).is_err());
+        assert_eq!(t, trusted, "trusted untouched on failure");
+    }
+
+    #[test]
+    fn sub_quorum_rejected() {
+        let signers: Vec<NodeIdentity> = (0..4).map(|_| NodeIdentity::generate()).collect();
+        let trusted = signer_ids(&signers);
+        let nodes = vec![entry(200, "h")];
+        let mut blob = build_blob(&signers, &nodes, &trusted, 100);
+        blob.approvals.truncate(2); // 2 < quorum(4) = 3
+        assert!(verify_and_advance(&blob, &mut trusted.clone()).is_err());
+    }
+
+    #[test]
+    fn wrong_list_root_rejected() {
+        let signers: Vec<NodeIdentity> = (0..4).map(|_| NodeIdentity::generate()).collect();
+        let trusted = signer_ids(&signers);
+        let nodes = vec![entry(200, "h")];
+        let mut blob = build_blob(&signers, &nodes, &trusted, 100);
+        blob.list_root = hex::encode([9u8; 32]);
+        assert!(verify_and_advance(&blob, &mut trusted.clone()).is_err());
+    }
+
+    #[test]
+    fn outsider_signed_checkpoint_rejected() {
+        // A checkpoint signed entirely by NON-trusted keys must be rejected: the proposer isn't
+        // trusted and none of the approvals count, so an attacker can't self-certify a node list.
+        let real: Vec<NodeIdentity> = (0..4).map(|_| NodeIdentity::generate()).collect();
+        let trusted = signer_ids(&real);
+        let attackers: Vec<NodeIdentity> = (0..4).map(|_| NodeIdentity::generate()).collect();
+        let atk_set = signer_ids(&attackers);
+        let nodes = vec![entry(200, "evil.example")];
+        let blob = build_blob(&attackers, &nodes, &atk_set, 100);
+        assert!(verify_and_advance(&blob, &mut trusted.clone()).is_err());
+    }
+}

--- a/bins/ghost-miner-proxy/src/main.rs
+++ b/bins/ghost-miner-proxy/src/main.rs
@@ -1,0 +1,252 @@
+//! ghost-miner-proxy — a decentralised mining-discovery shim.
+//!
+//! Point your ASIC/Bitaxe at this proxy instead of a DNS name. It fetches the BFT-signed Ghost
+//! node-list checkpoint, verifies it offline against a baked-in genesis signer set (advancing
+//! that set along the signed forward chain), and transparently stratum-proxies your miner to a
+//! live pool node — failing over to another node if one is down. After the first fetch it needs
+//! neither DNS nor the website: any one node serves the whole verifiable list.
+//!
+//! DISCOVERY, NOT CONSENSUS: this is a pure client. It never signs or votes; it only verifies.
+
+mod checkpoint;
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use anyhow::{bail, Context, Result};
+use clap::Parser;
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::RwLock;
+use tracing::{info, warn};
+
+use ghost_common::types::NodeId;
+
+use checkpoint::{verify_and_advance, CheckpointBlob, VerifiedNode};
+
+const ENDPOINT_PATH: &str = "/api/v1/pool/mesh-node-list-checkpoint";
+
+#[derive(Parser, Clone)]
+#[command(
+    name = "ghost-miner-proxy",
+    about = "Decentralised mining discovery: verify the signed Ghost node list and proxy your miner to a live pool node"
+)]
+struct Args {
+    /// Address to listen on for the miner — point your ASIC/Bitaxe here.
+    #[arg(long, default_value = "127.0.0.1:3333")]
+    listen: String,
+
+    /// Checkpoint endpoint seed(s) (repeatable). The endpoint path is appended automatically,
+    /// e.g. `--seed https://pool.bitcoinghost.org` or `--seed http://203.0.113.7:8080`.
+    /// After the first successful fetch, any verified node also serves as a seed.
+    #[arg(long = "seed", required = true)]
+    seeds: Vec<String>,
+
+    /// Genesis signer set: comma-separated hex node ids (the MPC elders) — the root of trust.
+    #[arg(long)]
+    genesis_signers: Option<String>,
+
+    /// File with one hex node id per line (`#` comments allowed): the genesis signer set.
+    #[arg(long)]
+    genesis_file: Option<std::path::PathBuf>,
+
+    /// Proxy to the Stratum V2 port instead of V1.
+    #[arg(long)]
+    sv2: bool,
+
+    /// Seconds between checkpoint refreshes (min 15).
+    #[arg(long, default_value_t = 300)]
+    refresh_secs: u64,
+}
+
+/// The shim's live, verified view.
+struct PoolState {
+    nodes: Vec<VerifiedNode>,
+    trusted: Vec<NodeId>,
+    rr: AtomicUsize,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
+    // reqwest's rustls-tls backend needs a process-wide crypto provider installed.
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
+    let args = Args::parse();
+    let genesis = load_genesis(&args)?;
+    info!(
+        signers = genesis.len(),
+        "loaded genesis signer set (root of trust)"
+    );
+
+    let state = Arc::new(RwLock::new(PoolState {
+        nodes: Vec::new(),
+        trusted: genesis,
+        rr: AtomicUsize::new(0),
+    }));
+
+    // Best-effort initial fetch so we can route immediately; otherwise the background loop fills
+    // it in shortly.
+    if let Err(e) = refresh(&args, &state).await {
+        warn!(error = %e, "initial checkpoint fetch failed — retrying in the background");
+    }
+
+    // Background refresh: node lists change often (nodes join/leave), signer sets rarely.
+    {
+        let args = args.clone();
+        let state = Arc::clone(&state);
+        tokio::spawn(async move {
+            let mut iv =
+                tokio::time::interval(std::time::Duration::from_secs(args.refresh_secs.max(15)));
+            iv.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            loop {
+                iv.tick().await;
+                if let Err(e) = refresh(&args, &state).await {
+                    warn!(error = %e, "checkpoint refresh failed (keeping last verified list)");
+                }
+            }
+        });
+    }
+
+    let listener = TcpListener::bind(&args.listen)
+        .await
+        .with_context(|| format!("binding {}", args.listen))?;
+    info!(listen = %args.listen, sv2 = args.sv2, "listening — point your miner here");
+    loop {
+        let (inbound, peer) = match listener.accept().await {
+            Ok(x) => x,
+            Err(e) => {
+                warn!(error = %e, "accept failed");
+                continue;
+            }
+        };
+        let state = Arc::clone(&state);
+        let sv2 = args.sv2;
+        tokio::spawn(async move {
+            if let Err(e) = handle_conn(inbound, sv2, &state).await {
+                warn!(peer = %peer, error = %e, "miner connection ended");
+            }
+        });
+    }
+}
+
+/// Fetch the latest signed checkpoint from a seed, verify it, and update the live view. The
+/// seed list is the configured seeds plus every currently-verified node (so DNS/the site are
+/// only ever needed for the very first fetch).
+async fn refresh(args: &Args, state: &Arc<RwLock<PoolState>>) -> Result<()> {
+    // Snapshot trusted set + build the candidate seed list (configured + known nodes).
+    let (mut trusted, mut urls) = {
+        let s = state.read().await;
+        let mut urls: Vec<String> = args.seeds.clone();
+        for n in &s.nodes {
+            // Verified nodes serve the same endpoint on their HTTP port (8080).
+            urls.push(format!("http://{}:8080", n.host));
+        }
+        (s.trusted.clone(), urls)
+    };
+    urls.dedup();
+
+    let blob = fetch_blob(&urls).await?;
+    let nodes = verify_and_advance(&blob, &mut trusted)?;
+    let mut s = state.write().await;
+    s.nodes = nodes;
+    s.trusted = trusted;
+    info!(
+        nodes = s.nodes.len(),
+        height = blob.height,
+        "checkpoint verified and applied"
+    );
+    Ok(())
+}
+
+/// Try each seed URL until one returns a parseable checkpoint blob.
+async fn fetch_blob(seeds: &[String]) -> Result<CheckpointBlob> {
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()?;
+    let mut last_err = None;
+    for seed in seeds {
+        let url = format!("{}{}", seed.trim_end_matches('/'), ENDPOINT_PATH);
+        match client.get(&url).send().await {
+            Ok(resp) if resp.status().is_success() => match resp.json::<CheckpointBlob>().await {
+                Ok(b) => return Ok(b),
+                Err(e) => last_err = Some(anyhow::anyhow!("parse {url}: {e}")),
+            },
+            Ok(resp) => last_err = Some(anyhow::anyhow!("{url}: HTTP {}", resp.status())),
+            Err(e) => last_err = Some(anyhow::anyhow!("{url}: {e}")),
+        }
+    }
+    Err(last_err.unwrap_or_else(|| anyhow::anyhow!("no seeds configured")))
+}
+
+/// Route one miner connection to a verified node, round-robin, failing over to the next node on
+/// a connection error. Transparent byte proxy — the miner's Stratum session terminates on the node.
+async fn handle_conn(
+    mut inbound: TcpStream,
+    sv2: bool,
+    state: &Arc<RwLock<PoolState>>,
+) -> Result<()> {
+    let candidates: Vec<VerifiedNode> = {
+        let s = state.read().await;
+        let n = s.nodes.len();
+        if n == 0 {
+            bail!("no verified nodes yet — waiting on the first checkpoint");
+        }
+        let start = s.rr.fetch_add(1, Ordering::Relaxed);
+        (0..n).map(|i| s.nodes[(start + i) % n].clone()).collect()
+    };
+
+    for node in candidates {
+        let port = if sv2 { node.sv2_port } else { node.sv1_port };
+        let addr = format!("{}:{}", node.host, port);
+        match TcpStream::connect(&addr).await {
+            Ok(mut outbound) => {
+                info!(upstream = %addr, "routing miner");
+                let _ = tokio::io::copy_bidirectional(&mut inbound, &mut outbound).await;
+                return Ok(());
+            }
+            Err(e) => warn!(upstream = %addr, error = %e, "node unreachable — trying next"),
+        }
+    }
+    bail!("all verified nodes unreachable")
+}
+
+/// Parse the genesis signer set from `--genesis-signers` and/or `--genesis-file` into a sorted,
+/// de-duplicated set of 32-byte node ids.
+fn load_genesis(args: &Args) -> Result<Vec<NodeId>> {
+    let mut raw: Vec<String> = Vec::new();
+    if let Some(s) = &args.genesis_signers {
+        raw.extend(
+            s.split(',')
+                .map(|p| p.trim().to_string())
+                .filter(|p| !p.is_empty()),
+        );
+    }
+    if let Some(path) = &args.genesis_file {
+        let text =
+            std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+        raw.extend(
+            text.lines()
+                .map(|l| l.trim().to_string())
+                .filter(|l| !l.is_empty() && !l.starts_with('#')),
+        );
+    }
+    if raw.is_empty() {
+        bail!("provide --genesis-signers or --genesis-file (the MPC elder node ids = the root of trust)");
+    }
+    let mut set = std::collections::BTreeSet::new();
+    for h in raw {
+        let b = hex::decode(&h).with_context(|| format!("invalid hex node id: {h}"))?;
+        if b.len() != 32 {
+            bail!("node id must be 32 bytes: {h}");
+        }
+        let mut id = [0u8; 32];
+        id.copy_from_slice(&b);
+        set.insert(id);
+    }
+    Ok(set.into_iter().collect())
+}

--- a/bins/ghost-pool/src/lib.rs
+++ b/bins/ghost-pool/src/lib.rs
@@ -57,6 +57,10 @@ pub mod payout;
 /// pure function of).
 pub mod payout_checkpoint;
 
+/// Mesh node-list checkpoint finalisation (signed public-mining node set for
+/// decentralised mining discovery). Dormant until `MESH_NODE_LIST_CHECKPOINT_HEIGHT`.
+pub mod mesh_node_checkpoint;
+
 /// Chain reorganization detection and recovery.
 pub mod reorg;
 
@@ -381,6 +385,13 @@ pub const CHALLENGER_ASSIGNMENT_SEED_LAG: u64 = ghost_verification::challenger_a
 /// the prior binary (`.bak`) = instant disarm.
 pub const ACTIVE_VOTER_SET_HEIGHT: u64 = 959_200;
 
+/// Mesh node-list checkpoint (decentralised mining discovery, v2). At and above this height,
+/// nodes propose/vote/finalise a BFT-signed snapshot of the public-mining node set that an
+/// untrusted miner-side shim can verify offline (see tasks/design_mesh_node_list_checkpoint.md).
+/// DORMANT (`u64::MAX`): below it nothing is proposed, so the binary is behaviour-neutral. Built
+/// dormant — a concrete height is set only after fleet-wide convergence is proven, like the rest.
+pub const MESH_NODE_LIST_CHECKPOINT_HEIGHT: u64 = u64::MAX;
+
 /// Activation heights, resolved once at startup.
 ///
 /// A regtest chain is ~100 blocks tall, so every mainnet gate is dormant there and a regtest
@@ -407,6 +418,7 @@ mod gates {
     pub(super) static ACTIVE_VOTER_SET: OnceLock<u64> = OnceLock::new();
     pub(super) static SHARE_ADDR_BIND: OnceLock<u64> = OnceLock::new();
     pub(super) static OBSERVED_SETTLEMENT: OnceLock<u64> = OnceLock::new();
+    pub(super) static MESH_NODE_LIST_CHECKPOINT: OnceLock<u64> = OnceLock::new();
 
     pub(super) fn from_env(var: &str, network: &BitcoinNetwork, default: u64) -> u64 {
         if matches!(network, BitcoinNetwork::Mainnet) {
@@ -476,6 +488,11 @@ pub fn init_activation_heights(network: &ghost_common::config::BitcoinNetwork) {
         network,
         ARCHIVE_TX_PROOF_HEIGHT,
     );
+    let mesh_node_list_checkpoint = gates::from_env(
+        "GHOST_MESH_NODE_LIST_CHECKPOINT_HEIGHT",
+        network,
+        MESH_NODE_LIST_CHECKPOINT_HEIGHT,
+    );
     let _ = gates::CLUSTER_ENFORCEMENT.set(enforcement);
     let _ = gates::COINBASE_FEE_SPLIT.set(fee);
     let _ = gates::VOTER_SET_QUALIFICATION.set(voter_set);
@@ -487,6 +504,7 @@ pub fn init_activation_heights(network: &ghost_common::config::BitcoinNetwork) {
     let _ = gates::PAYOUT_MEDIAN_ADOPTION.set(payout_median);
     let _ = gates::STRATUM_HANDSHAKE_PROOF.set(stratum_proof);
     let _ = gates::ARCHIVE_TX_PROOF.set(archive_tx);
+    let _ = gates::MESH_NODE_LIST_CHECKPOINT.set(mesh_node_list_checkpoint);
 
     if enforcement != CLUSTER_ENFORCEMENT_HEIGHT
         || fee != COINBASE_FEE_SPLIT_HEIGHT
@@ -496,6 +514,7 @@ pub fn init_activation_heights(network: &ghost_common::config::BitcoinNetwork) {
         || active_voter_set != ACTIVE_VOTER_SET_HEIGHT
         || share_addr_bind != SHARE_ADDR_BIND_HEIGHT
         || observed_settlement != OBSERVED_SETTLEMENT_HEIGHT
+        || mesh_node_list_checkpoint != MESH_NODE_LIST_CHECKPOINT_HEIGHT
     {
         tracing::warn!(
             cluster_enforcement_height = enforcement,
@@ -506,6 +525,7 @@ pub fn init_activation_heights(network: &ghost_common::config::BitcoinNetwork) {
             active_voter_set_height = active_voter_set,
             share_addr_bind_height = share_addr_bind,
             observed_settlement_height = observed_settlement,
+            mesh_node_list_checkpoint_height = mesh_node_list_checkpoint,
             network = ?network,
             "Activation heights OVERRIDDEN from the environment — non-mainnet only"
         );
@@ -592,6 +612,12 @@ pub fn binds_payout_address(height: u64) -> bool {
 /// doc deliberately does not restate the value, so it cannot go stale when the gate moves.
 pub fn active_voter_set_height() -> u64 {
     *gates::ACTIVE_VOTER_SET.get_or_init(|| ACTIVE_VOTER_SET_HEIGHT)
+}
+
+/// The height at/above which nodes propose+finalise the signed mesh node-list checkpoint for
+/// decentralised mining discovery. DORMANT (`u64::MAX`) — behaviour-neutral until armed.
+pub fn mesh_node_list_checkpoint_height() -> u64 {
+    *gates::MESH_NODE_LIST_CHECKPOINT.get_or_init(|| MESH_NODE_LIST_CHECKPOINT_HEIGHT)
 }
 
 /// GhostGlyph P2P handler for visual identity registration.

--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -645,7 +645,7 @@ struct Args {
     #[arg(long)]
     genesis_password: Option<String>,
 
-    /// Show node status in load balancer and exit
+    /// Show what this node can establish about itself, and exit
     #[arg(long)]
     status: bool,
 
@@ -3560,7 +3560,7 @@ async fn main() -> Result<()> {
             compute_ledger_root_fn,
         )
         .with_diag(compute_ledger_root_diag_fn)
-        .with_active_voter_set_fn(active_voter_set_fn),
+        .with_active_voter_set_fn(active_voter_set_fn.clone()),
     );
     mesh.register_handler(Arc::clone(&payout_checkpoint_mgr)
         as Arc<dyn ghost_consensus::mesh::MessageHandler + Send + Sync>);
@@ -3598,6 +3598,124 @@ async fn main() -> Result<()> {
                 // Alarm if that backfill isn't keeping up — a sustained gap means the
                 // fleet is not converging and miners are not being paid (#548).
                 mgr.check_convergence_stall(height);
+            }
+        });
+    }
+
+    // ── Mesh node-list checkpoint (decentralised mining discovery) ────────────────
+    // The same BFT lifecycle as the payout checkpoint, over the PUBLIC-MINING node set:
+    // a signed snapshot a miner-side shim verifies offline to discover pool nodes without
+    // trusting DNS. DORMANT — gated on MESH_NODE_LIST_CHECKPOINT_HEIGHT (u64::MAX today), so
+    // the propose cadence below no-ops until armed. See tasks/design_mesh_node_list_checkpoint.md.
+    let (mnlchk_tx, mut mnlchk_rx) =
+        tokio::sync::mpsc::channel::<(ghost_consensus::MessageType, Vec<u8>)>(256);
+    {
+        let mesh_c = Arc::clone(&mesh);
+        tokio::spawn(async move {
+            while let Some((ty, bytes)) = mnlchk_rx.recv().await {
+                match mesh_c.create_envelope_raw(ty, bytes) {
+                    Ok(env) => {
+                        if let Err(e) = mesh_c.broadcast(env).await {
+                            tracing::debug!(error = %e, "mesh node-list checkpoint broadcast failed");
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(error = %e, "mesh node-list checkpoint envelope failed")
+                    }
+                }
+            }
+        });
+    }
+    let mnlchk_send: ghost_pool::payout_checkpoint::BroadcastFn = {
+        let tx = mnlchk_tx.clone();
+        Arc::new(move |ty, bytes| {
+            tx.try_send((ty, bytes)).map_err(|e| {
+                ghost_common::error::GhostError::P2PMessage(format!(
+                    "mesh-node-checkpoint channel: {e}"
+                ))
+            })
+        })
+    };
+    // compute_nodes: THIS node's view of the public-mining node set (self + connected
+    // public-mining peers), sorted+deduped by node_id. Stratum ports are the fixed
+    // well-known values; the shim appends them. Exact-set agreement means a divergent view
+    // simply doesn't reach quorum that round, so a transient mesh gap self-heals.
+    let compute_nodes_fn: ghost_pool::mesh_node_checkpoint::ComputeNodeListFn = {
+        let mesh_c = Arc::clone(&mesh);
+        let self_id = identity.node_id();
+        let self_addr = config.network.public_address.clone();
+        let self_public = is_public_mining;
+        Arc::new(move |_cutoff_ts, _height| {
+            use ghost_consensus::MeshNodeEntry;
+            const SV1_PORT: u16 = 3333;
+            const SV2_PORT: u16 = 34255;
+            let mut entries: Vec<MeshNodeEntry> = mesh_c
+                .peers()
+                .get_connected_peers(120)
+                .into_iter()
+                .filter(|p| p.capabilities.public_mining && !p.public_address.is_empty())
+                .map(|p| MeshNodeEntry {
+                    node_id: p.node_id,
+                    host: extract_peer_host(&p.public_address).to_string(),
+                    sv1_port: SV1_PORT,
+                    sv2_port: SV2_PORT,
+                })
+                .collect();
+            if self_public {
+                if let Some(addr) = self_addr.as_deref().filter(|a| !a.is_empty()) {
+                    entries.push(MeshNodeEntry {
+                        node_id: self_id,
+                        host: extract_peer_host(addr).to_string(),
+                        sv1_port: SV1_PORT,
+                        sv2_port: SV2_PORT,
+                    });
+                }
+            }
+            entries.sort_by(|a, b| a.node_id.cmp(&b.node_id));
+            entries.dedup_by(|a, b| a.node_id == b.node_id);
+            if entries.is_empty() {
+                return None; // nothing to checkpoint yet
+            }
+            Some(entries)
+        })
+    };
+    let mesh_node_checkpoint_mgr = Arc::new(
+        ghost_pool::mesh_node_checkpoint::MeshNodeListCheckpointManager::new(
+            Arc::clone(&identity),
+            Arc::clone(&db),
+            mnlchk_send,
+            compute_nodes_fn,
+        )
+        .with_active_voter_set_fn(active_voter_set_fn),
+    );
+    mesh.register_handler(Arc::clone(&mesh_node_checkpoint_mgr)
+        as Arc<dyn ghost_consensus::mesh::MessageHandler + Send + Sync>);
+    {
+        let mgr = Arc::clone(&mesh_node_checkpoint_mgr);
+        let rpc_c = Arc::clone(&rpc);
+        tokio::spawn(async move {
+            const LAG: u64 = 6;
+            let mut interval = tokio::time::interval(std::time::Duration::from_secs(30));
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            loop {
+                interval.tick().await;
+                let tip = match rpc_c.get_block_count().await {
+                    Ok(h) => h,
+                    Err(_) => continue,
+                };
+                if tip <= LAG {
+                    continue;
+                }
+                let height = tip - LAG;
+                let cutoff_ts = match rpc_c.get_block_hash(height).await {
+                    Ok(hash) => match rpc_c.get_block_header(&hash).await {
+                        Ok(hdr) => hdr.time as i64,
+                        Err(_) => continue,
+                    },
+                    Err(_) => continue,
+                };
+                mgr.maybe_propose(height, cutoff_ts).await;
+                mgr.maybe_request_backfill(height);
             }
         });
     }
@@ -6653,6 +6771,57 @@ async fn main() -> Result<()> {
                 farm_port: p.farm_port,
             })
             .collect()
+    });
+
+    // Signed mesh node-list checkpoint for the public /api/v1/pool/mesh-node-list-checkpoint
+    // endpoint. Serializes the latest finalised record into the verifiable blob a miner-side
+    // shim consumes (node list + signer-set forward-chain delta/root + proposer and ≥67%
+    // approver signatures, all hex). None until a checkpoint is finalised → the handler 404s
+    // (the gate is dormant on mainnet, so this returns 404 today).
+    let db_for_mnl_ckpt = Arc::clone(&db);
+    verification_state = verification_state.with_mesh_node_list_checkpoint(move || {
+        let rec = db_for_mnl_ckpt
+            .get_latest_mesh_node_list_checkpoint()
+            .ok()
+            .flatten()?;
+        let nodes: Vec<serde_json::Value> = rec
+            .nodes
+            .iter()
+            .map(|(id, host, s1, s2)| {
+                serde_json::json!({
+                    "node_id": hex::encode(id),
+                    "host": host,
+                    "sv1_port": s1,
+                    "sv2_port": s2,
+                })
+            })
+            .collect();
+        let approvals: Vec<serde_json::Value> = rec
+            .approvals
+            .iter()
+            .map(|(v, sig)| {
+                serde_json::json!({
+                    "voter": hex::encode(v),
+                    "signature": hex::encode(sig),
+                })
+            })
+            .collect();
+        Some(serde_json::json!({
+            "version": "MeshNodeListCheckpoint/v1",
+            "height": rec.height,
+            "cutoff_ts": rec.cutoff_ts,
+            "nodes": nodes,
+            "list_root": hex::encode(rec.list_root),
+            "signer_set_root": hex::encode(rec.signer_set_root),
+            "signer_set_delta": {
+                "added": rec.signer_set_delta.0.iter().map(hex::encode).collect::<Vec<_>>(),
+                "removed": rec.signer_set_delta.1.iter().map(hex::encode).collect::<Vec<_>>(),
+            },
+            "active_node_count": rec.active_node_count,
+            "proposer": rec.proposer_id,
+            "proposer_signature": hex::encode(&rec.proposer_signature),
+            "approvals": approvals,
+        }))
     });
 
     // Live mesh node list for the public /api/v1/pool/mesh-nodes endpoint.

--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -3671,7 +3671,7 @@ async fn main() -> Result<()> {
                     });
                 }
             }
-            entries.sort_by(|a, b| a.node_id.cmp(&b.node_id));
+            entries.sort_by_key(|n| n.node_id);
             entries.dedup_by(|a, b| a.node_id == b.node_id);
             if entries.is_empty() {
                 return None; // nothing to checkpoint yet

--- a/bins/ghost-pool/src/mesh_node_checkpoint.rs
+++ b/bins/ghost-pool/src/mesh_node_checkpoint.rs
@@ -1,0 +1,1126 @@
+//! Mesh node-list checkpoint finalisation (decentralised mining discovery).
+//!
+//! A BFT-finalised, signed snapshot of the public-mining node set that an UNTRUSTED
+//! miner-side shim can verify offline, so mining discovery no longer depends on trusting
+//! DNS or a website. Mirrors [`crate::payout_checkpoint`]'s BFT lifecycle, with three
+//! differences specific to this checkpoint:
+//!
+//! - **Agreement is exact-set, not tolerance.** A voter approves iff its own connected
+//!   public-mining set hashes to the same `list_root` as the proposer's.
+//! - **The signer set rides a forward chain.** Each checkpoint carries `signer_set_root`
+//!   (the root of the deterministic voter set, committed in `checkpoint_hash`) and a
+//!   `signer_set_delta` vs the previous checkpoint. A shim baked with the genesis signer set
+//!   (the MPC elders) advances it by applying deltas, verifying each resulting set against
+//!   the signed root (decision C — see `tasks/design_mesh_node_list_checkpoint.md`).
+//! - **The finalised record keeps signatures.** Unlike the payout checkpoint (whose consumer
+//!   is the local coinbase builder), this checkpoint is served to external shims, so the
+//!   proposer signature and the ≥67% approver signatures are persisted, and sync adoption
+//!   verifies the whole signed blob rather than recomputing from a (possibly unconverged)
+//!   local mesh view.
+//!
+//! DORMANT until `MESH_NODE_LIST_CHECKPOINT_HEIGHT` — below the gate nothing is proposed.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use async_trait::async_trait;
+use parking_lot::RwLock;
+use tracing::{debug, error, info, warn};
+
+use ghost_common::error::GhostResult;
+use ghost_common::identity::{verify_signature, NodeIdentity};
+use ghost_common::types::NodeId;
+use ghost_consensus::{
+    mesh_node_list_root, mesh_signer_set_root, MeshNodeEntry, MeshNodeListCheckpointMessage,
+    MeshNodeListCheckpointSyncEntry, MeshNodeListCheckpointSyncRequest,
+    MeshNodeListCheckpointSyncResponse, MeshNodeListCheckpointVoteMessage, MessageEnvelope,
+    MessageHandler, MessageType, SignerSetDelta,
+};
+use ghost_storage::{Database, MeshNodeListCheckpointRecord};
+
+use crate::payout_checkpoint::{widen_voter_set, BroadcastFn};
+
+/// BFT approval threshold (percent of the voter/signer set).
+const BFT_THRESHOLD_PERCENT: u64 = 67;
+
+/// Backfill cooldown (client re-request and per-peer serve). Mirrors the payout sync window.
+const SYNC_COOLDOWN_MS: u64 = 60_000;
+
+/// Max checkpoints served per sync response; the requester paginates if capped.
+const MAX_SYNC_CHECKPOINTS: u64 = 8;
+
+/// Computes THIS node's canonical public-mining node set at a cutoff:
+/// `(cutoff_ts, height) -> sorted node entries`. `None` = cannot compute yet (mesh view not
+/// ready) → the C-7 abstain rule. `main.rs` wires this to the live mesh peer state.
+pub type ComputeNodeListFn = Arc<dyn Fn(i64, u64) -> Option<Vec<MeshNodeEntry>> + Send + Sync>;
+
+/// Resolves the ACTIVE qualified voter set at a cutoff (see the payout manager's analog).
+/// `None` in tests → the elder floor is always used.
+pub type ActiveVoterSetFn = Arc<dyn Fn(i64, u64) -> Vec<NodeId> + Send + Sync>;
+
+struct PendingEntry {
+    /// The proposal content (needed to persist on finalise). `None` if a vote arrived first.
+    proposal: Option<MeshNodeListCheckpointMessage>,
+    /// voter -> their approve-vote signature over the vote signing message. Kept (not just a
+    /// `HashSet<NodeId>`) so the finalised record can carry the verifiable approver signatures.
+    approvals: HashMap<NodeId, [u8; 64]>,
+}
+
+struct Pending {
+    by_hash: HashMap<[u8; 32], PendingEntry>,
+    finalized: bool,
+}
+
+impl Pending {
+    fn new() -> Self {
+        Self {
+            by_hash: HashMap::new(),
+            finalized: false,
+        }
+    }
+    fn entry(&mut self, hash: [u8; 32]) -> &mut PendingEntry {
+        self.by_hash.entry(hash).or_insert_with(|| PendingEntry {
+            proposal: None,
+            approvals: HashMap::new(),
+        })
+    }
+}
+
+/// Drives mesh node-list checkpoint proposal/voting/finalisation and acts as the mesh
+/// `MessageHandler` for the three mesh-node-list-checkpoint message types.
+pub struct MeshNodeListCheckpointManager {
+    identity: Arc<NodeIdentity>,
+    db: Arc<Database>,
+    send: BroadcastFn,
+    compute_nodes: ComputeNodeListFn,
+    active_voter_set: Option<ActiveVoterSetFn>,
+    /// Activation-height override for tests. `None` (production) = read the live gate
+    /// `crate::mesh_node_list_checkpoint_height()` (u64::MAX = dormant on mainnet).
+    gate_height: Option<u64>,
+    pending: RwLock<HashMap<u64, Pending>>,
+    last_sync_request: RwLock<u64>,
+    sync_serves: RwLock<HashMap<NodeId, u64>>,
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Approvals required to finalise: ceil of 67% of `n` voters.
+fn quorum_for(n: usize) -> usize {
+    (n as u64 * BFT_THRESHOLD_PERCENT).div_ceil(100) as usize
+}
+
+/// Decode a hex node-id string back to a `NodeId`.
+fn decode_node_id(s: &str) -> Option<NodeId> {
+    let bytes = hex::decode(s).ok()?;
+    if bytes.len() != 32 {
+        return None;
+    }
+    let mut id = [0u8; 32];
+    id.copy_from_slice(&bytes);
+    Some(id)
+}
+
+/// A 64-byte signature from a `Vec<u8>` (storage/wire hold them as `Vec` since serde arrays
+/// stop at 32); `None` on a wrong length.
+fn vec_to_sig(v: &[u8]) -> Option<[u8; 64]> {
+    if v.len() != 64 {
+        return None;
+    }
+    let mut a = [0u8; 64];
+    a.copy_from_slice(v);
+    Some(a)
+}
+
+fn entries_to_storage(nodes: &[MeshNodeEntry]) -> Vec<([u8; 32], String, u16, u16)> {
+    nodes
+        .iter()
+        .map(|e| (e.node_id, e.host.clone(), e.sv1_port, e.sv2_port))
+        .collect()
+}
+
+fn storage_to_entries(nodes: &[([u8; 32], String, u16, u16)]) -> Vec<MeshNodeEntry> {
+    nodes
+        .iter()
+        .map(|(id, host, s1, s2)| MeshNodeEntry {
+            node_id: *id,
+            host: host.clone(),
+            sv1_port: *s1,
+            sv2_port: *s2,
+        })
+        .collect()
+}
+
+impl MeshNodeListCheckpointManager {
+    pub fn new(
+        identity: Arc<NodeIdentity>,
+        db: Arc<Database>,
+        send: BroadcastFn,
+        compute_nodes: ComputeNodeListFn,
+    ) -> Self {
+        Self {
+            identity,
+            db,
+            send,
+            compute_nodes,
+            active_voter_set: None,
+            gate_height: None,
+            pending: RwLock::new(HashMap::new()),
+            last_sync_request: RwLock::new(0),
+            sync_serves: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Attach the active-voter-set resolver (see the payout manager's analog). Once the
+    /// `ACTIVE_VOTER_SET` gate is active, the signer/voter set widens from the MPC elders to
+    /// the converged active qualified set.
+    pub fn with_active_voter_set_fn(mut self, f: ActiveVoterSetFn) -> Self {
+        self.active_voter_set = Some(f);
+        self
+    }
+
+    /// Override the activation height (tests only); production reads the live gate.
+    #[cfg(test)]
+    fn with_gate_height(mut self, h: u64) -> Self {
+        self.gate_height = Some(h);
+        self
+    }
+
+    /// The activation height at/above which this checkpoint is live. Below it the whole
+    /// subsystem is dormant: nothing is proposed, and no backfill is requested.
+    fn gate(&self) -> u64 {
+        self.gate_height
+            .unwrap_or_else(crate::mesh_node_list_checkpoint_height)
+    }
+
+    fn broadcast<T: serde::Serialize>(&self, ty: MessageType, msg: &T) {
+        match serde_json::to_vec(msg) {
+            Ok(bytes) => {
+                if let Err(e) = (self.send)(ty, bytes) {
+                    warn!(error = %e, "mesh node checkpoint: enqueue broadcast failed");
+                }
+            }
+            Err(e) => error!(error = %e, "mesh node checkpoint: serialise failed"),
+        }
+    }
+
+    /// Deterministic, fleet-agreed elder set, sorted. This is also the shim's genesis anchor.
+    fn elders_sorted(&self) -> Vec<NodeId> {
+        let mut e: Vec<NodeId> = self
+            .db
+            .get_mpc_elder_node_ids()
+            .unwrap_or_default()
+            .into_iter()
+            .collect();
+        e.sort_unstable();
+        e
+    }
+
+    /// The consensus voter/signer set for `height` at `cutoff_ts`: the MPC elder set below the
+    /// `ACTIVE_VOTER_SET` gate (or with no resolver), the widened active qualified set at/above
+    /// it. Identical logic and floor to the payout manager, so both consensuses draw the same set.
+    fn voter_set_for(&self, height: u64, cutoff_ts: i64) -> Vec<NodeId> {
+        let elders = self.elders_sorted();
+        if height >= crate::active_voter_set_height() {
+            if let Some(resolve) = &self.active_voter_set {
+                return widen_voter_set(elders, resolve(cutoff_ts, height));
+            }
+        }
+        elders
+    }
+
+    /// Deterministic proposer for `height` (round-robin over the voter set at `cutoff_ts`).
+    fn proposer_for(&self, height: u64, cutoff_ts: i64) -> Option<NodeId> {
+        let v = self.voter_set_for(height, cutoff_ts);
+        if v.is_empty() {
+            None
+        } else {
+            Some(v[(height as usize) % v.len()])
+        }
+    }
+
+    fn already_finalized(&self, height: u64) -> bool {
+        if self
+            .pending
+            .read()
+            .get(&height)
+            .map(|p| p.finalized)
+            .unwrap_or(false)
+        {
+            return true;
+        }
+        matches!(
+            self.db.get_mesh_node_list_checkpoint_at_or_before(height),
+            Ok(Some(r)) if r.height == height
+        )
+    }
+
+    /// The signer-set forward-chain delta from the previous checkpoint's set to `current`,
+    /// plus the root of `current`. The previous set is recomputed deterministically from the
+    /// latest finalised checkpoint's `(height, cutoff)`; with none yet, the genesis anchor is
+    /// the elder set (what the shim is baked with). The delta is not itself in `checkpoint_hash`
+    /// — it is verified by a shim against the committed `signer_set_root`.
+    fn signer_delta(&self, current: &[NodeId]) -> (SignerSetDelta, [u8; 32]) {
+        let prev_set = match self.db.get_latest_mesh_node_list_checkpoint() {
+            Ok(Some(prev)) => self.voter_set_for(prev.height, prev.cutoff_ts),
+            _ => self.elders_sorted(),
+        };
+        let prev: HashSet<NodeId> = prev_set.into_iter().collect();
+        let cur: HashSet<NodeId> = current.iter().copied().collect();
+        let mut added: Vec<NodeId> = cur.difference(&prev).copied().collect();
+        let mut removed: Vec<NodeId> = prev.difference(&cur).copied().collect();
+        added.sort_unstable();
+        removed.sort_unstable();
+        (
+            SignerSetDelta { added, removed },
+            mesh_signer_set_root(current),
+        )
+    }
+
+    /// Called on a cadence from `main.rs` with the target lagging checkpoint height. No-op
+    /// unless this node is the deterministic proposer AND the node set actually changed since
+    /// the latest finalised checkpoint (the cadence decision: re-affirm, don't re-checkpoint).
+    pub async fn maybe_propose(&self, height: u64, cutoff_ts: i64) {
+        if height < self.gate() {
+            return; // dormant below the activation gate — behaviour-neutral
+        }
+        let me = self.identity.node_id();
+        let voters = self.voter_set_for(height, cutoff_ts);
+        let proposer = (!voters.is_empty()).then(|| voters[(height as usize) % voters.len()]);
+        if proposer != Some(me) || self.already_finalized(height) {
+            return;
+        }
+        let Some(mut nodes) = (self.compute_nodes)(cutoff_ts, height) else {
+            warn!(
+                height,
+                "mesh node checkpoint: node set not computable yet — not proposing"
+            );
+            return;
+        };
+        nodes.sort_by(|a, b| a.node_id.cmp(&b.node_id));
+        let list_root = mesh_node_list_root(&nodes);
+
+        // Cadence: only checkpoint when the set changed. If the latest finalised checkpoint
+        // already commits this exact list, re-affirm silently rather than mint a duplicate.
+        if let Ok(Some(latest)) = self.db.get_latest_mesh_node_list_checkpoint() {
+            if latest.list_root == list_root {
+                debug!(
+                    height,
+                    "mesh node checkpoint: node set unchanged — not re-proposing"
+                );
+                return;
+            }
+        }
+
+        let (signer_set_delta, signer_set_root) = self.signer_delta(&voters);
+        let mut msg = MeshNodeListCheckpointMessage {
+            height,
+            cutoff_ts,
+            nodes,
+            list_root,
+            signer_set_delta,
+            signer_set_root,
+            active_node_count: voters.len() as u32,
+            proposer: me,
+            proposer_signature: [0u8; 64],
+            timestamp: now_ms(),
+        };
+        let hash = msg.checkpoint_hash();
+        msg.proposer_signature = self.identity.sign(&hash);
+
+        {
+            let mut pending = self.pending.write();
+            let p = pending.entry(height).or_insert_with(Pending::new);
+            p.entry(hash).proposal = Some(msg.clone());
+        }
+        info!(
+            height,
+            list_root = %hex::encode(&list_root[..8]),
+            nodes = msg.nodes.len(),
+            "mesh node checkpoint: proposing"
+        );
+        self.broadcast(MessageType::MeshNodeListCheckpoint, &msg);
+        self.cast_vote(height, hash, true);
+        self.maybe_finalize(height, hash);
+    }
+
+    async fn on_proposal(&self, env: &MessageEnvelope) -> GhostResult<()> {
+        let msg: MeshNodeListCheckpointMessage = match serde_json::from_slice(&env.payload) {
+            Ok(m) => m,
+            Err(_) => return Ok(()),
+        };
+        if env.sender != msg.proposer
+            || self.proposer_for(msg.height, msg.cutoff_ts) != Some(msg.proposer)
+        {
+            debug!(
+                height = msg.height,
+                "mesh node checkpoint: proposal from non-proposer — ignored"
+            );
+            return Ok(());
+        }
+        if self.already_finalized(msg.height) {
+            return Ok(());
+        }
+        let hash = msg.checkpoint_hash();
+
+        // INTEGRITY: the declared roots must actually describe the payload / deterministic set,
+        // else the signed hash wouldn't bind them.
+        let voters = self.voter_set_for(msg.height, msg.cutoff_ts);
+        if mesh_node_list_root(&msg.nodes) != msg.list_root
+            || mesh_signer_set_root(&voters) != msg.signer_set_root
+        {
+            warn!(
+                height = msg.height,
+                "mesh node checkpoint: proposal roots do not match — voting reject"
+            );
+            self.cast_vote(msg.height, hash, false);
+            return Ok(());
+        }
+
+        // EXACT-SET AGREEMENT: recompute our own connected public-mining set; approve iff it
+        // hashes to the same list_root. Cannot compute yet → abstain (C-7).
+        let Some(local) = (self.compute_nodes)(msg.cutoff_ts, msg.height) else {
+            warn!(
+                height = msg.height,
+                "mesh node checkpoint: cannot recompute node set — abstaining"
+            );
+            let height = msg.height;
+            let mut pending = self.pending.write();
+            pending
+                .entry(height)
+                .or_insert_with(Pending::new)
+                .entry(hash)
+                .proposal = Some(msg);
+            return Ok(());
+        };
+        let approve = mesh_node_list_root(&local) == msg.list_root;
+        info!(height = msg.height, approve, "mesh node checkpoint: vote");
+        {
+            let mut pending = self.pending.write();
+            pending
+                .entry(msg.height)
+                .or_insert_with(Pending::new)
+                .entry(hash)
+                .proposal = Some(msg.clone());
+        }
+        self.cast_vote(msg.height, hash, approve);
+        if approve {
+            self.maybe_finalize(msg.height, hash);
+        }
+        Ok(())
+    }
+
+    async fn on_vote(&self, env: &MessageEnvelope) -> GhostResult<()> {
+        let vote: MeshNodeListCheckpointVoteMessage = match serde_json::from_slice(&env.payload) {
+            Ok(v) => v,
+            Err(_) => return Ok(()),
+        };
+        if env.sender != vote.voter || !vote.approve {
+            return Ok(());
+        }
+        // Defence in depth: only record a signature that actually verifies for the voter.
+        if !verify_signature(&vote.voter, &vote.signing_message(), &vote.signature).unwrap_or(false)
+        {
+            return Ok(());
+        }
+        {
+            let mut pending = self.pending.write();
+            pending
+                .entry(vote.height)
+                .or_insert_with(Pending::new)
+                .entry(vote.checkpoint_hash)
+                .approvals
+                .insert(vote.voter, vote.signature);
+        }
+        self.maybe_finalize(vote.height, vote.checkpoint_hash);
+        Ok(())
+    }
+
+    fn cast_vote(&self, height: u64, checkpoint_hash: [u8; 32], approve: bool) {
+        let mut vote = MeshNodeListCheckpointVoteMessage {
+            height,
+            checkpoint_hash,
+            voter: self.identity.node_id(),
+            approve,
+            signature: [0u8; 64],
+            timestamp: now_ms(),
+        };
+        vote.signature = self.identity.sign(&vote.signing_message());
+        if approve {
+            // Record our own approval signature locally so a checkpoint we finalise carries it.
+            let mut pending = self.pending.write();
+            pending
+                .entry(height)
+                .or_insert_with(Pending::new)
+                .entry(checkpoint_hash)
+                .approvals
+                .insert(vote.voter, vote.signature);
+        }
+        self.broadcast(MessageType::MeshNodeListCheckpointVote, &vote);
+    }
+
+    /// Persist once ≥67% of the voter set have approved a hash for which we hold the proposal.
+    /// The record keeps the proposer + approver signatures so it can be served to shims.
+    fn maybe_finalize(&self, height: u64, hash: [u8; 32]) {
+        let mut pending = self.pending.write();
+        let Some(p) = pending.get_mut(&height) else {
+            return;
+        };
+        if p.finalized {
+            return;
+        }
+        let (approvals, msg) = {
+            let Some(entry) = p.by_hash.get(&hash) else {
+                return;
+            };
+            let Some(msg) = entry.proposal.clone() else {
+                return;
+            };
+            (entry.approvals.clone(), msg)
+        };
+        let voters = self.voter_set_for(height, msg.cutoff_ts);
+        let needed = quorum_for(voters.len());
+        if needed == 0 {
+            return;
+        }
+        let approved: Vec<(NodeId, [u8; 64])> = voters
+            .iter()
+            .filter_map(|v| approvals.get(v).map(|s| (*v, *s)))
+            .collect();
+        if approved.len() < needed {
+            return;
+        }
+        let record = MeshNodeListCheckpointRecord {
+            height,
+            cutoff_ts: msg.cutoff_ts,
+            list_root: msg.list_root,
+            signer_set_root: msg.signer_set_root,
+            proposer_id: hex::encode(msg.proposer),
+            active_node_count: msg.active_node_count,
+            proposer_signature: msg.proposer_signature.to_vec(),
+            nodes: entries_to_storage(&msg.nodes),
+            signer_set_delta: (
+                msg.signer_set_delta.added.clone(),
+                msg.signer_set_delta.removed.clone(),
+            ),
+            approvals: approved.iter().map(|(v, s)| (*v, s.to_vec())).collect(),
+        };
+        match self.db.upsert_mesh_node_list_checkpoint(&record) {
+            Ok(()) => {
+                p.finalized = true;
+                info!(
+                    height,
+                    list_root = %hex::encode(&msg.list_root[..8]),
+                    approvals = approved.len(),
+                    needed,
+                    "mesh node-list checkpoint FINALISED"
+                );
+            }
+            Err(e) => error!(height, error = %e, "mesh node checkpoint: persist failed"),
+        }
+    }
+
+    /// Backfill trigger (propose cadence): if our latest finalised checkpoint lags the anchor,
+    /// broadcast a bounded, rate-limited sync request to recover a missed proposal.
+    pub fn maybe_request_backfill(&self, target_height: u64) {
+        if target_height < self.gate() {
+            return; // dormant below the activation gate
+        }
+        let latest = self
+            .db
+            .get_latest_mesh_node_list_checkpoint()
+            .ok()
+            .flatten()
+            .map(|r| r.height)
+            .unwrap_or(0);
+        if latest >= target_height {
+            return;
+        }
+        let now = now_ms();
+        {
+            let mut last = self.last_sync_request.write();
+            if now.saturating_sub(*last) < SYNC_COOLDOWN_MS {
+                return;
+            }
+            *last = now;
+        }
+        let from_height = (latest + 1).max(target_height.saturating_sub(MAX_SYNC_CHECKPOINTS - 1));
+        let req = MeshNodeListCheckpointSyncRequest {
+            requesting_node: self.identity.node_id(),
+            from_height,
+            timestamp: now,
+        };
+        info!(
+            from_height,
+            latest,
+            target = target_height,
+            "mesh node checkpoint: requesting backfill"
+        );
+        self.broadcast(MessageType::MeshNodeListCheckpointSync, &req);
+    }
+
+    async fn on_sync_request(&self, env: &MessageEnvelope) -> GhostResult<()> {
+        let req: MeshNodeListCheckpointSyncRequest = match serde_json::from_slice(&env.payload) {
+            Ok(r) => r,
+            Err(_) => return Ok(()),
+        };
+        if env.sender != req.requesting_node {
+            return Ok(());
+        }
+        let now = now_ms();
+        {
+            let mut serves = self.sync_serves.write();
+            if let Some(&last) = serves.get(&req.requesting_node) {
+                if now.saturating_sub(last) < SYNC_COOLDOWN_MS {
+                    return Ok(());
+                }
+            }
+            serves.insert(req.requesting_node, now);
+        }
+        let records = match self
+            .db
+            .get_mesh_node_list_checkpoints_from_height(req.from_height, MAX_SYNC_CHECKPOINTS)
+        {
+            Ok(r) => r,
+            Err(e) => {
+                warn!(error = %e, "mesh node checkpoint: sync query failed");
+                return Ok(());
+            }
+        };
+        if records.is_empty() {
+            return Ok(());
+        }
+        let has_more = records.len() as u64 >= MAX_SYNC_CHECKPOINTS;
+        let mut checkpoints = Vec::with_capacity(records.len());
+        for r in records {
+            let (Some(proposer), Some(proposer_signature)) = (
+                decode_node_id(&r.proposer_id),
+                vec_to_sig(&r.proposer_signature),
+            ) else {
+                continue;
+            };
+            checkpoints.push(MeshNodeListCheckpointSyncEntry {
+                height: r.height,
+                cutoff_ts: r.cutoff_ts,
+                nodes: storage_to_entries(&r.nodes),
+                list_root: r.list_root,
+                signer_set_delta: SignerSetDelta {
+                    added: r.signer_set_delta.0,
+                    removed: r.signer_set_delta.1,
+                },
+                signer_set_root: r.signer_set_root,
+                active_node_count: r.active_node_count,
+                proposer,
+                proposer_signature,
+                approvals: r.approvals,
+            });
+        }
+        if checkpoints.is_empty() {
+            return Ok(());
+        }
+        let resp = MeshNodeListCheckpointSyncResponse {
+            responding_node: self.identity.node_id(),
+            checkpoints,
+            has_more,
+            timestamp: now,
+        };
+        debug!(
+            count = resp.checkpoints.len(),
+            to = %hex::encode(&req.requesting_node[..4]),
+            "mesh node checkpoint: serving backfill"
+        );
+        self.broadcast(MessageType::MeshNodeListCheckpointSync, &resp);
+        Ok(())
+    }
+
+    async fn on_sync_response(&self, env: &MessageEnvelope) -> GhostResult<()> {
+        let resp: MeshNodeListCheckpointSyncResponse = match serde_json::from_slice(&env.payload) {
+            Ok(r) => r,
+            Err(_) => return Ok(()),
+        };
+        if env.sender != resp.responding_node {
+            return Ok(());
+        }
+        let mut applied = 0usize;
+        for entry in &resp.checkpoints {
+            if self.apply_synced_checkpoint(entry) {
+                applied += 1;
+            }
+        }
+        if applied > 0 {
+            info!(applied, "mesh node checkpoint: backfilled");
+        }
+        Ok(())
+    }
+
+    /// Trustlessly adopt one synced checkpoint by verifying the WHOLE signed blob — authorship,
+    /// root integrity, the proposer signature, and a ≥67% quorum of valid approver signatures
+    /// from the deterministic voter set. This is exactly the check an external shim performs,
+    /// so it never depends on the local mesh view being converged at the historical cutoff.
+    /// Returns true iff newly persisted.
+    fn apply_synced_checkpoint(&self, entry: &MeshNodeListCheckpointSyncEntry) -> bool {
+        if self.already_finalized(entry.height) {
+            return false;
+        }
+        if self.proposer_for(entry.height, entry.cutoff_ts) != Some(entry.proposer) {
+            return false;
+        }
+        let voters = self.voter_set_for(entry.height, entry.cutoff_ts);
+        if mesh_node_list_root(&entry.nodes) != entry.list_root
+            || mesh_signer_set_root(&voters) != entry.signer_set_root
+        {
+            return false;
+        }
+        // Reconstruct the checkpoint hash and verify the proposer's signature over it.
+        let msg = MeshNodeListCheckpointMessage {
+            height: entry.height,
+            cutoff_ts: entry.cutoff_ts,
+            nodes: entry.nodes.clone(),
+            list_root: entry.list_root,
+            signer_set_delta: entry.signer_set_delta.clone(),
+            signer_set_root: entry.signer_set_root,
+            active_node_count: entry.active_node_count,
+            proposer: entry.proposer,
+            proposer_signature: entry.proposer_signature,
+            timestamp: 0,
+        };
+        let hash = msg.checkpoint_hash();
+        if !verify_signature(&entry.proposer, &hash, &entry.proposer_signature).unwrap_or(false) {
+            return false;
+        }
+        // Count valid, distinct approver signatures from the voter set.
+        let voter_set: HashSet<NodeId> = voters.iter().copied().collect();
+        let needed = quorum_for(voters.len());
+        if needed == 0 {
+            return false;
+        }
+        let mut seen = HashSet::new();
+        let mut valid = 0usize;
+        for (voter, sig) in &entry.approvals {
+            if !voter_set.contains(voter) || !seen.insert(*voter) {
+                continue;
+            }
+            let Some(sig) = vec_to_sig(sig) else { continue };
+            let vote = MeshNodeListCheckpointVoteMessage {
+                height: entry.height,
+                checkpoint_hash: hash,
+                voter: *voter,
+                approve: true,
+                signature: sig,
+                timestamp: 0,
+            };
+            if verify_signature(voter, &vote.signing_message(), &sig).unwrap_or(false) {
+                valid += 1;
+            }
+        }
+        if valid < needed {
+            warn!(
+                height = entry.height,
+                valid, needed, "mesh node checkpoint: synced checkpoint lacks quorum — rejected"
+            );
+            return false;
+        }
+        let record = MeshNodeListCheckpointRecord {
+            height: entry.height,
+            cutoff_ts: entry.cutoff_ts,
+            list_root: entry.list_root,
+            signer_set_root: entry.signer_set_root,
+            proposer_id: hex::encode(entry.proposer),
+            active_node_count: entry.active_node_count,
+            proposer_signature: entry.proposer_signature.to_vec(),
+            nodes: entries_to_storage(&entry.nodes),
+            signer_set_delta: (
+                entry.signer_set_delta.added.clone(),
+                entry.signer_set_delta.removed.clone(),
+            ),
+            approvals: entry.approvals.clone(),
+        };
+        match self.db.upsert_mesh_node_list_checkpoint(&record) {
+            Ok(()) => {
+                self.pending
+                    .write()
+                    .entry(entry.height)
+                    .or_insert_with(Pending::new)
+                    .finalized = true;
+                true
+            }
+            Err(e) => {
+                error!(height = entry.height, error = %e, "mesh node checkpoint: sync persist failed");
+                false
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl MessageHandler for MeshNodeListCheckpointManager {
+    async fn handle_message(&self, envelope: Arc<MessageEnvelope>) -> GhostResult<()> {
+        match envelope.msg_type {
+            MessageType::MeshNodeListCheckpoint => self.on_proposal(&envelope).await,
+            MessageType::MeshNodeListCheckpointVote => self.on_vote(&envelope).await,
+            MessageType::MeshNodeListCheckpointSync => {
+                // Multiplex request/response by trial-deserialise (only the request carries
+                // `from_height`), matching the payout-checkpoint sync handler.
+                if serde_json::from_slice::<MeshNodeListCheckpointSyncRequest>(&envelope.payload)
+                    .is_ok()
+                {
+                    self.on_sync_request(&envelope).await
+                } else {
+                    self.on_sync_response(&envelope).await
+                }
+            }
+            _ => Ok(()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! In-process N-node cluster tests with real identities/signatures and induced per-node
+    //! node-set divergence — the property that only a converged set finalises, that an
+    //! unchanged set is not re-checkpointed, and that a signed checkpoint backfills trustlessly.
+    use super::*;
+    use ghost_storage::MpcContributionRecord;
+    use std::sync::Mutex;
+
+    type Outbox = Arc<Mutex<Vec<(MessageType, Vec<u8>)>>>;
+
+    struct Node {
+        id: NodeId,
+        db: Arc<Database>,
+        mgr: MeshNodeListCheckpointManager,
+        outbox: Outbox,
+    }
+
+    fn register_elders(db: &Database, elders: &[NodeId]) {
+        for (i, e) in elders.iter().enumerate() {
+            db.save_mpc_contribution(&MpcContributionRecord {
+                elder_position: (i as u32) + 1,
+                contributor_node_id: hex::encode(e),
+                prev_params_hash: [0u8; 32],
+                new_params_hash: [0u8; 32],
+                contribution_proof: Vec::new(),
+                epoch: 0,
+                created_at: 0,
+            })
+            .expect("save elder");
+        }
+    }
+
+    fn entry(id: u8, host: &str) -> MeshNodeEntry {
+        MeshNodeEntry {
+            node_id: [id; 32],
+            host: host.to_string(),
+            sv1_port: 3333,
+            sv2_port: 34255,
+        }
+    }
+
+    /// The shared "converged" public-mining set every node computes.
+    fn std_nodes() -> Vec<MeshNodeEntry> {
+        vec![entry(200, "203.0.113.1"), entry(201, "203.0.113.2")]
+    }
+
+    /// Build `n` nodes; node at SORTED elder position `i` computes `lists[i]` as its own view
+    /// (`None` = C-7 abstain). Sorted order means `nodes[i].id == elders_sorted[i]`, so the
+    /// proposer for height `H` is `nodes[H % n]`.
+    fn build(n: usize, lists: &[Option<Vec<MeshNodeEntry>>]) -> (Vec<Node>, Vec<NodeId>) {
+        assert_eq!(n, lists.len());
+        let ids: Vec<Arc<NodeIdentity>> =
+            (0..n).map(|_| Arc::new(NodeIdentity::generate())).collect();
+        let mut elders: Vec<NodeId> = ids.iter().map(|i| i.node_id()).collect();
+        elders.sort_unstable();
+
+        let mut nodes = Vec::new();
+        for (pos, &want) in elders.iter().enumerate() {
+            let identity = ids.iter().find(|i| i.node_id() == want).unwrap().clone();
+            let db = Arc::new(Database::in_memory().expect("db"));
+            register_elders(&db, &elders);
+            let outbox: Outbox = Arc::new(Mutex::new(Vec::new()));
+            let ob = Arc::clone(&outbox);
+            let send: BroadcastFn = Arc::new(move |ty, bytes| {
+                ob.lock().unwrap().push((ty, bytes));
+                Ok(())
+            });
+            let list = lists[pos].clone();
+            let compute: ComputeNodeListFn = Arc::new(move |_c, _h| list.clone());
+            let mgr = MeshNodeListCheckpointManager::new(
+                identity.clone(),
+                Arc::clone(&db),
+                send,
+                compute,
+            )
+            .with_gate_height(0); // armed for the cluster tests
+            nodes.push(Node {
+                id: identity.node_id(),
+                db,
+                mgr,
+                outbox,
+            });
+        }
+        (nodes, elders)
+    }
+
+    fn drain(n: &Node) -> Vec<(MessageType, Vec<u8>)> {
+        std::mem::take(&mut *n.outbox.lock().unwrap())
+    }
+
+    async fn gossip_until_quiet(nodes: &[Node]) {
+        for _ in 0..20 {
+            let mut msgs = Vec::new();
+            for n in nodes {
+                for (ty, payload) in drain(n) {
+                    msgs.push((n.id, ty, payload));
+                }
+            }
+            if msgs.is_empty() {
+                break;
+            }
+            for (from, ty, payload) in msgs {
+                for n in nodes {
+                    if n.id != from {
+                        let env = Arc::new(MessageEnvelope::new(
+                            ty,
+                            from,
+                            payload.clone(),
+                            0,
+                            [0u8; 64],
+                        ));
+                        n.mgr.handle_message(env).await.expect("handle");
+                    }
+                }
+            }
+        }
+    }
+
+    const H: u64 = 100; // 100 % 4 == 0 → proposer is sorted-elder[0] = nodes[0]
+    const CUTOFF: i64 = 1_784_000_000;
+
+    #[tokio::test]
+    async fn dormant_below_the_gate_proposes_nothing() {
+        // A manager with the DEFAULT (production) gate — u64::MAX in tests, since the activation
+        // OnceLock is never armed here — must be fully inert even when it is the sole proposer
+        // (quorum_for(1) == 1, so without the gate it WOULD finalise). This proves the gate is
+        // actually enforced, not merely declared.
+        let ident = Arc::new(NodeIdentity::generate());
+        let elders = vec![ident.node_id()];
+        let db = Arc::new(Database::in_memory().expect("db"));
+        register_elders(&db, &elders);
+        let outbox: Outbox = Arc::new(Mutex::new(Vec::new()));
+        let ob = Arc::clone(&outbox);
+        let send: BroadcastFn = Arc::new(move |ty, bytes| {
+            ob.lock().unwrap().push((ty, bytes));
+            Ok(())
+        });
+        let compute: ComputeNodeListFn = Arc::new(|_, _| Some(std_nodes()));
+        // No .with_gate_height → uses the live gate (dormant u64::MAX).
+        let mgr = MeshNodeListCheckpointManager::new(ident, Arc::clone(&db), send, compute);
+        mgr.maybe_propose(100, CUTOFF).await;
+        mgr.maybe_request_backfill(100);
+        assert!(
+            outbox.lock().unwrap().is_empty(),
+            "dormant manager broadcasts nothing"
+        );
+        assert!(
+            db.get_latest_mesh_node_list_checkpoint().unwrap().is_none(),
+            "dormant manager finalises nothing"
+        );
+    }
+
+    #[tokio::test]
+    async fn convergent_fleet_finalises_signed_list() {
+        let (nodes, _) = build(4, &vec![Some(std_nodes()); 4]);
+        assert_eq!(nodes[0].mgr.proposer_for(H, CUTOFF), Some(nodes[0].id));
+        assert_eq!(quorum_for(4), 3, "67% of 4 = 3");
+        for n in &nodes {
+            n.mgr.maybe_propose(H, CUTOFF).await;
+        }
+        gossip_until_quiet(&nodes).await;
+        let want_root = mesh_node_list_root(&std_nodes());
+        for n in &nodes {
+            let rec =
+                n.db.get_latest_mesh_node_list_checkpoint()
+                    .unwrap()
+                    .expect("every node finalises");
+            assert_eq!(rec.height, H);
+            assert_eq!(rec.list_root, want_root);
+            assert_eq!(rec.nodes.len(), 2, "adopted node list");
+            assert_eq!(
+                rec.proposer_signature.len(),
+                64,
+                "proposer signature persisted"
+            );
+            assert!(
+                rec.approvals.len() >= 3,
+                "≥quorum approver signatures persisted, got {}",
+                rec.approvals.len()
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn divergent_node_set_does_not_finalise() {
+        // Proposer + one peer see std; two peers see a DIFFERENT set → they reject → only 2
+        // approvals < 3 → nothing finalises (safe).
+        let other = vec![entry(210, "198.51.100.9")];
+        let (nodes, _) = build(
+            4,
+            &[
+                Some(std_nodes()),
+                Some(std_nodes()),
+                Some(other.clone()),
+                Some(other),
+            ],
+        );
+        for n in &nodes {
+            n.mgr.maybe_propose(H, CUTOFF).await;
+        }
+        gossip_until_quiet(&nodes).await;
+        for n in &nodes {
+            assert!(n
+                .db
+                .get_latest_mesh_node_list_checkpoint()
+                .unwrap()
+                .is_none());
+        }
+    }
+
+    #[tokio::test]
+    async fn unchanged_node_set_is_not_re_proposed() {
+        let (nodes, _) = build(4, &vec![Some(std_nodes()); 4]);
+        for n in &nodes {
+            n.mgr.maybe_propose(H, CUTOFF).await;
+        }
+        gossip_until_quiet(&nodes).await;
+        // All finalised H. Now the proposer for a later height with the SAME set must not
+        // propose again (cadence: re-affirm, don't re-checkpoint).
+        let h2 = 104; // 104 % 4 == 0 → proposer is nodes[0]
+        nodes[0].mgr.maybe_propose(h2, CUTOFF).await;
+        assert!(
+            !drain(&nodes[0])
+                .iter()
+                .any(|(ty, _)| *ty == MessageType::MeshNodeListCheckpoint),
+            "unchanged set → no new proposal"
+        );
+    }
+
+    #[tokio::test]
+    async fn changed_node_set_is_re_proposed() {
+        // Pre-seed a stale finalised checkpoint whose list_root differs from the current set, so
+        // the proposer sees a change and DOES propose (the other direction of the cadence gate).
+        let (nodes, _) = build(4, &vec![Some(std_nodes()); 4]);
+        let stale = MeshNodeListCheckpointRecord {
+            height: 96,
+            cutoff_ts: CUTOFF,
+            list_root: [1u8; 32], // != mesh_node_list_root(std_nodes())
+            signer_set_root: [2u8; 32],
+            proposer_id: hex::encode(nodes[0].id),
+            active_node_count: 4,
+            proposer_signature: vec![0u8; 64],
+            nodes: vec![],
+            signer_set_delta: (vec![], vec![]),
+            approvals: vec![],
+        };
+        nodes[0]
+            .db
+            .upsert_mesh_node_list_checkpoint(&stale)
+            .unwrap();
+        nodes[0].mgr.maybe_propose(H, CUTOFF).await; // H=100 → proposer is nodes[0]
+        assert!(
+            drain(&nodes[0])
+                .iter()
+                .any(|(ty, _)| *ty == MessageType::MeshNodeListCheckpoint),
+            "changed set → proposes"
+        );
+    }
+
+    #[tokio::test]
+    async fn missed_checkpoint_backfills_via_signed_sync() {
+        // Build a fleet, finalise H with real signatures, then hand the finalised checkpoint to a
+        // BYSTANDER that missed it. It adopts only after verifying the full signed blob.
+        let (nodes, elders) = build(4, &vec![Some(std_nodes()); 4]);
+        for n in &nodes {
+            n.mgr.maybe_propose(H, CUTOFF).await;
+        }
+        gossip_until_quiet(&nodes).await;
+        let rec = nodes[0]
+            .db
+            .get_latest_mesh_node_list_checkpoint()
+            .unwrap()
+            .expect("finalised");
+
+        // Reconstruct the sync entry a peer would serve from that record.
+        let synced = MeshNodeListCheckpointSyncEntry {
+            height: rec.height,
+            cutoff_ts: rec.cutoff_ts,
+            nodes: storage_to_entries(&rec.nodes),
+            list_root: rec.list_root,
+            signer_set_delta: SignerSetDelta {
+                added: rec.signer_set_delta.0.clone(),
+                removed: rec.signer_set_delta.1.clone(),
+            },
+            signer_set_root: rec.signer_set_root,
+            active_node_count: rec.active_node_count,
+            proposer: decode_node_id(&rec.proposer_id).unwrap(),
+            proposer_signature: vec_to_sig(&rec.proposer_signature).unwrap(),
+            approvals: rec.approvals.clone(),
+        };
+
+        // A bystander with the same elder registration but no checkpoint.
+        let db = Arc::new(Database::in_memory().expect("db"));
+        register_elders(&db, &elders);
+        let send: BroadcastFn = Arc::new(|_, _| Ok(()));
+        let compute: ComputeNodeListFn = Arc::new(|_, _| None); // apply verifies sigs, not view
+        let bystander = MeshNodeListCheckpointManager::new(
+            Arc::new(NodeIdentity::generate()),
+            Arc::clone(&db),
+            send,
+            compute,
+        );
+
+        assert!(
+            bystander.apply_synced_checkpoint(&synced),
+            "valid signed checkpoint adopted"
+        );
+        assert_eq!(
+            db.get_latest_mesh_node_list_checkpoint()
+                .unwrap()
+                .unwrap()
+                .height,
+            H
+        );
+
+        // Tamper: flip one approver signature byte → quorum fails → rejected.
+        let mut bad = synced.clone();
+        let db2 = Arc::new(Database::in_memory().expect("db2"));
+        register_elders(&db2, &elders);
+        let send2: BroadcastFn = Arc::new(|_, _| Ok(()));
+        let compute2: ComputeNodeListFn = Arc::new(|_, _| None);
+        let bystander2 = MeshNodeListCheckpointManager::new(
+            Arc::new(NodeIdentity::generate()),
+            Arc::clone(&db2),
+            send2,
+            compute2,
+        );
+        if let Some(first) = bad.approvals.first_mut() {
+            if let Some(b) = first.1.first_mut() {
+                *b ^= 0xff;
+            }
+        }
+        // Drop the tampered approver below quorum by also truncating to force <3 valid.
+        bad.approvals.truncate(2);
+        assert!(
+            !bystander2.apply_synced_checkpoint(&bad),
+            "sub-quorum / tampered signatures rejected"
+        );
+        assert!(db2
+            .get_latest_mesh_node_list_checkpoint()
+            .unwrap()
+            .is_none());
+    }
+}

--- a/bins/ghost-pool/src/mesh_node_checkpoint.rs
+++ b/bins/ghost-pool/src/mesh_node_checkpoint.rs
@@ -302,7 +302,7 @@ impl MeshNodeListCheckpointManager {
             );
             return;
         };
-        nodes.sort_by(|a, b| a.node_id.cmp(&b.node_id));
+        nodes.sort_by_key(|n| n.node_id);
         let list_root = mesh_node_list_root(&nodes);
 
         // Cadence: only checkpoint when the set changed. If the latest finalised checkpoint

--- a/bins/translator-sv2/src/lib/load_balancer.rs
+++ b/bins/translator-sv2/src/lib/load_balancer.rs
@@ -13,7 +13,13 @@
 //! | < warn_pct        | Normal          | accept + maybe proxy via utilisation routing     |
 //! | ≥ warn_pct        | Warning         | log warning, still accept, prefer-proxy harder   |
 //! | ≥ reject_pct      | RejectNew       | TCP-close incoming connections immediately       |
-//! | ≥ evict_pct       | Critical        | (TODO) send `client.reconnect` to N miners       |
+//! | ≥ evict_pct       | Critical        | reject new AND shed existing miners              |
+//!
+//! Utilisation above is `miner_count / max_capacity`. Separately, opt-in
+//! **compute protection** (`compute_shed_enabled`) forces `Critical` when this
+//! node's per-core 1-minute load average reaches `compute_evict_pct`, so a node
+//! under real CPU pressure sheds miners (they reconnect elsewhere via DNS)
+//! rather than starving share validation / template building.
 //!
 //! See `bins/ghost-pool/src/capacity.rs` for how `max_capacity` is derived
 //! per node from CPU/RAM/FD limits.
@@ -50,16 +56,18 @@ pub struct LoadBalancerConfig {
     #[serde(default = "default_evict_pct")]
     pub evict_pct: u32,
 
-    /// Opt-in hourly rebalancer — when this node's utilisation exceeds the
-    /// cluster minimum by `rebalance_imbalance_pct`, evict ONE miner via
-    /// Stratum `client.reconnect`. Default false: don't disrupt healthy
-    /// mining for cosmetic balance.
+    /// Compute-protection shedding (opt-in, default off). When enabled, if this node's
+    /// 1-minute load average per core reaches `compute_evict_pct`%, the node enters `Critical`:
+    /// it stops accepting new miners and sheds existing ones (they reconnect via DNS to a
+    /// less-loaded node), so a node under compute pressure protects itself instead of degrading
+    /// share validation / block-template building.
     #[serde(default)]
-    pub rebalance_enabled: bool,
-    #[serde(default = "default_rebalance_interval_secs")]
-    pub rebalance_interval_secs: u64,
-    #[serde(default = "default_rebalance_imbalance_pct")]
-    pub rebalance_imbalance_pct: u32,
+    pub compute_shed_enabled: bool,
+    #[serde(default = "default_compute_evict_pct")]
+    pub compute_evict_pct: u32,
+    /// Miners to shed per shedding tick (gentle: re-evaluated each tick).
+    #[serde(default = "default_shed_batch_size")]
+    pub shed_batch_size: u32,
 }
 
 fn default_ghost_pool_url() -> String {
@@ -83,11 +91,11 @@ fn default_reject_pct() -> u32 {
 fn default_evict_pct() -> u32 {
     95
 }
-fn default_rebalance_interval_secs() -> u64 {
-    3600
+fn default_compute_evict_pct() -> u32 {
+    90
 }
-fn default_rebalance_imbalance_pct() -> u32 {
-    20
+fn default_shed_batch_size() -> u32 {
+    1
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -237,6 +245,15 @@ impl LoadBalancer {
     /// Falls back to `Normal` if the cache hasn't populated yet (better to
     /// err on the side of accepting connections than to refuse during boot).
     pub async fn check_capacity(&self) -> CapacityState {
+        // Compute protection (opt-in): a node under real CPU pressure goes straight to Critical
+        // regardless of miner count, so share validation / template building never starves.
+        if self.config.compute_shed_enabled {
+            if let Some(load_pct) = read_loadavg_pct() {
+                if load_pct >= self.config.compute_evict_pct {
+                    return CapacityState::Critical;
+                }
+            }
+        }
         let cache = self.cache.read().await;
         let Some(cache) = cache.as_ref() else {
             return CapacityState::Normal;
@@ -246,12 +263,12 @@ impl LoadBalancer {
             return CapacityState::Normal;
         }
         let pct = (this.miner_count.saturating_mul(100)) / this.max_capacity;
-        match pct {
-            x if x >= self.config.evict_pct => CapacityState::Critical,
-            x if x >= self.config.reject_pct => CapacityState::RejectNew,
-            x if x >= self.config.warn_pct => CapacityState::Warning,
-            _ => CapacityState::Normal,
-        }
+        state_for_pct(
+            pct,
+            self.config.warn_pct,
+            self.config.reject_pct,
+            self.config.evict_pct,
+        )
     }
 
     /// Should this connection be rejected at the TCP layer due to local
@@ -413,17 +430,47 @@ impl LoadBalancer {
         )
     }
 
-    /// Read the rebalance config (used by sv1_server to decide whether to
-    /// spawn the optional hourly evictor).
-    pub fn rebalance_enabled(&self) -> bool {
-        self.config.rebalance_enabled
+    /// Whether compute-protection shedding is enabled (accept loop only spawns the
+    /// shed tick when this is true).
+    pub fn compute_shed_enabled(&self) -> bool {
+        self.config.compute_shed_enabled
     }
-    pub fn rebalance_interval_secs(&self) -> u64 {
-        self.config.rebalance_interval_secs
+
+    /// Miners to shed per shedding tick.
+    pub fn shed_batch_size(&self) -> usize {
+        self.config.shed_batch_size.max(1) as usize
     }
-    pub fn rebalance_imbalance_pct(&self) -> u32 {
-        self.config.rebalance_imbalance_pct
+
+    /// True when this node is `Critical` (over compute or miner-capacity threshold) — the
+    /// accept loop's shed tick uses this to evict existing miners so they reconnect elsewhere.
+    pub async fn should_shed(&self) -> bool {
+        self.config.compute_shed_enabled
+            && matches!(self.check_capacity().await, CapacityState::Critical)
     }
+}
+
+/// Map a utilisation percentage to a capacity state given the three thresholds. Pure so the
+/// tiering is unit-testable independent of the cache/poll plumbing.
+fn state_for_pct(pct: u32, warn: u32, reject: u32, evict: u32) -> CapacityState {
+    match pct {
+        x if x >= evict => CapacityState::Critical,
+        x if x >= reject => CapacityState::RejectNew,
+        x if x >= warn => CapacityState::Warning,
+        _ => CapacityState::Normal,
+    }
+}
+
+/// This node's 1-minute load average as a percentage of available cores (100 = one full
+/// core-equivalent of load per core). Linux-only via `/proc/loadavg`; `None` elsewhere or on
+/// read failure, which callers treat as "no compute-pressure signal".
+fn read_loadavg_pct() -> Option<u32> {
+    let contents = std::fs::read_to_string("/proc/loadavg").ok()?;
+    let load1: f64 = contents.split_whitespace().next()?.parse().ok()?;
+    let cores = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1) as f64;
+    let pct = (load1 / cores * 100.0).round().clamp(0.0, 100_000.0);
+    Some(pct as u32)
 }
 
 fn peer_util_pct(p: &PeerInfo) -> u32 {
@@ -464,6 +511,26 @@ async fn poll_pool_nodes(host_port: &str) -> Result<PoolNodesResponse, String> {
 mod tests {
     use super::*;
 
+    #[test]
+    fn state_thresholds_map_correctly() {
+        assert_eq!(state_for_pct(0, 80, 90, 95), CapacityState::Normal);
+        assert_eq!(state_for_pct(79, 80, 90, 95), CapacityState::Normal);
+        assert_eq!(state_for_pct(80, 80, 90, 95), CapacityState::Warning);
+        assert_eq!(state_for_pct(89, 80, 90, 95), CapacityState::Warning);
+        assert_eq!(state_for_pct(90, 80, 90, 95), CapacityState::RejectNew);
+        assert_eq!(state_for_pct(94, 80, 90, 95), CapacityState::RejectNew);
+        assert_eq!(state_for_pct(95, 80, 90, 95), CapacityState::Critical);
+        assert_eq!(state_for_pct(200, 80, 90, 95), CapacityState::Critical);
+    }
+
+    #[test]
+    fn loadavg_pct_is_bounded() {
+        // On Linux this reads real /proc/loadavg; just assert it's a sane bounded value.
+        if let Some(pct) = read_loadavg_pct() {
+            assert!(pct < 100_000);
+        }
+    }
+
     fn cfg() -> LoadBalancerConfig {
         LoadBalancerConfig {
             ghost_pool_url: "127.0.0.1:8080".into(),
@@ -473,9 +540,9 @@ mod tests {
             warn_pct: 80,
             reject_pct: 90,
             evict_pct: 95,
-            rebalance_enabled: false,
-            rebalance_interval_secs: 3600,
-            rebalance_imbalance_pct: 20,
+            compute_shed_enabled: false,
+            compute_evict_pct: 90,
+            shed_batch_size: 1,
         }
     }
 

--- a/config/mainnet.toml
+++ b/config/mainnet.toml
@@ -409,40 +409,6 @@ epoch_blocks = 2160
 wraith_enabled = true
 
 # =============================================================================
-# [registry] - DNS Load Balancer Registration (Optional)
-# =============================================================================
-# Configure to register with Ghost DNS load balancer for miner discovery
-# Only needed for public pools wanting DNS-based miner routing
-
-# [registry]
-#
-# # Registry service URL
-# # Options: HTTP/HTTPS URL
-# # Default: None
-# url = "https://registry.bitcoinghost.org:8333"
-#
-# # Heartbeat interval in seconds
-# # How often to send health updates to registry
-# # Options: 10-300
-# # Default: 30
-# heartbeat_interval_secs = 30
-#
-# # Geographic region for latency-based routing
-# # Options:
-# #   - "us_east"
-# #   - "us_west"
-# #   - "eu_west"
-# #   - "eu_central"
-# #   - "asia_southeast"
-# #   - "asia_northeast"
-# #   - "oceania"
-# #   - "south_america"
-# #   - "africa"
-# #   - "unknown"
-# # Default: "unknown"
-# region = "us_east"
-
-# =============================================================================
 # Environment Variables Reference
 # =============================================================================
 #

--- a/config/registry.env.example
+++ b/config/registry.env.example
@@ -1,4 +1,0 @@
-# Ghost Registry service credentials
-# Copy this file to /etc/ghost/registry.env and set real values.
-# Ensure permissions: chmod 600 /etc/ghost/registry.env
-CLOUDFLARE_API_TOKEN=CHANGE_ME_TO_YOUR_CLOUDFLARE_API_TOKEN

--- a/crates/ghost-common/src/config.rs
+++ b/crates/ghost-common/src/config.rs
@@ -112,7 +112,6 @@ pub struct NodeConfig {
     /// Reaper configuration (dead code detection in witness scripts)
     #[serde(default)]
     pub reaper: ReaperSettings,
-    /// Registry configuration (optional, for load balancer registration)
     /// Decentralised Wraith coordinator-election configuration.
     ///
     /// Read-only and gated OFF by default: when `wraith_election_enabled` is
@@ -1828,42 +1827,6 @@ impl Default for GhostPayConfig {
             wraith_enabled: true,
             payout_address: None,
         }
-    }
-}
-
-/// Geographic region for miner routing
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-#[derive(Default)]
-pub enum Region {
-    UsEast,
-    UsWest,
-    EuWest,
-    EuCentral,
-    AsiaSoutheast,
-    AsiaNortheast,
-    Oceania,
-    SouthAmerica,
-    Africa,
-    #[default]
-    Unknown,
-}
-
-impl std::fmt::Display for Region {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let s = match self {
-            Self::UsEast => "us-east",
-            Self::UsWest => "us-west",
-            Self::EuWest => "eu-west",
-            Self::EuCentral => "eu-central",
-            Self::AsiaSoutheast => "asia-southeast",
-            Self::AsiaNortheast => "asia-northeast",
-            Self::Oceania => "oceania",
-            Self::SouthAmerica => "south-america",
-            Self::Africa => "africa",
-            Self::Unknown => "unknown",
-        };
-        write!(f, "{}", s)
     }
 }
 

--- a/crates/ghost-consensus/src/mesh.rs
+++ b/crates/ghost-consensus/src/mesh.rs
@@ -1014,19 +1014,6 @@ impl SeenMessageCache {
         self.sender_counts.retain(|_, &mut count| count > 0);
         self.sender_queues.retain(|_, queue| !queue.is_empty());
     }
-
-    /// CRIT-5: Check if a message has expired based on TTL
-    ///
-    /// Returns true if the message timestamp is older than message_ttl_secs
-    #[allow(dead_code)]
-    fn is_message_expired(&self, timestamp: u64) -> bool {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_secs())
-            .unwrap_or(0);
-
-        now.saturating_sub(timestamp) > self.message_ttl_secs
-    }
 }
 
 impl MeshNetwork {
@@ -1826,6 +1813,9 @@ impl MeshNetwork {
             | MessageType::ShareBatchProposal
             | MessageType::ShareBatchVote
             | MessageType::ShareBatchSync
+            | MessageType::MeshNodeListCheckpoint
+            | MessageType::MeshNodeListCheckpointVote
+            | MessageType::MeshNodeListCheckpointSync
             | MessageType::ElderUpdate
             | MessageType::ZkBlockProposal
             | MessageType::ZkVote
@@ -2207,6 +2197,9 @@ impl MeshNetwork {
             | MessageType::PayoutLedgerCheckpointVote
             | MessageType::PayoutLedgerCheckpointSync
             | MessageType::PayoutProposalSync
+            | MessageType::MeshNodeListCheckpoint
+            | MessageType::MeshNodeListCheckpointVote
+            | MessageType::MeshNodeListCheckpointSync
             | MessageType::L2TreeSync
             | MessageType::L2ShieldBroadcast => self.config.ports.consensus_voting,
             // GhostGlyph messages use consensus voting port
@@ -3293,6 +3286,9 @@ impl MeshNetwork {
             | MessageType::PayoutLedgerCheckpointVote
             | MessageType::PayoutLedgerCheckpointSync
             | MessageType::PayoutProposalSync
+            | MessageType::MeshNodeListCheckpoint
+            | MessageType::MeshNodeListCheckpointVote
+            | MessageType::MeshNodeListCheckpointSync
             | MessageType::L2TreeSync
             | MessageType::L2ShieldBroadcast => self.config.ports.consensus_voting,
             MessageType::VerificationResult | MessageType::ChallengeConvergence => {
@@ -4222,6 +4218,9 @@ mod tests {
                 | MessageType::ShareBatchProposal
                 | MessageType::ShareBatchVote
                 | MessageType::ShareBatchSync
+                | MessageType::MeshNodeListCheckpoint
+                | MessageType::MeshNodeListCheckpointVote
+                | MessageType::MeshNodeListCheckpointSync
                 | MessageType::ElderUpdate
                 | MessageType::ZkBlockProposal
                 | MessageType::ZkVote

--- a/crates/ghost-consensus/src/message.rs
+++ b/crates/ghost-consensus/src/message.rs
@@ -1509,7 +1509,7 @@ pub struct MeshNodeEntry {
 pub fn mesh_node_list_root(nodes: &[MeshNodeEntry]) -> [u8; 32] {
     use sha2::{Digest, Sha256};
     let mut sorted: Vec<&MeshNodeEntry> = nodes.iter().collect();
-    sorted.sort_by(|a, b| a.node_id.cmp(&b.node_id));
+    sorted.sort_by_key(|n| n.node_id);
     let mut hasher = Sha256::new();
     hasher.update(b"MeshNodeList/v1");
     hasher.update((sorted.len() as u32).to_le_bytes());
@@ -2209,5 +2209,49 @@ mod tests {
 
         assert!(!vote.approve);
         assert_eq!(vote.rejection_reason, Some(ZkRejectionReason::InvalidProof));
+    }
+
+    /// The list root is what makes every node derive the SAME `checkpoint_hash` from
+    /// the same node set, so it must not depend on the order the set arrives in. That
+    /// is the whole convergence property #402 is accepted on, and nothing covered it.
+    #[test]
+    fn mesh_node_list_root_is_order_independent_and_set_sensitive() {
+        let mk = |id: u8, host: &str, sv1: u16, sv2: u16| MeshNodeEntry {
+            node_id: [id; 32],
+            host: host.to_string(),
+            sv1_port: sv1,
+            sv2_port: sv2,
+        };
+        let a = mk(3, "203.0.113.7", 3333, 34255);
+        let b = mk(1, "198.51.100.9", 3333, 34255);
+        let c = mk(2, "example.invalid", 4444, 34255);
+
+        // Same set, three different input orders -> one root.
+        let r1 = mesh_node_list_root(&[a.clone(), b.clone(), c.clone()]);
+        let r2 = mesh_node_list_root(&[c.clone(), a.clone(), b.clone()]);
+        let r3 = mesh_node_list_root(&[b.clone(), c.clone(), a.clone()]);
+        assert_eq!(r1, r2, "root changed with input order");
+        assert_eq!(r1, r3, "root changed with input order");
+
+        // A different set must not collide.
+        assert_ne!(
+            r1,
+            mesh_node_list_root(&[a.clone(), b.clone()]),
+            "dropping a node kept the root"
+        );
+        let mut moved = c.clone();
+        moved.host = "203.0.113.8".to_string();
+        assert_ne!(
+            r1,
+            mesh_node_list_root(&[a.clone(), b.clone(), moved]),
+            "changing a host kept the root"
+        );
+        let mut reported = c.clone();
+        reported.sv1_port = 3334;
+        assert_ne!(
+            r1,
+            mesh_node_list_root(&[a, b, reported]),
+            "changing a port kept the root"
+        );
     }
 }

--- a/crates/ghost-consensus/src/message.rs
+++ b/crates/ghost-consensus/src/message.rs
@@ -75,6 +75,12 @@ pub mod topics {
     pub const SHARE_BATCH_VOTE: &[u8] = b"sbvote";
     /// Share-batch chain: on-demand backfill of adopted batches
     pub const SHARE_BATCH_SYNC: &[u8] = b"sbsync";
+    /// Mesh node-list checkpoint proposal (signed public-mining node set for discovery)
+    pub const MESH_NODE_LIST_CHECKPOINT: &[u8] = b"mnlchk";
+    /// Mesh node-list checkpoint vote
+    pub const MESH_NODE_LIST_VOTE: &[u8] = b"mnlvote";
+    /// Mesh node-list checkpoint sync (on-demand backfill of missed checkpoints)
+    pub const MESH_NODE_LIST_SYNC: &[u8] = b"mnlsync";
     /// L2 shield commitment broadcast
     pub const L2_SHIELD: &[u8] = b"l2shld";
     /// GhostGlyph visual identity
@@ -286,6 +292,13 @@ pub enum MessageType {
     /// against its own head — it must fetch, not guess. Verified by rehashing: an adopted batch is
     /// accepted only if it hashes to the parent the next one names.
     ShareBatchSync,
+    /// Mesh node-list checkpoint proposal (proposer → all): the BFT-finalised, signed
+    /// snapshot of the public-mining node set for decentralised mining discovery.
+    MeshNodeListCheckpoint,
+    /// Mesh node-list checkpoint vote (validator → all)
+    MeshNodeListCheckpointVote,
+    /// Mesh node-list checkpoint sync request/response (node ↔ peer): on-demand backfill.
+    MeshNodeListCheckpointSync,
 }
 
 impl MessageType {
@@ -324,6 +337,9 @@ impl MessageType {
             Self::ShareBatchProposal => topics::SHARE_BATCH,
             Self::ShareBatchVote => topics::SHARE_BATCH_VOTE,
             Self::ShareBatchSync => topics::SHARE_BATCH_SYNC,
+            Self::MeshNodeListCheckpoint => topics::MESH_NODE_LIST_CHECKPOINT,
+            Self::MeshNodeListCheckpointVote => topics::MESH_NODE_LIST_VOTE,
+            Self::MeshNodeListCheckpointSync => topics::MESH_NODE_LIST_SYNC,
             Self::L2TreeSync => topics::L2_SYNC,
             Self::L2ShieldBroadcast => topics::L2_SHIELD,
             Self::GhostGlyphClaim | Self::GhostGlyphRegistered => topics::GLYPH,
@@ -366,6 +382,9 @@ impl MessageType {
             Self::ShareBatchProposal => "sbatch",
             Self::ShareBatchVote => "sbvote",
             Self::ShareBatchSync => "sbsync",
+            Self::MeshNodeListCheckpoint => "mnlchk",
+            Self::MeshNodeListCheckpointVote => "mnlvote",
+            Self::MeshNodeListCheckpointSync => "mnlsync",
             Self::L2TreeSync => "l2sync",
             Self::L2ShieldBroadcast => "l2shield",
             Self::GhostGlyphClaim | Self::GhostGlyphRegistered => "glyph",
@@ -1455,6 +1474,236 @@ pub struct PayoutCheckpointSyncResponse {
     pub timestamp: u64,
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Mesh node-list checkpoint (decentralised mining discovery).
+//
+// A BFT-finalised, signed snapshot of the public-mining node set that an
+// UNTRUSTED miner-side client can verify offline. Mirrors the payout-ledger
+// checkpoint machinery. Trust model (design decision C, hybrid): a shim carries
+// a baked-in genesis signer set and advances it via the signed forward chain —
+// each checkpoint's `signer_set_delta` is attested by ≥67% of the PRIOR set
+// (the approver signatures over `checkpoint_hash`, which commits `signer_set_root`).
+// Because `node_id` IS the node's Ed25519 public key, a shim verifies every
+// signature with no key distribution. See tasks/design_mesh_node_list_checkpoint.md.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// One public-mining node in a mesh node-list checkpoint: the {identity, endpoint}
+/// tuple a miner-side shim needs to connect. `node_id` is the node's Ed25519 public
+/// key, so a shim can verify anything this node signs with no key distribution.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MeshNodeEntry {
+    /// Node identity = Ed25519 public key.
+    #[serde(with = "ghost_common::serde_hex::bytes32")]
+    pub node_id: NodeId,
+    /// Public host WITHOUT a port, e.g. "203.0.113.7" or a hostname.
+    pub host: String,
+    /// Stratum V1 port (SV1 miners: Bitaxe/CGMiner).
+    pub sv1_port: u16,
+    /// Stratum V2 port.
+    pub sv2_port: u16,
+}
+
+/// Canonical Merkle-free root over a node list: sort by `node_id`, then hash each
+/// entry length-prefixed. Every node derives the byte-identical root from the same
+/// set, so `list_root` binds the list inside `checkpoint_hash`.
+pub fn mesh_node_list_root(nodes: &[MeshNodeEntry]) -> [u8; 32] {
+    use sha2::{Digest, Sha256};
+    let mut sorted: Vec<&MeshNodeEntry> = nodes.iter().collect();
+    sorted.sort_by(|a, b| a.node_id.cmp(&b.node_id));
+    let mut hasher = Sha256::new();
+    hasher.update(b"MeshNodeList/v1");
+    hasher.update((sorted.len() as u32).to_le_bytes());
+    for n in sorted {
+        hasher.update(n.node_id);
+        let hb = n.host.as_bytes();
+        hasher.update((hb.len() as u32).to_le_bytes());
+        hasher.update(hb);
+        hasher.update(n.sv1_port.to_le_bytes());
+        hasher.update(n.sv2_port.to_le_bytes());
+    }
+    hasher.finalize().into()
+}
+
+/// Canonical root over a signer set (sort + dedup, then hash). Binds the resulting
+/// signer set inside `checkpoint_hash` so the forward-chain delta is authenticated.
+pub fn mesh_signer_set_root(set: &[NodeId]) -> [u8; 32] {
+    use sha2::{Digest, Sha256};
+    let mut sorted = set.to_vec();
+    sorted.sort_unstable();
+    sorted.dedup();
+    let mut hasher = Sha256::new();
+    hasher.update(b"MeshSignerSet/v1");
+    hasher.update((sorted.len() as u32).to_le_bytes());
+    for id in sorted {
+        hasher.update(id);
+    }
+    hasher.finalize().into()
+}
+
+/// How the signer set changed versus the previous checkpoint — the signed forward
+/// chain (decision C). A shim applies this to advance its trusted set; the delta is
+/// authenticated because `checkpoint_hash` commits `signer_set_root` (the root of
+/// the set AFTER applying it) and the checkpoint is approved by ≥67% of the prior set.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SignerSetDelta {
+    /// Node IDs added to the signer set since the previous checkpoint.
+    #[serde(default)]
+    pub added: Vec<NodeId>,
+    /// Node IDs removed from the signer set since the previous checkpoint.
+    #[serde(default)]
+    pub removed: Vec<NodeId>,
+}
+
+/// Mesh node-list checkpoint proposal (proposer → all). The BFT-finalised, signed
+/// snapshot a miner-side shim consumes for trustless discovery.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MeshNodeListCheckpointMessage {
+    /// Lagging anchor height this checkpoint pins the node list at.
+    pub height: u64,
+    /// Cutoff = the anchor block's timestamp (deterministic, chain-committed).
+    pub cutoff_ts: i64,
+    /// The canonical public-mining node set as of `cutoff_ts`. Voters recompute
+    /// their own connected public-mining set and approve iff it matches; adopted
+    /// verbatim on finalise.
+    #[serde(default)]
+    pub nodes: Vec<MeshNodeEntry>,
+    /// `mesh_node_list_root(nodes)` — binds the list inside `checkpoint_hash`.
+    #[serde(with = "ghost_common::serde_hex::bytes32")]
+    pub list_root: [u8; 32],
+    /// Signer-set change vs the previous checkpoint (the signed forward chain).
+    #[serde(default)]
+    pub signer_set_delta: SignerSetDelta,
+    /// `mesh_signer_set_root(set)` of the signer set AFTER applying the delta —
+    /// committed in `checkpoint_hash`, so a shim can authenticate the new set.
+    #[serde(with = "ghost_common::serde_hex::bytes32")]
+    pub signer_set_root: [u8; 32],
+    /// Number of active nodes at this checkpoint.
+    pub active_node_count: u32,
+    /// Proposer's node ID (deterministic election for `height`).
+    #[serde(with = "ghost_common::serde_hex::bytes32")]
+    pub proposer: NodeId,
+    /// Proposer's signature over `checkpoint_hash()`.
+    #[serde(with = "ghost_common::serde_hex::bytes64")]
+    pub proposer_signature: [u8; 64],
+    /// Timestamp (Unix milliseconds).
+    pub timestamp: u64,
+}
+
+impl MeshNodeListCheckpointMessage {
+    /// Content hash (excludes the signature) — the object voters sign/compare.
+    /// Commits the list root AND the resulting signer-set root, so both the node
+    /// list and the forward-chain delta are authenticated by every approval.
+    pub fn checkpoint_hash(&self) -> [u8; 32] {
+        use sha2::{Digest, Sha256};
+        let mut hasher = Sha256::new();
+        hasher.update(b"MeshNodeListCheckpoint/v1");
+        hasher.update(self.height.to_le_bytes());
+        hasher.update(self.cutoff_ts.to_le_bytes());
+        hasher.update(self.list_root);
+        hasher.update(self.signer_set_root);
+        hasher.update(self.active_node_count.to_le_bytes());
+        hasher.update(self.proposer);
+        hasher.finalize().into()
+    }
+}
+
+/// Mesh node-list checkpoint vote (validator → all).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MeshNodeListCheckpointVoteMessage {
+    /// Checkpoint height being voted on.
+    pub height: u64,
+    /// Hash of the checkpoint being voted on (`MeshNodeListCheckpointMessage::checkpoint_hash`).
+    #[serde(with = "ghost_common::serde_hex::bytes32")]
+    pub checkpoint_hash: [u8; 32],
+    /// Voter's node ID.
+    #[serde(with = "ghost_common::serde_hex::bytes32")]
+    pub voter: NodeId,
+    /// Vote (true = approve; the voter reproduced the same `list_root`).
+    pub approve: bool,
+    /// Voter's signature over `signing_message()`.
+    #[serde(with = "ghost_common::serde_hex::bytes64")]
+    pub signature: [u8; 64],
+    /// Timestamp (Unix milliseconds).
+    pub timestamp: u64,
+}
+
+impl MeshNodeListCheckpointVoteMessage {
+    /// Get the message to be signed.
+    pub fn signing_message(&self) -> [u8; 32] {
+        use sha2::{Digest, Sha256};
+        let mut hasher = Sha256::new();
+        hasher.update(b"MeshNodeListCheckpointVote/v1");
+        hasher.update(self.height.to_le_bytes());
+        hasher.update(self.checkpoint_hash);
+        hasher.update([self.approve as u8]);
+        hasher.finalize().into()
+    }
+}
+
+/// One finalised mesh node-list checkpoint carried in a sync response. Unlike the payout
+/// sync entry, this carries the FULL signed blob — the proposer signature and the ≥67%
+/// approver signatures — so a syncing peer verifies the quorum itself (never trusting the
+/// serving peer) and can then serve the same verifiable blob to shims. Approver signatures
+/// are `Vec<u8>` (64 bytes) because serde's array impls stop at 32.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MeshNodeListCheckpointSyncEntry {
+    /// Lagging anchor height.
+    pub height: u64,
+    /// Cutoff = anchor block's timestamp.
+    pub cutoff_ts: i64,
+    /// Canonical public-mining node set as of `cutoff_ts`.
+    #[serde(default)]
+    pub nodes: Vec<MeshNodeEntry>,
+    /// `mesh_node_list_root(nodes)`.
+    #[serde(with = "ghost_common::serde_hex::bytes32")]
+    pub list_root: [u8; 32],
+    /// Signer-set change vs the previous checkpoint.
+    #[serde(default)]
+    pub signer_set_delta: SignerSetDelta,
+    /// `mesh_signer_set_root` of the set after the delta.
+    #[serde(with = "ghost_common::serde_hex::bytes32")]
+    pub signer_set_root: [u8; 32],
+    /// Active-node count at this checkpoint.
+    pub active_node_count: u32,
+    /// Deterministic proposer for `height` (checked against `proposer_for(height)` on apply).
+    #[serde(with = "ghost_common::serde_hex::bytes32")]
+    pub proposer: NodeId,
+    /// Proposer's signature over the checkpoint hash.
+    #[serde(with = "ghost_common::serde_hex::bytes64")]
+    pub proposer_signature: [u8; 64],
+    /// The ≥67% approver signatures over the vote signing message: `(voter, signature)`.
+    #[serde(default)]
+    pub approvals: Vec<(NodeId, Vec<u8>)>,
+}
+
+/// Mesh node-list checkpoint sync REQUEST (node → peers): backfill finalised
+/// checkpoints from `from_height` up.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MeshNodeListCheckpointSyncRequest {
+    /// The node asking to be backfilled.
+    #[serde(with = "ghost_common::serde_hex::bytes32")]
+    pub requesting_node: NodeId,
+    /// Lowest height the requester lacks (its `latest_finalised + 1`).
+    pub from_height: u64,
+    /// Timestamp (Unix milliseconds).
+    pub timestamp: u64,
+}
+
+/// Mesh node-list checkpoint sync RESPONSE (peer → requester): a bounded, ascending
+/// page of finalised checkpoints. `has_more` signals the requester to paginate.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MeshNodeListCheckpointSyncResponse {
+    /// The peer serving the backfill.
+    #[serde(with = "ghost_common::serde_hex::bytes32")]
+    pub responding_node: NodeId,
+    /// Finalised checkpoints, ascending from the requested height (bounded page).
+    pub checkpoints: Vec<MeshNodeListCheckpointSyncEntry>,
+    /// True if the responder hit its page cap — the requester should re-request.
+    pub has_more: bool,
+    /// Timestamp (Unix milliseconds).
+    pub timestamp: u64,
+}
+
 /// L2: Tree sync request (new node → peer)
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct L2TreeSyncRequest {
@@ -1755,6 +2004,115 @@ mod tests {
 
         assert_eq!(decoded.round_id, 1);
         assert!(decoded.approve);
+    }
+
+    // ── Mesh node-list checkpoint wire types ────────────────────────────────
+    fn mesh_entry(i: u8) -> MeshNodeEntry {
+        let mut id = [0u8; 32];
+        id[0] = i;
+        id[1] = i.wrapping_mul(7);
+        MeshNodeEntry {
+            node_id: id,
+            host: format!("10.0.0.{i}"),
+            sv1_port: 3333,
+            sv2_port: 34255,
+        }
+    }
+
+    fn sample_mesh_checkpoint() -> MeshNodeListCheckpointMessage {
+        let nodes = vec![mesh_entry(1), mesh_entry(2)];
+        let signer_set = vec![[1u8; 32], [2u8; 32]];
+        MeshNodeListCheckpointMessage {
+            height: 959_400,
+            cutoff_ts: 1_760_000_000,
+            list_root: mesh_node_list_root(&nodes),
+            nodes,
+            signer_set_delta: SignerSetDelta {
+                added: vec![[2u8; 32]],
+                removed: vec![],
+            },
+            signer_set_root: mesh_signer_set_root(&signer_set),
+            active_node_count: 2,
+            proposer: [1u8; 32],
+            proposer_signature: [0u8; 64],
+            timestamp: 1,
+        }
+    }
+
+    #[test]
+    fn mesh_node_list_root_is_order_independent_and_content_sensitive() {
+        let a = vec![mesh_entry(1), mesh_entry(2), mesh_entry(3)];
+        let mut b = a.clone();
+        b.reverse();
+        assert_eq!(
+            mesh_node_list_root(&a),
+            mesh_node_list_root(&b),
+            "collection order must not change the root"
+        );
+        let mut c = a.clone();
+        c[0].host = "changed".to_string();
+        assert_ne!(
+            mesh_node_list_root(&a),
+            mesh_node_list_root(&c),
+            "a changed endpoint must change the root"
+        );
+    }
+
+    #[test]
+    fn mesh_signer_set_root_is_order_and_dup_independent() {
+        let s1 = vec![[1u8; 32], [2u8; 32], [3u8; 32]];
+        let mut s2 = vec![[3u8; 32], [2u8; 32], [1u8; 32], [2u8; 32]]; // reordered + dup
+        assert_eq!(mesh_signer_set_root(&s1), mesh_signer_set_root(&s2));
+        s2.push([9u8; 32]);
+        assert_ne!(
+            mesh_signer_set_root(&s1),
+            mesh_signer_set_root(&s2),
+            "a genuinely different member must change the root"
+        );
+    }
+
+    #[test]
+    fn mesh_checkpoint_hash_excludes_signature_and_binds_content() {
+        let cp = sample_mesh_checkpoint();
+        let h = cp.checkpoint_hash();
+        let mut cp2 = cp.clone();
+        cp2.proposer_signature = [7u8; 64];
+        assert_eq!(
+            h,
+            cp2.checkpoint_hash(),
+            "signature must not affect the hash"
+        );
+        let mut cp3 = cp.clone();
+        cp3.list_root = [9u8; 32];
+        assert_ne!(h, cp3.checkpoint_hash(), "list_root is bound");
+        let mut cp4 = cp.clone();
+        cp4.signer_set_root = [9u8; 32];
+        assert_ne!(h, cp4.checkpoint_hash(), "signer_set_root is bound");
+    }
+
+    #[test]
+    fn mesh_checkpoint_vote_signing_message_flips_with_approve() {
+        let cp = sample_mesh_checkpoint();
+        let mk = |approve: bool| MeshNodeListCheckpointVoteMessage {
+            height: cp.height,
+            checkpoint_hash: cp.checkpoint_hash(),
+            voter: [5u8; 32],
+            approve,
+            signature: [0u8; 64],
+            timestamp: 1,
+        };
+        assert_ne!(mk(true).signing_message(), mk(false).signing_message());
+        assert_eq!(mk(true).signing_message(), mk(true).signing_message());
+    }
+
+    #[test]
+    fn mesh_checkpoint_serde_roundtrip() {
+        let cp = sample_mesh_checkpoint();
+        let json = serde_json::to_vec(&cp).unwrap();
+        let back: MeshNodeListCheckpointMessage = serde_json::from_slice(&json).unwrap();
+        assert_eq!(back.checkpoint_hash(), cp.checkpoint_hash());
+        assert_eq!(back.nodes, cp.nodes);
+        assert_eq!(back.signer_set_delta, cp.signer_set_delta);
     }
 
     #[test]

--- a/crates/ghost-consensus/src/message_validator.rs
+++ b/crates/ghost-consensus/src/message_validator.rs
@@ -473,6 +473,9 @@ pub fn max_payload_size(msg_type: MessageType) -> usize {
         MessageType::ShareBatchProposal => MAX_SHARE_BATCH_SIZE,
         MessageType::ShareBatchVote => MAX_SHARE_BATCH_VOTE_SIZE,
         MessageType::ShareBatchSync => MAX_SHARE_BATCH_SYNC_SIZE,
+        MessageType::MeshNodeListCheckpoint => MAX_PAYOUT_PROPOSAL_SIZE,
+        MessageType::MeshNodeListCheckpointVote => MAX_VOTE_SIZE,
+        MessageType::MeshNodeListCheckpointSync => MAX_PAYOUT_SYNC_SIZE,
         MessageType::L2TreeSync => MAX_L2_TREE_SYNC_SIZE,
         MessageType::L2ShieldBroadcast => 256, // ShieldCommitment: 32-byte commitment + u64 index + u64 height
         MessageType::GhostGlyphClaim => MAX_GLYPH_CLAIM_SIZE,

--- a/crates/ghost-storage/src/lib.rs
+++ b/crates/ghost-storage/src/lib.rs
@@ -51,6 +51,7 @@ pub use models::*;
 pub use queries::BondRow;
 pub use queries::GlyphRecord;
 pub use queries::L2StateInfo;
+pub use queries::MeshNodeListCheckpointRecord;
 pub use queries::MpcContributionRecord;
 pub use queries::PayoutLedgerCheckpointRecord;
 pub use queries::{ConfidentialNoteRecord, ConfidentialTransferRecord};

--- a/crates/ghost-storage/src/queries.rs
+++ b/crates/ghost-storage/src/queries.rs
@@ -8466,6 +8466,63 @@ pub struct PayoutLedgerCheckpointRecord {
     pub node_shares: Vec<([u8; 32], i32)>,
 }
 
+/// A BFT-finalised mesh node-list checkpoint (migration v47): the signed snapshot of the
+/// public-mining node set a miner-side shim verifies offline. Unlike the payout checkpoint it
+/// keeps the proposer + approver signatures (so the served HTTP blob is independently
+/// verifiable) and the signer-set forward-chain delta (so a shim can advance its trusted set).
+/// Signatures are held as `Vec<u8>` (64 bytes) because serde's array impls stop at 32.
+#[derive(Debug, Clone)]
+pub struct MeshNodeListCheckpointRecord {
+    pub height: u64,
+    pub cutoff_ts: i64,
+    pub list_root: [u8; 32],
+    pub signer_set_root: [u8; 32],
+    /// Hex-encoded proposer node id.
+    pub proposer_id: String,
+    pub active_node_count: u32,
+    /// Proposer's Ed25519 signature over the checkpoint hash (64 bytes).
+    pub proposer_signature: Vec<u8>,
+    /// The canonical public-mining node list: `(node_id, host, sv1_port, sv2_port)`.
+    pub nodes: Vec<([u8; 32], String, u16, u16)>,
+    /// Signer-set forward-chain delta vs the previous checkpoint: `(added, removed)`.
+    pub signer_set_delta: (Vec<[u8; 32]>, Vec<[u8; 32]>),
+    /// Approver signatures over the vote signing message: `(voter_id, signature)` (64-byte sigs).
+    pub approvals: Vec<([u8; 32], Vec<u8>)>,
+}
+
+/// Decode a `mesh_node_list_checkpoints` row tuple into a record; returns `None` on a malformed
+/// root/blob (the same defensive tolerance the payout-checkpoint reader uses).
+#[allow(clippy::type_complexity)]
+fn mesh_row_to_record(
+    t: (i64, i64, Vec<u8>, Vec<u8>, String, i64, Vec<u8>, Vec<u8>),
+) -> Option<MeshNodeListCheckpointRecord> {
+    let (height, cutoff_ts, list_root_b, signer_root_b, proposer_id, active, sig, detail) = t;
+    if list_root_b.len() != 32 || signer_root_b.len() != 32 {
+        return None;
+    }
+    let mut list_root = [0u8; 32];
+    list_root.copy_from_slice(&list_root_b);
+    let mut signer_set_root = [0u8; 32];
+    signer_set_root.copy_from_slice(&signer_root_b);
+    let (nodes, signer_set_delta, approvals): (
+        Vec<([u8; 32], String, u16, u16)>,
+        (Vec<[u8; 32]>, Vec<[u8; 32]>),
+        Vec<([u8; 32], Vec<u8>)>,
+    ) = serde_json::from_slice(&detail).ok()?;
+    Some(MeshNodeListCheckpointRecord {
+        height: height as u64,
+        cutoff_ts,
+        list_root,
+        signer_set_root,
+        proposer_id,
+        active_node_count: active as u32,
+        proposer_signature: sig,
+        nodes,
+        signer_set_delta,
+        approvals,
+    })
+}
+
 /// L2 epoch record (lifecycle and compaction state)
 #[derive(Debug, Clone)]
 pub struct L2EpochRecord {
@@ -9175,6 +9232,118 @@ impl Database {
                     miner_payouts,
                     node_shares,
                 });
+            }
+            Ok(out)
+        })
+    }
+
+    /// Persist a finalised mesh node-list checkpoint (idempotent by height).
+    pub fn upsert_mesh_node_list_checkpoint(
+        &self,
+        r: &MeshNodeListCheckpointRecord,
+    ) -> GhostResult<()> {
+        let detail = serde_json::to_vec(&(&r.nodes, &r.signer_set_delta, &r.approvals))
+            .map_err(|e| GhostError::Database(e.to_string()))?;
+        self.with_connection(|conn| {
+            conn.execute(
+                "INSERT OR REPLACE INTO mesh_node_list_checkpoints
+                 (height, cutoff_ts, list_root, signer_set_root, proposer_id,
+                  active_node_count, proposer_signature, detail)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+                params![
+                    r.height as i64,
+                    r.cutoff_ts,
+                    r.list_root.as_slice(),
+                    r.signer_set_root.as_slice(),
+                    r.proposer_id,
+                    r.active_node_count as i64,
+                    r.proposer_signature.as_slice(),
+                    detail.as_slice(),
+                ],
+            )
+            .map_err(|e| GhostError::Database(e.to_string()))?;
+            Ok(())
+        })
+    }
+
+    /// The latest finalised mesh node-list checkpoint at or below `max_height`
+    /// (`u64::MAX` = the latest).
+    pub fn get_mesh_node_list_checkpoint_at_or_before(
+        &self,
+        max_height: u64,
+    ) -> GhostResult<Option<MeshNodeListCheckpointRecord>> {
+        self.with_connection(|conn| {
+            conn.query_row(
+                "SELECT height, cutoff_ts, list_root, signer_set_root, proposer_id,
+                        active_node_count, proposer_signature, detail
+                 FROM mesh_node_list_checkpoints
+                 WHERE height <= ?1 ORDER BY height DESC LIMIT 1",
+                params![max_height.min(i64::MAX as u64) as i64],
+                |row| {
+                    Ok((
+                        row.get::<_, i64>(0)?,
+                        row.get::<_, i64>(1)?,
+                        row.get::<_, Vec<u8>>(2)?,
+                        row.get::<_, Vec<u8>>(3)?,
+                        row.get::<_, String>(4)?,
+                        row.get::<_, i64>(5)?,
+                        row.get::<_, Vec<u8>>(6)?,
+                        row.get::<_, Vec<u8>>(7)?,
+                    ))
+                },
+            )
+            .optional()
+            .map_err(|e| GhostError::Database(e.to_string()))
+            .map(|opt| opt.and_then(mesh_row_to_record))
+        })
+    }
+
+    /// The latest finalised mesh node-list checkpoint.
+    pub fn get_latest_mesh_node_list_checkpoint(
+        &self,
+    ) -> GhostResult<Option<MeshNodeListCheckpointRecord>> {
+        self.get_mesh_node_list_checkpoint_at_or_before(u64::MAX)
+    }
+
+    /// Finalised mesh node-list checkpoints at `height >= from_height`, ascending, bounded by
+    /// `limit`. Backs the sync responder (analog of the payout-checkpoint backfill).
+    pub fn get_mesh_node_list_checkpoints_from_height(
+        &self,
+        from_height: u64,
+        limit: u64,
+    ) -> GhostResult<Vec<MeshNodeListCheckpointRecord>> {
+        self.with_connection(|conn| {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT height, cutoff_ts, list_root, signer_set_root, proposer_id,
+                            active_node_count, proposer_signature, detail
+                     FROM mesh_node_list_checkpoints
+                     WHERE height >= ?1 ORDER BY height ASC LIMIT ?2",
+                )
+                .map_err(|e| GhostError::Database(e.to_string()))?;
+            let rows = stmt
+                .query_map(
+                    params![from_height.min(i64::MAX as u64) as i64, limit as i64],
+                    |row| {
+                        Ok((
+                            row.get::<_, i64>(0)?,
+                            row.get::<_, i64>(1)?,
+                            row.get::<_, Vec<u8>>(2)?,
+                            row.get::<_, Vec<u8>>(3)?,
+                            row.get::<_, String>(4)?,
+                            row.get::<_, i64>(5)?,
+                            row.get::<_, Vec<u8>>(6)?,
+                            row.get::<_, Vec<u8>>(7)?,
+                        ))
+                    },
+                )
+                .map_err(|e| GhostError::Database(e.to_string()))?;
+            let mut out = Vec::new();
+            for row in rows {
+                let tuple = row.map_err(|e| GhostError::Database(e.to_string()))?;
+                if let Some(rec) = mesh_row_to_record(tuple) {
+                    out.push(rec);
+                }
             }
             Ok(out)
         })
@@ -10536,6 +10705,53 @@ mod tests {
             2,
             "a second distinct win counts"
         );
+    }
+
+    /// Mesh node-list checkpoints persist and read back byte-identical, are idempotent by
+    /// height, and honour the at-or-before / from-height range reads.
+    #[test]
+    fn mesh_node_list_checkpoint_round_trips() {
+        let db = Database::in_memory().expect("in-memory db");
+        assert!(db.get_latest_mesh_node_list_checkpoint().unwrap().is_none());
+
+        let rec = MeshNodeListCheckpointRecord {
+            height: 959_400,
+            cutoff_ts: 1_760_000_000,
+            list_root: [7u8; 32],
+            signer_set_root: [9u8; 32],
+            proposer_id: "aa".repeat(32),
+            active_node_count: 3,
+            proposer_signature: vec![1u8; 64],
+            nodes: vec![
+                ([1u8; 32], "203.0.113.7".to_string(), 3333, 34255),
+                ([2u8; 32], "198.51.100.4".to_string(), 3333, 34255),
+            ],
+            signer_set_delta: (vec![[2u8; 32]], vec![]),
+            approvals: vec![([1u8; 32], vec![5u8; 64]), ([2u8; 32], vec![6u8; 64])],
+        };
+        db.upsert_mesh_node_list_checkpoint(&rec).unwrap();
+
+        let got = db.get_latest_mesh_node_list_checkpoint().unwrap().unwrap();
+        assert_eq!(got.height, 959_400);
+        assert_eq!(got.list_root, [7u8; 32]);
+        assert_eq!(got.signer_set_root, [9u8; 32]);
+        assert_eq!(got.proposer_signature, vec![1u8; 64]);
+        assert_eq!(got.nodes.len(), 2);
+        assert_eq!(got.nodes[0].1, "203.0.113.7");
+        assert_eq!(got.signer_set_delta.0, vec![[2u8; 32]]);
+        assert_eq!(got.approvals.len(), 2);
+        assert_eq!(got.approvals[1].1, vec![6u8; 64]);
+
+        // Idempotent by height (INSERT OR REPLACE), and range reads behave.
+        db.upsert_mesh_node_list_checkpoint(&rec).unwrap();
+        let from = db
+            .get_mesh_node_list_checkpoints_from_height(0, 10)
+            .unwrap();
+        assert_eq!(from.len(), 1, "idempotent by height");
+        assert!(db
+            .get_mesh_node_list_checkpoint_at_or_before(959_399)
+            .unwrap()
+            .is_none());
     }
 
     /// A-2: the `/24` subnet extractor must accept only dotted-quad IPv4 literals

--- a/crates/ghost-verification/src/routes.rs
+++ b/crates/ghost-verification/src/routes.rs
@@ -237,6 +237,13 @@ pub fn create_router(state: Arc<VerificationState>) -> Router {
         // website render the node list from one node instead of a hard-coded
         // VM set, so new nodes appear automatically.
         .route("/api/v1/pool/mesh-nodes", get(api_pool_mesh_nodes_handler))
+        // Signed, verifiable snapshot of the public-mining node set — the blob a miner-side
+        // shim fetches for trustless decentralised discovery. 404 until a checkpoint is
+        // finalised (the gate is dormant on mainnet today).
+        .route(
+            "/api/v1/pool/mesh-node-list-checkpoint",
+            get(api_pool_mesh_node_list_checkpoint_handler),
+        )
         // Rolling server-side time-series of pool hashrate + connected miners,
         // sampled every 30s (24h retention). `?window=1h|24h`. Lets the pool
         // page chart real history instead of a client-side session buffer.
@@ -2728,6 +2735,25 @@ fn mesh_node_to_json(node: &MeshNodeInfo, is_registry_elder: bool) -> serde_json
         "healthy": node.healthy,
         "is_self": false,
     })
+}
+
+/// The latest finalised, signed mesh node-list checkpoint — the verifiable blob a miner-side
+/// shim fetches for decentralised discovery: the public-mining node set plus the proposer
+/// signature and the ≥67% approver signatures, so the shim verifies it offline against its
+/// trusted signer set (never trusting DNS or this server). PUBLIC, no auth (the data is the
+/// same openly-gossiped node set as `mesh-nodes`, just BFT-signed). 404 until a checkpoint is
+/// finalised — the gate is dormant on mainnet, so this returns 404 today.
+async fn api_pool_mesh_node_list_checkpoint_handler(
+    State(state): State<Arc<VerificationState>>,
+) -> impl IntoResponse {
+    match state.mesh_node_list_checkpoint() {
+        Some(blob) => (StatusCode::OK, Json(blob)).into_response(),
+        None => (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({ "error": "no finalised mesh node-list checkpoint" })),
+        )
+            .into_response(),
+    }
 }
 
 /// Live mesh node list = this node (self) + every connected peer.

--- a/crates/ghost-verification/src/server.rs
+++ b/crates/ghost-verification/src/server.rs
@@ -1457,6 +1457,11 @@ pub struct VerificationState {
     /// prepends this node (self) from local state. None on deploys without the
     /// provider wired — the endpoint then returns just self.
     get_mesh_nodes: Option<Box<dyn Fn() -> Vec<MeshNodeInfo> + Send + Sync>>,
+    /// Returns the latest finalised mesh node-list checkpoint as a pre-built, verifiable JSON
+    /// blob (proposal fields + proposer signature + ≥67% approver signatures), or None if none
+    /// is finalised / the provider isn't wired. Serves the signed
+    /// `/api/v1/pool/mesh-node-list-checkpoint` endpoint a miner-side shim verifies offline.
+    get_mesh_node_list_checkpoint: Option<Box<dyn Fn() -> Option<serde_json::Value> + Send + Sync>>,
     /// Signal to trigger graceful restart (set by config update API)
     /// When true, main.rs will initiate shutdown and exit with code 100
     pub restart_signal: Arc<AtomicBool>,
@@ -1717,6 +1722,7 @@ impl VerificationState {
             get_round_elapsed_secs: None,
             get_mesh_best_records: None,
             get_mesh_nodes: None,
+            get_mesh_node_list_checkpoint: None,
             // VF-C2: Default to requiring internal auth for security
             require_internal_auth: true,
             restart_signal: Arc::new(AtomicBool::new(false)),
@@ -2578,6 +2584,23 @@ impl VerificationState {
             .as_ref()
             .map(|f| f())
             .unwrap_or_default()
+    }
+
+    /// Wire the signed mesh node-list checkpoint provider (see the field).
+    pub fn with_mesh_node_list_checkpoint(
+        mut self,
+        f: impl Fn() -> Option<serde_json::Value> + Send + Sync + 'static,
+    ) -> Self {
+        self.get_mesh_node_list_checkpoint = Some(Box::new(f));
+        self
+    }
+
+    /// The latest finalised signed mesh node-list checkpoint blob, or None if none is
+    /// finalised or no provider is wired.
+    pub fn mesh_node_list_checkpoint(&self) -> Option<serde_json::Value> {
+        self.get_mesh_node_list_checkpoint
+            .as_ref()
+            .and_then(|f| f())
     }
 
     /// Set archive handler

--- a/ghost-web/endpoints.html
+++ b/ghost-web/endpoints.html
@@ -1,0 +1,368 @@
+<!-- Bitcoin Ghost · Mining Endpoints -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Mining endpoints · Bitcoin Ghost</title>
+  <meta name="description" content="Live list of public Ghost mining nodes. Point an ASIC at any node — the mesh load-balances you across the pool. Any node is a valid entry point, so no single address can strand you.">
+  <meta property="og:site_name" content="Bitcoin Ghost">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="Mining endpoints · Bitcoin Ghost">
+  <meta property="og:description" content="Live list of public Ghost mining nodes. Point an ASIC at any node — the mesh load-balances you across the pool.">
+  <meta property="og:url" content="https://bitcoinghost.org/endpoints.html">
+  <meta property="og:image" content="https://bitcoinghost.org/logo.png">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:site" content="@defenwycke">
+  <meta name="twitter:creator" content="@defenwycke">
+  <meta name="twitter:title" content="Mining endpoints · Bitcoin Ghost">
+  <meta name="twitter:description" content="Live list of public Ghost mining nodes. Point an ASIC at any node — the mesh load-balances you across the pool.">
+  <meta name="twitter:image" content="https://bitcoinghost.org/logo.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css?v=20260424">
+  <script>
+    (function () {
+      var saved = localStorage.getItem('ghost-theme');
+      var system = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+      document.documentElement.setAttribute('data-theme', saved || system);
+    })();
+  </script>
+</head>
+<body>
+
+<header class="site-header">
+  <div class="container">
+    <a href="/" class="brand bare">
+      <svg class="logo-ghost" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M9 10h.01"/>
+        <path d="M15 10h.01"/>
+        <path d="M12 2a8 8 0 0 0-8 8v12l3-3 2.5 2.5L12 19l2.5 2.5L17 19l3 3V10a8 8 0 0 0-8-8z"/>
+      </svg>
+      <span class="wordmark">bitcoinghost</span>
+    </a>
+    <nav class="primary">
+      <a href="/">overview</a>
+      <a href="/core.html">core</a>
+      <a href="/pool.html">pool</a>
+      <a href="/pay.html">pay</a>
+      <a href="/nodes.html">nodes</a>
+      <a href="/hazync.html">hazync</a>
+      <a href="/miners.html">miners</a>
+      <a href="/endpoints.html" class="current">endpoints</a>
+      <a href="/downloads.html">downloads</a>
+      <a href="/docs/">docs</a>
+    </nav>
+    <div class="utils">
+      <a href="https://github.com/bitcoin-ghost" class="bare icon-btn" aria-label="GitHub">
+        <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+          <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/>
+        </svg>
+      </a>
+      <button id="theme-toggle" class="theme-toggle" aria-label="Toggle colour scheme"></button>
+    </div>
+  </div>
+</header>
+
+<section class="hero">
+  <div class="container">
+    <span class="eyebrow">Mining endpoints</span>
+    <h1>Point at any node. Mine the whole pool.</h1>
+    <p class="lead">
+      Every public Ghost node is a valid entry point. Connect an ASIC to any
+      one of them and the mesh load-balances your hashrate across the pool
+      automatically — the balancing happens at the nodes, not at a central
+      proxy. So this list is a <strong>bootstrap seed</strong>: pick a couple,
+      set them as your pool + fallbacks, and no single address can ever strand
+      you.
+    </p>
+    <div class="hero-actions">
+      <a href="#endpoints" class="btn btn-primary">Live nodes <span class="arrow">↓</span></a>
+      <a href="#setup" class="btn btn-ghost">Resilient setup</a>
+    </div>
+  </div>
+</section>
+
+<!-- ───────── Live endpoints ───────── -->
+<section class="block" id="endpoints">
+  <div class="container">
+    <div class="section-label">live nodes</div>
+    <h2 class="section-title">Public mining endpoints.</h2>
+    <p class="section-lead">
+      Fetched live from the mesh. Every node here has <strong>public mining</strong>
+      enabled and accepts external miners. Stratum V1 is the common choice for
+      Bitaxe and CGMiner; Stratum V2 is available on the same hosts.
+    </p>
+
+    <div id="ep-status" class="pending-note" style="margin-bottom:1rem">Loading live node list…</div>
+
+    <div class="hw-table-wrap">
+      <table class="hw-table" id="ep-table" style="display:none">
+        <thead>
+          <tr>
+            <th>Node</th>
+            <th>Stratum V1</th>
+            <th>Stratum V2</th>
+            <th>Miners</th>
+            <th>Load</th>
+            <th>Hashrate</th>
+            <th>Status</th>
+          </tr>
+        </thead>
+        <tbody id="ep-rows"></tbody>
+      </table>
+    </div>
+
+    <p class="section-lead" style="margin-top:1rem;font-size:0.85rem;opacity:0.7">
+      List refreshes every 30s. Pulled from one node's view of the whole mesh —
+      so nodes joining or leaving appear here automatically, with no hard-coded
+      list. Load is current miners ÷ node capacity.
+    </p>
+  </div>
+</section>
+
+<!-- ───────── How routing works ───────── -->
+<section class="block" style="border-top:none">
+  <div class="container">
+    <div class="section-label">how it routes</div>
+    <h2 class="section-title">The balancing is at the nodes.</h2>
+    <p class="section-lead">
+      You don't need a smart address to reach a lightly-loaded node — you just
+      need to reach <em>any</em> node. When your miner connects, that node checks
+      the live mesh and, if a less-loaded peer exists, transparently forwards
+      your Stratum session to it. Your miner never notices. That's why any entry
+      point works, and why losing one address doesn't cost you the pool.
+    </p>
+    <div class="core-tiles core-tiles-3">
+      <div class="ct-tile">
+        <div class="k">entry</div>
+        <div class="v">any node</div>
+        <div class="sub">every public node accepts you</div>
+      </div>
+      <div class="ct-tile">
+        <div class="k">routing</div>
+        <div class="v accent">at the node</div>
+        <div class="sub">mesh-driven, no central proxy</div>
+      </div>
+      <div class="ct-tile">
+        <div class="k">failover</div>
+        <div class="v">to a peer</div>
+        <div class="sub">set fallbacks; never stranded</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ───────── Resilient setup ───────── -->
+<section class="block" id="setup">
+  <div class="container">
+    <div class="section-label">resilient setup</div>
+    <h2 class="section-title">Set a primary and fallbacks.</h2>
+    <p class="section-lead">
+      Mining firmware fails over automatically when a pool drops. Give it more
+      than one Ghost node — a primary plus one or two fallbacks from the list
+      above — and your rig keeps hashing even if a whole node (or an address)
+      goes offline. Use the fixed stratum ports: <code>:3333</code> for V1,
+      <code>:34255</code> for V2.
+    </p>
+
+    <ul class="feature-list node-core-pink">
+      <li>
+        <svg class="gh-bullet" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 10h.01"/><path d="M15 10h.01"/><path d="M12 2a8 8 0 0 0-8 8v12l3-3 2.5 2.5L12 19l2.5 2.5L17 19l3 3V10a8 8 0 0 0-8-8z"/></svg>
+        <div>
+          <div class="fl-name">Bitaxe / AxeOS</div>
+          <div class="fl-desc">In the web UI under <strong>Settings</strong>, set <code>pool.bitcoinghost.org:3333</code> (or any node from the list) as the <strong>Stratum</strong> host, and a second node as the <strong>Fallback Stratum</strong> host. AxeOS switches to the fallback automatically if the primary stops responding.</div>
+        </div>
+      </li>
+      <li>
+        <svg class="gh-bullet" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 10h.01"/><path d="M15 10h.01"/><path d="M12 2a8 8 0 0 0-8 8v12l3-3 2.5 2.5L12 19l2.5 2.5L17 19l3 3V10a8 8 0 0 0-8-8z"/></svg>
+        <div>
+          <div class="fl-name">CGMiner / BFGMiner</div>
+          <div class="fl-desc">Pass each node as its own <code>--url</code>; they're tried in priority order with automatic failover:<br><code>--url stratum+tcp://pool.bitcoinghost.org:3333 --url stratum+tcp://&lt;node-2&gt;:3333 --url stratum+tcp://&lt;node-3&gt;:3333</code><br>Use the same <code>--user &lt;your-bc1…-address&gt;</code> on each.</div>
+        </div>
+      </li>
+      <li>
+        <svg class="gh-bullet" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 10h.01"/><path d="M15 10h.01"/><path d="M12 2a8 8 0 0 0-8 8v12l3-3 2.5 2.5L12 19l2.5 2.5L17 19l3 3V10a8 8 0 0 0-8-8z"/></svg>
+        <div>
+          <div class="fl-name">Your address is your username</div>
+          <div class="fl-desc">Ghost has no accounts. Your <code>bc1…</code> payout address <em>is</em> your Stratum username — set it the same on every node so all your shares aggregate to one payout, whichever node you land on.</div>
+        </div>
+      </li>
+    </ul>
+
+    <div class="pending-note" style="margin-top:1.5rem">
+      Coming: a verifiable, consensus-signed node list a small local helper can
+      follow automatically — so discovery needs neither DNS nor this page after
+      first run. For now, a primary plus a fallback or two gives you
+      address-independent resilience today.
+    </div>
+  </div>
+</section>
+
+<footer class="site-footer">
+  <div class="container">
+    <div class="colophon">
+      <div class="brand">
+        <svg class="logo-ghost" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" style="width:22px;height:22px;">
+          <path d="M9 10h.01"/>
+          <path d="M15 10h.01"/>
+          <path d="M12 2a8 8 0 0 0-8 8v12l3-3 2.5 2.5L12 19l2.5 2.5L17 19l3 3V10a8 8 0 0 0-8-8z"/>
+        </svg>
+        <span class="wordmark">bitcoinghost</span>
+      </div>
+      <div class="meta">Open source under the MIT license. No ICO, no foundation, no venture money.</div>
+    </div>
+    <div><h4>Core</h4><ul></ul></div>
+    <div><h4>Pool</h4><ul></ul></div>
+    <div><h4>Pay</h4><ul></ul></div>
+    <div><h4>Products</h4><ul></ul></div>
+    <div>
+      <h4>Project</h4>
+      <ul>
+        <li><a href="https://github.com/bitcoin-ghost">GitHub</a></li>
+        <li><a href="https://x.com/defenwycke">@defenwycke</a></li>
+        <li><a href="https://defenwycke.org">defenwycke.org</a></li>
+        <li><a href="https://github.com/bitcoin-ghost/ghost/blob/main/LICENSE">MIT License</a></li>
+      </ul>
+    </div>
+  </div>
+</footer>
+
+<script>
+  (function () {
+    var html = document.documentElement;
+    var btn = document.getElementById('theme-toggle');
+    var sun = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>';
+    var moon = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>';
+    function render() { btn.innerHTML = html.getAttribute('data-theme') === 'dark' ? sun : moon; }
+    render();
+    btn.addEventListener('click', function () {
+      var next = html.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+      html.setAttribute('data-theme', next);
+      localStorage.setItem('ghost-theme', next);
+      render();
+    });
+  })();
+
+  // ── Live public-mining endpoint list ───────────────────────────────────
+  // Bootstrap seeds = the original four load-balancer proxies. A new mesh node
+  // has no per-node proxy, so we always enter through one of these seeds; the
+  // /api/v1/pool/mesh-nodes endpoint then returns the WHOLE mesh (self + every
+  // connected peer) from that single node, so nodes 5, 6, … appear here with no
+  // hard-coded list. Same pattern the overview page uses.
+  (function () {
+    var VMS = ['vm1', 'vm2', 'vm3', 'vm4'];
+    var SV1_PORT = 3333;    // config/mainnet.toml sv1_port
+    var SV2_PORT = 34255;   // config/mainnet.toml sv2_port
+
+    async function fetchMeshNodes() {
+      for (var i = 0; i < VMS.length; i++) {
+        try {
+          var ctl = new AbortController();
+          var t = setTimeout(function () { ctl.abort(); }, 5000);
+          var r = await fetch('/api/pool/' + VMS[i] + '/api/v1/pool/mesh-nodes', { signal: ctl.signal });
+          clearTimeout(t);
+          if (r.ok) {
+            var d = await r.json();
+            if (d && Array.isArray(d.nodes) && d.nodes.length) return d.nodes;
+          }
+        } catch (e) { /* try the next seed */ }
+      }
+      return null;
+    }
+
+    function formatHashrate(ths) {
+      if (!isFinite(ths) || ths <= 0) return '0 <span class="unit">TH/s</span>';
+      if (ths < 0.001) return (ths * 1e6).toFixed(1) + ' <span class="unit">MH/s</span>';
+      if (ths < 1)     return (ths * 1000).toFixed(1) + ' <span class="unit">GH/s</span>';
+      if (ths < 1000)  return ths.toFixed(2) + ' <span class="unit">TH/s</span>';
+      if (ths < 1e6)   return (ths / 1000).toFixed(2) + ' <span class="unit">PH/s</span>';
+      return (ths / 1e6).toFixed(2) + ' <span class="unit">EH/s</span>';
+    }
+
+    // Strip the :8080 API port off an "host:port" address, leaving the bare host.
+    function hostOf(address) {
+      if (!address) return '';
+      var s = String(address);
+      var i = s.lastIndexOf(':');
+      return i > 0 ? s.slice(0, i) : s;
+    }
+
+    function esc(s) {
+      return String(s).replace(/[&<>"']/g, function (c) {
+        return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c];
+      });
+    }
+
+    function loadPct(node) {
+      var cap = Number(node.max_capacity) || 0;
+      var mc = Number(node.miner_count) || 0;
+      if (cap <= 0) return null;
+      return Math.min(100, Math.round((mc / cap) * 100));
+    }
+
+    var statusEl = document.getElementById('ep-status');
+    var tableEl = document.getElementById('ep-table');
+    var rowsEl = document.getElementById('ep-rows');
+
+    function render(nodes) {
+      // Only nodes advertising public mining accept external miners.
+      var pub = nodes.filter(function (n) {
+        return n && n.capabilities && n.capabilities.public_mining && hostOf(n.address);
+      });
+      if (!pub.length) {
+        statusEl.textContent = 'No public mining nodes are reporting right now. Try again shortly.';
+        statusEl.style.display = '';
+        tableEl.style.display = 'none';
+        return;
+      }
+      // Lightest-loaded first, so a miner picking the top row lands well.
+      pub.sort(function (a, b) {
+        var la = loadPct(a), lb = loadPct(b);
+        if (la == null) la = 999; if (lb == null) lb = 999;
+        return la - lb;
+      });
+
+      var html = '';
+      pub.forEach(function (n) {
+        var host = hostOf(n.address);
+        var lp = loadPct(n);
+        var loadStr = (lp == null) ? '—' : (lp + '%');
+        var miners = (n.miner_count != null) ? n.miner_count : '—';
+        var healthy = n.healthy !== false;
+        var elder = n.capabilities && n.capabilities.elder;
+        var nodeLabel = elder ? 'elder node' : 'node';
+        html += '<tr>'
+          + '<td><strong>' + esc(nodeLabel) + '</strong>'
+            + (elder ? ' <span class="fl-badge">elder</span>' : '') + '</td>'
+          + '<td><code>' + esc(host) + ':' + SV1_PORT + '</code></td>'
+          + '<td><code>' + esc(host) + ':' + SV2_PORT + '</code></td>'
+          + '<td>' + esc(miners) + '</td>'
+          + '<td>' + loadStr + '</td>'
+          + '<td>' + formatHashrate(Number(n.hashrate_th) || 0) + '</td>'
+          + '<td>' + (healthy ? '<span class="accent">● online</span>' : '○ syncing') + '</td>'
+          + '</tr>';
+      });
+      rowsEl.innerHTML = html;
+      tableEl.style.display = '';
+      statusEl.style.display = 'none';
+    }
+
+    async function refresh() {
+      var nodes = await fetchMeshNodes();
+      if (nodes) {
+        render(nodes);
+      } else if (tableEl.style.display === 'none') {
+        statusEl.textContent = 'Could not reach the pool right now. This list will retry automatically.';
+        statusEl.style.display = '';
+      }
+    }
+
+    refresh();
+    setInterval(refresh, 30000);
+  })();
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
Lands the mechanism for #402 / #599. **Dormant** — `MESH_NODE_LIST_CHECKPOINT_HEIGHT` ships at
`u64::MAX`, so this changes no behaviour on the fleet. Arming is a follow-up, and is gated on
proving convergence first.

## Why

Miners find the pool through one DNS name, `pool.bitcoinghost.org` — four A records. Seize it,
misdirect it, or let it lapse and every miner loses the pool at once. DNS is exactly what gets
leaned on when a pool becomes worth leaning on.

`bins/ghost-miner-proxy` removes the dependency. It runs on the **miner's** side, holds its own
list of pool nodes, and verifies that list offline against the genesis signer set in
`config/genesis-signers.txt` — 12 signers (8 fleet + 4 offline-only), 9 required at
`BFT_THRESHOLD_PERCENT = 67`. Trust then rolls forward: a new list is accepted when >=67% of the
signers already trusted have signed it.

`mesh_node_checkpoint` is the pool side — it finalises the signed public-mining node set.

## Why the signer arithmetic matters

`required(n) = ceil(n * 67 / 100)`, so:

| signers | required | fleet's own 8 keys sufficient? |
|---|---|---|
| 8 fleet only | 6 | **yes** |
| 8 + 3 offline | 8 | **yes** — exactly reaches it |
| **8 + 4 offline** | **9** | **no** |

Four offline keys is the smallest number that puts the fleet's own keys BELOW the threshold, so
compromising every production node no longer yields control of miner discovery. The 8 fleet ids are
the nodes' operational `node.key`, used at 32 signing sites — a node cannot run without its own key,
so offline signers have to be separate keypairs rather than fleet keys held back.

## Rebase notes — four of five conflicts took a different side

Rebased from a base 68 commits behind main. Two of the resulting defects were invisible to the
compiler, so they are recorded here rather than in a commit nobody re-reads:

- **`lib.rs` gate registration is a UNION.** The incoming side registered only the mesh gate.
  Taking it verbatim would have dropped `PAYOUT_MEDIAN_ADOPTION`, `STRATUM_HANDSHAKE_PROOF` and
  `ARCHIVE_TX_PROOF` — three armed gates — **and still compiled**.
- **`--status` / `--watch` are restored.** The incoming `main.rs` predates the B4 work, so the
  cherry-pick removed both the CLI arguments and their dispatch with no error and no warning of its
  own. Only the orphaned handler gave it away. That command carries the `in_dns` check written to
  catch #596.
- **`payout_validator` was NOT reinstated** — `15f2c416d` deleted it as dead (audit L-15, #500).
  The incoming `lib.rs` still declares it because its base predates that removal.
- **`Region` and a dangling registry doc comment are dropped** — `ghost-registry` is already retired
  on main and `config::Region` had no remaining users.

## Verification

- `record-tests.sh` green; **365** feature-gated consensus tests (main's baseline is 360; the +5 are
  new `MeshNodeListCheckpoint` message tests).
- 12 tests across both sides: shim rejects a wrong list root, a sub-quorum, an outsider signature and
  a tampered proposer signature; pool side stays dormant below the gate, does not finalise on a
  divergent node set, and backfills a missed checkpoint via signed sync.
- `sub_quorum_rejected` is **mutation-checked** — dropping `BFT_THRESHOLD_PERCENT` to 1 fails that
  test and only that test.
- **Canary vm5, 60 minutes**: 0 restarts, 0 ERROR-level lines in every 10-minute window, ShareProof
  100-121 per window, and **zero** mesh-checkpoint log lines throughout — the dormant path proposes
  nothing in production, as its unit test claims.
- Endpoint registered but empty: `/api/v1/pool/mesh-node-list-checkpoint` returns 404 where a
  fabricated control path returns 401 (blanket auth). Before this build both returned 401.

## Not done here

Arming. `>=3 independently-operated seeds` also remains unmet — there is one operator today — and
should be stated as a v1 limitation rather than quietly treated as satisfied.
