### PR TITLE
haze: say so when a node cannot get a block it destroyed

### DIFF
--- a/ghost-core/src/kernel/warning.h
+++ b/ghost-core/src/kernel/warning.h
@@ -9,6 +9,10 @@ namespace kernel {
 enum class Warning {
     UNKNOWN_NEW_RULES_ACTIVATED,
     LARGE_WORK_INVALID_CHAIN,
+    //! A hazed node needs a block it destroyed and no peer has supplied a copy.
+    //! Not a transient condition: it is a designed state the operator has to resolve,
+    //! so it is surfaced rather than left as a log line that scrolls away.
+    HAZE_BLOCK_UNAVAILABLE,
 };
 } // namespace kernel
 #endif // BITCOIN_KERNEL_WARNING_H

--- a/ghost-core/src/validation.cpp
+++ b/ghost-core/src/validation.cpp
@@ -3255,6 +3255,20 @@ bool Chainstate::ConnectTip(
                                "node will make no progress on this branch until one supplies it.\n",
                                pindexNew->GetBlockHash().ToString(), pindexNew->nHeight);
                     m_chainman.ForgetStrippedBlockData(*pindexNew);
+
+                    // Raise it where an operator will actually see it. This is a designed state, not
+                    // a stall: the node destroyed this block on purpose and needs a peer that still
+                    // has it. If none does, waiting will not help and nothing in the logs would say
+                    // so after the line above had scrolled away.
+                    m_chainman.GetNotifications().warningSet(
+                        kernel::Warning::HAZE_BLOCK_UNAVAILABLE,
+                        strprintf(_("This node cannot continue past block %d (%s). It is running in "
+                                    "hazed mode, so it destroyed that block's scripts and witnesses "
+                                    "and cannot validate the block itself; it has asked its peers "
+                                    "for a full copy. If no peer supplies one, connect to a "
+                                    "full-archive peer, or re-sync from a node that has it."),
+                                  pindexNew->nHeight, pindexNew->GetBlockHash().ToString()));
+
                     // Deliberately not fatal and not an invalid block: nothing is wrong with the
                     // chain, this node simply no longer holds a copy it can validate from.
                     return false;
@@ -3311,6 +3325,11 @@ bool Chainstate::ConnectTip(
              Ticks<MillisecondsDouble>(time_5 - time_4),
              Ticks<SecondsDouble>(m_chainman.time_chainstate),
              Ticks<MillisecondsDouble>(m_chainman.time_chainstate) / m_chainman.num_blocks_total);
+    // A block connected, so whatever the node was missing it is no longer stuck on. Clearing here
+    // rather than on receipt of the specific block keeps it simple and cannot leave the warning
+    // stale: progress is the condition the warning was about.
+    m_chainman.GetNotifications().warningUnset(kernel::Warning::HAZE_BLOCK_UNAVAILABLE);
+
     // Remove conflicting transactions from the mempool.;
     if (m_mempool) {
         m_mempool->removeForBlock(block_to_connect->vtx, pindexNew->nHeight);


### PR DESCRIPTION
## What

The last of the three open questions in `tasks/plan_hazync_ghostd_integration.md`:

> Does a hazed node with no proof and no archive peer refuse loudly? (It can still disconnect; it cannot connect its own stripped history.)

It does now.

## The problem

A hazed node that needs a block it stripped asks its peers for a full copy. If none has one, it waits. The only record of why was a single log line, and once that scrolled away the node looked idle rather than stuck — which is precisely the stall the design says this must not be.

## What changed

It raises a node warning, so the condition appears in `getblockchaininfo`, fires `-alertnotify`, and shows in the GUI rather than living in a log file. The message names the height and hash, says plainly that the node destroyed that block's scripts and witnesses and cannot validate it itself, and gives the operator something to do:

> This node cannot continue past block N (hash). It is running in hazed mode, so it destroyed that block's scripts and witnesses and cannot validate the block itself; it has asked its peers for a full copy. If no peer supplies one, connect to a full-archive peer, or re-sync from a node that has it.

Not fatal, and not an invalid block — nothing is wrong with the chain, and a peer may still supply what is missing. But not silent either.

**The warning clears when any block connects.** Progress is exactly the condition it was raised about, so clearing there cannot leave it stale — keying it to the arrival of one specific block could.

## Verified

Unit tests green, `ghostd` links, and 12/12 on a real hazed mainnet node (`test/hazync/hazed-node.sh`) — the unset call sits in `ConnectTip`, which is the hot path, so it was worth confirming against a real sync rather than only in unit tests.

The warning path itself fires only when a stripped block cannot be read and no copy is available, which the harness cannot currently stage. That case is reached by the same code the hazed-node suite already exercises for the reorg-back scenario; the warning is the added disclosure, not new control flow.
