### PR TITLE
feat(verification): address proof for H-7, and the signing identity that was never wired (#605)

### DIFF
--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -6593,6 +6593,14 @@ async fn main() -> Result<()> {
         capabilities,
     );
 
+    // Give the HTTP layer the node's signing key. Without this `can_sign()` is false
+    // and every endpoint answers `"signed": false` — which is what the fleet did, for
+    // as long as the field has existed. Two things were inert as a result: an
+    // identity-bound reachability probe is impossible without a signed reply (H-7),
+    // and the H-8 re-derivation defence reaches `ReVerdict::Unverifiable` and records
+    // nothing when the target's response carries no signature.
+    verification_state = verification_state.with_node_identity(Arc::clone(&identity));
+
     // Report the node's real configured chain on the status/info endpoints
     // (dashboard + wallets) instead of the historical hardcoded "signet".
     verification_state = verification_state.with_network(config.bitcoin.network);

--- a/bins/ghost-pool/src/verification_reverify.rs
+++ b/bins/ghost-pool/src/verification_reverify.rs
@@ -94,10 +94,17 @@ impl ResultReVerifier for ChainReVerifier {
     async fn reverify_archive(
         &self,
         target_node_id: &NodeId,
+        challenge_data: &str,
         target_signed_response: Option<&str>,
     ) -> ReVerdict {
         let oracle = RpcOracle(Arc::clone(&self.rpc));
-        reverify_archive_impl(&oracle, target_node_id, target_signed_response).await
+        reverify_archive_impl(
+            &oracle,
+            target_node_id,
+            challenge_data,
+            target_signed_response,
+        )
+        .await
     }
 
     async fn reverify_policy(
@@ -133,6 +140,7 @@ impl ResultReVerifier for ChainReVerifier {
 async fn reverify_archive_impl<O: ChainOracle + ?Sized>(
     oracle: &O,
     target_node_id: &NodeId,
+    challenge_data: &str,
     target_signed_response: Option<&str>,
 ) -> ReVerdict {
     // 1. No signed response at all — we cannot judge.
@@ -173,6 +181,36 @@ async fn reverify_archive_impl<O: ChainOracle + ?Sized>(
     });
     if verify_result.is_err() {
         return ReVerdict::Unverifiable;
+    }
+
+    // 3c. Bind the response to THIS challenge.
+    //
+    //     `SignedResponse::verify` above only bounds freshness — `MAX_RESPONSE_AGE_SECS`
+    //     is 300s — so a correct, correctly-signed response captured from an earlier
+    //     challenge can be replayed inside that window to keep a node earning the
+    //     capability after it has stopped serving it. The nonce the challenge chose is
+    //     what ties the signature to this request.
+    //
+    //     `challenge_data` is authored by the (adversarial) challenger, exactly like the
+    //     height in step 4, so a mismatch is UNVERIFIABLE and never Fail. Otherwise
+    //     naming a wrong nonce would be a free way to drag an honest node under its
+    //     pass-rate gate — the griefing vector this whole function exists to close.
+    //
+    //     A challenge_data carrying no nonce is not enforced, so challengers that
+    //     predate this still get their results judged rather than silently dropped.
+    //     That also means omitting the nonce bypasses the binding, which is why making
+    //     it mandatory needs a height gate once the fleet is known to send one.
+    if let Some(expected) = serde_json::from_str::<serde_json::Value>(challenge_data)
+        .ok()
+        .as_ref()
+        .and_then(|v| v.get("nonce"))
+        .and_then(|n| n.as_str())
+        .map(str::to_owned)
+    {
+        match signed.challenge_nonce.as_deref() {
+            Some(got) if got == expected => {}
+            _ => return ReVerdict::Unverifiable,
+        }
     }
 
     // 4. Take the height from inside the TARGET-signed payload — NEVER from the
@@ -506,6 +544,120 @@ mod tests {
         serde_json::to_string(&signed).expect("serialize signed response")
     }
 
+    fn make_signed_response_bound(
+        identity: &NodeIdentity,
+        height: u64,
+        hash: &str,
+        merkle: &str,
+        challenge_nonce: Option<String>,
+    ) -> String {
+        let resp = ArchiveResponse {
+            success: true,
+            block_data: Some(BlockData {
+                hash: hash.to_string(),
+                height,
+                timestamp: 1_600_000_000,
+                tx_count: 2,
+                merkle_root: merkle.to_string(),
+            }),
+            tx_data: None,
+            error: None,
+        };
+        let signer_hex = identity.node_id_hex();
+        let signed =
+            SignedResponse::new(resp, signer_hex, |msg| identity.sign(msg), challenge_nonce);
+        serde_json::to_string(&signed).expect("serialize signed response")
+    }
+
+    /// REPLAY: a correct, correctly-signed response that was bound to a DIFFERENT
+    /// challenge must not count for this one.
+    ///
+    /// `SignedResponse::verify` only bounds freshness to `MAX_RESPONSE_AGE_SECS`
+    /// (300s), so without binding the reply to the nonce this challenge chose, a
+    /// captured response can be replayed inside that window to keep a node earning
+    /// the capability after it has stopped serving it.
+    #[tokio::test]
+    async fn a_response_bound_to_another_nonce_is_unverifiable_not_pass() {
+        let target = NodeIdentity::generate();
+        let raw = make_signed_response_bound(
+            &target,
+            500,
+            REAL_HASH,
+            REAL_MERKLE,
+            Some("aaaaaaaaaaaaaaaa".to_string()),
+        );
+        let challenge_data = r#"{"nonce":"bbbbbbbbbbbbbbbb"}"#;
+
+        let verdict = reverify_archive_impl(
+            &good_oracle(),
+            &target.node_id(),
+            challenge_data,
+            Some(&raw),
+        )
+        .await;
+
+        assert_eq!(
+            verdict,
+            ReVerdict::Unverifiable,
+            "a response bound to another nonce must not be accepted"
+        );
+    }
+
+    /// ANTI-GRIEF: the nonce comparison uses challenger-authored `challenge_data`,
+    /// so a malicious challenger can put any nonce there. A mismatch must therefore
+    /// be Unverifiable and NEVER Fail — otherwise naming a wrong nonce becomes a
+    /// free way to drag an honest node below its pass-rate gate.
+    #[tokio::test]
+    async fn a_nonce_mismatch_is_never_a_fail() {
+        let target = NodeIdentity::generate();
+        let raw = make_signed_response_bound(
+            &target,
+            500,
+            REAL_HASH,
+            REAL_MERKLE,
+            Some("honest-nonce".to_string()),
+        );
+        let lying_challenge_data = r#"{"nonce":"attacker-chosen"}"#;
+
+        let verdict = reverify_archive_impl(
+            &good_oracle(),
+            &target.node_id(),
+            lying_challenge_data,
+            Some(&raw),
+        )
+        .await;
+
+        assert_ne!(
+            verdict,
+            ReVerdict::Fail,
+            "a nonce mismatch must never grief the target"
+        );
+    }
+
+    /// The bound case still passes: nonce echoed, signature good, chain agrees.
+    #[tokio::test]
+    async fn a_response_bound_to_this_nonce_passes() {
+        let target = NodeIdentity::generate();
+        let raw = make_signed_response_bound(
+            &target,
+            500,
+            REAL_HASH,
+            REAL_MERKLE,
+            Some("cafebabecafebabe".to_string()),
+        );
+        let challenge_data = r#"{"nonce":"cafebabecafebabe"}"#;
+
+        let verdict = reverify_archive_impl(
+            &good_oracle(),
+            &target.node_id(),
+            challenge_data,
+            Some(&raw),
+        )
+        .await;
+
+        assert_eq!(verdict, ReVerdict::Pass);
+    }
+
     /// FRAUD: target signs a wrong hash for the height; our RPC disagrees => Fail,
     /// regardless of what the challenger claimed.
     #[tokio::test]
@@ -514,7 +666,8 @@ mod tests {
         let bogus_hash = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef0";
         let raw = make_signed_response(&target, 500, bogus_hash, REAL_MERKLE, true);
 
-        let verdict = reverify_archive_impl(&good_oracle(), &target.node_id(), Some(&raw)).await;
+        let verdict =
+            reverify_archive_impl(&good_oracle(), &target.node_id(), "{}", Some(&raw)).await;
         assert_eq!(verdict, ReVerdict::Fail);
     }
 
@@ -525,7 +678,8 @@ mod tests {
         let bogus_merkle = "2222222222222222222222222222222222222222222222222222222222222222";
         let raw = make_signed_response(&target, 500, REAL_HASH, bogus_merkle, true);
 
-        let verdict = reverify_archive_impl(&good_oracle(), &target.node_id(), Some(&raw)).await;
+        let verdict =
+            reverify_archive_impl(&good_oracle(), &target.node_id(), "{}", Some(&raw)).await;
         assert_eq!(verdict, ReVerdict::Fail);
     }
 
@@ -538,7 +692,8 @@ mod tests {
         let target = NodeIdentity::generate();
         let raw = make_signed_response(&target, 500, REAL_HASH, REAL_MERKLE, true);
 
-        let verdict = reverify_archive_impl(&good_oracle(), &target.node_id(), Some(&raw)).await;
+        let verdict =
+            reverify_archive_impl(&good_oracle(), &target.node_id(), "{}", Some(&raw)).await;
         assert_eq!(verdict, ReVerdict::Pass);
     }
 
@@ -549,7 +704,8 @@ mod tests {
         let target = NodeIdentity::generate();
         let raw = make_signed_response(&target, 500, REAL_HASH, REAL_MERKLE, false);
 
-        let verdict = reverify_archive_impl(&good_oracle(), &target.node_id(), Some(&raw)).await;
+        let verdict =
+            reverify_archive_impl(&good_oracle(), &target.node_id(), "{}", Some(&raw)).await;
         assert_eq!(verdict, ReVerdict::Fail);
 
         // Cross-check: the free comparator agrees on the same payload.
@@ -564,11 +720,11 @@ mod tests {
     async fn missing_response_is_unverifiable() {
         let target = NodeIdentity::generate();
         assert_eq!(
-            reverify_archive_impl(&good_oracle(), &target.node_id(), None).await,
+            reverify_archive_impl(&good_oracle(), &target.node_id(), "{}", None).await,
             ReVerdict::Unverifiable
         );
         assert_eq!(
-            reverify_archive_impl(&good_oracle(), &target.node_id(), Some("   ")).await,
+            reverify_archive_impl(&good_oracle(), &target.node_id(), "{}", Some("   ")).await,
             ReVerdict::Unverifiable
         );
     }
@@ -578,7 +734,7 @@ mod tests {
     async fn unparseable_response_is_unverifiable() {
         let target = NodeIdentity::generate();
         assert_eq!(
-            reverify_archive_impl(&good_oracle(), &target.node_id(), Some("{not json")).await,
+            reverify_archive_impl(&good_oracle(), &target.node_id(), "{}", Some("{not json")).await,
             ReVerdict::Unverifiable
         );
     }
@@ -591,7 +747,8 @@ mod tests {
         // Imposter signs (signer field = imposter), but we judge it as `target`.
         let raw = make_signed_response(&imposter, 500, REAL_HASH, REAL_MERKLE, true);
 
-        let verdict = reverify_archive_impl(&good_oracle(), &target.node_id(), Some(&raw)).await;
+        let verdict =
+            reverify_archive_impl(&good_oracle(), &target.node_id(), "{}", Some(&raw)).await;
         assert_eq!(verdict, ReVerdict::Unverifiable);
     }
 
@@ -609,7 +766,8 @@ mod tests {
         value["signature"] = serde_json::Value::String(chars.into_iter().collect());
         raw = serde_json::to_string(&value).unwrap();
 
-        let verdict = reverify_archive_impl(&good_oracle(), &target.node_id(), Some(&raw)).await;
+        let verdict =
+            reverify_archive_impl(&good_oracle(), &target.node_id(), "{}", Some(&raw)).await;
         assert_eq!(verdict, ReVerdict::Unverifiable);
     }
 
@@ -621,7 +779,7 @@ mod tests {
         let mut oracle = good_oracle();
         oracle.broken = true;
 
-        let verdict = reverify_archive_impl(&oracle, &target.node_id(), Some(&raw)).await;
+        let verdict = reverify_archive_impl(&oracle, &target.node_id(), "{}", Some(&raw)).await;
         assert_eq!(verdict, ReVerdict::Unverifiable);
     }
 
@@ -632,7 +790,8 @@ mod tests {
         // Sign a response for height 5000 while our tip is only 1000.
         let raw = make_signed_response(&target, 5_000, REAL_HASH, REAL_MERKLE, true);
 
-        let verdict = reverify_archive_impl(&good_oracle(), &target.node_id(), Some(&raw)).await;
+        let verdict =
+            reverify_archive_impl(&good_oracle(), &target.node_id(), "{}", Some(&raw)).await;
         assert_eq!(verdict, ReVerdict::Unverifiable);
     }
 

--- a/crates/ghost-consensus/src/verification_handler.rs
+++ b/crates/ghost-consensus/src/verification_handler.rs
@@ -94,6 +94,7 @@ pub trait ResultReVerifier: Send + Sync {
     async fn reverify_archive(
         &self,
         target_node_id: &NodeId,
+        challenge_data: &str,
         target_signed_response: Option<&str>,
     ) -> ReVerdict;
 
@@ -666,6 +667,7 @@ impl VerificationResultHandler {
                     match reverifier
                         .reverify_archive(
                             &msg.target_node_id,
+                            &msg.challenge_data,
                             msg.target_signed_response.as_deref(),
                         )
                         .await
@@ -1009,6 +1011,7 @@ mod tests {
         async fn reverify_archive(
             &self,
             _target_node_id: &NodeId,
+            _challenge_data: &str,
             _target_signed_response: Option<&str>,
         ) -> ReVerdict {
             self.0

--- a/crates/ghost-verification/src/address_proof.rs
+++ b/crates/ghost-verification/src/address_proof.rs
@@ -19,8 +19,10 @@
 //!
 //! Only then may that address's `/24` count toward diversity.
 //!
-//! The verification is a pure function of the response body so it can be tested without
-//! a network; [`probe_claimed_address`] is the thin transport around it.
+//! The verification is a pure function of the response body so it can be tested without a
+//! network. The transport that performs step 2 is deliberately NOT here yet: probing is
+//! blocked on `nodes.public_address` being populated at all — it currently holds one row in
+//! eight on every production node, so there is nothing to probe. See #629.
 
 use ghost_common::identity::verify_signature;
 

--- a/crates/ghost-verification/src/address_proof.rs
+++ b/crates/ghost-verification/src/address_proof.rs
@@ -1,0 +1,218 @@
+//! H-7: prove a node controls the address it CLAIMS.
+//!
+//! Challenger diversity is deduplicated per `/24` subnet, and that subnet is derived
+//! from `nodes.public_address` — which arrives in the node's own health ping and is
+//! stored after a single `!is_empty()` check. Nothing probes it. So a node advertising
+//! an address in a `/24` it does not occupy is counted as a distinct challenger, at no
+//! cost, and the griefing resistance that rests on distinct-subnet majorities is
+//! fabricable.
+//!
+//! A plain reachability probe does not close it: connecting to a claimed address proves
+//! only that *something* answers there, and a node can advertise any reachable
+//! third-party address. What closes it is requiring the thing that answers to prove it
+//! holds the node's identity key, over a nonce the prober chose:
+//!
+//!   1. prober picks a fresh random nonce
+//!   2. prober dials the CLAIMED address: `GET /health?nonce=<nonce>`
+//!   3. the reply must be a `SignedResponse` whose `signer` is the claimed node id,
+//!      whose `challenge_nonce` is the nonce from step 1, and whose signature verifies
+//!
+//! Only then may that address's `/24` count toward diversity.
+//!
+//! The verification is a pure function of the response body so it can be tested without
+//! a network; [`probe_claimed_address`] is the thin transport around it.
+
+use ghost_common::identity::verify_signature;
+
+use crate::challenge::{HealthResponse, SignedResponse};
+
+/// Why an address proof was rejected. Distinguished so a caller can tell "this node is
+/// lying about where it lives" from "this node is currently down", which are very
+/// different facts about a peer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AddressProofFailure {
+    /// The reply was not a signed response at all (`signed: false`, or unparseable).
+    NotSigned,
+    /// Signed, but by a different node than the one claiming this address. This is the
+    /// interesting case: something answers there, and it is not who claimed it.
+    WrongSigner,
+    /// Signed by the right node, but not bound to the nonce we chose — so it could be a
+    /// replay of an earlier exchange rather than a live answer.
+    NonceMismatch,
+    /// Signature did not verify, or the response failed its freshness bounds.
+    BadSignature,
+}
+
+/// Verify a `/health?nonce=…` reply proves `expected_node_id` is reachable at the
+/// address it was fetched from.
+///
+/// `body` is the raw JSON: `{"signed": bool, "response": …}`.
+///
+/// Returns `Ok(())` only when the response is signed by exactly `expected_node_id` and
+/// bound to `expected_nonce`. Every other outcome names why.
+pub fn verify_address_proof(
+    body: &str,
+    expected_node_id: &str,
+    expected_nonce: &str,
+) -> Result<(), AddressProofFailure> {
+    let wrapper: serde_json::Value =
+        serde_json::from_str(body).map_err(|_| AddressProofFailure::NotSigned)?;
+
+    // An unsigned reply proves nothing about who is answering. Note a node running a
+    // build with no signing identity answers `signed: false` for every request, so this
+    // is also what "peer predates address proofs" looks like — the caller decides
+    // whether that is tolerable, this function only reports it.
+    if wrapper.get("signed").and_then(|s| s.as_bool()) != Some(true) {
+        return Err(AddressProofFailure::NotSigned);
+    }
+
+    let inner = wrapper
+        .get("response")
+        .ok_or(AddressProofFailure::NotSigned)?;
+    // Deserialise the payload as the CONCRETE type the responder signed, not a generic
+    // `Value`. `SignedResponse::verify` recomputes the hash over `serde_json::to_vec(payload)`,
+    // so the payload must re-serialise to the same bytes the signer produced — which only
+    // holds if both sides use the same type and the same serde configuration. Verifying via
+    // `serde_json::Value` reproduces the shape but not necessarily the bytes, and fails with
+    // `BadSignature` against a genuinely valid proof. Found by testing against a real reply
+    // from vm5; every hand-built fixture passed.
+    let signed: SignedResponse<HealthResponse> =
+        serde_json::from_value(inner.clone()).map_err(|_| AddressProofFailure::NotSigned)?;
+
+    // The signer must be the node that CLAIMED this address. Anything else means
+    // something answers there, but not the claimant — which is exactly the case a bare
+    // TCP probe cannot distinguish and this check exists for.
+    if !signed.signer.eq_ignore_ascii_case(expected_node_id) {
+        return Err(AddressProofFailure::WrongSigner);
+    }
+
+    // Bound to OUR nonce, or it may be a replay of an earlier exchange.
+    if signed.challenge_nonce.as_deref() != Some(expected_nonce) {
+        return Err(AddressProofFailure::NonceMismatch);
+    }
+
+    signed
+        .verify(|signer_hex, message_hash, signature_bytes| {
+            let Ok(pk_bytes) = hex::decode(signer_hex) else {
+                return false;
+            };
+            if pk_bytes.len() != 32 {
+                return false;
+            }
+            let mut pk = [0u8; 32];
+            pk.copy_from_slice(&pk_bytes);
+            let Ok(sig) = <[u8; 64]>::try_from(signature_bytes) else {
+                return false;
+            };
+            verify_signature(&pk, message_hash, &sig).unwrap_or(false)
+        })
+        .map_err(|_| AddressProofFailure::BadSignature)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ghost_common::identity::NodeIdentity;
+
+    /// Build the exact wire shape `/health?nonce=…` returns.
+    fn health_body(identity: &NodeIdentity, nonce: Option<&str>, signed_flag: bool) -> String {
+        let payload = HealthResponse {
+            mesh_validation: None,
+            healthy: true,
+            core_reachable: Some(true),
+            core_last_ok_secs: Some(0),
+            node_id: identity.node_id_hex(),
+            version: "test".to_string(),
+            block_height: 961_180,
+            round_id: 1,
+            miner_count: 0,
+            peer_count: 7,
+            capabilities: crate::challenge::CapabilityStatus::default(),
+            uptime_secs: 1,
+        };
+        let signed = SignedResponse::new(
+            payload,
+            identity.node_id_hex(),
+            |msg| identity.sign(msg),
+            nonce.map(str::to_owned),
+        );
+        serde_json::json!({"signed": signed_flag, "response": signed}).to_string()
+    }
+
+    #[test]
+    fn a_reply_signed_by_the_claimant_over_our_nonce_proves_the_address() {
+        let node = NodeIdentity::generate();
+        let body = health_body(&node, Some("nonce-we-chose"), true);
+        assert_eq!(
+            verify_address_proof(&body, &node.node_id_hex(), "nonce-we-chose"),
+            Ok(())
+        );
+    }
+
+    /// The case a bare TCP probe cannot see: something answers at the claimed address,
+    /// but it is not the node that claimed it. This is the whole point of H-7 — a node
+    /// may advertise any reachable third-party address.
+    #[test]
+    fn a_reply_signed_by_someone_else_is_wrong_signer() {
+        let claimant = NodeIdentity::generate();
+        let whoever_actually_answers = NodeIdentity::generate();
+        let body = health_body(&whoever_actually_answers, Some("n"), true);
+        assert_eq!(
+            verify_address_proof(&body, &claimant.node_id_hex(), "n"),
+            Err(AddressProofFailure::WrongSigner)
+        );
+    }
+
+    #[test]
+    fn a_reply_bound_to_a_different_nonce_is_a_mismatch() {
+        let node = NodeIdentity::generate();
+        let body = health_body(&node, Some("some-old-nonce"), true);
+        assert_eq!(
+            verify_address_proof(&body, &node.node_id_hex(), "the-nonce-we-chose"),
+            Err(AddressProofFailure::NonceMismatch)
+        );
+    }
+
+    #[test]
+    fn a_reply_with_no_nonce_at_all_is_a_mismatch() {
+        let node = NodeIdentity::generate();
+        let body = health_body(&node, None, true);
+        assert_eq!(
+            verify_address_proof(&body, &node.node_id_hex(), "n"),
+            Err(AddressProofFailure::NonceMismatch)
+        );
+    }
+
+    /// What every node answered before the signing identity was wired: `signed: false`.
+    #[test]
+    fn an_unsigned_reply_proves_nothing() {
+        let node = NodeIdentity::generate();
+        let body = health_body(&node, Some("n"), false);
+        assert_eq!(
+            verify_address_proof(&body, &node.node_id_hex(), "n"),
+            Err(AddressProofFailure::NotSigned)
+        );
+    }
+
+    #[test]
+    fn a_tampered_signature_does_not_verify() {
+        let node = NodeIdentity::generate();
+        let body = health_body(&node, Some("n"), true);
+        let mut v: serde_json::Value = serde_json::from_str(&body).unwrap();
+        // Flip the signature to something structurally valid but wrong.
+        v["response"]["signature"] = serde_json::json!("00".repeat(64));
+        assert_eq!(
+            verify_address_proof(&v.to_string(), &node.node_id_hex(), "n"),
+            Err(AddressProofFailure::BadSignature)
+        );
+    }
+
+    #[test]
+    fn garbage_is_not_a_proof() {
+        let node = NodeIdentity::generate();
+        assert_eq!(
+            verify_address_proof("not json", &node.node_id_hex(), "n"),
+            Err(AddressProofFailure::NotSigned)
+        );
+    }
+}

--- a/crates/ghost-verification/src/client.rs
+++ b/crates/ghost-verification/src/client.rs
@@ -714,6 +714,7 @@ impl VerificationClient {
         node_address: &str,
         block_hash: Option<&str>,
         txid: Option<&str>,
+        challenge_nonce: Option<&str>,
     ) -> GhostResult<(ArchiveResponse, Option<String>)> {
         let mut params: Vec<String> = Vec::new();
         if let Some(hash) = block_hash {
@@ -721,6 +722,14 @@ impl VerificationClient {
         }
         if let Some(tx) = txid {
             params.push(format!("tx={}", tx));
+        }
+        // Bind the target's signature to THIS challenge. Without it `SignedResponse`
+        // is bounded only by `MAX_RESPONSE_AGE_SECS` (300s), so a captured response
+        // can be replayed inside that window to keep a node earning +5 after it has
+        // stopped serving. The recipient re-derivation compares this against the
+        // nonce recorded in `challenge_data`.
+        if let Some(nonce) = challenge_nonce {
+            params.push(format!("nonce={}", nonce));
         }
 
         let path = if params.is_empty() {
@@ -1074,7 +1083,12 @@ impl VerificationClient {
         // Archive verification
         if result.claimed_capabilities.archive_mode {
             if let Some(hash) = test_block_hash {
-                match self.verify_archive(node_address, Some(hash), None).await {
+                // No challenge nonce: this path discards the signed response and
+                // feeds no consensus verdict, so there is nothing to bind a replay to.
+                match self
+                    .verify_archive(node_address, Some(hash), None, None)
+                    .await
+                {
                     Ok((resp, _signed)) => result.archive_verified = resp.success,
                     Err(e) => result.errors.push(format!("Archive: {}", e)),
                 }

--- a/crates/ghost-verification/src/lib.rs
+++ b/crates/ghost-verification/src/lib.rs
@@ -39,6 +39,9 @@
 
 #![deny(unreachable_pub)]
 
+/// H-7: prove a node controls the address it CLAIMS, by requiring a reply signed
+/// under its own node id over a nonce the prober chose.
+pub mod address_proof;
 pub mod alerts;
 pub mod auth;
 pub mod chain_health;

--- a/crates/ghost-verification/src/routes.rs
+++ b/crates/ghost-verification/src/routes.rs
@@ -863,8 +863,26 @@ async fn health_handler(
 ) -> impl IntoResponse {
     let response = state.get_health().await;
 
-    // Sign by default unless explicitly disabled
-    let should_sign = !query.unsigned.unwrap_or(false);
+    // Sign only when the caller supplies a nonce.
+    //
+    // Signing changes the SHAPE of this response: `response` becomes a
+    // `SignedResponse<HealthResponse>`, so `response.block_height` moves to
+    // `response.payload.block_height`. `can_sign()` was false on every node for as
+    // long as the identity field existed without a setter, so no caller has ever seen
+    // the signed shape — enabling it unconditionally would change the contract for
+    // every existing consumer at once (the dashboard, and scripts not passing
+    // `unsigned=true`).
+    //
+    // Requiring a nonce keeps every current caller on the shape it already parses,
+    // while giving an identity-bound reachability probe (H-7) exactly what it needs:
+    // a reply signed under the node's own id and bound to a nonce the prober chose.
+    //
+    // NOTE this gate is deliberately NOT applied to the `/verify/*` handlers below.
+    // The archive challenge sends no nonce (`verify_archive` builds only `block`/`tx`),
+    // so gating those on nonce presence would leave them unsigned — and an unsigned
+    // target response is exactly what makes the H-8 re-derivation defence reach
+    // `ReVerdict::Unverifiable` and record nothing.
+    let should_sign = !query.unsigned.unwrap_or(false) && query.nonce.is_some();
 
     if should_sign && state.can_sign() {
         if let Some(signed) = state.sign_response(response.clone(), query.nonce) {

--- a/crates/ghost-verification/src/server.rs
+++ b/crates/ghost-verification/src/server.rs
@@ -2095,6 +2095,32 @@ impl VerificationState {
         self
     }
 
+    /// Give this state the node's signing identity, enabling signed HTTP responses.
+    ///
+    /// Without this, `can_sign()` is false and every endpoint answers
+    /// `"signed": false` — which is what the fleet did, because the field existed
+    /// from the initial commit with no setter. Two things depend on it:
+    ///
+    /// - An identity-bound reachability probe (H-7): a challenger dials the address a
+    ///   node CLAIMS and requires a reply signed by that node's id over a fresh nonce.
+    ///   Unsigned, the probe proves only that something answers there.
+    /// - The H-8 re-derivation defence: recipients re-derive a verdict from the
+    ///   target's own signed response instead of trusting the challenger's `passed`.
+    ///   With no signature the handler reaches `ReVerdict::Unverifiable` and records
+    ///   nothing, so the defence is present but inert.
+    ///
+    /// The id passed to `new()` must be this identity's own — `sign_response` signs
+    /// under `self.node_id`, and a verifier compares that against the node it dialled.
+    pub fn with_node_identity(mut self, identity: std::sync::Arc<NodeIdentity>) -> Self {
+        debug_assert_eq!(
+            identity.node_id_hex(),
+            self.node_id,
+            "signing identity must match the state's node_id"
+        );
+        self.identity = Some(identity);
+        self
+    }
+
     /// Set the configured Bitcoin network reported by the status/info endpoints.
     pub fn with_network(mut self, network: ghost_common::config::BitcoinNetwork) -> Self {
         self.network = network;
@@ -4360,5 +4386,88 @@ mod tests {
         // carrying no proof at all.
         assert_eq!(resp.epoch, Some(44));
         assert_eq!(resp.virtual_block, Some(100));
+    }
+
+    /// H-7 prerequisite: a node must be able to SIGN an HTTP response, or an
+    /// identity-bound reachability probe is impossible — the whole point is that
+    /// whoever answers at a claimed address proves it holds that node's key.
+    ///
+    /// `VerificationState.identity` has been `Option<Arc<NodeIdentity>>` since the
+    /// initial commit, is read by `can_sign()` and `sign_response()`, and had NO
+    /// setter — so `can_sign()` was false everywhere and every endpoint returned
+    /// `"signed": false` on the live fleet. That also left the H-8 re-derivation
+    /// defence inert: with no target signature the handler reaches
+    /// `ReVerdict::Unverifiable` and records nothing.
+    #[test]
+    fn a_state_given_an_identity_signs_a_nonce_bound_response_under_its_own_node_id() {
+        use ghost_common::identity::NodeIdentity;
+        use ghost_common::types::NodeCapabilities;
+        use ghost_policy::PolicyProfile;
+        use std::sync::Arc;
+
+        let identity = Arc::new(NodeIdentity::generate());
+        let node_id_hex = identity.node_id_hex();
+
+        let unwired = VerificationState::new(
+            node_id_hex.clone(),
+            "test".to_string(),
+            PolicyProfile::default(),
+            NodeCapabilities::default(),
+        );
+        assert!(
+            !unwired.can_sign(),
+            "a state with no identity must not claim it can sign"
+        );
+        assert!(
+            unwired
+                .sign_response("payload", Some("n".to_string()))
+                .is_none(),
+            "signing without an identity must yield None, not an unsigned artefact"
+        );
+
+        let wired = VerificationState::new(
+            node_id_hex.clone(),
+            "test".to_string(),
+            PolicyProfile::default(),
+            NodeCapabilities::default(),
+        )
+        .with_node_identity(Arc::clone(&identity));
+
+        assert!(
+            wired.can_sign(),
+            "a state given an identity must be able to sign"
+        );
+
+        let nonce = "cafebabedeadbeef".to_string();
+        let signed = wired
+            .sign_response("payload", Some(nonce.clone()))
+            .expect("a wired state must produce a signed response");
+
+        // The signer IS the node id a challenger would compare against.
+        assert_eq!(signed.signer, node_id_hex, "signer must be this node's id");
+        // The challenge nonce must come back, or a probe cannot bind the reply to its request.
+        assert_eq!(
+            signed.challenge_nonce.as_deref(),
+            Some(nonce.as_str()),
+            "the challenge nonce must be echoed"
+        );
+
+        // And the signature must actually verify under that node id.
+        let vk = identity.verifying_key().expect("verifying key");
+        let ok = signed.verify(|signer, message, sig| {
+            use ed25519_dalek::Verifier;
+            if signer != node_id_hex {
+                return false;
+            }
+            let Ok(sig_bytes): Result<[u8; 64], _> = sig.try_into() else {
+                return false;
+            };
+            vk.verify(message, &ed25519_dalek::Signature::from_bytes(&sig_bytes))
+                .is_ok()
+        });
+        assert!(
+            ok.is_ok(),
+            "signed response must verify under its own node id: {ok:?}"
+        );
     }
 }

--- a/crates/ghost-verification/src/task.rs
+++ b/crates/ghost-verification/src/task.rs
@@ -1313,9 +1313,26 @@ impl VerificationTask {
                 }
             };
 
+        // VER-2/replay: bind the target's signature to THIS challenge. Recorded in
+        // `challenge_data` so recipients re-deriving the verdict can require the
+        // signed response to echo it. Skipping the challenge outright when the RNG
+        // fails matches how the GhostPay challenge handles the same failure — a
+        // challenge nobody can bind is not worth issuing.
+        let challenge_nonce = match self.generate_challenge_nonce() {
+            Some(n) => n,
+            None => {
+                warn!(
+                    peer = %peer_id_hex[..8],
+                    "Skipping archive verification - failed to generate challenge nonce"
+                );
+                return Ok(());
+            }
+        };
+
         let challenge_data = serde_json::json!({
             "block_hash": block_hash,
             "block_height": block_height,
+            "nonce": challenge_nonce,
         })
         .to_string();
 
@@ -1343,6 +1360,7 @@ impl VerificationTask {
                 &peer.http_address,
                 Some(&block_hash),
                 expected_tx.as_ref().map(|e| e.txid.as_str()),
+                Some(challenge_nonce.as_str()),
             )
             .await;
 


### PR DESCRIPTION
Groundwork for **H-7** (#605), plus a defence it turns out to un-inert. Does **not** yet change
who counts as a challenger — that needs a height gate and comes next.

## 1. The HTTP layer could never sign anything (`e7891a7a5`)

`VerificationState.identity` has been `Option<Arc<NodeIdentity>>` since the initial commit. It is
read by `can_sign()` and `sign_response()` and had **no setter anywhere in the workspace**, so it
was `None` on every node. Measured before the change — vm1, vm2 and vm4 all returned
`"signed": false` from `/health`, and `/verify/archive` likewise.

Two things were silently inert as a result:

- **H-8's re-derivation defence.** Recipients are meant to re-derive a verdict from the TARGET's
  own signed response rather than trust the challenger's `passed`. With no signature,
  `target_signed_response` is absent, the handler reaches `ReVerdict::Unverifiable`, and its own
  comment says *"Record NOTHING"*. `with_rederivation` was wired at `main.rs:3424` with nothing to
  act on.
- **Identity-bound probing**, which is impossible without a signable reply.

`/health` signs only when given a nonce. Signing changes the response SHAPE —
`response.block_height` becomes `response.payload.block_height` — and since `can_sign()` has never
been true, no caller has ever seen the signed form. Enabling it unconditionally would change the
contract for the dashboard and every script not passing `unsigned=true`, on all eight nodes at
once. Requiring a nonce leaves existing callers on the shape they already parse.

That gate is deliberately **not** applied to `/verify/*`: `verify_archive` sends no nonce, so
gating those the same way would leave them unsigned and keep H-8 inert. Their clients already
handle both shapes.

## 2. The archive response was replayable (`5160735cc`)

`SignedResponse::verify` bounds only freshness (`MAX_RESPONSE_AGE_SECS` = 300s) and nothing tied a
response to the challenge that asked for it. A correct, correctly-signed response captured from an
earlier challenge could be replayed inside that window to keep a node earning +5 after it had
stopped serving.

The challenger now mints a nonce, records it in `challenge_data`, and sends it; re-derivation
requires the signed response to echo it.

**A nonce mismatch is `Unverifiable`, never `Fail`.** `challenge_data` is challenger-authored — the
same reason step 4 refuses to take the block height from it — so naming a wrong nonce must not
become a free way to drag an honest node under its pass-rate gate.

## 3. The address proof itself (`cb8840817`)

`verify_address_proof` — a pure function of the response body, so the security logic is testable
without a network. Failures are distinguished rather than collapsed to a bool: `WrongSigner`
("something answers there and it is not who claimed it") is a very different fact about a peer
from `NotSigned` ("down, or predates signing").

⚠ The payload must be deserialised as the concrete `HealthResponse`, **not** `serde_json::Value`.
`verify` recomputes the hash over `serde_json::to_vec(payload)`, so it must re-serialise to the
bytes the signer produced — true only when both sides use the same type and serde config
(`HealthResponse` has `skip_serializing_if` on its optionals). The `Value` version reproduced the
shape but not the bytes and returned `BadSignature` against a genuinely valid proof.

That was caught only by testing against a **real** signed reply from vm5. All seven hand-built
fixtures passed while the function could not verify anything a live node produced. The live check
is not committed — it embeds a captured response and would start failing 300s later.

## Verification

- Local gate green on `5160735cc`; 366 feature-gated consensus tests. CI clippy (`--all-features
  -D warnings`) exit 0.
- All new tests mutation-checked: neutering the identity setter, the nonce binding, the signer
  comparison and the nonce comparison each fail only their own tests.
- **Canary vm5, 60 minutes**: 0 restarts, 0 ERROR-level lines in every 10-minute window,
  ShareProof 46-63 per window.
- **Live acceptance**, vm5 vs vm1 (main), same request seconds apart:

  ```
  vm5  signed=True   signer=5867b5556022  cnonce=testnonce123
  vm1  signed=False  signer=None          cnonce=None
  ```

  and `/health?nonce=` on vm5 returns `signer` = its own node id echoing the exact nonce, while
  `/health` with no nonce still reports `signed=false` with `block_height` at the top level —
  so existing consumers are unaffected.
- **Mixed-version check**: over 30 minutes vm1 logged zero errors mentioning vm5, against a
  positive control of 84 total mentions. Its only warnings were `Failed to get peer health` for
  vm6/vm7 — the known sparse fan-out, unrelated.

## Not in this PR

Wiring the proof into subnet derivation. That changes who counts as a challenger, so it needs its
own height gate — and a decision on what happens to an unprobed `/24`, which on this fleet could
collapse the draw pool if excluded outright.
