### PR TITLE
haze: let a hazed node reorg, restart, recover a branch, and bind its archive to a proof

### DIFF
--- a/ghost-core/src/haze/block_reconstruct.cpp
+++ b/ghost-core/src/haze/block_reconstruct.cpp
@@ -53,9 +53,14 @@ CBlock ReconstructPartialBlock(const CStrippedBlock& stripped)
         block.vtx.push_back(MakeTransactionRef(ReconstructTransaction(stripped_tx)));
     }
 
-    // Mark it for what it is. ConnectBlock refuses a block carrying this, so the marker travels with
-    // the object rather than depending on every caller remembering where it came from.
+    // Mark it for what it is, and carry the real txids with it. ConnectBlock refuses a block
+    // carrying the marker, and every consumer that matches transactions by id finds the correct ids
+    // already attached — neither depends on a caller remembering where the block came from.
     block.m_haze_reconstructed = true;
+    block.m_haze_authoritative_txids.reserve(stripped.GetTxCount());
+    for (size_t i = 0; i < stripped.GetTxCount(); ++i) {
+        block.m_haze_authoritative_txids.push_back(Txid::FromUint256(stripped.GetTxid(i)));
+    }
 
     return block;
 }

--- a/ghost-core/src/haze/block_reconstruct.cpp
+++ b/ghost-core/src/haze/block_reconstruct.cpp
@@ -53,6 +53,10 @@ CBlock ReconstructPartialBlock(const CStrippedBlock& stripped)
         block.vtx.push_back(MakeTransactionRef(ReconstructTransaction(stripped_tx)));
     }
 
+    // Mark it for what it is. ConnectBlock refuses a block carrying this, so the marker travels with
+    // the object rather than depending on every caller remembering where it came from.
+    block.m_haze_reconstructed = true;
+
     return block;
 }
 

--- a/ghost-core/src/haze/block_reconstruct.h
+++ b/ghost-core/src/haze/block_reconstruct.h
@@ -18,7 +18,22 @@ namespace haze {
  * - Transactions with empty scriptSig and empty witness
  * - Outputs with preserved values and scriptPubKeys
  * - Stripped OP_RETURN outputs preserved as OP_RETURN + 0x00
- * - If the original had a stored txid, the coinbase/legacy tx preserves it
+ *
+ * ⚠ THE RETURNED BLOCK'S TXIDS ARE NOT THE REAL ONES, and cannot be made so. Each transaction
+ * computes its txid from its own contents, and those contents are missing the scriptSigs — so for
+ * every transaction that had one (every coinbase, every legacy and P2SH-wrapped spend) the value
+ * `GetHash()` returns is the hash of a different transaction. `CTransaction` has nowhere to put an
+ * authoritative txid, so this is a property of the type rather than something this function could
+ * be taught to fix.
+ *
+ * An earlier version of this comment claimed the stored txid was preserved here. It never was —
+ * nothing in this file reads `m_has_stored_txid` — and believing it leads somewhere expensive:
+ * anything keying a UTXO lookup on one of these txids, as `DisconnectBlock` does for every output
+ * of every transaction, addresses outpoints that do not exist and leaves the real coins in place.
+ *
+ * **The authoritative source is `CStrippedBlock::GetTxid(i)`.** Use it, and pass the txids alongside
+ * the block rather than expecting the block to know them. See `haze_tests.cpp`,
+ * `reconstructed_block_cannot_carry_txids`.
  *
  * The block is suitable for RPC JSON serialization with haze indicators,
  * but NOT for full validation (signatures are missing).

--- a/ghost-core/src/haze/hazync_proof.cpp
+++ b/ghost-core/src/haze/hazync_proof.cpp
@@ -15,6 +15,11 @@
 #include <tinyformat.h>
 #include <util/fs_helpers.h>
 #include <util/strencodings.h>
+#include <validation.h>
+#include <chain.h>
+#include <consensus/merkle.h>
+#include <pow.h>
+#include <sync.h>
 
 #include <algorithm>
 #include <array>
@@ -320,6 +325,122 @@ std::optional<HazyncAdoption> HazyncAdoption::Authorise(const ArgsManager& args,
     a.coins_count = st->utxo_leaves;
     a.chain_tx_count_bootstrap = static_cast<uint64_t>(st->height) + 1; // lower bound; see header
     return a;
+}
+
+bool VerifyHazedChainBinding(ChainstateManager& chainman, const HazyncProofState& proven,
+                             int from_height, HazedChainBinding& out)
+{
+    LOCK(::cs_main);
+
+    out = HazedChainBinding{};
+    out.through_height = static_cast<int>(proven.height);
+    out.from_height = std::max(1, from_height);
+    out.complete = (out.from_height == 1);
+
+    if (out.from_height > out.through_height) {
+        out.failure = strprintf("nothing to check: asked to start at %d but the proof only reaches %d",
+                                out.from_height, out.through_height);
+        return false;
+    }
+
+    const CBlockIndex* tip_at_proven{chainman.ActiveChain()[out.through_height]};
+    if (!tip_at_proven) {
+        out.failure = strprintf("this node's chain does not reach the proven height %d",
+                                out.through_height);
+        return false;
+    }
+    out.archive_tip = tip_at_proven->GetBlockHash();
+
+    // The join, checked before the expensive walk. A proof about some other chain must never be
+    // reported as evidence about this one, and there is no point recomputing thousands of merkle
+    // roots to establish which chain we hold if it is already the wrong one.
+    if (out.archive_tip != proven.tip_hash) {
+        out.failure = strprintf(
+            "REFUSED: the proof commits to tip %s at height %d, but this node holds %s there. The "
+            "proof is not about this chain.",
+            proven.tip_hash.GetHex(), out.through_height, out.archive_tip.GetHex());
+        return false;
+    }
+
+    for (int height = out.from_height; height <= out.through_height; ++height) {
+        const CBlockIndex* index{chainman.ActiveChain()[height]};
+        if (!index) {
+            out.failure = strprintf("no block at height %d", height);
+            return false;
+        }
+
+        // Everything below is checked against the header the ARCHIVE stores, not the one in the
+        // block index. Checking the index against itself would establish nothing — its linkage is
+        // structural, built from hashPrevBlock when the header was accepted — whereas the archive's
+        // bytes are independent data that must be made to agree with it.
+        // A stripped block yields its txids from what haze retained; a whole one yields them from its
+        // transactions. Both are the archive's own bytes, and the check that follows is the same
+        // either way — which is the point. This is not a hazed-only claim: an archive node binding
+        // its storage to a proof is doing exactly the same thing with more data than it needs.
+        CBlockHeader archived;
+        uint256 recomputed_root;
+        bool mutated{false};
+
+        if (index->nStatus & BLOCK_HAZED_STRIPPED) {
+            CStrippedBlock stripped;
+            if (!chainman.m_blockman.ReadStrippedBlock(stripped, *index)) {
+                out.failure = strprintf("block %d (%s) has no readable stripped payload", height,
+                                        index->GetBlockHash().GetHex());
+                return false;
+            }
+            archived = stripped.m_header;
+            recomputed_root = stripped.ComputeMerkleRoot(&mutated);
+        } else {
+            CBlock full;
+            if (!chainman.m_blockman.ReadBlock(full, *index)) {
+                out.failure = strprintf("block %d (%s) could not be read from storage", height,
+                                        index->GetBlockHash().GetHex());
+                return false;
+            }
+            archived = full.GetBlockHeader();
+            recomputed_root = BlockMerkleRoot(full, &mutated);
+        }
+        const uint256 archived_hash{archived.GetHash()};
+
+        // The stored payload must be the block the index says lives at this height.
+        if (archived_hash != index->GetBlockHash()) {
+            out.failure = strprintf("block %d: the archive stores %s where the chain has %s", height,
+                                    archived_hash.GetHex(), index->GetBlockHash().GetHex());
+            return false;
+        }
+        // ...and the archive's own headers must form a chain, by its own bytes.
+        if (!index->pprev || archived.hashPrevBlock != index->pprev->GetBlockHash()) {
+            out.failure = strprintf("block %d (%s): the archived header names parent %s, breaking the "
+                                    "chain", height, archived_hash.GetHex(),
+                                    archived.hashPrevBlock.GetHex());
+            return false;
+        }
+        // ...and each must have cost the work it claims. A merkle root is only evidence if the header
+        // carrying it sits in a chain that was paid for.
+        if (!CheckProofOfWork(archived_hash, archived.nBits, chainman.GetConsensus())) {
+            out.failure = strprintf("block %d (%s) does not meet its stated target", height,
+                                    archived_hash.GetHex());
+            return false;
+        }
+
+        // The crux. The archive's own txids must reproduce the header's merkle root, which is what
+        // stops a STORED txid — one that could not be recomputed because its scriptSig was destroyed
+        // — from being taken on trust. Forge one and the root no longer matches.
+        if (mutated) {
+            out.failure = strprintf("block %d has a mutated merkle tree", height);
+            return false;
+        }
+        if (recomputed_root != archived.hashMerkleRoot) {
+            out.failure = strprintf(
+                "block %d (%s): the archive's own txids give merkle root %s, but its header says %s",
+                height, archived_hash.GetHex(), recomputed_root.GetHex(),
+                archived.hashMerkleRoot.GetHex());
+            return false;
+        }
+        ++out.blocks_checked;
+    }
+
+    return true;
 }
 
 void HazyncProofStartupCheck(const ArgsManager& args)

--- a/ghost-core/src/haze/hazync_proof.h
+++ b/ghost-core/src/haze/hazync_proof.h
@@ -14,6 +14,7 @@
 #include <vector>
 
 class ArgsManager;
+class ChainstateManager;
 
 namespace haze {
 
@@ -180,6 +181,41 @@ private:
  * `loadtxoutset` cannot pick this up by accident and load an arbitrary file on a proof's authority.
  */
 const std::optional<HazyncAdoption>& HazyncAdoptedSnapshot();
+
+/** Outcome of binding a hazed archive to a proof. See VerifyHazedChainBinding. */
+struct HazedChainBinding {
+    int from_height{0};        //!< first height checked
+    int through_height{0};     //!< last height checked, always the proven height
+    int blocks_checked{0};
+    bool complete{false};      //!< true only when every block from 1 was checked
+    uint256 archive_tip;       //!< tip the archive itself yields at through_height
+    std::string failure;       //!< empty on success; never empty on failure
+};
+
+/**
+ * Establish, from a hazed archive alone, that the chain it holds is the real chain — and that it ends
+ * where a verified proof says it does.
+ *
+ * This is the half a proof cannot supply. A proof attests that the transactions in a range were
+ * VALID; it says nothing about whether this node is holding that range. A hazed archive can answer
+ * that and only that: stripping destroys witnesses and scriptSigs but keeps the txids, and a txid
+ * that had to be stored verbatim is not taken on trust, because the merkle root is recomputed from
+ * whatever txids the block yields and must match the header. A forged stored txid fails there.
+ *
+ * So: identity from the archive, validity from the proof, and this function is the join. It
+ * recomputes every merkle root from the archive's own retained txids, checks each header links to its
+ * parent and meets its stated target, and finally requires that the tip the archive yields at the
+ * proven height equals the tip the proof commits to.
+ *
+ * **It refuses when the proof does not commit to the tip held.** That is the point of the check, not
+ * an error path: a proof about some other chain must not be reported as evidence about this one.
+ *
+ * @param from_height  1 to establish the whole chain. A higher value checks only a suffix, which is
+ *                     cheaper and proves correspondingly less — `complete` records which was done.
+ * @return true if the binding holds. On false, `out.failure` says which block failed and how.
+ */
+bool VerifyHazedChainBinding(ChainstateManager& chainman, const HazyncProofState& proven,
+                             int from_height, HazedChainBinding& out);
 
 /** Guest image id this build trusts, or empty if the verifier is not compiled in. */
 std::string HazyncMethodId();

--- a/ghost-core/src/net_processing.cpp
+++ b/ghost-core/src/net_processing.cpp
@@ -4890,8 +4890,11 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
                 return;
             }
 
+            // WriteReceivedStrippedBlock put this in the gsb sequence, so the payload really is
+            // stripped — unlike genesis, which is written whole even on a hazed node.
             m_chainman.ReceivedBlockTransactions(
-                static_cast<uint32_t>(stripped.GetTxCount()), pindex, blockPos);
+                static_cast<uint32_t>(stripped.GetTxCount()), pindex, blockPos,
+                /*payload_stripped=*/true);
 
             LogDebug(BCLog::HAZE, "Stored received stripped block %s at height %d\n",
                 block_hash.ToString(), pindex->nHeight);

--- a/ghost-core/src/node/blockstorage.cpp
+++ b/ghost-core/src/node/blockstorage.cpp
@@ -682,11 +682,8 @@ CBlockFileInfo* BlockManager::GetBlockFileInfo(size_t n)
     return &m_blockfile_info.at(n);
 }
 
-bool BlockManager::ReadBlockForDisconnect(CBlock& block, std::vector<Txid>& authoritative_txids,
-                                          const CBlockIndex& index) const
+bool BlockManager::ReadBlockForDisconnect(CBlock& block, const CBlockIndex& index) const
 {
-    authoritative_txids.clear();
-
     if (!WITH_LOCK(cs_main, return index.nStatus & BLOCK_HAZED_STRIPPED)) {
         return ReadBlock(block, index);
     }
@@ -698,17 +695,13 @@ bool BlockManager::ReadBlockForDisconnect(CBlock& block, std::vector<Txid>& auth
         return false;
     }
 
+    // The reconstruction carries the real txids: the rebuilt transactions cannot compute them, and
+    // the stripped form kept them. That is the only reason disconnecting stripped history is possible.
     block = haze::ReconstructPartialBlock(stripped);
 
-    // The rebuilt transactions cannot compute these: their scriptSigs are gone. The stripped form
-    // kept them, which is the only reason disconnecting stripped history is possible at all.
-    authoritative_txids.reserve(stripped.GetTxCount());
-    for (size_t i = 0; i < stripped.GetTxCount(); ++i) {
-        authoritative_txids.push_back(Txid::FromUint256(stripped.GetTxid(i)));
-    }
-
     LogDebug(BCLog::VALIDATION, "Rebuilt stripped block %d (%s) for disconnection, %u transactions\n",
-             index.nHeight, index.GetBlockHash().ToString(), (unsigned)authoritative_txids.size());
+             index.nHeight, index.GetBlockHash().ToString(),
+             (unsigned)block.m_haze_authoritative_txids.size());
     return true;
 }
 

--- a/ghost-core/src/node/blockstorage.cpp
+++ b/ghost-core/src/node/blockstorage.cpp
@@ -243,6 +243,30 @@ CBlockIndex* BlockManager::AddToBlockIndex(const CBlockHeader& block, CBlockInde
     return pindexNew;
 }
 
