### PR TITLE
feat(verification): H-7 address probe — prove a node holds its key at the address it claims (#605)

### DIFF
--- a/crates/ghost-verification/src/address_proof.rs
+++ b/crates/ghost-verification/src/address_proof.rs
@@ -24,6 +24,7 @@
 //! blocked on `nodes.public_address` being populated at all — it currently holds one row in
 //! eight on every production node, so there is nothing to probe. See #629.
 
+use ghost_common::constants::HTTP_API_PORT;
 use ghost_common::identity::verify_signature;
 
 use crate::challenge::{HealthResponse, SignedResponse};
@@ -43,6 +44,48 @@ pub enum AddressProofFailure {
     NonceMismatch,
     /// Signature did not verify, or the response failed its freshness bounds.
     BadSignature,
+    /// Nothing could be reached at the claimed address, or the request was refused
+    /// before it was made (SSRF guard, unresolvable host, timeout).
+    ///
+    /// Deliberately distinct from every other variant: "I could not reach it" is not
+    /// evidence that the claimant lied, and must not be treated as such. A node that is
+    /// merely down would otherwise lose its subnet on the strength of a transient.
+    Unreachable,
+}
+
+/// The `/health` endpoint to probe for an address a node advertises.
+///
+/// A node's stored `public_address` carries whichever port it advertised — on this fleet
+/// that is the **mesh** port (`:8559`), and some rows carry no port at all. `/health` is on
+/// [`HTTP_API_PORT`]. Probing the stored value verbatim therefore fails for every peer:
+/// measured against a live node, `83.136.251.162:8559` gave `Unreachable` while
+/// `83.136.251.162:8080` verified.
+///
+/// That failure mode is worse than the bug this whole feature exists to fix — gating on a
+/// probe that can never succeed would exclude every subnet and collapse the challenger pool
+/// to zero, where today it is at least populated.
+///
+/// So the host is taken and the API port applied. IPv6 literals keep their brackets; a bare
+/// unbracketed IPv6 address is ambiguous (its colons are not a port separator) and is
+/// returned unchanged rather than silently truncated to nothing.
+pub(crate) fn health_endpoint_for(claimed_address: &str) -> String {
+    let trimmed = claimed_address.trim();
+
+    if let Some(rest) = trimmed.strip_prefix('[') {
+        // Bracketed IPv6, with or without a port: [::1] / [::1]:8559
+        if let Some((host, _)) = rest.split_once(']') {
+            return format!("[{}]:{}", host, HTTP_API_PORT);
+        }
+        return trimmed.to_string();
+    }
+
+    // More than one colon and no brackets: a bare IPv6 literal. Splitting would destroy it.
+    if trimmed.matches(':').count() > 1 {
+        return trimmed.to_string();
+    }
+
+    let host = trimmed.split(':').next().unwrap_or(trimmed);
+    format!("{}:{}", host, HTTP_API_PORT)
 }
 
 /// Verify a `/health?nonce=…` reply proves `expected_node_id` is reachable at the
@@ -216,5 +259,33 @@ mod tests {
             verify_address_proof("not json", &node.node_id_hex(), "n"),
             Err(AddressProofFailure::NotSigned)
         );
+    }
+
+    /// The stored address carries the MESH port; `/health` is on the API port. Probing the
+    /// stored value verbatim fails for every peer — measured live: `:8559` was Unreachable,
+    /// `:8080` verified. Gating on that would exclude every subnet.
+    #[test]
+    fn the_probe_endpoint_uses_the_api_port_not_the_advertised_one() {
+        assert_eq!(
+            health_endpoint_for("83.136.251.162:8559"),
+            "83.136.251.162:8080"
+        );
+        // Some rows carry no port at all (a node's own row is stored that way).
+        assert_eq!(health_endpoint_for("94.237.102.192"), "94.237.102.192:8080");
+        // Whitespace must not defeat it.
+        assert_eq!(health_endpoint_for("  1.2.3.4:9999 "), "1.2.3.4:8080");
+    }
+
+    /// IPv6 must not be silently truncated: splitting on the first colon would turn
+    /// `[::1]:8559` into an empty host and probe nothing.
+    #[test]
+    fn ipv6_survives_endpoint_normalisation() {
+        assert_eq!(
+            health_endpoint_for("[2001:db8::1]:8559"),
+            "[2001:db8::1]:8080"
+        );
+        assert_eq!(health_endpoint_for("[::1]"), "[::1]:8080");
+        // Bare unbracketed IPv6 is ambiguous — returned unchanged, never truncated.
+        assert_eq!(health_endpoint_for("2001:db8::1"), "2001:db8::1");
     }
 }

--- a/crates/ghost-verification/src/client.rs
+++ b/crates/ghost-verification/src/client.rs
@@ -1135,6 +1135,64 @@ impl VerificationClient {
 
         result
     }
