### PR TITLE
fix(consensus): stop the health ping wiping every peer's discovered address (#629)

### DIFF
--- a/crates/ghost-consensus/src/health_handler.rs
+++ b/crates/ghost-consensus/src/health_handler.rs
@@ -934,9 +934,19 @@ impl HealthPingHandler {
             let peer_pow_hex = ping.pow_proof.map(|(nonce, difficulty)| {
                 ghost_common::identity::NodeIdProof { nonce, difficulty }.to_hex()
             });
+            // #629: the ping carries no address post-S-7, so take the one discovery observed.
+            // Passing the ping's empty string straight through wiped the stored address on
+            // every ping, because the upsert uses `COALESCE(?2, public_address)` and an empty
+            // string is a value, not an absence.
+            let discovered = self
+                .peers
+                .get_peer(&envelope.sender)
+                .map(|p| p.public_address);
+            let address_for_db = address_to_persist(discovered.as_deref(), &ping.public_address);
+
             if let Err(e) = db.register_node_with_elder_check_and_pow(
                 &node_id_hex,
-                Some(ping.public_address.as_str()),
+                address_for_db,
                 None, // display_name not available from health ping
                 &capabilities_str,
                 peer_pow_hex.as_deref(),
@@ -1012,6 +1022,26 @@ impl MessageHandler for HealthPingHandler {
         }
         Ok(())
     }
+}
+
+/// Which address to persist for a peer, given what discovery observed and what the ping carried.
+///
+/// Post-S-7 the health ping deliberately carries no address (`mesh.rs`:
+/// `public_address: String::new(), // S-7: Don't broadcast IP in cleartext ZMQ`), and discovery
+/// is the designated path for pairing an identity with an address. But the ping handler still
+/// passed `Some(ping.public_address.as_str())` — always `Some("")` — into an upsert whose column
+/// is written as `COALESCE(?2, public_address)`. `COALESCE` accepts an empty string as a value, so
+/// every ping destroyed the address discovery had learned, at a ~10s cadence. The result:
+/// `nodes.public_address` held one populated row in eight on every production node — each node's
+/// own — and the challenger `/24` diversity draw, which reads that column, had nothing to work
+/// with (#629).
+///
+/// Returning `None` is the important case: it lets `COALESCE` preserve what is already stored
+/// instead of overwriting it with nothing.
+fn address_to_persist<'a>(discovered: Option<&'a str>, ping_address: &'a str) -> Option<&'a str> {
+    discovered
+        .filter(|a| !a.is_empty())
+        .or(Some(ping_address).filter(|a| !a.is_empty()))
 }
 
 #[cfg(test)]
@@ -1277,6 +1307,38 @@ mod tests {
         assert!(
             BASE_POW_DIFFICULTY >= 8,
             "BASE difficulty should be at least 8 for minimum security"
+        );
+    }
+
+    /// #629: post-S-7 the ping is always empty, so the address discovery observed must win.
+    #[test]
+    fn discovered_address_is_used_when_the_ping_carries_none() {
+        assert_eq!(
+            address_to_persist(Some("203.0.113.7:8555"), ""),
+            Some("203.0.113.7:8555")
+        );
+    }
+
+    /// The regression this fixes. With nothing to offer, the handler must pass `None` so the
+    /// upsert's `COALESCE(?2, public_address)` PRESERVES the stored value. Passing `Some("")`
+    /// is what silently wiped every peer's address roughly every ten seconds.
+    #[test]
+    fn nothing_to_offer_yields_none_so_coalesce_preserves() {
+        assert_eq!(address_to_persist(None, ""), None);
+        assert_eq!(address_to_persist(Some(""), ""), None);
+    }
+
+    /// If the ping ever carries an address again it is still usable — but only as a fallback.
+    #[test]
+    fn the_ping_is_a_fallback_not_a_preference() {
+        assert_eq!(
+            address_to_persist(None, "198.51.100.9:8555"),
+            Some("198.51.100.9:8555")
+        );
+        // Both available: prefer what discovery observed over what the node asserted.
+        assert_eq!(
+            address_to_persist(Some("203.0.113.7:8555"), "198.51.100.9:8555"),
+            Some("203.0.113.7:8555")
         );
     }
 }


### PR DESCRIPTION
Closes #629.

`nodes.public_address` held **one populated row in eight** on every production node — each node's
own. The challenger `/24` diversity draw reads that column, so it had a pool of one. The mechanism
exists to resist griefing by requiring distinct-subnet majorities; it cannot do that on a pool of
one, and the gate scoping it has been live since 959_161.

## Not a missing write — an active clobber, ~every 10 seconds

Three pieces, each correct alone:

1. `mesh.rs:3101` sends `public_address: String::new()` **deliberately** — S-7, don't broadcast IPs
   in cleartext ZMQ. `discovery_handler.rs:896` records that discovery is the designated path for
   pairing identities with addresses instead.
2. `health_handler.rs` nevertheless passed `Some(ping.public_address.as_str())` — post-S-7 always
   `Some("")`.
3. The upsert writes `public_address = COALESCE(?2, public_address)`. `COALESCE` returns its first
   **non-NULL** argument, and an empty string is not NULL — so it won, and the address discovery
   had learned was destroyed on every ping.

So a security fix silently disabled a different security mechanism, because the write path was not
updated to match.

Discovery never persists: `discovery_handler` only calls `peers.upsert_peer(...)`, so what it learns
lives in `PeerManager` and reaches no table. The only other writer is `main.rs:2697` — the node
registering **itself**, which is exactly why each database held one address.

## The change

The handler takes the address discovery observed (`peers.get_peer(...)`), falls back to the ping
only if it ever carries one again, and passes `None` when neither has anything so `COALESCE`
preserves what is stored. Nothing new is broadcast — S-7 is untouched.

The decision is a pure function (`address_to_persist`) because this crate has no DB-backed tests
and the security-relevant logic should be testable without one.

## Verification

- 3 tests, **mutation-checked**: restoring the old `Some(ping_address)` behaviour fails all three.
- Local gate green; **369** feature-gated consensus tests, up from 366 — exactly the three added.
- CI clippy (`--all-features -D warnings`) and rustdoc (`-D warnings`) both clean.

**Live on canary vm5**, which is what a unit test cannot show — whether `peers.get_peer()` actually
returns a populated address at that call site on a real mesh:

```
before:  8 rows, 1 with address
after:   8 rows, 8 with address        (~2 minutes after deploy)

46141044 → 5.22.219.246      (vm6)     849bcece → 85.9.198.212     (vm2)
4c8c2272 → 209.50.50.67      (vm8)     9fe860bd → 95.111.221.169   (vm4)
5867b555 → 94.237.102.192    (vm5)     e557c97a → 213.163.207.46   (vm3)
f0215f1f → 212.147.227.108   (vm7)     fb71fee8 → 83.136.251.162   (vm1)
```

Every address matches the fleet map. And the effect that matters:

```
assignment-pool candidates with an address:  1  ->  8
distinct /24 subnets:                        1  ->  8
```

## Scope

Does **not** change who counts as a challenger — that still needs the H-7 probe and a height gate
(#605). This only makes the column hold something worth probing, which is the ordering
populate → probe → gate.

## Noted, not fixed here

Peer rows carry the mesh port (`:8559`) while a node's own row carries a bare host. `ipv4_subnet_24`
parses the host before the colon so both derive the same `/24`, but the inconsistency is worth
tidying separately rather than in a fix that is already load-bearing.