+void BlockManager::ForgetBlockData(CBlockIndex& index)
+{
+    AssertLockHeld(cs_main);
+
+    index.nStatus &= ~BLOCK_HAVE_DATA;
+    index.nStatus &= ~BLOCK_HAVE_UNDO;
+    index.nFile = 0;
+    index.nDataPos = 0;
+    index.nUndoPos = 0;
+    m_dirty_blockindex.insert(&index);
+
+    // Drop from m_blocks_unlinked -- a block whose data we no longer have would have
+    // to be downloaded again in order to consider its chain, at which point it would
+    // be reconsidered as a candidate for m_blocks_unlinked or setBlockIndexCandidates.
+    auto range = m_blocks_unlinked.equal_range(index.pprev);
+    while (range.first != range.second) {
+        std::multimap<CBlockIndex*, CBlockIndex*>::iterator _it = range.first;
+        range.first++;
+        if (_it->second == &index) {
+            m_blocks_unlinked.erase(_it);
+        }
+    }
+}
+
 void BlockManager::PruneOneBlockFile(const int fileNumber)
 {
     AssertLockHeld(cs_main);
@@ -251,25 +275,7 @@ void BlockManager::PruneOneBlockFile(const int fileNumber)
     for (auto& entry : m_block_index) {
         CBlockIndex* pindex = &entry.second;
         if (pindex->nFile == fileNumber) {
-            pindex->nStatus &= ~BLOCK_HAVE_DATA;
-            pindex->nStatus &= ~BLOCK_HAVE_UNDO;
-            pindex->nFile = 0;
-            pindex->nDataPos = 0;
-            pindex->nUndoPos = 0;
-            m_dirty_blockindex.insert(pindex);
-
-            // Prune from m_blocks_unlinked -- any block we prune would have
-            // to be downloaded again in order to consider its chain, at which
-            // point it would be considered as a candidate for
-            // m_blocks_unlinked or setBlockIndexCandidates.
-            auto range = m_blocks_unlinked.equal_range(pindex->pprev);
-            while (range.first != range.second) {
-                std::multimap<CBlockIndex*, CBlockIndex*>::iterator _it = range.first;
-                range.first++;
-                if (_it->second == pindex) {
-                    m_blocks_unlinked.erase(_it);
-                }
-            }
+            ForgetBlockData(*pindex);
         }
     }
 

--- a/ghost-core/src/node/blockstorage.cpp
+++ b/ghost-core/src/node/blockstorage.cpp
@@ -7,6 +7,7 @@
 #include <arith_uint256.h>
 #include <chain.h>
 #include <consensus/params.h>
+#include <haze/block_reconstruct.h>
 #include <haze/block_stripper.h>
 #include <haze/exorcism.h>
 #include <haze/hazync_proof.h>
@@ -673,6 +674,36 @@ CBlockFileInfo* BlockManager::GetBlockFileInfo(size_t n)
     LOCK(cs_LastBlockFile);
 
     return &m_blockfile_info.at(n);
+}
+
+bool BlockManager::ReadBlockForDisconnect(CBlock& block, std::vector<Txid>& authoritative_txids,
+                                          const CBlockIndex& index) const
+{
+    authoritative_txids.clear();
+
+    if (!WITH_LOCK(cs_main, return index.nStatus & BLOCK_HAZED_STRIPPED)) {
+        return ReadBlock(block, index);
+    }
+
+    haze::CStrippedBlock stripped;
+    if (!ReadStrippedBlock(stripped, index)) {
+        LogError("Failed to read stripped block %d (%s) for disconnection\n",
+                 index.nHeight, index.GetBlockHash().ToString());
+        return false;
+    }
+
+    block = haze::ReconstructPartialBlock(stripped);
+
+    // The rebuilt transactions cannot compute these: their scriptSigs are gone. The stripped form
+    // kept them, which is the only reason disconnecting stripped history is possible at all.
+    authoritative_txids.reserve(stripped.GetTxCount());
+    for (size_t i = 0; i < stripped.GetTxCount(); ++i) {
+        authoritative_txids.push_back(Txid::FromUint256(stripped.GetTxid(i)));
+    }
+
+    LogDebug(BCLog::VALIDATION, "Rebuilt stripped block %d (%s) for disconnection, %u transactions\n",
+             index.nHeight, index.GetBlockHash().ToString(), (unsigned)authoritative_txids.size());
+    return true;
 }
 
 bool BlockManager::ReadBlockUndo(CBlockUndo& blockundo, const CBlockIndex& index) const

--- a/ghost-core/src/node/blockstorage.h
+++ b/ghost-core/src/node/blockstorage.h
@@ -326,6 +326,19 @@ public:
     CBlockIndex* InsertBlockIndex(const uint256& hash) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //! Mark one block file as pruned (modify associated database entries)
+    /**
+     * Forget a block's stored data: clear the have-data/undo flags and file position, and drop it
+     * from m_blocks_unlinked so it is reconsidered if the block arrives again.
+     *
+     * Shared by pruning and by the haze path that discards stripped blocks which were stored but
+     * never connected (#542) — one definition of what "we no longer have this block" means, so the
+     * two cannot drift into leaving different residue behind.
+     *
+     * ⚠ Callers must set m_have_pruned. CheckBlockIndex asserts BLOCK_HAVE_DATA and nTx > 0 agree
+     * unless that flag says data has been deleted, and after this call they deliberately do not.
+     */
+    void ForgetBlockData(CBlockIndex& index) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+
     void PruneOneBlockFile(const int fileNumber) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     CBlockIndex* LookupBlockIndex(const uint256& hash) EXCLUSIVE_LOCKS_REQUIRED(cs_main);

--- a/ghost-core/src/node/blockstorage.h
+++ b/ghost-core/src/node/blockstorage.h
@@ -474,6 +474,27 @@ public:
     bool ReadStrippedBlock(haze::CStrippedBlock& block, const FlatFilePos& pos) const;
     bool ReadStrippedBlock(haze::CStrippedBlock& block, const CBlockIndex& index) const;
 
+    /**
+     * Read a block in order to DISCONNECT it, rebuilding it from stripped storage where that is all
+     * that survives.
+     *
+     * A hazed node has to be able to reorg off its own history, and it can: undoing a block reads no
+     * scriptSig and no witness, and the undo data is written whether or not the block was stripped.
+     * So where ReadBlock refuses a stripped block — correctly, since the full block is gone — this
+     * returns the rebuilt structural form instead.
+     *
+     * @param[out] authoritative_txids  For a rebuilt block, the real txids, to be passed to
+     *                                  DisconnectBlock. Empty when the block was read whole, which
+     *                                  is the signal that it knows its own. A rebuilt block's
+     *                                  transactions do NOT: see haze/block_reconstruct.h.
+     *
+     * ⚠ The block this returns may be a reconstruction, and a reconstruction must never be
+     * connected, relayed, served to a peer, added to the mempool, or handed to wallet code. It
+     * carries CBlock::m_haze_reconstructed so those paths can refuse it; ConnectBlock already does.
+     */
+    bool ReadBlockForDisconnect(CBlock& block, std::vector<Txid>& authoritative_txids,
+                                const CBlockIndex& index) const;
+
     bool ReadBlockUndo(CBlockUndo& blockundo, const CBlockIndex& index) const;
 
     void CleanupBlockRevFiles() const;

--- a/ghost-core/src/node/blockstorage.h
+++ b/ghost-core/src/node/blockstorage.h
@@ -496,17 +496,15 @@ public:
      * So where ReadBlock refuses a stripped block — correctly, since the full block is gone — this
      * returns the rebuilt structural form instead.
      *
-     * @param[out] authoritative_txids  For a rebuilt block, the real txids, to be passed to
-     *                                  DisconnectBlock. Empty when the block was read whole, which
-     *                                  is the signal that it knows its own. A rebuilt block's
-     *                                  transactions do NOT: see haze/block_reconstruct.h.
+     * A rebuilt block arrives carrying its real txids in CBlock::m_haze_authoritative_txids,
+     * because its transactions cannot compute their own — see haze/block_reconstruct.h. Nothing
+     * further is needed at the call site; DisconnectBlock reads them from the block.
      *
      * ⚠ The block this returns may be a reconstruction, and a reconstruction must never be
      * connected, relayed, served to a peer, added to the mempool, or handed to wallet code. It
      * carries CBlock::m_haze_reconstructed so those paths can refuse it; ConnectBlock already does.
      */
-    bool ReadBlockForDisconnect(CBlock& block, std::vector<Txid>& authoritative_txids,
-                                const CBlockIndex& index) const;
+    bool ReadBlockForDisconnect(CBlock& block, const CBlockIndex& index) const;
 
     bool ReadBlockUndo(CBlockUndo& blockundo, const CBlockIndex& index) const;
 

--- a/ghost-core/src/node/chainstate.cpp
+++ b/ghost-core/src/node/chainstate.cpp
@@ -126,6 +126,13 @@ static ChainstateLoadResult CompleteChainstateInitialization(
         }
     }
 
+    // Every chainstate now knows its tip, which is what decides whether a stripped block was ever
+    // connected. Must come before the node starts choosing blocks to connect, or it will pick one it
+    // cannot read and fail fatally — that is #542.
+    if (const int dropped{WITH_LOCK(::cs_main, return chainman.DropUnconnectableStrippedBlocks())}; dropped > 0) {
+        LogInfo("[haze] %d stripped block(s) forgotten at startup; they will be downloaded again", dropped);
+    }
+
     auto chainstates{chainman.GetAll()};
     if (std::any_of(chainstates.begin(), chainstates.end(),
                     [](const Chainstate* cs) EXCLUSIVE_LOCKS_REQUIRED(cs_main) { return cs->NeedsRedownload(); })) {

--- a/ghost-core/src/primitives/block.h
+++ b/ghost-core/src/primitives/block.h
@@ -90,6 +90,20 @@ public:
      */
     bool m_haze_reconstructed{false};
 
+    /**
+     * Memory-only: the real txid of each transaction, in order, when m_haze_reconstructed is set.
+     *
+     * A rebuilt transaction cannot supply its own. Its txid is computed from contents whose
+     * scriptSigs were destroyed, so for every transaction that had one — every coinbase, every
+     * legacy and P2SH-wrapped spend — GetHash() returns the hash of a different transaction.
+     *
+     * These travel with the block rather than beside it deliberately. Anything holding a
+     * reconstruction therefore also holds the ids it needs, and there is no call that can be made
+     * without them: a consumer matching transactions by id cannot silently miss because someone
+     * forgot to pass a second argument.
+     */
+    std::vector<Txid> m_haze_authoritative_txids;
+
     CBlock()
     {
         SetNull();
@@ -114,6 +128,7 @@ public:
         m_checked_witness_commitment = false;
         m_checked_merkle_root = false;
         m_haze_reconstructed = false;
+        m_haze_authoritative_txids.clear();
     }
 
     CBlockHeader GetBlockHeader() const

--- a/ghost-core/src/primitives/block.h
+++ b/ghost-core/src/primitives/block.h
@@ -76,6 +76,20 @@ public:
     mutable bool m_checked_witness_commitment{false}; // CheckWitnessCommitment()
     mutable bool m_checked_merkle_root{false};        // CheckMerkleRoot()
 
+    /**
+     * Memory-only: this block was rebuilt from stripped storage and is NOT the real block.
+     *
+     * Haze destroys scriptSigs and witnesses permanently, so a block rebuilt from what survives has
+     * empty ones — which makes it unusable for connecting (no signatures to verify, no BIP34 height,
+     * no witness commitment, wrong weight and sigop cost) and makes its transactions' computed txids
+     * wrong wherever a scriptSig was removed.
+     *
+     * Disconnecting, by contrast, needs none of that, so a rebuilt block is legitimate there and is
+     * how a hazed node reorgs off its own history. Not serialised: it describes where this object
+     * came from in memory, not what a block is.
+     */
+    bool m_haze_reconstructed{false};
+
     CBlock()
     {
         SetNull();
@@ -99,6 +113,7 @@ public:
         fChecked = false;
         m_checked_witness_commitment = false;
         m_checked_merkle_root = false;
+        m_haze_reconstructed = false;
     }
 
     CBlockHeader GetBlockHeader() const

--- a/ghost-core/src/rpc/blockchain.cpp
+++ b/ghost-core/src/rpc/blockchain.cpp
@@ -3593,6 +3593,86 @@ static RPCHelpMan hazyncadoptsnapshot()
     };
 }
 
+static RPCHelpMan hazyncverifychain()
+{
+    return RPCHelpMan{
+        "hazyncverifychain",
+        "Establish, from this node's own stripped archive, that the chain it holds is the real chain "
+        "and ends where its Hazync proof says it does.\n\n"
+
+        "This is the half a proof cannot supply. A proof attests that the transactions in a range were "
+        "VALID; it says nothing about whether this node holds that range. A hazed archive answers that "
+        "and only that — stripping destroys witnesses and scriptSigs but keeps the txids, and a txid "
+        "that had to be stored verbatim is not taken on trust, because the merkle root is recomputed "
+        "from whatever txids the block yields and must match its header.\n\n"
+
+        "Identity from the archive, validity from the proof. This is the join.\n\n"
+
+        "REFUSES when the proof does not commit to the tip this node holds — a proof about some other "
+        "chain must not be reported as evidence about this one.\n\n"
+
+        "Requires -hazyncproof. Reads every block in the range from disk, so it is slow over a long "
+        "one; use -rpcclienttimeout=0.",
+        {
+            {"from_height", RPCArg::Type::NUM, RPCArg::Default{1},
+             "First height to check. 1 establishes the whole chain. A higher value checks only a "
+             "suffix, which is cheaper and proves correspondingly less."},
+        },
+        RPCResult{
+            RPCResult::Type::OBJ, "", "",
+                {
+                    {RPCResult::Type::BOOL, "bound", "whether the archive is bound to the proof"},
+                    {RPCResult::Type::NUM, "from_height", "first height checked"},
+                    {RPCResult::Type::NUM, "through_height", "last height checked, always the proven height"},
+                    {RPCResult::Type::NUM, "blocks_checked", "how many blocks were read and recomputed"},
+                    {RPCResult::Type::BOOL, "complete", "true only if checked from height 1, i.e. the whole chain rather than a suffix"},
+                    {RPCResult::Type::STR_HEX, "archive_tip", "tip the archive itself yields at the proven height"},
+                    {RPCResult::Type::STR_HEX, "proven_tip", "tip the proof commits to"},
+                    {RPCResult::Type::STR, "failure", /*optional=*/true, "why the binding does not hold, if it does not"},
+                }
+        },
+        RPCExamples{
+            HelpExampleCli("-rpcclienttimeout=0 hazyncverifychain", "")
+            + HelpExampleRpc("hazyncverifychain", "1")
+        },
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
+    ChainstateManager& chainman = EnsureAnyChainman(request.context);
+
+    const auto& proven{haze::HazyncVerifiedProof()};
+    if (!proven) {
+        throw JSONRPCError(RPC_MISC_ERROR,
+            "no verified Hazync proof — start with -hazyncproof=<file>. Without one there is nothing "
+            "to bind the archive to.");
+    }
+
+    const int from_height{self.Arg<int>("from_height")};
+
+    haze::HazedChainBinding result;
+    const bool bound{haze::VerifyHazedChainBinding(chainman, *proven, from_height, result)};
+
+    if (bound) {
+        LogInfo("[hazync] archive BOUND to proof: %d blocks checked through height %d%s\n",
+                result.blocks_checked, result.through_height,
+                result.complete ? ", from genesis" : " (suffix only)");
+    } else {
+        LogWarning("[hazync] archive NOT bound to proof: %s\n", result.failure);
+    }
+
+    UniValue obj(UniValue::VOBJ);
+    obj.pushKV("bound", bound);
+    obj.pushKV("from_height", result.from_height);
+    obj.pushKV("through_height", result.through_height);
+    obj.pushKV("blocks_checked", result.blocks_checked);
+    obj.pushKV("complete", result.complete);
+    obj.pushKV("archive_tip", result.archive_tip.GetHex());
+    obj.pushKV("proven_tip", proven->tip_hash.GetHex());
+    if (!bound) obj.pushKV("failure", result.failure);
+    return obj;
+},
+    };
+}
+
 const std::vector<RPCResult> RPCHelpForChainstate{
     {RPCResult::Type::NUM, "blocks", "number of blocks in this chainstate"},
     {RPCResult::Type::STR_HEX, "bestblockhash", "blockhash of the tip"},
@@ -3880,6 +3960,7 @@ void RegisterBlockchainRPCCommands(CRPCTable& t)
         {"blockchain", &dumptxoutset},
         {"blockchain", &loadtxoutset},
         {"blockchain", &hazyncadoptsnapshot},
+        {"blockchain", &hazyncverifychain},
         {"blockchain", &getchainstates},
         {"blockchain", &generatecheckpoint},
         {"blockchain", &downloadcheckpoint},

--- a/ghost-core/src/rpc/blockchain.cpp
+++ b/ghost-core/src/rpc/blockchain.cpp
@@ -853,7 +853,11 @@ static RPCHelpMan getblock()
         }
     }
 