+
+    /// H-7: prove a node holds its identity key at the address it CLAIMS.
+    ///
+    /// The `/24` used for challenger diversity is derived from `nodes.public_address`,
+    /// which a node advertises about itself. A bare reachability probe cannot close that:
+    /// connecting proves only that *something* answers there, and a node may advertise any
+    /// reachable third-party address. So this dials the claimed address and requires the
+    /// answer to be signed under `expected_node_id` over a nonce chosen here.
+    ///
+    /// The nonce is fresh per call, so a reply captured from an earlier probe cannot be
+    /// replayed — `SignedResponse` bounds freshness only to `MAX_RESPONSE_AGE_SECS`.
+    ///
+    /// `build_url` applies the SSRF guard (M-11) and the DNS-rebinding re-check (M-19),
+    /// which matter more here than anywhere else in this client: the host being dialled is
+    /// attacker-supplied by construction — it is precisely the value this function exists
+    /// to distrust.
+    ///
+    /// A failure to reach the address returns
+    /// [`crate::address_proof::AddressProofFailure::Unreachable`], which callers MUST NOT
+    /// treat as evidence of a lie. Down is not dishonest.
+    pub async fn probe_claimed_address(
+        &self,
+        claimed_address: &str,
+        expected_node_id: &str,
+    ) -> Result<(), crate::address_proof::AddressProofFailure> {
+        use crate::address_proof::{verify_address_proof, AddressProofFailure};
+
+        let mut nonce_bytes = [0u8; 16];
+        if getrandom::getrandom(&mut nonce_bytes).is_err() {
+            // No randomness means no binding, and an unbound probe is worse than none —
+            // it would accept a replay. Report unreachable rather than issue it.
+            warn!("H-7: no randomness for an address-proof nonce - skipping probe");
+            return Err(AddressProofFailure::Unreachable);
+        }
+        let nonce = hex::encode(nonce_bytes);
+
+        let url = self
+            .build_url(
+                &crate::address_proof::health_endpoint_for(claimed_address),
+                &format!("/health?nonce={}", nonce),
+            )
+            .map_err(|e| {
+                debug!(address = %claimed_address, error = %e, "H-7: refusing to probe address");
+                AddressProofFailure::Unreachable
+            })?;
+
+        let response = self.client.get(&url).send().await.map_err(|e| {
+            debug!(address = %claimed_address, error = %e, "H-7: address probe did not connect");
+            AddressProofFailure::Unreachable
+        })?;
+
+        let body = response.text().await.map_err(|e| {
+            debug!(address = %claimed_address, error = %e, "H-7: address probe body unreadable");
+            AddressProofFailure::Unreachable
+        })?;
+
+        verify_address_proof(&body, expected_node_id, &nonce)
+    }
 }
 
 /// Result of full verification suite
@@ -1639,5 +1697,32 @@ mod tests {
         // Should allow public IPs
         let result = client.build_url("93.184.216.34:8080", "/health");
         assert!(result.is_ok());
+    }
+
+    /// H-7: the address being probed is attacker-supplied by construction — it is the
+    /// value the probe exists to distrust. So the SSRF guard must apply to it, and a
+    /// refusal must surface as `Unreachable` rather than as evidence the node lied.
+    ///
+    /// Uses an internal address, which `build_url` refuses (M-11), so no request is made.
+    #[tokio::test]
+    async fn probing_an_internal_address_is_refused_as_unreachable() {
+        use crate::address_proof::AddressProofFailure;
+
+        let client = VerificationClient::with_config(VerificationClientConfig {
+            use_https: false,
+            timeout: std::time::Duration::from_millis(200),
+            danger_accept_invalid_certs: false,
+            is_mainnet: false,
+        })
+        .expect("client");
+
+        for addr in ["127.0.0.1:8080", "10.0.0.1:8080", "192.168.1.1:8080"] {
+            let got = client.probe_claimed_address(addr, &"ab".repeat(32)).await;
+            assert_eq!(
+                got,
+                Err(AddressProofFailure::Unreachable),
+                "{addr} must be refused as Unreachable, not treated as a failed proof"
+            );
+        }
     }
 }

