### PR TITLE
haze: stripped blocks from a peer are history, never a way to extend the chain

### DIFF
--- a/ghost-core/src/net_processing.cpp
+++ b/ghost-core/src/net_processing.cpp
@@ -24,6 +24,7 @@
 #include <haze/checkpoint_signing.h>
 #include <haze/chunk_downloader.h>
 #include <haze/haze_p2p.h>
+#include <haze/hazync_proof.h>
 #include <haze/stripped_block.h>
 #include <headerssync.h>
 #include <index/blockfilterindex.h>
@@ -4864,10 +4865,24 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
         LogDebug(BCLog::NET, "received stripped block %s peer=%d (%zu txs)\n",
             stripped.m_header.GetHash().ToString(), pfrom.GetId(), stripped.GetTxCount());
 
-        // Store the stripped block directly to GSB if we're in Hazed mode.
-        // This is a storage-only path — it writes to GSB and updates the block
-        // index but does NOT call ActivateBestChain(). Stripped blocks cannot be
-        // connected (scriptPubKeys are modified, so UTXO construction would fail).
+        // Store the stripped block to GSB if we're in Hazed mode.
+        //
+        // This is ARCHIVE BACKFILL and nothing else: it fills in economic history for blocks this
+        // node already has in its chain — typically everything below a proven UTXO set adopted at
+        // some height N, which such a node holds no history for.
+        //
+        // It is deliberately not a way to EXTEND the chain, and a proof would not make it one. The
+        // stripper rewrites OP_RETURN and non-standard scriptPubKeys, so UTXO construction from
+        // stripped data is unsound for any output that was both non-standard and spendable. No proof
+        // supplies the UTXO effects of a block whose outputs are no longer held faithfully. Fast sync
+        // is G4's job — adopt the proven set at N and validate from N+1 — not this path's.
+        //
+        // The requirement below was previously absent, and the comment here claimed the path was
+        // storage-only because it does not call ActivateBestChain itself. It does not; but
+        // ReceivedBlockTransactions ends in TryAddBlockIndexCandidate, so the block became a
+        // connection candidate anyway and ActivateBestChain picked it up on its own schedule. It
+        // could never connect, so the node stored the block, tried to connect it, discarded it and
+        // downloaded it again as a full block.
         if (m_chainman.m_blockman.IsHazeMode()) {
             LOCK(cs_main);
 
@@ -4876,6 +4891,30 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
             if (!pindex) {
                 LogDebug(BCLog::NET, "Stripped block %s not in block index\n", block_hash.ToString());
                 return;
+            }
+
+            // Already part of the chain we have chosen, so accepting it cannot change which chain
+            // that is. A block not in the active chain would be a candidate to extend it, which is
+            // exactly what stripped data cannot support.
+            if (!m_chainman.ActiveChain().Contains(pindex)) {
+                LogDebug(BCLog::NET, "Ignoring stripped block %s from peer %d: not in the active "
+                    "chain, and stripped data cannot be used to extend it\n",
+                    block_hash.ToString(), pfrom.GetId());
+                return;
+            }
+
+            // Below an adopted snapshot base this node never validated the block itself, so the
+            // merkle binding establishes only WHICH block it is. That it was VALID comes from the
+            // proof, and without one there is nothing to license storing it as history.
+            const auto snapshot_base{m_chainman.GetSnapshotBaseHeight()};
+            if (snapshot_base && pindex->nHeight < *snapshot_base) {
+                const auto& proven{haze::HazyncVerifiedProof()};
+                if (!proven || pindex->nHeight > static_cast<int>(proven->height)) {
+                    LogDebug(BCLog::NET, "Ignoring stripped block %s at height %d from peer %d: "
+                        "below the adopted snapshot base and not covered by a verified proof\n",
+                        block_hash.ToString(), pindex->nHeight, pfrom.GetId());
+                    return;
+                }
             }
 
             if (pindex->nStatus & BLOCK_HAVE_DATA) {

--- a/ghost-web/docs/haze.md
+++ b/ghost-web/docs/haze.md
@@ -98,9 +98,9 @@ A hazed node's life looks like this:
 
 ```
 1. Operator picks haze_mode = "Hazed" in pool.toml at first launch.
-2. Node syncs from peers — could be hazed peers (fast, structural-only)
-   or full peers (still works; received blocks pass through Exorcism
-   on this side and only the stripped form lands on disk).
+2. Node syncs from FULL peers. Received blocks pass through Exorcism on
+   this side, so only the stripped form lands on disk. It cannot sync from
+   a hazed peer — see below.
 3. From the very first block written, only structural data is on disk.
 4. Routine operation: blocks arrive, validate in RAM, write structural,
    zero RAM. Exorcism is invisible from the outside.
@@ -120,6 +120,31 @@ When a peer asks specifically for a transaction's witness data (e.g. for inscrip
 2. **Refuse.** Some nodes operate in environments where redirecting is itself a liability concern. Refusal is consistent with Bitcoin's protocol-level "this peer doesn't have what you want" semantics.
 
 For a node validating the chain, neither matters: validation only needs the full witness during block acceptance, and it has it then (the block arrives over the wire fully formed). Witness data only becomes "missing" *after* validation, when it's been stripped from disk.
+
+## A hazed node cannot sync from another hazed node
+
+Worth stating plainly, because it is the natural thing to assume and it is not true.
+
+**Neither party holds the full block.** A hazed node cannot serve what it destroyed, so there is no
+exchange in which the receiver obtains what it needs. This is not a matter of deferring validation or
+of a protocol that has not been written: the data does not exist on either side.
+
+Three separate things would each be enough to prevent it:
+
+- the receiver has no scriptSigs or witnesses, so it cannot validate;
+- stripping rewrites OP_RETURN and non-standard scriptPubKeys, so even building the UTXO set from
+  stripped data is unsound for any output that was both non-standard and spendable;
+- and a hazed node does not advertise `NODE_NETWORK`, precisely because it cannot serve full
+  historical blocks — so block download never selects it in the first place.
+
+Measured, not assumed: two hazed regtest nodes, one with 120 blocks, the other connected to it.
+Headers transfer fine — the second node learns the whole chain. **Zero blocks transfer, and the
+second node stays at height 0.** (`test/hazync/hazed-to-hazed.sh`.)
+
+**Fast sync is a different mechanism entirely.** A node adopts a proven UTXO set at some height and
+validates forward from there, downloading nothing below it — see [Hazync sync](#hazync). Stripped
+blocks moving between hazed nodes are *history*, filling in economic data for a chain the receiver
+already holds, and a proof is what licenses trusting it.
 
 ## Reorgs, restarts, and the limits of stripped storage
 

--- a/test/hazync/hazed-to-hazed.sh
+++ b/test/hazync/hazed-to-hazed.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# Two hazed nodes, talking to each other, on regtest.
+#
+# A hazed node serves GHOST_STRIPPED_BLOCK to any peer advertising NODE_GHOST_HAZE, so two hazed
+# nodes exercise the whole path — serve, transfer, receive — without touching mainnet. Regtest keeps
+# it to seconds rather than the minutes a mainnet sync costs.
+#
+# WHAT THIS IS FOR. The receive path decides what a node may do with structural data from a peer,
+# and that decision cannot be tested with one node. It answers a question the documentation and the
+# code disagree about: whether a hazed node can actually sync from another hazed node.
+#
+# Usage: GHOSTD=/path/to/ghostd ./test/hazync/hazed-to-hazed.sh
+set -uo pipefail
+
+GHOSTD="${GHOSTD:-}"
+[ -x "$GHOSTD" ] || { echo "set GHOSTD=<path to ghostd>" >&2; exit 2; }
+command -v curl >/dev/null 2>&1 || { echo "curl is required" >&2; exit 2; }
+
+pass=0; fail=0
+ok(){  echo "  ok    $1"; pass=$((pass+1)); }
+bad(){ echo "  FAIL  $1"; fail=$((fail+1)); }
+note(){ echo "  --    $1"; }
+
+DD_A=$(mktemp -d); DD_B=$(mktemp -d)
+PID_A=""; PID_B=""
+# ⚠ With -listen=1 the node also binds 127.0.0.1:<port+1> for the Tor onion listener, so an RPC port
+# adjacent to the P2P port collides and the node exits with "Failed to listen on any port".
+P2P_A=19444; RPC_A=19999; RPC_B=19998
+cleanup(){
+    [ -n "$PID_B" ] && { kill "$PID_B" 2>/dev/null; wait "$PID_B" 2>/dev/null; }
+    [ -n "$PID_A" ] && { kill "$PID_A" 2>/dev/null; wait "$PID_A" 2>/dev/null; }
+    rm -rf "$DD_A" "$DD_B"
+}
+trap cleanup EXIT
+
+rpc(){ # rpc <port> <body>
+    curl -s --max-time 60 --user t:t --data-binary "$2" \
+        -H 'content-type: text/plain;' "http://127.0.0.1:$1/" 2>/dev/null
+}
+jq_(){ python3 -c "import sys,json
+try: r=json.load(sys.stdin)['result']
+except Exception: print('none'); sys.exit()
+if r is None: print('none'); sys.exit()
+$1"; }
+height(){ rpc "$1" '{"jsonrpc":"1.0","id":"t","method":"getblockchaininfo","params":[]}' | jq_ "print(r['blocks'])"; }
+
+wait_rpc(){ for i in $(seq 1 60); do [ "$(height "$1")" != "none" ] && return 0; sleep 1; done; return 1; }
+
+echo "Ghost Haze — hazed node syncing from a hazed node (regtest)"
+
+# ── node A: hazed, with a chain ────────────────────────────────────────────────────────────────
+"$GHOSTD" -regtest -datadir="$DD_A" -printtoconsole=1 -server=1 -hazemode=hazed \
+    -port=$P2P_A -rpcport=$RPC_A -rpcuser=t -rpcpassword=t -listen=1 -discover=0 \
+    >"$DD_A/debug.out" 2>&1 &
+PID_A=$!
+wait_rpc $RPC_A || { bad "node A never started"; tail -10 "$DD_A/debug.out" | sed 's/^/    /'; echo; echo "passed $pass, failed $fail"; exit 1; }
+ok "node A started (hazed, regtest)"
+
+# A fixed P2WPKH regtest address (BIP173 test vector key), so this needs no wallet build.
+ADDR="bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080"
+rpc $RPC_A "{\"jsonrpc\":\"1.0\",\"id\":\"t\",\"method\":\"generatetoaddress\",\"params\":[120,\"$ADDR\"]}" >/dev/null
+HA=$(height $RPC_A)
+[ "${HA:-0}" -ge 100 ] 2>/dev/null \
+    && ok "node A mined to height $HA" \
+    || { bad "node A did not mine (height $HA) — no wallet, or generatetoaddress failed"
+         tail -6 "$DD_A/debug.out" | sed 's/^/    /'; echo; echo "passed $pass, failed $fail"; exit 1; }
+
+grep -q "Ghost Exorcism initialized in HAZED mode" "$DD_A/debug.out" \
+    && ok "node A is hazed — it holds only stripped storage to serve" \
+    || bad "node A is not hazed; this tests nothing"
+
+# ── node B: hazed, empty, pointed at A ─────────────────────────────────────────────────────────
+"$GHOSTD" -regtest -datadir="$DD_B" -printtoconsole=1 -server=1 -hazemode=hazed \
+    -rpcport=$RPC_B -rpcuser=t -rpcpassword=t -listen=0 -discover=0 \
+    -connect=127.0.0.1:$P2P_A \
+    >"$DD_B/debug.out" 2>&1 &
+PID_B=$!
+wait_rpc $RPC_B || { bad "node B never started"; tail -10 "$DD_B/debug.out" | sed 's/^/    /'; echo; echo "passed $pass, failed $fail"; exit 1; }
+ok "node B started (hazed, empty) and pointed at A"
+
+# Give them time to handshake, exchange headers, and attempt block transfer.
+for i in $(seq 1 60); do
+    HB=$(height $RPC_B)
+    [ "${HB:-0}" -ge "$HA" ] 2>/dev/null && break
+    sleep 1
+done
+HB=$(height $RPC_B)
+
+PEERS=$(rpc $RPC_B '{"jsonrpc":"1.0","id":"t","method":"getpeerinfo","params":[]}' | jq_ "print(len(r))")
+[ "${PEERS:-0}" -ge 1 ] 2>/dev/null \
+    && ok "node B is connected to A ($PEERS peer)" \
+    || bad "node B never connected to A"
+
+HEADERS_B=$(rpc $RPC_B '{"jsonrpc":"1.0","id":"t","method":"getblockchaininfo","params":[]}' | jq_ "print(r['headers'])")
+[ "${HEADERS_B:-0}" -ge "$HA" ] 2>/dev/null \
+    && ok "node B received A's headers (to $HEADERS_B) — the peering works" \
+    || bad "node B did not get headers from A (got $HEADERS_B)"
+
+# ── the actual question ────────────────────────────────────────────────────────────────────────
+echo
+echo "  === did stripped blocks transfer, and could B use them? ==="
+# grep -c already prints 0 and exits 1 when nothing matches, so `|| echo 0` appends a second zero.
+SERVED=$(grep -c "served stripped block" "$DD_A/debug.out" 2>/dev/null; true)
+RECVD=$(grep -c "received stripped block" "$DD_B/debug.out" 2>/dev/null; true)
+REFUSED=$(grep -c "stripped data cannot be used to extend it" "$DD_B/debug.out" 2>/dev/null; true)
+NO_NETWORK=$(grep -c "not advertising NODE_NETWORK" "$DD_A/debug.out" 2>/dev/null; true)
+note "A served $SERVED, B received $RECVD, B refused-as-extension $REFUSED"
+note "A height $HA, B height $HB"
+
+# The finding this test exists to record. A hazed node cannot serve full blocks and so does not
+# advertise NODE_NETWORK; block download will not select such a peer, so the stripped-block serving
+# path is never even reached. Hazed sync does not fail validation — it never starts.
+if [ "${RECVD:-0}" -gt 0 ]; then
+    note "stripped blocks transferred ($RECVD)"
+else
+    ok "no stripped blocks transferred — B never asked, because A cannot advertise NODE_NETWORK"
+fi
+[ "${NO_NETWORK:-0}" -gt 0 ] \
+    && ok "node A declines NODE_NETWORK, which is why nothing requests blocks from it" \
+    || note "node A did advertise NODE_NETWORK — the reasoning above needs rechecking"
+
+# The load-bearing conclusion: a hazed node cannot sync another hazed node, and no protocol change
+# fixes it, because NEITHER PARTY HOLDS THE FULL BLOCK. The data the receiver needs does not exist
+# anywhere in the exchange. Fast sync from a hazed peer is G4's job — adopt a proven UTXO set — not
+# this path's.
+[ "${HB:-0}" -eq 0 ] 2>/dev/null \
+    && ok "node B synced NO blocks from a hazed peer — the documented expectation is wrong" \
+    || note "node B reached height $HB, which contradicts the analysis and wants investigating"
+
+# B must NOT have advanced its chain on stripped data. Whether it refuses them or simply cannot use
+# them, the tip must not move on blocks whose scriptPubKeys were rewritten.
+if [ "${HB:-0}" -gt 0 ] 2>/dev/null && [ "${RECVD:-0}" -gt 0 ]; then
+    bad "node B advanced to height $HB using stripped blocks — UTXO construction from stripped data is unsound"
+else
+    ok "node B did not advance its chain on stripped data (height $HB)"
+fi
+
+# And it must not have died trying.
+kill -0 "$PID_B" 2>/dev/null \
+    && ok "node B is still alive" \
+    || bad "node B died while handling stripped blocks"
+grep -q "A fatal internal error" "$DD_B/debug.out" \
+    && bad "node B hit a fatal internal error" \
+    || ok "no fatal error on node B"
+
+echo
+echo "passed $pass, failed $fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## What

Makes the stripped-block receive path what its comment already claimed to be — archive backfill — and records, with a measurement, that hazed→hazed *sync* is not achievable at all.

## Hazed nodes cannot sync from each other, and no protocol change fixes it

**Neither party holds the full block.** A hazed node cannot serve what it destroyed, so there is no exchange in which the receiver obtains what it needs. This is not deferred validation or a missing message type: the data does not exist on either side.

Three things would each be sufficient on their own:

- the receiver has no scriptSigs or witnesses, so it cannot validate;
- stripping rewrites OP_RETURN and non-standard scriptPubKeys, so building the UTXO set from stripped data is unsound for any output that was both non-standard **and** spendable;
- a hazed node does not advertise `NODE_NETWORK` — precisely because it cannot serve full historical blocks — so block download never selects it and the serving path is never reached.

Measured rather than argued. `test/hazync/hazed-to-hazed.sh` runs two hazed regtest nodes, one holding 120 blocks and the other connected to it:

```
ok  node B is connected to A (1 peer)
ok  node B received A's headers (to 120) — the peering works
--  A served 0, B received 0
--  A height 120, B height 0
ok  node A declines NODE_NETWORK, which is why nothing requests blocks from it
ok  node B synced NO blocks from a hazed peer — the documented expectation is wrong
```

Headers transfer fine. Zero blocks do. **Fast sync is G4's job** — adopt a proven UTXO set and validate forward — not this path's.

## What the path is for

Archive backfill: filling in economic history for blocks the node already has in its chain, typically everything below a proven UTXO set adopted at some height, which such a node holds no history for.

Three conditions are now enforced:

1. **The block must already be in the active chain**, so accepting it cannot change which chain that is. A block outside it would be a candidate to extend the chain, which is exactly what stripped data cannot support.
2. It must not already have data.
3. **Below an adopted snapshot base**, where the node never validated the block itself, a verified proof must cover its height. The merkle root establishes only *which* block it is; that it was *valid* comes from the proof. Above the base the node validated it and no proof is needed.

Identity from the merkle root against a header the node already holds, validity from the proof. Neither comes from the peer, which is never believed about anything.

## A live defect this fixes

The comment claimed the path was storage-only because it does not call `ActivateBestChain` itself. It does not — but `ReceivedBlockTransactions` ends in `TryAddBlockIndexCandidate`, so the block **became a connection candidate** and `ActivateBestChain` picked it up on its own schedule. It could never connect, so the node stored a stripped block, tried to connect it, discarded it, and downloaded it again as a full block. Before the disconnect work in #627 it was a fatal error instead.

## Documentation

`ghost-web/docs/haze.md` said a node *"syncs from peers — could be hazed peers (fast, structural-only)"*. That is wrong. Corrected, with the reasoning and the measurement, in a new section.

## Caveat

The guard is enforced on a path a hazed peer cannot currently reach, since nothing requests blocks from a node that declines `NODE_NETWORK`. So it is exercised by construction rather than by transfer — the two-node test demonstrates the absence, not the guard firing. If stripped-block transfer is ever driven deliberately (an explicit backfill request rather than ordinary block download), that is when the guard earns its keep, and the harness is in place to test it.

Unit tests green and `ghostd` links.
