### PR TITLE
fix(verification): H-7 probe must use the port matching its own scheme (#605)

### DIFF
--- a/crates/ghost-verification/src/address_proof.rs
+++ b/crates/ghost-verification/src/address_proof.rs
@@ -24,7 +24,6 @@
 //! blocked on `nodes.public_address` being populated at all — it currently holds one row in
 //! eight on every production node, so there is nothing to probe. See #629.
 
-use ghost_common::constants::HTTP_API_PORT;
 use ghost_common::identity::verify_signature;
 
 use crate::challenge::{HealthResponse, SignedResponse};
@@ -57,7 +56,7 @@ pub enum AddressProofFailure {
 ///
 /// A node's stored `public_address` carries whichever port it advertised — on this fleet
 /// that is the **mesh** port (`:8559`), and some rows carry no port at all. `/health` is on
-/// [`HTTP_API_PORT`]. Probing the stored value verbatim therefore fails for every peer:
+/// [`api_port`]. Probing the stored value verbatim therefore fails for every peer:
 /// measured against a live node, `83.136.251.162:8559` gave `Unreachable` while
 /// `83.136.251.162:8080` verified.
 ///
@@ -65,16 +64,29 @@ pub enum AddressProofFailure {
 /// probe that can never succeed would exclude every subnet and collapse the challenger pool
 /// to zero, where today it is at least populated.
 ///
-/// So the host is taken and the API port applied. IPv6 literals keep their brackets; a bare
-/// unbracketed IPv6 address is ambiguous (its colons are not a port separator) and is
-/// returned unchanged rather than silently truncated to nothing.
-pub(crate) fn health_endpoint_for(claimed_address: &str) -> String {
+/// So the host is taken and the caller's API port applied. The port is a PARAMETER rather
+/// than a constant because it depends on the scheme the client is configured for:
+/// `HTTP_API_PORT` (8080) serves plaintext, `VERIFICATION_HTTPS_PORT` (8443) serves TLS.
+/// Hardcoding 8080 while the production client runs with `use_https: true` builds
+/// `https://host:8080` — TLS against the plaintext port — which fails for every peer.
+/// Measured on the fleet:
+///
+/// ```text
+/// http://host:8080/health   -> 200
+/// https://host:8080/health  -> 000   (what the hardcoded version built)
+/// https://host:8443/health  -> signed response
+/// ```
+///
+/// IPv6 literals keep their brackets; a bare unbracketed IPv6 address is ambiguous (its
+/// colons are not a port separator) and is returned unchanged rather than silently
+/// truncated to nothing.
+pub(crate) fn health_endpoint_for(claimed_address: &str, api_port: u16) -> String {
     let trimmed = claimed_address.trim();
 
     if let Some(rest) = trimmed.strip_prefix('[') {
         // Bracketed IPv6, with or without a port: [::1] / [::1]:8559
         if let Some((host, _)) = rest.split_once(']') {
-            return format!("[{}]:{}", host, HTTP_API_PORT);
+            return format!("[{}]:{}", host, api_port);
         }
         return trimmed.to_string();
     }
@@ -85,7 +97,7 @@ pub(crate) fn health_endpoint_for(claimed_address: &str) -> String {
     }
 
     let host = trimmed.split(':').next().unwrap_or(trimmed);
-    format!("{}:{}", host, HTTP_API_PORT)
+    format!("{}:{}", host, api_port)
 }
 
 /// Verify a `/health?nonce=…` reply proves `expected_node_id` is reachable at the
@@ -267,13 +279,22 @@ mod tests {
     #[test]
     fn the_probe_endpoint_uses_the_api_port_not_the_advertised_one() {
         assert_eq!(
-            health_endpoint_for("83.136.251.162:8559"),
+            health_endpoint_for("83.136.251.162:8559", 8080),
             "83.136.251.162:8080"
         );
         // Some rows carry no port at all (a node's own row is stored that way).
-        assert_eq!(health_endpoint_for("94.237.102.192"), "94.237.102.192:8080");
+        assert_eq!(
+            health_endpoint_for("94.237.102.192", 8080),
+            "94.237.102.192:8080"
+        );
         // Whitespace must not defeat it.
-        assert_eq!(health_endpoint_for("  1.2.3.4:9999 "), "1.2.3.4:8080");
+        assert_eq!(health_endpoint_for("  1.2.3.4:9999 ", 8080), "1.2.3.4:8080");
+        // And an HTTPS client must get the TLS port. Hardcoding 8080 while the client
+        // speaks https built `https://host:8080` and made every probe Unreachable.
+        assert_eq!(
+            health_endpoint_for("83.136.251.162:8559", 8443),
+            "83.136.251.162:8443"
+        );
     }
 
     /// IPv6 must not be silently truncated: splitting on the first colon would turn
@@ -281,11 +302,11 @@ mod tests {
     #[test]
     fn ipv6_survives_endpoint_normalisation() {
         assert_eq!(
-            health_endpoint_for("[2001:db8::1]:8559"),
+            health_endpoint_for("[2001:db8::1]:8559", 8080),
             "[2001:db8::1]:8080"
         );
-        assert_eq!(health_endpoint_for("[::1]"), "[::1]:8080");
+        assert_eq!(health_endpoint_for("[::1]", 8080), "[::1]:8080");
         // Bare unbracketed IPv6 is ambiguous — returned unchanged, never truncated.
-        assert_eq!(health_endpoint_for("2001:db8::1"), "2001:db8::1");
+        assert_eq!(health_endpoint_for("2001:db8::1", 8080), "2001:db8::1");
     }
 }

--- a/crates/ghost-verification/src/client.rs
+++ b/crates/ghost-verification/src/client.rs
@@ -1136,6 +1136,19 @@ impl VerificationClient {
         result
     }
 
+    /// The API port matching this client's configured scheme.
+    ///
+    /// `HTTP_API_PORT` (8080) serves plaintext; `VERIFICATION_HTTPS_PORT` (8443) serves TLS.
+    /// They are not interchangeable: `https://host:8080` fails outright, which is what the
+    /// first version of the H-7 probe built on every peer because the port was hardcoded.
+    fn api_port(&self) -> u16 {
+        if self.config.use_https {
+            ghost_common::constants::VERIFICATION_HTTPS_PORT
+        } else {
+            ghost_common::constants::HTTP_API_PORT
+        }
+    }
+
     /// H-7: prove a node holds its identity key at the address it CLAIMS.
     ///
     /// The `/24` used for challenger diversity is derived from `nodes.public_address`,
@@ -1173,7 +1186,7 @@ impl VerificationClient {
 
         let url = self
             .build_url(
-                &crate::address_proof::health_endpoint_for(claimed_address),
+                &crate::address_proof::health_endpoint_for(claimed_address, self.api_port()),
                 &format!("/health?nonce={}", nonce),
             )
             .map_err(|e| {


### PR DESCRIPTION
Follow-up to #633. The H-7 probe fires correctly but every result was `Unreachable` on the canary.

## The bug

`health_endpoint_for` hardcoded `HTTP_API_PORT` (8080) while the production client runs
`use_https: true`, so it built `https://host:8080` — TLS against the plaintext port. The canary log
named its own cause:

```
address=212.147.227.108:8559 failure=Unreachable reachable_at=212.147.227.108:8443
```

Measured on the fleet:

```
http://host:8080/health   -> 200
https://host:8080/health  -> 000     <- what was being built
https://host:8443/health  -> signed response
```

The port is now a parameter supplied by `api_port()`: `VERIFICATION_HTTPS_PORT` (8443) when the
client speaks TLS, `HTTP_API_PORT` (8080) otherwise. The committed test asserts **both**, so the
coupling between scheme and port is pinned rather than implied.

## Why the pre-merge live test missed it

Worth recording, because "I tested it against real nodes" was true and still insufficient.

Before merging #633 I probed three real fleet nodes and got `Ok(())` from all three — using a
client I constructed with `use_https: false`. **That configuration does not exist on the fleet.**
The test proved the verifier and the transport while saying nothing about the endpoint.

The second attempt failed for a *third* reason: a plain `with_config` client does CA validation and
the nodes serve self-signed certificates. Production uses `VerificationClient::with_pinning` with a
`PubkeyAllowList` (`main.rs`: `new_with_identity_pinned`), so TLS is validated by pinning the
peer's key, not by a CA.

Re-verified with a client built the way production builds it — pinned, https, mainnet:

```
api_port() = 8443
83.136.251.162:8559 (vm1) -> Ok(())
85.9.198.212:8559   (vm2) -> Ok(())
213.163.207.46:8559 (vm3) -> Ok(())
control: right address, WRONG node id -> Err(WrongSigner)
```

Those live checks are not committed — they embed fleet addresses and need the fleet up.

## What contained it

The probe shipped **reporting-only**. A probe that could never succeed therefore cost nothing but
the log lines that exposed it. Had the gate been armed on this, it would have excluded every subnet
and collapsed the challenger pool to zero — strictly worse than the pool of one #629 fixed, and the
"looks scheduled, will not fire" failure #608 warns about.

## Checks

293 crate tests, CI clippy (`--all-features -D warnings`) 0, rustdoc workspace `--all-features`
`-D warnings` 0.