--- a/crates/ghost-verification/src/task.rs
+++ b/crates/ghost-verification/src/task.rs
@@ -1244,6 +1244,12 @@ impl VerificationTask {
         let capabilities = health.capabilities;
         let timestamp = chrono::Utc::now().timestamp();
 
+        // H-7: prove the peer holds its key at the address its /24 is derived from.
+        // Rides this existing rotation rather than adding a fan-out, so the cost scales
+        // with NODES_TO_VERIFY_PER_ROUND, not with the square of the fleet (#605, #625).
+        self.probe_claimed_address_of(peer, &peer_id_hex, short_id)
+            .await;
+
         // Verify each claimed capability
         // CRIT-VER-3: Log DB errors but continue with other capabilities
         if capabilities.archive_mode {
@@ -1280,6 +1286,59 @@ impl VerificationTask {
             {
                 warn!(peer = %short_id, error = %e, "GhostPay verification DB error");
             }
+        }
+    }
+
+    /// H-7: probe the address this peer CLAIMS, and report whether it proved it.
+    ///
+    /// The address probed is `nodes.public_address` — the value the challenger `/24`
+    /// diversity draw is derived from — NOT `peer.http_address`, which is the address we
+    /// already reach it on. Probing the latter would prove nothing about the claim, which
+    /// is the whole point: a node may advertise a `/24` it does not occupy.
+    ///
+    /// Reports only. Nothing is gated on the outcome yet, deliberately: the freshness
+    /// window and the treatment of an unprobed subnet should be chosen from an observed
+    /// pass rate, not guessed. Logged at INFO so that rate is readable without a
+    /// log-level change on a production node.
+    async fn probe_claimed_address_of(
+        &self,
+        peer: &VerifiablePeer,
+        peer_id_hex: &str,
+        short_id: &str,
+    ) {
+        let claimed = match self.db.get_node(peer_id_hex) {
+            Ok(Some(node)) => node.public_address,
+            Ok(None) => None,
+            Err(e) => {
+                debug!(peer = %short_id, error = %e, "H-7: could not read claimed address");
+                return;
+            }
+        };
+
+        let Some(address) = claimed.filter(|a| !a.is_empty()) else {
+            // Before #629 this was every peer: the health ping overwrote the discovered
+            // address with an empty string on every ping.
+            debug!(peer = %short_id, "H-7: no claimed address recorded - nothing to probe");
+            return;
+        };
+
+        match self
+            .client
+            .probe_claimed_address(&address, peer_id_hex)
+            .await
+        {
+            Ok(()) => info!(
+                peer = %short_id,
+                address = %address,
+                "H-7 address proof PASSED - peer holds its key at the address it claims"
+            ),
+            Err(failure) => info!(
+                peer = %short_id,
+                address = %address,
+                failure = ?failure,
+                reachable_at = %peer.http_address,
+                "H-7 address proof did not pass"
+            ),
         }
     }
 


### PR DESCRIPTION
H-7 (#605): prove a node holds its identity key at the address it CLAIMS, so challenger `/24`
diversity rests on something verified rather than self-asserted.

**Reports only — nothing is gated.** That is the point of this PR: it produces the pass-rate data
the gate decision needs.

## Why a reachability probe is not enough

The `/24` used for diversity comes from `nodes.public_address`, which a node advertises about
itself. Connecting to it proves only that *something* answers there — a node can advertise any
reachable third-party address. What closes it is requiring whatever answers to prove it holds the
claimed node's key, over a nonce the prober chose.

## What is here

- `probe_claimed_address` — dials the claimed address, demands a `/health?nonce=` reply signed
  under the claimed node id, feeds it to `verify_address_proof` (merged in #628).
- Wired into `VerificationTask`'s existing per-peer flow. **No new fan-out**: cost scales with
  `NODES_TO_VERIFY_PER_ROUND` (3 per 300s), not the square of the fleet — the O(n²) concern from
  #625.
- `AddressProofFailure::Unreachable`, deliberately distinct. "I could not reach it" is not evidence
  the claimant lied, and a node that is merely down must not lose its subnet on a transient.

Probes `nodes.public_address`, **not** `peer.http_address` — the latter is the address we already
reach the peer on, so probing it would prove nothing about the claim.

`build_url` applies the SSRF guard (M-11) and the DNS-rebinding re-check (M-19). Those matter more
here than anywhere else in the client: the host being dialled is attacker-supplied by construction.

## The port problem, found by testing live

Stored `public_address` carries whatever the node advertised — on this fleet the **mesh** port
(`:8559`), and some rows carry none. `/health` is on `HTTP_API_PORT` (8080). Probing the stored
value verbatim fails for **every** peer. Measured before fixing:

```
83.136.251.162:8559  ->  Err(Unreachable)
83.136.251.162:8080  ->  Ok(())
```

Every unit test passed while that was true. Gating on a probe that can never succeed would have
excluded every subnet and collapsed the challenger pool to **zero** — strictly worse than the pool
of one #629 just fixed, and exactly the "looks scheduled, will not fire" failure #608 warns about.

`health_endpoint_for` takes the host and applies the API port. IPv6 literals keep their brackets; a
bare unbracketed IPv6 address is returned unchanged rather than truncated to nothing by a naive
split on the first colon.

## Verification

Live, against three real nodes using their **exact stored addresses**:

```
83.136.251.162:8559  (vm1) -> Ok(())
85.9.198.212:8559    (vm2) -> Ok(())
213.163.207.46:8559  (vm3) -> Ok(())
control: right address, WRONG node id -> Err(WrongSigner)
```

The control is the thesis: the probe distinguishes who **answers** from who **claimed**, which a
bare TCP connect cannot. Those live checks are not committed — they embed fleet addresses and
depend on the fleet being up.

Committed tests cover the SSRF refusal path and endpoint normalisation including IPv6. Full crate
suite green, CI clippy (`--all-features -D warnings`) and rustdoc (`-D warnings`) both clean.

## Deliberately not here

- **No gate.** The freshness window and the treatment of an unprobed subnet should follow an
  observed pass rate, not precede it.
- **No storage.** The gate will need per-probe history, but that table's shape should follow the
  numbers too.

Depends on #632 (already merged and rolled): before it, `nodes.public_address` held one row in
eight, so there was nothing to probe.