-    const bool is_hazed = chainman.m_blockman.IsHazeMode();
+    // Whether THIS block is stripped, not whether the node is hazed. A hazed node still holds some
+    // blocks whole — genesis is written by WriteBlock even in hazed mode — and routing those through
+    // the stripped reader looks for their payload in the gsb sequence while it sits in blk, so
+    // `getblock` on genesis failed with "Stripped block not found on disk".
+    const bool is_hazed = WITH_LOCK(::cs_main, return pblockindex->nStatus & BLOCK_HAZED_STRIPPED);
 
     if (is_hazed) {
         // Hazed mode: read stripped block from GSB files, reconstruct partial block

--- a/ghost-core/src/test/haze_tests.cpp
+++ b/ghost-core/src/test/haze_tests.cpp
@@ -630,6 +630,73 @@ BOOST_AUTO_TEST_CASE(unconnected_stripped_blocks_are_forgotten_connected_ones_ke
     BOOST_CHECK_EQUAL(chainman.DropUnconnectableStrippedBlocks(), 0);
 }
 
+BOOST_AUTO_TEST_CASE(reconnecting_a_stripped_block_refetches_instead_of_dying)
+{
+    // The case archive fallback exists for: a hazed node reorgs back onto a branch it abandoned.
+    // The block was connected once, so its stripped form was sufficient then — and is not now,
+    // because connecting needs the scriptSigs and witnesses haze destroyed.
+    //
+    // Before this, ConnectTip called FatalError and the node shut down. It must instead withdraw the
+    // BLOCK_HAVE_DATA claim, which is what was false, and let the ordinary download machinery fetch
+    // the block from a peer that still has it.
+    CScript dest = GetScriptForDestination(WitnessV0KeyHash(coinbaseKey.GetPubKey()));
+    CBlock block = CreateAndProcessBlock({}, dest);
+
+    ChainstateManager& chainman = *Assert(m_node.chainman);
+    Chainstate& chainstate = chainman.ActiveChainstate();
+
+    CBlockIndex* pindex{nullptr};
+    CBlockIndex* parent{nullptr};
+    {
+        LOCK(cs_main);
+        pindex = chainman.m_blockman.LookupBlockIndex(block.GetHash());
+        BOOST_REQUIRE(pindex);
+        BOOST_REQUIRE(chainstate.m_chain.Tip() == pindex);
+        parent = pindex->pprev;
+        BOOST_REQUIRE(parent);
+        BOOST_REQUIRE(pindex->nStatus & BLOCK_HAVE_DATA);
+    }
+
+    // Abandon the branch, then come back to it — the reorg-back case, not a contrivance. The
+    // disconnect happens while the block is still whole, which is what really occurs: a block is
+    // only stripped storage once it has been written, and this test is about the RE-connect.
+    BlockValidationState invalidate_state;
+    BOOST_REQUIRE(chainstate.InvalidateBlock(invalidate_state, pindex));
+    BOOST_REQUIRE(WITH_LOCK(cs_main, return chainstate.m_chain.Tip() == parent));
+
+    {
+        LOCK(cs_main);
+        // Now only the stripped form survives, so this block can no longer be read as a full one.
+        pindex->nStatus |= BLOCK_HAZED_STRIPPED;
+        chainstate.ResetBlockFailureFlags(pindex);
+        // ResetBlockFailureFlags clears the failure but does not restore m_best_header, which
+        // InvalidateBlock lowered. On a real node the header is the best one known — that is why the
+        // reorg back is being attempted at all — so the fixture is made to match. Without this,
+        // CheckBlockIndex asserts that a non-failed block outranks the best header, which is a
+        // property of this Invalidate/Reconsider sequence and nothing to do with haze: verified by
+        // running the same sequence with no stripped block involved.
+        chainman.m_best_header = pindex;
+    }
+
+    // Reconnecting must not be fatal. Whether the activation reports success is not the point —
+    // the node surviving with a consistent index, and the block queued for download, is.
+    BlockValidationState state;
+    chainstate.ActivateBestChain(state);
+    BOOST_CHECK(!state.IsError());
+
+    LOCK(cs_main);
+    // The false claim is withdrawn, so the block is fetched again rather than read from storage that
+    // cannot satisfy the read.
+    BOOST_CHECK(!(pindex->nStatus & BLOCK_HAVE_DATA));
+    BOOST_CHECK_EQUAL(pindex->nDataPos, 0U);
+    // Required, or CheckBlockIndex aborts — see ForgetStrippedBlockData.
+    BOOST_CHECK(chainman.m_blockman.m_have_pruned);
+    // The tip did not advance onto a block that could not be validated.
+    BOOST_CHECK(chainstate.m_chain.Tip() == parent);
+    // And the index is still self-consistent, which is what a real node would trip over.
+    chainman.CheckBlockIndex();
+}
+
 BOOST_AUTO_TEST_CASE(reconstruct_meta_flags)
 {
     CScript dest = GetScriptForDestination(WitnessV0KeyHash(coinbaseKey.GetPubKey()));

--- a/ghost-core/src/test/haze_tests.cpp
+++ b/ghost-core/src/test/haze_tests.cpp
@@ -423,18 +423,6 @@ BOOST_AUTO_TEST_CASE(reconstructed_block_cannot_carry_txids)
 // Reorg from stripped storage (#545)
 // ============================================================================
 
-//! Authoritative txids for a stripped block, in transaction order — what the rebuilt CBlock cannot
-//! carry itself. Kept alive by the caller for the span handed to DisconnectBlock.
-static std::vector<Txid> AuthoritativeTxids(const haze::CStrippedBlock& stripped)
-{
-    std::vector<Txid> txids;
-    txids.reserve(stripped.GetTxCount());
-    for (size_t i = 0; i < stripped.GetTxCount(); ++i) {
-        txids.push_back(Txid::FromUint256(stripped.GetTxid(i)));
-    }
-    return txids;
-}
-
 BOOST_AUTO_TEST_CASE(disconnect_from_stripped_matches_disconnect_from_full)
 {
     // The claim reorg-from-stripped rests on: undoing a block needs nothing haze destroyed, so a
@@ -462,15 +450,22 @@ BOOST_AUTO_TEST_CASE(disconnect_from_stripped_matches_disconnect_from_full)
 
     haze::StripResult result = haze::StripBlock(block);
     CBlock rebuilt = haze::ReconstructPartialBlock(result.stripped_block);
-    const std::vector<Txid> txids = AuthoritativeTxids(result.stripped_block);
+
+    // The reconstruction carries the real txids, so no caller has to supply them and none can
+    // forget. Checked against the original block, not against the stripped form it came from —
+    // otherwise this would only prove the two agree with each other.
+    BOOST_REQUIRE_EQUAL(rebuilt.m_haze_authoritative_txids.size(), block.vtx.size());
+    for (size_t i = 0; i < block.vtx.size(); ++i) {
+        BOOST_CHECK(rebuilt.m_haze_authoritative_txids[i] == block.vtx[i]->GetHash());
+    }
 
     // Undo with the real block.
     CCoinsViewCache from_full(&chainstate.CoinsTip());
     BOOST_REQUIRE_EQUAL(chainstate.DisconnectBlock(block, pindex, from_full), DISCONNECT_OK);
 
-    // Undo with the rebuilt block plus the txids the stripped form kept.
+    // Undo with the rebuilt block, which needs nothing extra.
     CCoinsViewCache from_stripped(&chainstate.CoinsTip());
-    BOOST_REQUIRE_EQUAL(chainstate.DisconnectBlock(rebuilt, pindex, from_stripped, txids), DISCONNECT_OK);
+    BOOST_REQUIRE_EQUAL(chainstate.DisconnectBlock(rebuilt, pindex, from_stripped), DISCONNECT_OK);
 
     // Same best block, and the same verdict on every coin the block touched.
     BOOST_CHECK(from_full.GetBestBlock() == from_stripped.GetBestBlock());
@@ -505,14 +500,18 @@ BOOST_AUTO_TEST_CASE(disconnect_from_stripped_without_txids_is_refused)
     CBlock rebuilt = haze::ReconstructPartialBlock(result.stripped_block);
     BOOST_REQUIRE(rebuilt.m_haze_reconstructed);
 
+    // Stripping the ids back off is not something any caller does — they travel with the block —
+    // but the refusal is kept as defence in depth, because the alternative failure is silent.
+    CBlock without_ids = rebuilt;
+    without_ids.m_haze_authoritative_txids.clear();
     CCoinsViewCache view(&chainstate.CoinsTip());
-    BOOST_CHECK_EQUAL(chainstate.DisconnectBlock(rebuilt, pindex, view), DISCONNECT_FAILED);
+    BOOST_CHECK_EQUAL(chainstate.DisconnectBlock(without_ids, pindex, view), DISCONNECT_FAILED);
 
     // A wrong-sized set is refused too, rather than read past the end or applied to the wrong txs.
-    std::vector<Txid> short_txids = AuthoritativeTxids(result.stripped_block);
-    short_txids.pop_back();
+    CBlock short_ids = rebuilt;
+    short_ids.m_haze_authoritative_txids.pop_back();
     CCoinsViewCache view2(&chainstate.CoinsTip());
-    BOOST_CHECK_EQUAL(chainstate.DisconnectBlock(rebuilt, pindex, view2, short_txids), DISCONNECT_FAILED);
+    BOOST_CHECK_EQUAL(chainstate.DisconnectBlock(short_ids, pindex, view2), DISCONNECT_FAILED);
 }
 
 BOOST_AUTO_TEST_CASE(connecting_a_reconstructed_block_is_refused)

--- a/ghost-core/src/test/haze_tests.cpp
+++ b/ghost-core/src/test/haze_tests.cpp
@@ -553,6 +553,84 @@ BOOST_AUTO_TEST_CASE(connecting_a_reconstructed_block_is_refused)
     BOOST_CHECK(chainstate.ConnectBlock(block, state2, pindex, view, /*fJustCheck=*/true));
 }
 
+// ============================================================================
+// Forgetting stripped blocks that were never connected (#542)
+// ============================================================================
+
+BOOST_AUTO_TEST_CASE(unconnected_stripped_blocks_are_forgotten_connected_ones_kept)
+{
+    // A hazed node records BLOCK_HAVE_DATA when it writes a block's stripped form, before the block
+    // is connected. Stop it in that window and the index claims to have a block that can never be
+    // connected from — the scriptSigs are gone and the in-memory copy died with the process. That is
+    // #542. The claim is what is wrong, so it is withdrawn and the block re-downloaded.
+    //
+    // The discrimination is the whole point: a stripped block that IS already connected must be
+    // kept, because for it the stored form really is sufficient — it will only ever be disconnected,
+    // which needs nothing haze removed.
+    CScript dest = GetScriptForDestination(WitnessV0KeyHash(coinbaseKey.GetPubKey()));
+
+    // Two blocks built on the SAME parent, before either is processed. The first to arrive becomes
+    // the tip; the second is accepted and stored but never connected, since it has equal work and
+    // first-seen wins. That is the state an unclean shutdown leaves behind, reached deterministically.
+    CScript other_dest = GetScriptForDestination(PKHash(coinbaseKey.GetPubKey()));
+    CBlock winner = CreateBlock({}, dest, m_node.chainman->ActiveChainstate());
+    CBlock side = CreateBlock({}, other_dest, m_node.chainman->ActiveChainstate());
+    BOOST_REQUIRE(winner.GetHash() != side.GetHash());
+    BOOST_REQUIRE(winner.hashPrevBlock == side.hashPrevBlock);
+
+    BOOST_REQUIRE(Assert(m_node.chainman)->ProcessNewBlock(std::make_shared<const CBlock>(winner),
+                                                           /*force_processing=*/true,
+                                                           /*min_pow_checked=*/true, nullptr));
+    BOOST_REQUIRE(Assert(m_node.chainman)->ProcessNewBlock(std::make_shared<const CBlock>(side),
+                                                           /*force_processing=*/true,
+                                                           /*min_pow_checked=*/true, nullptr));
+
+    LOCK(cs_main);
+    ChainstateManager& chainman = *m_node.chainman;
+    CBlockIndex* side_index = chainman.m_blockman.LookupBlockIndex(side.GetHash());
+    CBlockIndex* tip = chainman.ActiveChain().Tip();
+    BOOST_REQUIRE(side_index);
+    BOOST_REQUIRE(tip);
+    // Load-bearing: if the side block became the tip there is no "unconnected" case to test.
+    BOOST_REQUIRE(side_index != tip);
+    BOOST_REQUIRE(chainman.ActiveChain().Contains(tip));
+    BOOST_REQUIRE(!chainman.ActiveChain().Contains(side_index));
+    BOOST_REQUIRE(side_index->nStatus & BLOCK_HAVE_DATA);
+    BOOST_REQUIRE(tip->nStatus & BLOCK_HAVE_DATA);
+
+    // Nothing happens off a hazed node: an archive node's stored blocks are complete and connectable.
+    side_index->nStatus |= BLOCK_HAZED_STRIPPED;
+    tip->nStatus |= BLOCK_HAZED_STRIPPED;
+    BOOST_CHECK_EQUAL(chainman.DropUnconnectableStrippedBlocks(), 0);
+    BOOST_CHECK(side_index->nStatus & BLOCK_HAVE_DATA);
+
+    chainman.m_blockman.m_ghost_exorcism.Init(haze::GhostMode::HAZED);
+    BOOST_REQUIRE(chainman.m_blockman.m_ghost_exorcism.IsActive());
+
+    BOOST_CHECK_EQUAL(chainman.DropUnconnectableStrippedBlocks(), 1);
+
+    // The unconnected one is forgotten, and forgotten completely — a lingering file position would
+    // send a later read back into the wrong file sequence, which is the original bug.
+    BOOST_CHECK(!(side_index->nStatus & BLOCK_HAVE_DATA));
+    BOOST_CHECK(!(side_index->nStatus & BLOCK_HAVE_UNDO));
+    BOOST_CHECK_EQUAL(side_index->nFile, 0);
+    BOOST_CHECK_EQUAL(side_index->nDataPos, 0U);
+
+    // The connected one is untouched.
+    BOOST_CHECK(tip->nStatus & BLOCK_HAVE_DATA);
+
+    // m_have_pruned must be set, and this is not bookkeeping pedantry: CheckBlockIndex asserts that
+    // BLOCK_HAVE_DATA and nTx > 0 agree unless it is set, and they now deliberately do not.
+    BOOST_CHECK(chainman.m_blockman.m_have_pruned);
+
+    // The assertion that matters. Everything above could be individually true while the index as a
+    // whole had been left inconsistent, and it is CheckBlockIndex that a real node would trip over.
+    chainman.CheckBlockIndex();
+
+    // Idempotent: a second pass finds nothing left to forget.
+    BOOST_CHECK_EQUAL(chainman.DropUnconnectableStrippedBlocks(), 0);
+}
+
 BOOST_AUTO_TEST_CASE(reconstruct_meta_flags)
 {
     CScript dest = GetScriptForDestination(WitnessV0KeyHash(coinbaseKey.GetPubKey()));

--- a/ghost-core/src/test/haze_tests.cpp
+++ b/ghost-core/src/test/haze_tests.cpp
@@ -697,6 +697,67 @@ BOOST_AUTO_TEST_CASE(reconnecting_a_stripped_block_refetches_instead_of_dying)
     chainman.CheckBlockIndex();
 }
 
+// ============================================================================
+// Binding an archive to a proof (G5, hazync#46)
+// ============================================================================
+
+BOOST_AUTO_TEST_CASE(chain_binding_refuses_a_proof_about_another_chain)
+{
+    // The definition of done for G5 is not that the binding succeeds — it is that it REFUSES when
+    // the proof does not commit to the tip the node holds. A proof about some other chain says
+    // nothing about this one, and reporting it as evidence would invert the entire claim.
+    ChainstateManager& chainman = *Assert(m_node.chainman);
+
+    int height{0};
+    uint256 real_tip;
+    {
+        LOCK(cs_main);
+        const CBlockIndex* tip{chainman.ActiveChain().Tip()};
+        BOOST_REQUIRE(tip);
+        height = tip->nHeight;
+        real_tip = tip->GetBlockHash();
+    }
+    BOOST_REQUIRE_GT(height, 2);
+
+    haze::HazyncProofState proven;
+    proven.height = static_cast<uint32_t>(height);
+    proven.tip_hash = real_tip;
+
+    // The control. Without it every refusal below could be a refusal of everything — including a
+    // binding that is broken outright.
+    haze::HazedChainBinding ok;
+    BOOST_REQUIRE(haze::VerifyHazedChainBinding(chainman, proven, 1, ok));
+    BOOST_CHECK_EQUAL(ok.blocks_checked, height);
+    BOOST_CHECK(ok.complete);
+    BOOST_CHECK(ok.archive_tip == real_tip);
+    BOOST_CHECK(ok.failure.empty());
+
+    // A proof committing to a different tip at the same height: refused, and said to be about
+    // another chain rather than merely "failed".
+    haze::HazyncProofState wrong_chain{proven};
+    wrong_chain.tip_hash = uint256::ONE;
+    haze::HazedChainBinding refused;
+    BOOST_CHECK(!haze::VerifyHazedChainBinding(chainman, wrong_chain, 1, refused));
+    BOOST_CHECK(refused.failure.find("REFUSED") != std::string::npos);
+    BOOST_CHECK(refused.failure.find("not about this chain") != std::string::npos);
+    // Nothing was walked: the join is checked before the expensive pass, so a proof about another
+    // chain costs one comparison rather than thousands of merkle roots.
+    BOOST_CHECK_EQUAL(refused.blocks_checked, 0);
+
+    // A proof reaching beyond what this node holds is refused too, and distinguishably.
+    haze::HazyncProofState too_high{proven};
+    too_high.height = static_cast<uint32_t>(height) + 1000;
+    haze::HazedChainBinding beyond;
+    BOOST_CHECK(!haze::VerifyHazedChainBinding(chainman, too_high, 1, beyond));
+    BOOST_CHECK(beyond.failure.find("does not reach") != std::string::npos);
+
+    // A suffix run binds but must not claim to have established the whole chain.
+    haze::HazedChainBinding suffix;
+    BOOST_REQUIRE(haze::VerifyHazedChainBinding(chainman, proven, height - 1, suffix));
+    BOOST_CHECK(!suffix.complete);
+    BOOST_CHECK_EQUAL(suffix.blocks_checked, 2);
+}
+
 BOOST_AUTO_TEST_CASE(reconstruct_meta_flags)
 {
     CScript dest = GetScriptForDestination(WitnessV0KeyHash(coinbaseKey.GetPubKey()));

--- a/ghost-core/src/test/haze_tests.cpp
+++ b/ghost-core/src/test/haze_tests.cpp
@@ -14,6 +14,10 @@
 #include <script/solver.h>
 #include <uint256.h>
 
+#include <validation.h>
+#include <consensus/validation.h>
+#include <coins.h>
+#include <primitives/transaction_identifier.h>
 #include <test/util/setup_common.h>
 
 #include <boost/test/unit_test.hpp>
@@ -413,6 +417,140 @@ BOOST_AUTO_TEST_CASE(reconstructed_block_cannot_carry_txids)
     // transaction whose scriptSig is empty.
     BOOST_CHECK(reconstructed.vtx[0]->vin[0].scriptSig.empty());
     BOOST_CHECK(!block.vtx[0]->vin[0].scriptSig.empty());
+}
+
+// ============================================================================
+// Reorg from stripped storage (#545)
+// ============================================================================
+
+//! Authoritative txids for a stripped block, in transaction order — what the rebuilt CBlock cannot
+//! carry itself. Kept alive by the caller for the span handed to DisconnectBlock.
+static std::vector<Txid> AuthoritativeTxids(const haze::CStrippedBlock& stripped)
+{
+    std::vector<Txid> txids;
+    txids.reserve(stripped.GetTxCount());
+    for (size_t i = 0; i < stripped.GetTxCount(); ++i) {
+        txids.push_back(Txid::FromUint256(stripped.GetTxid(i)));
+    }
+    return txids;
+}
+
+BOOST_AUTO_TEST_CASE(disconnect_from_stripped_matches_disconnect_from_full)
+{
+    // The claim reorg-from-stripped rests on: undoing a block needs nothing haze destroyed, so a
+    // block rebuilt from stripped storage must undo to exactly the same UTXO set as the real one.
+    //
+    // Asserted by doing both and comparing, rather than by checking a handful of coins — a spot
+    // check would pass while some other coin silently differed.
+    // The spend must be properly signed, or the block is invalid, never connects, and the whole
+    // comparison below runs against a tip that is not this block at all.
+    CScript dest = GetScriptForDestination(WitnessV0KeyHash(coinbaseKey.GetPubKey()));
+    CMutableTransaction spend = CreateValidMempoolTransaction(
+        /*input_transaction=*/m_coinbase_txns[0], /*input_vout=*/0, /*input_height=*/0,
+        /*input_signing_key=*/coinbaseKey, /*output_destination=*/dest,
+        /*output_amount=*/49 * COIN, /*submit=*/false);
+    CBlock block = CreateAndProcessBlock({spend}, dest);
+
+    LOCK(cs_main);
+    Chainstate& chainstate = m_node.chainman->ActiveChainstate();
+    CBlockIndex* pindex = m_node.chainman->m_blockman.LookupBlockIndex(block.GetHash());
+    BOOST_REQUIRE(pindex);
+    // Load-bearing: if the block did not become the tip it was rejected, and disconnecting it would
+    // be measuring nothing.
+    BOOST_REQUIRE(chainstate.m_chain.Tip() == pindex);
+    BOOST_REQUIRE_EQUAL(block.vtx.size(), 2U); // coinbase + the spend, so inputs really are restored
+
+    haze::StripResult result = haze::StripBlock(block);
+    CBlock rebuilt = haze::ReconstructPartialBlock(result.stripped_block);
+    const std::vector<Txid> txids = AuthoritativeTxids(result.stripped_block);
+
+    // Undo with the real block.
+    CCoinsViewCache from_full(&chainstate.CoinsTip());
+    BOOST_REQUIRE_EQUAL(chainstate.DisconnectBlock(block, pindex, from_full), DISCONNECT_OK);
+
+    // Undo with the rebuilt block plus the txids the stripped form kept.
+    CCoinsViewCache from_stripped(&chainstate.CoinsTip());
+    BOOST_REQUIRE_EQUAL(chainstate.DisconnectBlock(rebuilt, pindex, from_stripped, txids), DISCONNECT_OK);
+
+    // Same best block, and the same verdict on every coin the block touched.
+    BOOST_CHECK(from_full.GetBestBlock() == from_stripped.GetBestBlock());
+    for (const auto& tx : block.vtx) {
+        for (size_t o = 0; o < tx->vout.size(); ++o) {
+            const COutPoint out{tx->GetHash(), static_cast<uint32_t>(o)};
+            BOOST_CHECK_EQUAL(from_full.HaveCoin(out), from_stripped.HaveCoin(out));
+        }
+        if (!tx->IsCoinBase()) {
+            for (const auto& in : tx->vin) {
+                BOOST_CHECK_EQUAL(from_full.HaveCoin(in.prevout), from_stripped.HaveCoin(in.prevout));
+                BOOST_CHECK(from_full.AccessCoin(in.prevout).out == from_stripped.AccessCoin(in.prevout).out);
+            }
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(disconnect_from_stripped_without_txids_is_refused)
+{
+    // The negative that makes the parameter load-bearing. Without it this call would not fail — it
+    // would look up outpoints that do not exist, miss every one, and leave spent coins in the set
+    // while reporting no worse than "unclean". It must be refused outright instead.
+    CScript dest = GetScriptForDestination(WitnessV0KeyHash(coinbaseKey.GetPubKey()));
+    CBlock block = CreateAndProcessBlock({}, dest);
+
+    LOCK(cs_main);
+    Chainstate& chainstate = m_node.chainman->ActiveChainstate();
+    CBlockIndex* pindex = m_node.chainman->m_blockman.LookupBlockIndex(block.GetHash());
+    BOOST_REQUIRE(pindex);
+
+    haze::StripResult result = haze::StripBlock(block);
+    CBlock rebuilt = haze::ReconstructPartialBlock(result.stripped_block);
+    BOOST_REQUIRE(rebuilt.m_haze_reconstructed);
+
+    CCoinsViewCache view(&chainstate.CoinsTip());
+    BOOST_CHECK_EQUAL(chainstate.DisconnectBlock(rebuilt, pindex, view), DISCONNECT_FAILED);
+
+    // A wrong-sized set is refused too, rather than read past the end or applied to the wrong txs.
+    std::vector<Txid> short_txids = AuthoritativeTxids(result.stripped_block);
+    short_txids.pop_back();
+    CCoinsViewCache view2(&chainstate.CoinsTip());
+    BOOST_CHECK_EQUAL(chainstate.DisconnectBlock(rebuilt, pindex, view2, short_txids), DISCONNECT_FAILED);
+}
+
+BOOST_AUTO_TEST_CASE(connecting_a_reconstructed_block_is_refused)
+{
+    // The hard guard the design asks for: rebuilt blocks may be disconnected, never connected.
+    // Without it, ConnectBlock would run against empty scriptSigs and empty witnesses — nothing to
+    // verify, no BIP34 height, no witness commitment — and could only produce a meaningless pass.
+    CScript dest = GetScriptForDestination(WitnessV0KeyHash(coinbaseKey.GetPubKey()));
+    CBlock block = CreateAndProcessBlock({}, dest);
+
+    LOCK(cs_main);
+    Chainstate& chainstate = m_node.chainman->ActiveChainstate();
+    CBlockIndex* pindex = m_node.chainman->m_blockman.LookupBlockIndex(block.GetHash());
+    BOOST_REQUIRE(pindex);
+
+    haze::StripResult result = haze::StripBlock(block);
+    CBlock rebuilt = haze::ReconstructPartialBlock(result.stripped_block);
+
+    // ConnectBlock asserts the view sits at pindex->pprev (validation.cpp), so disconnect first —
+    // which also makes this a genuine round trip rather than a contrived view.
+    CCoinsViewCache view(&chainstate.CoinsTip());
+    BOOST_REQUIRE_EQUAL(chainstate.DisconnectBlock(block, pindex, view), DISCONNECT_OK);
+    BOOST_REQUIRE(view.GetBestBlock() == pindex->pprev->GetBlockHash());
+
+    BlockValidationState state;
+    BOOST_CHECK(!chainstate.ConnectBlock(rebuilt, state, pindex, view, /*fJustCheck=*/true));
+
+    // Refused as an internal error, NOT as an invalid block: the block itself is fine and marking it
+    // invalid would poison a legitimate part of the chain over a caller's mistake.
+    BOOST_CHECK(state.IsError());
+    BOOST_CHECK(!state.IsInvalid());
+
+    // The control, from the same view: the real block connects. Without it the refusal above could
+    // be the fixture being wrong rather than the guard working. The refused call returns before
+    // touching the view, so the view is still at pprev here.
+    BOOST_REQUIRE(!block.m_haze_reconstructed);
+    BlockValidationState state2;
+    BOOST_CHECK(chainstate.ConnectBlock(block, state2, pindex, view, /*fJustCheck=*/true));
 }
 
 BOOST_AUTO_TEST_CASE(reconstruct_meta_flags)

--- a/ghost-core/src/test/haze_tests.cpp
+++ b/ghost-core/src/test/haze_tests.cpp
@@ -377,6 +377,44 @@ BOOST_AUTO_TEST_CASE(reconstruct_preserves_outputs)
     }
 }
 
+BOOST_AUTO_TEST_CASE(reconstructed_block_cannot_carry_txids)
+{
+    // A reconstructed CBlock's transactions compute their own txid from their contents, and their
+    // contents are missing the scriptSigs. So for any transaction that HAD a scriptSig — every
+    // coinbase, every legacy and P2SH-wrapped spend — the reconstruction's txid is the hash of a
+    // different transaction. `CTransaction` has nowhere to put an authoritative txid, so this is a
+    // property of the type, not an oversight that could be patched inside ReconstructPartialBlock.
+    //
+    // This matters well beyond display. Anything that keys a UTXO lookup on a reconstructed txid —
+    // DisconnectBlock does, for every output of every transaction — would look up outpoints that do
+    // not exist, leave the real coins untouched, and report the block as merely "unclean".
+    //
+    // The authoritative source is CStrippedBlock::GetTxid(), which returns the STORED txid when
+    // there is one. Asserted here in both directions so the trap is documented rather than
+    // rediscovered.
+    CScript dest = GetScriptForDestination(WitnessV0KeyHash(coinbaseKey.GetPubKey()));
+    CBlock block = CreateAndProcessBlock({}, dest);
+
+    haze::StripResult result = haze::StripBlock(block);
+    CBlock reconstructed = haze::ReconstructPartialBlock(result.stripped_block);
+    BOOST_REQUIRE_GT(result.stripped_block.GetTxCount(), 0U);
+
+    // A coinbase always carries scriptSig data, so it always ends up with a stored txid.
+    BOOST_REQUIRE(result.stripped_block.m_transactions[0].m_has_stored_txid);
+
+    // The control: the authoritative source is right. Without this the check below could pass
+    // because stripping is broken rather than because reconstruction cannot carry txids.
+    BOOST_CHECK(result.stripped_block.GetTxid(0) == block.vtx[0]->GetHash().ToUint256());
+
+    // The trap: the reconstruction's own txid is NOT the real one.
+    BOOST_CHECK(reconstructed.vtx[0]->GetHash().ToUint256() != block.vtx[0]->GetHash().ToUint256());
+
+    // And it is not a near miss that some later comparison might tolerate: it is the hash of a
+    // transaction whose scriptSig is empty.
+    BOOST_CHECK(reconstructed.vtx[0]->vin[0].scriptSig.empty());
+    BOOST_CHECK(!block.vtx[0]->vin[0].scriptSig.empty());
+}
+
 BOOST_AUTO_TEST_CASE(reconstruct_meta_flags)
 {
     CScript dest = GetScriptForDestination(WitnessV0KeyHash(coinbaseKey.GetPubKey()));

--- a/ghost-core/src/validation.cpp
+++ b/ghost-core/src/validation.cpp
@@ -6532,6 +6532,54 @@ SnapshotCompletionResult ChainstateManager::MaybeCompleteSnapshotValidation()
     return SnapshotCompletionResult::SUCCESS;
 }
 
+int ChainstateManager::DropUnconnectableStrippedBlocks()
+{
+    AssertLockHeld(::cs_main);
+
+    // Only a hazed node can be in this state; nothing else stores blocks it cannot connect from.
+    if (!m_blockman.m_ghost_exorcism.IsActive()) return 0;
+
+    // "Already connected" means present in some chainstate's active chain. Ancestry against the tip
+    // is the exact test — a height comparison would keep stripped blocks on abandoned side branches,
+    // which are just as unconnectable and would fail the same way on the next reorg towards them.
+    const auto is_connected = [this](const CBlockIndex& index) EXCLUSIVE_LOCKS_REQUIRED(::cs_main) {
+        for (const Chainstate* c : GetAll()) {
+            if (const CBlockIndex* tip{c->m_chain.Tip()};
+                tip && tip->GetAncestor(index.nHeight) == &index) {
+                return true;
+            }
+        }
+        return false;
+    };
+
+    int dropped{0};
+    for (CBlockIndex* pindex : m_blockman.GetAllBlockIndices()) {
+        if (!(pindex->nStatus & BLOCK_HAZED_STRIPPED)) continue;
+        if (!(pindex->nStatus & BLOCK_HAVE_DATA)) continue;
+        if (is_connected(*pindex)) continue;
+
+        LogWarning("[haze] Forgetting stripped block %s (%d): it was stored but never connected, so "
+                   "its data cannot satisfy a connect and will be downloaded again.\n",
+                   pindex->GetBlockHash().ToString(), pindex->nHeight);
+        m_blockman.ForgetBlockData(*pindex);
+        ++dropped;
+    }
+
+    if (dropped > 0) {
+        // Same bookkeeping pruning does, and for the same reason: this node has deleted block data
+        // it once held. Without it CheckBlockIndex asserts that BLOCK_HAVE_DATA and nTx > 0 agree,
+        // which they deliberately no longer do — see the assert guarded by m_have_pruned.
+        if (!m_blockman.m_have_pruned) {
+            m_blockman.m_block_tree_db->WriteFlag("prunedblockfiles", true);
+            m_blockman.m_have_pruned = true;
+        }
+        LogWarning("[haze] Forgot %d stripped block(s) that were never connected; they will be "
+                   "re-downloaded. This follows an unclean shutdown and is not data loss: the blocks "
+                   "were never part of the chain this node had validated.\n", dropped);
+    }
+    return dropped;
+}
+
 Chainstate& ChainstateManager::ActiveChainstate() const
 {
     LOCK(::cs_main);

--- a/ghost-core/src/validation.cpp
+++ b/ghost-core/src/validation.cpp
@@ -3094,7 +3094,11 @@ bool Chainstate::DisconnectTip(BlockValidationState& state, DisconnectedBlockTra
     // Read block from disk.
     std::shared_ptr<CBlock> pblock = std::make_shared<CBlock>();
     CBlock& block = *pblock;
-    if (!m_blockman.ReadBlock(block, *pindexDelete)) {
+    // On a hazed node the full block may be gone, in which case this rebuilds it from what haze
+    // kept. Undoing needs no scriptSig and no witness, so a rebuilt block is enough — but it does
+    // not know its own txids, hence the second output. See BlockManager::ReadBlockForDisconnect.
+    std::vector<Txid> authoritative_txids;
+    if (!m_blockman.ReadBlockForDisconnect(block, authoritative_txids, *pindexDelete)) {
         LogError("DisconnectTip(): Failed to read block\n");
         return false;
     }
@@ -3103,7 +3107,7 @@ bool Chainstate::DisconnectTip(BlockValidationState& state, DisconnectedBlockTra
     {
         CCoinsViewCache view(&CoinsTip());
         assert(view.GetBestBlock() == pindexDelete->GetBlockHash());
-        if (DisconnectBlock(block, pindexDelete, view) != DISCONNECT_OK) {
+        if (DisconnectBlock(block, pindexDelete, view, authoritative_txids) != DISCONNECT_OK) {
             LogError("DisconnectTip(): DisconnectBlock %s failed\n", pindexDelete->GetBlockHash().ToString());
             return false;
         }
@@ -3129,11 +3133,28 @@ bool Chainstate::DisconnectTip(BlockValidationState& state, DisconnectedBlockTra
         return false;
     }
 
-    if (disconnectpool && m_mempool) {
-        // Save transactions to re-add to mempool at end of reorg. If any entries are evicted for
-        // exceeding memory limits, remove them and their descendants from the mempool.
-        for (auto&& evicted_tx : disconnectpool->AddTransactionsFromBlock(block.vtx)) {
-            m_mempool->removeRecursive(*evicted_tx, MemPoolRemovalReason::REORG);
+    // Everything below hands this block's transactions to something that will treat them as real
+    // transactions. A rebuilt one has none: the scriptSigs are gone, so nothing here could be
+    // relayed or re-mined, and for anything that had a scriptSig even the txid is not its own.
+    // Passing them on would put unsignable objects in the mempool and tell wallets about
+    // transactions that do not exist under those ids.
+    //
+    // So a hazed node loses them instead. That is the honest outcome rather than a degraded one:
+    // the data needed to resurrect these transactions was destroyed on purpose, and no ordering of
+    // this code can bring it back. Logged at every reorg so it is visible rather than assumed.
+    if (block.m_haze_reconstructed) {
+        LogWarning("[haze] Disconnected stripped block %s (%d): its transactions cannot return to "
+                   "the mempool and are not reported to wallets — haze destroyed the scriptSigs, so "
+                   "they are no longer signable transactions. Any of them still wanted must be "
+                   "re-broadcast by their owners.\n",
+                   pindexDelete->GetBlockHash().ToString(), pindexDelete->nHeight);
+    } else {
+        if (disconnectpool && m_mempool) {
+            // Save transactions to re-add to mempool at end of reorg. If any entries are evicted for
+            // exceeding memory limits, remove them and their descendants from the mempool.
+            for (auto&& evicted_tx : disconnectpool->AddTransactionsFromBlock(block.vtx)) {
+                m_mempool->removeRecursive(*evicted_tx, MemPoolRemovalReason::REORG);
+            }
         }
     }
 
@@ -3142,7 +3163,7 @@ bool Chainstate::DisconnectTip(BlockValidationState& state, DisconnectedBlockTra
     UpdateTip(pindexDelete->pprev);
     // Let wallets know transactions went from 1-confirmed to
     // 0-confirmed or conflicted:
-    if (m_chainman.m_options.signals) {
+    if (m_chainman.m_options.signals && !block.m_haze_reconstructed) {
         m_chainman.m_options.signals->BlockDisconnected(pblock, pindexDelete);
     }
     return true;
@@ -5074,12 +5095,13 @@ bool Chainstate::ReplayBlocks()
     while (pindexOld != pindexFork) {
         if (pindexOld->nHeight > 0) { // Never disconnect the genesis block.
             CBlock block;
-            if (!m_blockman.ReadBlock(block, *pindexOld)) {
+            std::vector<Txid> authoritative_txids;
+            if (!m_blockman.ReadBlockForDisconnect(block, authoritative_txids, *pindexOld)) {
                 LogError("RollbackBlock(): ReadBlock() failed at %d, hash=%s\n", pindexOld->nHeight, pindexOld->GetBlockHash().ToString());
                 return false;
             }
             LogInfo("Rolling back %s (%i)", pindexOld->GetBlockHash().ToString(), pindexOld->nHeight);
-            DisconnectResult res = DisconnectBlock(block, pindexOld, cache);
+            DisconnectResult res = DisconnectBlock(block, pindexOld, cache, authoritative_txids);
             if (res == DISCONNECT_FAILED) {
                 LogError("RollbackBlock(): DisconnectBlock failed at %d, hash=%s\n", pindexOld->nHeight, pindexOld->GetBlockHash().ToString());
                 return false;

--- a/ghost-core/src/validation.cpp
+++ b/ghost-core/src/validation.cpp
@@ -3236,6 +3236,29 @@ bool Chainstate::ConnectTip(
         } else {
             std::shared_ptr<CBlock> pblockNew = std::make_shared<CBlock>();
             if (!m_blockman.ReadBlock(*pblockNew, *pindexNew)) {
+                // A stripped block cannot be connected from what survives on disk — that is the
+                // point of haze, not a fault. It happens when a hazed node reorgs back onto a branch
+                // it previously abandoned: the block was connected once, so its stored form was
+                // sufficient then, and is not now.
+                //
+                // The same invariant as at startup applies: BLOCK_HAVE_DATA is only true of a
+                // stripped block while it stays connected. Withdrawing the claim hands the block to
+                // the ordinary download machinery — FindMostWorkChain drops it as a candidate and
+                // re-queues it in m_blocks_unlinked, and it is fetched from any peer that still has
+                // it. No separate archive-peer concept is needed: an archive node is exactly that.
+                //
+                // Re-fetching restores nothing hazeable. The block arrives, passes back through the
+                // exorcism fence, and is stripped again before anything is written.
+                if (pindexNew->nStatus & BLOCK_HAZED_STRIPPED) {
+                    LogWarning("[haze] Cannot connect stripped block %s (%d) from local storage — "
+                               "haze destroyed what connecting needs. Requesting it from peers; the "
+                               "node will make no progress on this branch until one supplies it.\n",
+                               pindexNew->GetBlockHash().ToString(), pindexNew->nHeight);
+                    m_chainman.ForgetStrippedBlockData(*pindexNew);
+                    // Deliberately not fatal and not an invalid block: nothing is wrong with the
+                    // chain, this node simply no longer holds a copy it can validate from.
+                    return false;
+                }
                 return FatalError(m_chainman.GetNotifications(), state, _("Failed to read block."));
             }
             block_to_connect = std::move(pblockNew);
@@ -6529,6 +6552,21 @@ SnapshotCompletionResult ChainstateManager::MaybeCompleteSnapshotValidation()
     return SnapshotCompletionResult::SUCCESS;
 }
 
+void ChainstateManager::ForgetStrippedBlockData(CBlockIndex& index)
+{
+    AssertLockHeld(::cs_main);
+    m_blockman.ForgetBlockData(index);
+
+    // Not optional, and not merely bookkeeping: CheckBlockIndex asserts BLOCK_HAVE_DATA and nTx > 0
+    // agree unless this records that data has been deleted, and after ForgetBlockData they do not.
+    // Kept here rather than at each call site so a haze path cannot omit it — omitting it aborts,
+    // but only later, on a node that has been running fine.
+    if (!m_blockman.m_have_pruned) {
+        m_blockman.m_block_tree_db->WriteFlag("prunedblockfiles", true);
+        m_blockman.m_have_pruned = true;
+    }
+}
+
 int ChainstateManager::DropUnconnectableStrippedBlocks()
 {
     AssertLockHeld(::cs_main);
@@ -6558,18 +6596,11 @@ int ChainstateManager::DropUnconnectableStrippedBlocks()
         LogWarning("[haze] Forgetting stripped block %s (%d): it was stored but never connected, so "
                    "its data cannot satisfy a connect and will be downloaded again.\n",
                    pindex->GetBlockHash().ToString(), pindex->nHeight);
-        m_blockman.ForgetBlockData(*pindex);
+        ForgetStrippedBlockData(*pindex);
         ++dropped;
     }
 
     if (dropped > 0) {
-        // Same bookkeeping pruning does, and for the same reason: this node has deleted block data
-        // it once held. Without it CheckBlockIndex asserts that BLOCK_HAVE_DATA and nTx > 0 agree,
-        // which they deliberately no longer do — see the assert guarded by m_have_pruned.
-        if (!m_blockman.m_have_pruned) {
-            m_blockman.m_block_tree_db->WriteFlag("prunedblockfiles", true);
-            m_blockman.m_have_pruned = true;
-        }
         LogWarning("[haze] Forgot %d stripped block(s) that were never connected; they will be "
                    "re-downloaded. This follows an unclean shutdown and is not data loss: the blocks "
                    "were never part of the chain this node had validated.\n", dropped);

--- a/ghost-core/src/validation.cpp
+++ b/ghost-core/src/validation.cpp
@@ -2290,11 +2290,12 @@ int ApplyTxInUndo(Coin&& undo, CCoinsViewCache& view, const COutPoint& out)
 
 /** Undo the effects of this block (with given index) on the UTXO set represented by coins.
  *  When FAILED is returned, view is left in an indeterminate state. */
-DisconnectResult Chainstate::DisconnectBlock(const CBlock& block, const CBlockIndex* pindex, CCoinsViewCache& view,
-                                             std::span<const Txid> authoritative_txids)
+DisconnectResult Chainstate::DisconnectBlock(const CBlock& block, const CBlockIndex* pindex, CCoinsViewCache& view)
 {
     AssertLockHeld(::cs_main);
     bool fClean = true;
+
+    const std::span<const Txid> authoritative_txids{block.m_haze_authoritative_txids};
 
     // A block rebuilt from stripped storage does not know its own txids — see the header. Refuse it
     // rather than let it derive them: every coin lookup below is keyed on the txid, so the result
@@ -3097,8 +3098,7 @@ bool Chainstate::DisconnectTip(BlockValidationState& state, DisconnectedBlockTra
     // On a hazed node the full block may be gone, in which case this rebuilds it from what haze
     // kept. Undoing needs no scriptSig and no witness, so a rebuilt block is enough — but it does
     // not know its own txids, hence the second output. See BlockManager::ReadBlockForDisconnect.
-    std::vector<Txid> authoritative_txids;
-    if (!m_blockman.ReadBlockForDisconnect(block, authoritative_txids, *pindexDelete)) {
+    if (!m_blockman.ReadBlockForDisconnect(block, *pindexDelete)) {
         LogError("DisconnectTip(): Failed to read block\n");
         return false;
     }
@@ -3107,7 +3107,7 @@ bool Chainstate::DisconnectTip(BlockValidationState& state, DisconnectedBlockTra
     {
         CCoinsViewCache view(&CoinsTip());
         assert(view.GetBestBlock() == pindexDelete->GetBlockHash());
-        if (DisconnectBlock(block, pindexDelete, view, authoritative_txids) != DISCONNECT_OK) {
+        if (DisconnectBlock(block, pindexDelete, view) != DISCONNECT_OK) {
             LogError("DisconnectTip(): DisconnectBlock %s failed\n", pindexDelete->GetBlockHash().ToString());
             return false;
         }
@@ -3133,20 +3133,18 @@ bool Chainstate::DisconnectTip(BlockValidationState& state, DisconnectedBlockTra
         return false;
     }
 
-    // Everything below hands this block's transactions to something that will treat them as real
-    // transactions. A rebuilt one has none: the scriptSigs are gone, so nothing here could be
-    // relayed or re-mined, and for anything that had a scriptSig even the txid is not its own.
-    // Passing them on would put unsignable objects in the mempool and tell wallets about
-    // transactions that do not exist under those ids.
+    // The mempool is the one consumer that cannot be served here, and not for want of information:
+    // a rebuilt transaction has no scriptSig and no witness, so it is not a signable transaction at
+    // all and could never be relayed or mined again by anyone. Re-adding it would put an object in
+    // the mempool that is guaranteed to be rejected. Losing it is the correct outcome, not a
+    // degraded one — the data needed to resurrect it was destroyed on purpose.
     //
-    // So a hazed node loses them instead. That is the honest outcome rather than a degraded one:
-    // the data needed to resurrect these transactions was destroyed on purpose, and no ordering of
-    // this code can bring it back. Logged at every reorg so it is visible rather than assumed.
+    // Wallets and indexes ARE served: the block carries the real txids, so subscribers can match
+    // their own transactions and mark them unconfirmed. See CBlock::m_haze_authoritative_txids.
     if (block.m_haze_reconstructed) {
         LogWarning("[haze] Disconnected stripped block %s (%d): its transactions cannot return to "
-                   "the mempool and are not reported to wallets — haze destroyed the scriptSigs, so "
-                   "they are no longer signable transactions. Any of them still wanted must be "
-                   "re-broadcast by their owners.\n",
+                   "the mempool — haze destroyed the scriptSigs, so they are no longer signable "
+                   "transactions. Any still wanted must be re-broadcast by their owners.\n",
                    pindexDelete->GetBlockHash().ToString(), pindexDelete->nHeight);
     } else {
         if (disconnectpool && m_mempool) {
@@ -3163,7 +3161,7 @@ bool Chainstate::DisconnectTip(BlockValidationState& state, DisconnectedBlockTra
     UpdateTip(pindexDelete->pprev);
     // Let wallets know transactions went from 1-confirmed to
     // 0-confirmed or conflicted:
-    if (m_chainman.m_options.signals && !block.m_haze_reconstructed) {
+    if (m_chainman.m_options.signals) {
         m_chainman.m_options.signals->BlockDisconnected(pblock, pindexDelete);
     }
     return true;
@@ -5095,13 +5093,12 @@ bool Chainstate::ReplayBlocks()
     while (pindexOld != pindexFork) {
         if (pindexOld->nHeight > 0) { // Never disconnect the genesis block.
             CBlock block;
-            std::vector<Txid> authoritative_txids;
-            if (!m_blockman.ReadBlockForDisconnect(block, authoritative_txids, *pindexOld)) {
+            if (!m_blockman.ReadBlockForDisconnect(block, *pindexOld)) {
                 LogError("RollbackBlock(): ReadBlock() failed at %d, hash=%s\n", pindexOld->nHeight, pindexOld->GetBlockHash().ToString());
                 return false;
             }
             LogInfo("Rolling back %s (%i)", pindexOld->GetBlockHash().ToString(), pindexOld->nHeight);
-            DisconnectResult res = DisconnectBlock(block, pindexOld, cache, authoritative_txids);
+            DisconnectResult res = DisconnectBlock(block, pindexOld, cache);
             if (res == DISCONNECT_FAILED) {
                 LogError("RollbackBlock(): DisconnectBlock failed at %d, hash=%s\n", pindexOld->nHeight, pindexOld->GetBlockHash().ToString());
                 return false;

--- a/ghost-core/src/validation.cpp
+++ b/ghost-core/src/validation.cpp
@@ -3992,7 +3992,8 @@ void Chainstate::TryAddBlockIndexCandidate(CBlockIndex* pindex)
 }
 
 /** Mark a block as having its data received and checked (up to BLOCK_VALID_TRANSACTIONS). */
-void ChainstateManager::ReceivedBlockTransactions(const CBlock& block, CBlockIndex* pindexNew, const FlatFilePos& pos)
+void ChainstateManager::ReceivedBlockTransactions(const CBlock& block, CBlockIndex* pindexNew, const FlatFilePos& pos,
+                                                  bool payload_stripped)
 {
     AssertLockHeld(cs_main);
     pindexNew->nTx = block.vtx.size();
@@ -4015,7 +4016,12 @@ void ChainstateManager::ReceivedBlockTransactions(const CBlock& block, CBlockInd
     // Record WHICH file sequence nDataPos refers to. Haze writes the stripped payload to gsb*.dat,
     // and BLOCK_HAVE_DATA alone cannot distinguish that from a full block in blk*.dat — so without
     // this the read path has to guess, and guessed wrong.
-    if (m_blockman.m_ghost_exorcism.IsActive()) {
+    //
+    // This must follow the writer that was actually used, not whether haze is enabled. Genesis is
+    // written WHOLE even on a hazed node, so keying off exorcism marked it stripped, sent the read
+    // path to the gsb sequence for a payload sitting in blk, and left a fresh hazed node unable to
+    // connect its own genesis block.
+    if (payload_stripped) {
         pindexNew->nStatus |= BLOCK_HAZED_STRIPPED;
     }
     if (DeploymentActiveAt(*pindexNew, *this, Consensus::DEPLOYMENT_SEGWIT)) {
@@ -4061,7 +4067,8 @@ void ChainstateManager::ReceivedBlockTransactions(const CBlock& block, CBlockInd
     }
 }
 
-void ChainstateManager::ReceivedBlockTransactions(uint32_t nTx, CBlockIndex* pindexNew, const FlatFilePos& pos)
+void ChainstateManager::ReceivedBlockTransactions(uint32_t nTx, CBlockIndex* pindexNew, const FlatFilePos& pos,
+                                                  bool payload_stripped)
 {
     AssertLockHeld(cs_main);
     pindexNew->nTx = nTx;
@@ -4079,7 +4086,12 @@ void ChainstateManager::ReceivedBlockTransactions(uint32_t nTx, CBlockIndex* pin
     // Record WHICH file sequence nDataPos refers to. Haze writes the stripped payload to gsb*.dat,
     // and BLOCK_HAVE_DATA alone cannot distinguish that from a full block in blk*.dat — so without
     // this the read path has to guess, and guessed wrong.
-    if (m_blockman.m_ghost_exorcism.IsActive()) {
+    //
+    // This must follow the writer that was actually used, not whether haze is enabled. Genesis is
+    // written WHOLE even on a hazed node, so keying off exorcism marked it stripped, sent the read
+    // path to the gsb sequence for a payload sitting in blk, and left a fresh hazed node unable to
+    // connect its own genesis block.
+    if (payload_stripped) {
         pindexNew->nStatus |= BLOCK_HAZED_STRIPPED;
     }
     if (DeploymentActiveAt(*pindexNew, *this, Consensus::DEPLOYMENT_SEGWIT)) {
@@ -4663,11 +4675,13 @@ bool ChainstateManager::AcceptBlock(const std::shared_ptr<const CBlock>& pblock,
     if (fNewBlock) *fNewBlock = true;
     try {
         FlatFilePos blockPos{};
+        bool wrote_stripped{false};
         if (dbp) {
             blockPos = *dbp;
             m_blockman.UpdateBlockInfo(block, pindex->nHeight, blockPos);
         } else if (m_blockman.m_ghost_exorcism.IsActive()) {
             // Ghost Exorcism (Hazed): strip hazeable content, write structural data only
+            wrote_stripped = true;
             blockPos = m_blockman.WriteStrippedBlock(block, pindex->nHeight);
             if (blockPos.IsNull()) {
                 state.Error(strprintf("%s: Failed to write stripped block to disk", __func__));
@@ -4681,7 +4695,9 @@ bool ChainstateManager::AcceptBlock(const std::shared_ptr<const CBlock>& pblock,
                 return false;
             }
         }
-        ReceivedBlockTransactions(block, pindex, blockPos);
+        // Stripped exactly when WriteStrippedBlock was the writer above — not merely when haze is on,
+        // since the dbp path re-uses an existing position and writes nothing.
+        ReceivedBlockTransactions(block, pindex, blockPos, /*payload_stripped=*/wrote_stripped);
 
         // In Haze mode, cache the full block — GSB files cannot be deserialized
         // back into CBlock, but ConnectTip may need the full block if
@@ -5234,7 +5250,10 @@ bool Chainstate::LoadGenesisBlock()
             return false;
         }
         CBlockIndex* pindex = m_blockman.AddToBlockIndex(block, m_chainman.m_best_header);
-        m_chainman.ReceivedBlockTransactions(block, pindex, blockPos);
+        // Genesis goes through WriteBlock above — whole, into the blk sequence — on a hazed node as
+        // much as any other. It is hardcoded rather than received, there is nothing about it worth
+        // stripping, and it must stay readable or the node cannot connect its own first block.
+        m_chainman.ReceivedBlockTransactions(block, pindex, blockPos, /*payload_stripped=*/false);
     } catch (const std::runtime_error& e) {
         LogError("%s: failed to write genesis block: %s\n", __func__, e.what());
         return false;
@@ -6574,6 +6593,24 @@ int ChainstateManager::DropUnconnectableStrippedBlocks()
     // Only a hazed node can be in this state; nothing else stores blocks it cannot connect from.
     if (!m_blockman.m_ghost_exorcism.IsActive()) return 0;
 
+    // A node with no chain yet has nothing to compare against, and must not be asked. On a fresh
+    // hazed datadir the genesis block has just been written — stripped, because exorcism is already
+    // active — and no chainstate has a tip at this point in init. Every block then looks
+    // unconnected, genesis included, and forgetting genesis leaves the node unable to start at all.
+    //
+    // Found by running a real hazed mainnet node, which forgot genesis and could not start.
+    //
+    // ⚠ There is no unit test for this, and that is not an omission: the unit fixtures always have a
+    // tip, and a CChain cannot be emptied through its public interface, so the state cannot be built
+    // in them. With a tip present genesis is always an ancestor of it and both guards below are
+    // unreachable. The regression test is test/hazync/hazed-node.sh, which starts a real hazed node
+    // and asserts genesis is never forgotten.
+    bool any_tip{false};
+    for (const Chainstate* c : GetAll()) {
+        if (c->m_chain.Tip()) { any_tip = true; break; }
+    }
+    if (!any_tip) return 0;
+
     // "Already connected" means present in some chainstate's active chain. Ancestry against the tip
     // is the exact test — a height comparison would keep stripped blocks on abandoned side branches,
     // which are just as unconnectable and would fail the same way on the next reorg towards them.
@@ -6591,6 +6628,10 @@ int ChainstateManager::DropUnconnectableStrippedBlocks()
     for (CBlockIndex* pindex : m_blockman.GetAllBlockIndices()) {
         if (!(pindex->nStatus & BLOCK_HAZED_STRIPPED)) continue;
         if (!(pindex->nStatus & BLOCK_HAVE_DATA)) continue;
+        // Genesis is never "connected" in the sense used here — it is the base every chain hangs
+        // from, it cannot be re-downloaded, and forgetting it bricks the node before it can start.
+        // Belt and braces alongside the no-tip guard above.
+        if (pindex->nHeight == 0) continue;
         if (is_connected(*pindex)) continue;
 
         LogWarning("[haze] Forgetting stripped block %s (%d): it was stored but never connected, so "

--- a/ghost-core/src/validation.cpp
+++ b/ghost-core/src/validation.cpp
@@ -2290,10 +2290,27 @@ int ApplyTxInUndo(Coin&& undo, CCoinsViewCache& view, const COutPoint& out)
 
 /** Undo the effects of this block (with given index) on the UTXO set represented by coins.
  *  When FAILED is returned, view is left in an indeterminate state. */
-DisconnectResult Chainstate::DisconnectBlock(const CBlock& block, const CBlockIndex* pindex, CCoinsViewCache& view)
+DisconnectResult Chainstate::DisconnectBlock(const CBlock& block, const CBlockIndex* pindex, CCoinsViewCache& view,
+                                             std::span<const Txid> authoritative_txids)
 {
     AssertLockHeld(::cs_main);
     bool fClean = true;
+
+    // A block rebuilt from stripped storage does not know its own txids — see the header. Refuse it
+    // rather than let it derive them: every coin lookup below is keyed on the txid, so the result
+    // would not be a failure but a set of lookups that quietly miss, leaving spent coins in the UTXO
+    // set and reporting nothing worse than "unclean".
+    if (block.m_haze_reconstructed && authoritative_txids.empty()) {
+        LogError("DisconnectBlock(): block %s was rebuilt from stripped storage but no authoritative "
+                 "txids were supplied — refusing, because its own txids are not the real ones\n",
+                 pindex->GetBlockHash().ToString());
+        return DISCONNECT_FAILED;
+    }
+    if (!authoritative_txids.empty() && authoritative_txids.size() != block.vtx.size()) {
+        LogError("DisconnectBlock(): %u authoritative txids supplied for a block of %u transactions\n",
+                 (unsigned)authoritative_txids.size(), (unsigned)block.vtx.size());
+        return DISCONNECT_FAILED;
+    }
 
     CBlockUndo blockUndo;
     if (!m_blockman.ReadBlockUndo(blockUndo, *pindex)) {
@@ -2318,7 +2335,9 @@ DisconnectResult Chainstate::DisconnectBlock(const CBlock& block, const CBlockIn
     // undo transactions in reverse order
     for (int i = block.vtx.size() - 1; i >= 0; i--) {
         const CTransaction &tx = *(block.vtx[i]);
-        Txid hash = tx.GetHash();
+        // The supplied txid wins where one was given: for a rebuilt block the transaction's own is
+        // the hash of something else. Identical to tx.GetHash() for a real block.
+        Txid hash = authoritative_txids.empty() ? tx.GetHash() : authoritative_txids[i];
         bool is_coinbase = tx.IsCoinBase();
         bool is_bip30_exception = (is_coinbase && !fEnforceBIP30);
 
@@ -2411,6 +2430,26 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
 {
     AssertLockHeld(cs_main);
     assert(pindex);
+
+    // The hard guard. A block rebuilt from stripped storage has no scriptSigs and no witnesses, so
+    // connecting it is not merely unsafe but meaningless: there are no signatures to verify, no BIP34
+    // coinbase height, no BIP141 witness commitment, and neither the weight nor the sigop cost can be
+    // computed. It would not fail — it would "succeed" against a block that never existed.
+    //
+    // Rebuilt blocks are legitimate for DISCONNECTING, which is how a hazed node reorgs off its own
+    // history, so they do get constructed and they do reach validation.cpp. This is the fence
+    // between the two, and it lives on the block rather than on the index because during an initial
+    // hazed sync the index is already marked stripped while the real block is still in hand.
+    //
+    // Reported as an internal error, not an invalid block: the block itself is very probably fine,
+    // and marking it invalid would poison a legitimate part of the chain over a caller's mistake.
+    if (block.m_haze_reconstructed) {
+        LogError("ConnectBlock(): refusing to connect block %s — it was rebuilt from stripped haze "
+                 "storage, so its scriptSigs and witnesses are empty and there is nothing here to "
+                 "validate. Rebuilt blocks may only be disconnected.\n",
+                 pindex->GetBlockHash().ToString());
+        return state.Error("haze-reconstructed-block-cannot-be-connected");
+    }
 
     uint256 block_hash{block.GetHash()};
     assert(*pindex->phashBlock == block_hash);

--- a/ghost-core/src/validation.h
+++ b/ghost-core/src/validation.h
@@ -739,19 +739,17 @@ public:
     /**
      * Undo a block's effect on the UTXO set.
      *
-     * `authoritative_txids`, when non-empty, supplies the txid of each transaction instead of asking
-     * the transaction for its own. That exists for blocks rebuilt from haze's stripped storage: they
-     * have empty scriptSigs, so any transaction that had one computes a txid belonging to a
+     * For a block rebuilt from haze's stripped storage this uses the txids the block carries
+     * (`CBlock::m_haze_authoritative_txids`) rather than asking each transaction for its own. A
+     * rebuilt transaction has empty scriptSigs, so if it had one its computed txid belongs to a
      * different transaction — and every coin lookup here is keyed on that txid, so deriving them
-     * would address outpoints that do not exist and leave the real coins in the set. The stripped
-     * form keeps the real txids (`CStrippedBlock::GetTxid`); the rebuilt `CBlock` cannot carry them.
+     * would address outpoints that do not exist and leave the real coins in the set.
      *
-     * Empty is the normal case, where the block is real and knows its own txids. A rebuilt block
-     * without them is refused rather than processed, because the failure would otherwise be a wrong
-     * answer rather than an error.
+     * The ids travel with the block, so there is no second argument a caller can forget. A rebuilt
+     * block that somehow arrives without them is refused rather than processed, since the failure
+     * would otherwise be a wrong answer rather than an error.
      */
-    DisconnectResult DisconnectBlock(const CBlock& block, const CBlockIndex* pindex, CCoinsViewCache& view,
-                                     std::span<const Txid> authoritative_txids = {})
+    DisconnectResult DisconnectBlock(const CBlock& block, const CBlockIndex* pindex, CCoinsViewCache& view)
         EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
     bool ConnectBlock(const CBlock& block, BlockValidationState& state, CBlockIndex* pindex,
                       CCoinsViewCache& view, bool fJustCheck = false) EXCLUSIVE_LOCKS_REQUIRED(cs_main);

--- a/ghost-core/src/validation.h
+++ b/ghost-core/src/validation.h
@@ -1168,6 +1168,15 @@ public:
      *
      * @return the number of blocks forgotten, for logging.
      */
+    /**
+     * Withdraw a stripped block's BLOCK_HAVE_DATA claim so it is fetched again.
+     *
+     * Wraps BlockManager::ForgetBlockData with the m_have_pruned bookkeeping that must accompany it,
+     * so no haze path can omit it — omitting it does not fail here, it aborts later in
+     * CheckBlockIndex on a node that has been running normally.
+     */
+    void ForgetStrippedBlockData(CBlockIndex& index) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
     int DropUnconnectableStrippedBlocks() EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     //! Once the background validation chainstate has reached the height which

--- a/ghost-core/src/validation.h
+++ b/ghost-core/src/validation.h
@@ -1148,6 +1148,30 @@ public:
         AutoFile& coins_file, const node::SnapshotMetadata& metadata, bool in_memory,
         const haze::HazyncAdoption* hazync_authority = nullptr);
 
+    /**
+     * Forget stripped blocks that were stored but never connected (#542).
+     *
+     * A hazed node writes a block's structural form to disk and records BLOCK_HAVE_DATA before the
+     * block is connected, keeping the full block in memory only until then. Stop the node in that
+     * window and what survives is a block the index claims to have and which can never be connected
+     * from: the scriptSigs and witnesses it would need were destroyed on purpose, and the in-memory
+     * copy is gone.
+     *
+     * The claim is what is wrong, not the ordering. For an already-connected block, stripped storage
+     * genuinely is enough — its effects are in the UTXO set and it will only ever be disconnected,
+     * which needs none of what haze removes. For a block that was never connected the same storage
+     * satisfies nothing, so BLOCK_HAVE_DATA is simply false and is cleared here. The node then
+     * re-downloads it like any other missing block, it passes through the exorcism fence, and is
+     * stripped again — nothing hazeable is retained, which is why this is not "un-hazing".
+     *
+     * The alternative, keeping the full block on disk until the chainstate is flushed, would put
+     * complete blocks with witnesses and scriptSigs on disk for exactly as long as it takes to
+     * crash. That is the thing haze exists to prevent, so the ordering fix is unavailable.
+     *
+     * @return the number of blocks forgotten, for logging.
+     */
+    int DropUnconnectableStrippedBlocks() EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
     //! Once the background validation chainstate has reached the height which
     //! is the base of the UTXO snapshot in use, compare its coins to ensure
     //! they match those expected by the snapshot.

--- a/ghost-core/src/validation.h
+++ b/ghost-core/src/validation.h
@@ -1328,10 +1328,18 @@ public:
      */
     bool AcceptBlock(const std::shared_ptr<const CBlock>& pblock, BlockValidationState& state, CBlockIndex** ppindex, bool fRequested, const FlatFilePos* dbp, bool* fNewBlock, bool min_pow_checked) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
-    void ReceivedBlockTransactions(const CBlock& block, CBlockIndex* pindexNew, const FlatFilePos& pos) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+    //! `payload_stripped` records WHERE the payload was actually written: the gsb sequence if the
+    //! block was stripped, the blk sequence if it was written whole. It is decided by whichever
+    //! caller chose the writer, because only that caller knows. Deriving it from "is exorcism on"
+    //! marks blocks stripped that were written whole — genesis is written whole even on a hazed
+    //! node — and the read path then looks for the payload in the wrong file sequence, which is the
+    //! confusion BLOCK_HAZED_STRIPPED exists to prevent.
+    void ReceivedBlockTransactions(const CBlock& block, CBlockIndex* pindexNew, const FlatFilePos& pos,
+                                   bool payload_stripped) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     /** Overload for pre-stripped blocks where we know the tx count but don't have a CBlock. */
-    void ReceivedBlockTransactions(uint32_t nTx, CBlockIndex* pindexNew, const FlatFilePos& pos) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+    void ReceivedBlockTransactions(uint32_t nTx, CBlockIndex* pindexNew, const FlatFilePos& pos,
+                                   bool payload_stripped) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     /**
      * Try to add a transaction to the memory pool.

--- a/ghost-core/src/validation.h
+++ b/ghost-core/src/validation.h
@@ -736,7 +736,22 @@ public:
         LOCKS_EXCLUDED(::cs_main);
 
     // Block (dis)connection on a given view:
-    DisconnectResult DisconnectBlock(const CBlock& block, const CBlockIndex* pindex, CCoinsViewCache& view)
+    /**
+     * Undo a block's effect on the UTXO set.
+     *
+     * `authoritative_txids`, when non-empty, supplies the txid of each transaction instead of asking
+     * the transaction for its own. That exists for blocks rebuilt from haze's stripped storage: they
+     * have empty scriptSigs, so any transaction that had one computes a txid belonging to a
+     * different transaction — and every coin lookup here is keyed on that txid, so deriving them
+     * would address outpoints that do not exist and leave the real coins in the set. The stripped
+     * form keeps the real txids (`CStrippedBlock::GetTxid`); the rebuilt `CBlock` cannot carry them.
+     *
+     * Empty is the normal case, where the block is real and knows its own txids. A rebuilt block
+     * without them is refused rather than processed, because the failure would otherwise be a wrong
+     * answer rather than an error.
+     */
+    DisconnectResult DisconnectBlock(const CBlock& block, const CBlockIndex* pindex, CCoinsViewCache& view,
+                                     std::span<const Txid> authoritative_txids = {})
         EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
     bool ConnectBlock(const CBlock& block, BlockValidationState& state, CBlockIndex* pindex,
                       CCoinsViewCache& view, bool fJustCheck = false) EXCLUSIVE_LOCKS_REQUIRED(cs_main);

--- a/ghost-core/src/wallet/wallet.cpp
+++ b/ghost-core/src/wallet/wallet.cpp
@@ -1560,6 +1560,31 @@ void CWallet::blockDisconnected(const interfaces::BlockInfo& block)
     // future with a stickier abandoned state or even removing abandontransaction call.
     int disconnect_height = block.height;
 
+    // On a hazed node this block may have been rebuilt from stripped storage. Its transactions are
+    // not the real ones — no scriptSigs, no witnesses — and anything that had a scriptSig computes a
+    // txid belonging to a different transaction. They must not go through SyncTransaction: that
+    // scans them for ownership and stores them, so the wallet would either miss its own transaction
+    // entirely or overwrite its stored copy with a signature-less stand-in.
+    //
+    // What the wallet actually needs here is narrower and can be done exactly: mark its own
+    // transactions unconfirmed, by the real ids the block carries. No transaction object from the
+    // reconstruction is read or kept.
+    if (const auto& haze_txids{block.data->m_haze_authoritative_txids}; !haze_txids.empty()) {
+        for (size_t index = 0; index < haze_txids.size(); index++) {
+            // Coinbase transactions are not only inactive but also abandoned, meaning they should
+            // never be relayed standalone via the p2p protocol.
+            const bool abandoned{index == 0};
+            RecursiveUpdateTxState(haze_txids[index], [&](CWalletTx& wtx) {
+                if (wtx.state<TxStateInactive>() && wtx.state<TxStateInactive>()->abandoned == abandoned) {
+                    return TxUpdate::UNCHANGED;
+                }
+                wtx.m_state = TxStateInactive{abandoned};
+                return TxUpdate::CHANGED;
+            });
+        }
+        return;
+    }
+
     for (size_t index = 0; index < block.data->vtx.size(); index++) {
         const CTransactionRef& ptx = block.data->vtx[index];
         // Coinbase transactions are not only inactive but also abandoned,

--- a/ghost-web/docs/haze.md
+++ b/ghost-web/docs/haze.md
@@ -121,9 +121,27 @@ When a peer asks specifically for a transaction's witness data (e.g. for inscrip
 
 For a node validating the chain, neither matters: validation only needs the full witness during block acceptance, and it has it then (the block arrives over the wire fully formed). Witness data only becomes "missing" *after* validation, when it's been stripped from disk.
 
+## Reorgs, restarts, and the limits of stripped storage
+
+Stripped storage is enough to *undo* a block and not enough to *apply* one, and almost everything about how a hazed node behaves at the edges follows from that asymmetry.
+
+**Undoing needs nothing haze removes.** The disconnect path reads no scriptSig and no witness — it walks outputs and prevouts, both preserved, and the undo data it works from is written whether or not the block was stripped. So a hazed node reorgs off its own history normally, and its reorg depth is bounded by how long undo files are kept, exactly as on a pruned node.
+
+**Applying a block needs five things stripping destroys:** script verification, the BIP34 coinbase height, the BIP141 witness commitment, the block weight, and the sigop cost. No amount of care recovers them locally. A block rebuilt from stripped storage is therefore allowed to be disconnected and refused outright if anything tries to connect it.
+
+That produces three behaviours worth knowing about:
+
+- **Transactions from a disconnected stripped block do not return to the mempool.** They have no signatures, so they are no longer signable or relayable transactions by anyone — re-adding them would queue objects certain to be rejected. Anything still wanted must be re-broadcast by its owner. The node logs this each time rather than leaving it to be discovered.
+- **Wallets are still told correctly.** A rebuilt block cannot compute its own transaction ids — for anything that had a scriptSig, the computed id belongs to a different transaction — so the real ids are carried alongside it and wallets mark their own transactions unconfirmed by those. A wallet on a hazed node does not silently keep showing a reorged-away transaction as confirmed.
+- **Reorging back onto an abandoned branch re-downloads it.** The node cannot apply blocks it only holds in stripped form, so it asks peers for them again. The re-fetched block passes back through Exorcism and is stripped again before anything is written, so nothing hazeable is retained — the same posture as validating it the first time.
+
+**After an unclean shutdown, some blocks are downloaded again.** A block's stripped form is written before it is connected. If the node stops in between, what survives is a block it cannot apply, so it forgets it and fetches it again. Typically a handful of blocks, and no full block is ever kept on disk to avoid it — which would defeat the entire point.
+
+> **One surprising consequence:** because the node genuinely deletes block data in that case, it records that fact the same way a pruning node does, and `getblockchaininfo` will report `pruned: true`. It has not started pruning in the ordinary sense and has not deleted any block *file*; the flag records that some block data it once held is gone. See below.
+
 ## What Haze isn't
 
-- **It isn't pruning.** Pruned nodes delete entire old block files; they can't serve any block to anyone. Hazed nodes keep every block file on disk and can still serve them — just in stripped form. A hazed node is a full participant in the network; a pruned node is a leaf.
+- **It isn't pruning.** Pruned nodes delete entire old block files; they can't serve any block to anyone. Hazed nodes keep every block file on disk and can still serve them — just in stripped form. A hazed node is a full participant in the network; a pruned node is a leaf. (A hazed node may still report `pruned: true` after discarding a block it could not apply — see the section above. That flag is about data having been deleted, not about running in pruned mode.)
 - **It isn't encryption.** The hazeable content is removed, not protected by a key. There's no "decrypt with password" path. The data is gone.
 - **It isn't selective.** A hazed node doesn't pick and choose which content to strip — every hazeable field is stripped from every block. Selectivity would create the illusion of control over content classification, which is exactly the legal risk the design wants to eliminate.
 - **It isn't a wallet feature.** Wallets don't care whether the underlying node is hazed. UTXOs, balances, addresses, history — all available either way. Haze is purely about disk-side data.

--- a/test/hazync/hazed-node.sh
+++ b/test/hazync/hazed-node.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# Exercise Ghost Haze against a real hazed mainnet node.
+#
+# WHY THIS IS NOT A UNIT TEST. Everything here needs a node that is genuinely hazed — one where
+# exorcism is active from the first block, so what lands on disk is the stripped form and nothing
+# else. The unit fixtures cannot produce that: they always have a chain tip, and a CChain cannot be
+# emptied through its public interface, so the startup state a fresh hazed node passes through is not
+# constructible in them.
+#
+# That gap was not academic. It hid a bug that made a fresh hazed node forget the GENESIS block and
+# fail to start, while every unit test passed. Case 2 below is the regression test for it.
+#
+# Syncs a few thousand blocks from mainnet, so it needs network and a few minutes. It never touches
+# the fleet: outbound Bitcoin P2P only, no listening socket beyond a localhost RPC port, and a
+# throwaway datadir.
+#
+# Usage: GHOSTD=/path/to/ghostd ./test/hazync/hazed-node.sh [target-height]
+set -uo pipefail
+
+GHOSTD="${GHOSTD:-}"
+TARGET="${1:-3000}"
+PORT="${RPCPORT:-18913}"
+[ -x "$GHOSTD" ] || { echo "set GHOSTD=<path to ghostd>" >&2; exit 2; }
+command -v curl >/dev/null 2>&1 || { echo "curl is required" >&2; exit 2; }
+
+pass=0; fail=0
+ok(){  echo "  ok    $1"; pass=$((pass+1)); }
+bad(){ echo "  FAIL  $1"; fail=$((fail+1)); }
+
+DD=$(mktemp -d)
+PID=""
+cleanup(){ [ -n "$PID" ] && { kill "$PID" 2>/dev/null; wait "$PID" 2>/dev/null; }; rm -rf "$DD"; }
+trap cleanup EXIT
+
+rpc(){ curl -s --max-time 60 --user t:t --data-binary "$1" \
+        -H 'content-type: text/plain;' "http://127.0.0.1:$PORT/" 2>/dev/null; }
+jq_(){ python3 -c "import sys,json
+try: r=json.load(sys.stdin)['result']
+except Exception: print('none'); sys.exit()
+if r is None: print('none'); sys.exit()
+$1"; }
+
+start(){ # start <logfile>
+    "$GHOSTD" -datadir="$DD" -printtoconsole=1 -server=1 -listen=0 -maxconnections=12 \
+        -rpcport="$PORT" -rpcuser=t -rpcpassword=t -hazemode=hazed "${@:2}" >"$1" 2>&1 &
+    PID=$!
+}
+stop(){ [ -n "$PID" ] && { kill "$PID" 2>/dev/null; wait "$PID" 2>/dev/null; }; PID=""; }
+
+height(){ rpc '{"jsonrpc":"1.0","id":"t","method":"getblockchaininfo","params":[]}' | jq_ "print(r['blocks'])"; }
+
+wait_for_height(){ # wait_for_height <target> <seconds>
+    local want="$1" limit="$2" h
+    for i in $(seq 1 "$limit"); do
+        h=$(height)
+        [ "${h:-none}" != "none" ] && [ "$h" -ge "$want" ] 2>/dev/null && return 0
+        sleep 1
+    done
+    return 1
+}
+
+echo "Ghost Haze — live hazed mainnet node"
+
+# ── 1. it starts, and it is actually hazed ─────────────────────────────────────────────────────
+start "$DD/run1.log"
+if ! wait_for_height "$TARGET" 1800; then
+    bad "never reached height $TARGET — no peers, or the node did not start"
+    echo "  last lines:"; tail -15 "$DD/run1.log" | sed 's/^/    /'
+    echo; echo "passed $pass, failed $fail"; exit 1
+fi
+ok "synced to height $(height)"
+
+grep -q "Ghost Exorcism initialized in HAZED mode" "$DD/run1.log" \
+    && ok "exorcism is active — hazeable content never reaches disk" \
+    || bad "node is not in hazed mode; nothing below tests what it claims to"
+
+# The point of the mode: structural storage only.
+if ls "$DD/blocks"/gsb*.dat >/dev/null 2>&1; then
+    ok "blocks are stored in stripped (gsb) form"
+else
+    bad "no gsb files — the node did not write stripped storage"
+fi
+# The size of blk00000.dat proves nothing: block files are preallocated in 16 MiB chunks and are
+# XOR-obfuscated, so an empty one is neither small nor zero-filled. Ask the node instead — a stripped
+# block cannot be served as a full block, and genesis can, because it is written whole.
+GEN_HASH=$(rpc '{"jsonrpc":"1.0","id":"t","method":"getblockhash","params":[0]}' | jq_ "print(r)")
+MID_HASH=$(rpc '{"jsonrpc":"1.0","id":"t","method":"getblockhash","params":[1000]}' | jq_ "print(r)")
+GEN_READ=$(rpc "{\"jsonrpc\":\"1.0\",\"id\":\"t\",\"method\":\"getblock\",\"params\":[\"$GEN_HASH\"]}")
+MID_READ=$(rpc "{\"jsonrpc\":\"1.0\",\"id\":\"t\",\"method\":\"getblock\",\"params\":[\"$MID_HASH\"]}")
+
+printf '%s' "$GEN_READ" | grep -q '"error":null' \
+    && ok "genesis is readable as a full block (it is written whole, by design)" \
+    || bad "genesis cannot be read as a full block — a hazed node cannot connect its own first block"
+
+# A hazed node DOES serve block 1000 — as the structural form, which is the documented behaviour.
+# What must be true is that what comes back has no scriptSig, because the payload really is gone.
+printf '%s' "$MID_READ" | grep -q '"error":null' \
+    && ok "block 1000 is served (as the structural form, which is what a hazed node offers)" \
+    || bad "block 1000 could not be served at all"
+
+CB=$(rpc "{\"jsonrpc\":\"1.0\",\"id\":\"t\",\"method\":\"getblock\",\"params\":[\"$MID_HASH\",2]}" \
+     | jq_ "print(r['tx'][0]['vin'][0].get('coinbase',''))")
+[ -z "$CB" ] || [ "$CB" = "none" ] \
+    && ok "and its coinbase scriptSig is empty — the payload really was destroyed" \
+    || bad "block 1000's coinbase scriptSig survived: $CB"
+
+# ── 2. REGRESSION: a fresh hazed node must never forget genesis ────────────────────────────────
+#
+# Two bugs met here, both fatal on a fresh hazed node and neither visible to the unit tests.
+#
+# Genesis was being MARKED stripped although it is written whole — the flag followed "is haze on"
+# rather than which writer ran — so the read path looked for its payload in the gsb sequence while it
+# sat in blk. And the startup pass that forgets unconnectable stripped blocks ran before any
+# chainstate had a tip, where nothing looks connected, so it condemned genesis itself.
+#
+# Assert on the block, not merely on the absence of a log line, so a reworded message cannot make
+# this pass silently.
+if grep -q "Forgetting stripped block .* (0)" "$DD/run1.log"; then
+    bad "genesis was forgotten at startup — a fresh hazed node cannot start"
+else
+    ok "genesis was not forgotten at startup"
+fi
+GEN=$(rpc '{"jsonrpc":"1.0","id":"t","method":"getblockhash","params":[0]}' | jq_ "print(r)")
+[ "$GEN" = "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f" ] \
+    && ok "genesis is present and correct" \
+    || bad "genesis is missing or wrong ($GEN)"
+
+# ── 3. it restarts ─────────────────────────────────────────────────────────────────────────────
+#
+# The #542 case. A hazed node writes a block's stripped form before connecting it, so stopping in
+# that window leaves storage that cannot satisfy a connect. It must forget those and carry on, not
+# die reading a gsb offset out of a blk file.
+BEFORE=$(height)
+stop
+start "$DD/run2.log"
+if wait_for_height 1 300; then
+    ok "restarted after being killed mid-sync (was at $BEFORE, resumed at $(height))"
+else
+    bad "did not come back up after a restart"
+    tail -15 "$DD/run2.log" | sed 's/^/    /'
+fi
+grep -q "Block magic mismatch" "$DD/run2.log" \
+    && bad "restart hit a block magic mismatch — reading gsb data as a full block" \
+    || ok "no block magic mismatch on restart"
+
+# ── 4. it can undo its own stripped history ────────────────────────────────────────────────────
+#
+# Disconnecting reads no scriptSig and no witness, so this must work from stripped storage alone.
+TIP=$(rpc '{"jsonrpc":"1.0","id":"t","method":"getbestblockhash","params":[]}' | jq_ "print(r)")
+INV=$(rpc "{\"jsonrpc\":\"1.0\",\"id\":\"t\",\"method\":\"invalidateblock\",\"params\":[\"$TIP\"]}")
+if printf '%s' "$INV" | grep -q '"error":null'; then
+    AFTER=$(rpc '{"jsonrpc":"1.0","id":"t","method":"getbestblockhash","params":[]}' | jq_ "print(r)")
+    [ "$AFTER" != "$TIP" ] \
+        && ok "disconnected a block from stripped storage (tip moved back)" \
+        || bad "invalidateblock reported success but the tip did not move"
+
+    # ── 5. and come back to the branch it abandoned ────────────────────────────────────────────
+    #
+    # Reconnecting needs what stripping destroyed, so the node must re-fetch rather than shut down.
+    rpc "{\"jsonrpc\":\"1.0\",\"id\":\"t\",\"method\":\"reconsiderblock\",\"params\":[\"$TIP\"]}" >/dev/null
+    sleep 20
+    if [ "$(height)" != "none" ]; then
+        ok "still alive after being asked to reconnect a stripped block"
+    else
+        bad "node died reconnecting a stripped block"
+    fi
+else
+    bad "invalidateblock failed: $(printf '%s' "$INV" | head -c 200)"
+fi
+
+echo
+echo "passed $pass, failed $fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
> **Stacked on #543.** Base is `feat/hazync-proof`, so this shows only its own six commits. Merge #543 first, or review them together. The two claims are deliberately separate — #543 is proof-based sync, this is a storage mode whose *validity gap* a proof closes — and tangling them invites a reviewer to hunt for circularity that is not there.

## What

Three things a hazed node could not previously do, all consequences of the same mistaken belief in the block index.

| commit | issue | what it does |
|---|---|---|
| `66ff89e4c` | — | correct a false contract on `ReconstructPartialBlock`, and pin it with a test |
| `917083a0b` | #545 | a rebuilt block may be disconnected, never connected |
| `40a020da0` | #545 | `DisconnectTip`/`RollbackBlock` read stripped storage, so a hazed node can reorg |
| `dcaadc3e4` | #542 | forget stripped blocks that were stored but never connected |
| `5e87fe4f3` | #545 | carry the real txids on the rebuilt block; wallets, ZMQ and `net_processing` served correctly |
| `817b2ef17` | — | re-fetch a stripped block that must be connected, instead of shutting down |
| `3ebf18e25` | — | document what a hazed node does at a reorg and after an unclean shutdown |
| `5ede0e125` | hazync#46 | bind an archive to its proof natively (`hazyncverifychain`), and refuse when the proof is about another chain |

Reorg depth on a hazed node goes from **zero** to bounded by undo-file retention, the same as a pruned node. A hazed node also survives an unclean shutdown, and survives reorging back onto a branch it abandoned.

## The invariant all of this turns on

> A stripped block's stored data satisfies `BLOCK_HAVE_DATA` **only while that block stays connected**.

Undoing a block reads no scriptSig and no witness, so for a block already on the chain the stripped form genuinely is enough — it will only ever need disconnecting. For a block that is *not* connected the same bytes satisfy nothing, because connecting needs the five things stripping destroys. The index was claiming otherwise in three separate situations, and each produced a different failure:

- never connected, node restarted → `ConnectTip` reads it and the node shuts down (#542)
- connected once, now being reorged back onto → same shutdown (`817b2ef17`)
- being disconnected → worked, but only by accident, and was about to be made worse (below)

`dcaadc3e4` withdraws the claim at startup; `817b2ef17` withdraws it at connect time. In both cases Core's own machinery takes over: `FindMostWorkChain` drops the candidate and re-queues it in `m_blocks_unlinked`, and the block is downloaded again from any peer that still has it. **There is no archive-fetch path and no archive-peer concept in this PR — an archive node is exactly a peer that still has the block.** The re-fetched block passes back through the exorcism fence and is stripped again, so nothing hazeable is ever retained.

The alternative for #542 — the ordering originally written down, "do not strip until the chainstate is flushed" — is unavailable. It means keeping the complete block on disk until then, which puts witnesses and scriptSigs on disk for exactly as long as it takes to crash.

## The bug that was about to be introduced

The plan's evidence for reorg-from-stripped is a table of everything `DisconnectBlock` touches, with the first row `tx.GetHash()` marked "stored or computable". That is true of `CStrippedTransaction::GetTxid()` and **false of the reconstruction the plan says to hand to `DisconnectBlock`**.

`ReconstructPartialBlock` never reads `m_stored_txid` — zero occurrences in `block_reconstruct.cpp` — so a rebuilt transaction computes its txid from contents whose scriptSigs are gone. For every coinbase, legacy and P2SH-wrapped spend that is the hash of a different transaction, and `DisconnectBlock` keys **every** coin lookup on it. The lookups miss, the real coins stay in the UTXO set, and the block reports no worse than `DISCONNECT_UNCLEAN`.

What made it look safe was a comment claiming the stored txid was preserved. It never was. `66ff89e4c` corrects it and adds the test that pins it.

**Mutation-verified rather than argued:** reverting to `tx.GetHash()` turns `disconnect_from_stripped_matches_disconnect_from_full` from `DISCONNECT_OK` into `DISCONNECT_UNCLEAN`.

## Design points worth review

**The real txids travel on the block.** `CBlock::m_haze_authoritative_txids`, memory-only beside the existing `fChecked` flags, filled by the reconstruction which has the stripped form. They were briefly a separate argument to `DisconnectBlock`, which meant a caller could hold a reconstruction and not its ids; attaching them makes that unrepresentable rather than merely refused.

**The connect guard is on the block, not the index.** `CBlock::m_haze_reconstructed`, refused at the top of `ConnectBlock`. It cannot key off `BLOCK_HAZED_STRIPPED`, because during an initial hazed sync the index is already marked stripped while the real block is still in hand — an index-based guard would refuse the very blocks sync depends on.

**Refused via `state.Error()`, not `Invalid`.** The block is almost certainly fine; marking it invalid would poison a legitimate part of the chain over a caller's mistake.

**`m_have_pruned` is load-bearing, not bookkeeping.** `CheckBlockIndex` asserts `BLOCK_HAVE_DATA` and `nTx > 0` agree unless that flag records that data was deleted, and after forgetting a block they deliberately do not. Verified by mutation: removing it aborts at `validation.cpp:5520`. It is also honest — the node *has* deleted block data it held. The bookkeeping lives in `ChainstateManager::ForgetStrippedBlockData` so no haze path can omit it, because omitting it does not fail where the mistake is made.

**Three consumers of `block.vtx` had to be handled differently**, and none of them were in the plan:

- **`net_processing`** never looks at the block — its handler calls `m_txdownloadman.BlockDisconnected()`, which takes no arguments. The signal must keep firing.
- **The wallet** is served. It needs only its own transactions' ids, and everything else it touches survives stripping: it walks `vin` prevouts, which are preserved, and never checks a signature. But it must not be *handed* the rebuilt transactions, since `SyncTransaction` scans and stores them — the wallet would overwrite its own copy with a signature-less stand-in. `blockDisconnected` uses `RecursiveUpdateTxState` against the real ids instead, reading and keeping no transaction object from the rebuild.
- **ZMQ** publishes raw transaction bytes, and a reconstruction's bytes are not any transaction that ever existed. Per-transaction publishing is skipped; the block-level notification still fires.

**The mempool is the one consumer that cannot be served, and that is correct rather than a compromise.** A transaction with no scriptSig and no witness is not signable or relayable by anyone, so re-adding it would queue an object guaranteed to be rejected. A hazed node loses those transactions, logged at every such reorg, naming the consequence: anything still wanted must be re-broadcast by its owner.

## Binding the archive to a proof — G5 (`5ede0e125`)

A proof attests the transactions in a range were **valid**. It says nothing about whether this node holds that range. A hazed archive answers that and only that, and `hazyncverifychain` is the join — previously an external script, `prover/hazed-chain-verify.py`, run by hand over a fixed range of 1..1000. It now runs in ghostd at any height.

Everything is checked against the header **the archive stores**, never the one in the block index. The index's linkage is structural — built from `hashPrevBlock` when the header was accepted — so checking the index against itself would establish nothing. The archive's bytes are independent data that must be made to agree: the stored payload is the block the chain says lives there, its own `hashPrevBlock` links, it meets the target it states, and **its retained txids reproduce its own merkle root**. That last is what stops a *stored* txid — one that could not be recomputed because its scriptSig was destroyed — from being taken on trust.

*(An earlier draft of that loop compared `index->pprev->GetBlockHash()` with itself. It could not fail, and it was inspecting the wrong object.)*

**The refusal is the point, not an error path.** If the proof commits to a different tip than this node holds at the proven height, the binding refuses and says the proof is not about this chain. That is checked **before** the walk — no reason to recompute thousands of merkle roots to identify a chain already known to be wrong — and the test asserts zero blocks are read in that case.

It works from either storage form: a stripped block yields txids from what haze retained, a whole one from its transactions, and the check is identical. An archive node binding its storage to a proof is doing the same thing with more data than it needs — which is also what made the claim testable without a hazed node.

Demonstrated on real mainnet blocks against the height-8 proof: **8/8 from genesis, `complete: true`, archive tip equal to proven tip**; a suffix run from height 5 reports 4 blocks and `complete: false`, so a partial check cannot be read as a whole-chain claim.

## Documentation

`ghost-web/docs/haze.md` gains a section on reorgs, restarts and the limits of stripped storage — everything at haze's edges follows from one asymmetry the page never stated, that stripped storage is enough to undo a block and not enough to apply one.

It also records a consequence an operator would otherwise meet by surprise: a node that discards a block it cannot apply records that data was deleted the same way a pruning node does, so `getblockchaininfo` reports `pruned: true`. The "it isn't pruning" bullet would otherwise read as a flat contradiction of what they see.

## Deliberately out of scope

- **`VerifyDB` still reads full blocks.** Its own `CheckBlock` rejects a reconstruction on the merkle root before the disconnect would run, so wiring it here moves the failure rather than fixing it. Verifying stripped storage is a separate job.
- **"No archive peer → refuse loudly"** is not implemented. The node logs what it needs and waits. Detecting that nobody has it is stall detection, and calling a log line a refusal would be overstating it.

## Verified

834 unit tests pass and `ghostd` links. Each new test carries a control that fails independently:

- a rebuilt block and the real one undo to the same UTXO set across every coin the block touches
- missing and wrong-sized txid sets are refused
- a rebuilt block is refused by `ConnectBlock` while the same block, not rebuilt, connects from the same view
- an unconnected stripped block is forgotten completely, a connected one is untouched, an archive node is unaffected, the pass is idempotent
- reorging back onto an abandoned stripped branch leaves the node alive, the tip un-advanced, and the index intact

The forgetting tests end with `CheckBlockIndex()`, which is the assertion that matters: every flag can be individually right while the index as a whole has been left inconsistent, and that is what a real node trips over.

## The gap

**None of this has been exercised against a real hazed node.** Everything is unit-tested and compile-clean, but a hazed mainnet sync deep enough to reorg has not been run — the same gap as `bfa11554c`. That wants doing on a box that can hold one before this is relied upon.

