### PR TITLE
fix(sv2): hold the reserved port so nothing can take it (#612)

### DIFF
--- a/tests/integration-sv2/lib/sniffer.rs
+++ b/tests/integration-sv2/lib/sniffer.rs
@@ -122,11 +122,9 @@ impl<'a> Sniffer<'a> {
         //
         // Invisible on a fast machine, wide open under `cargo llvm-cov` — which is where it
         // showed up as 5h38m in a single test against 22 minutes uninstrumented (#408).
-        let std_listener =
-            std::net::TcpListener::bind(listening_address).expect("Sniffer: cannot bind");
-        std_listener
-            .set_nonblocking(true)
-            .expect("Sniffer: cannot set nonblocking");
+        // Claim the reservation rather than binding directly: `get_available_address` holds
+        // the port from the moment it is chosen, so an independent bind here fails (#612).
+        let std_listener = crate::utils::claim_listener(listening_address);
 
         tokio::spawn(async move {
             let listener = tokio::net::TcpListener::from_std(std_listener)

--- a/tests/integration-sv2/lib/utils.rs
+++ b/tests/integration-sv2/lib/utils.rs
@@ -7,7 +7,7 @@ use crate::{
 use async_channel::{Receiver, Sender};
 use once_cell::sync::Lazy;
 use std::{
-    collections::HashSet,
+    collections::HashMap,
     convert::TryInto,
     net::{SocketAddr, TcpListener},
     sync::{Arc, Mutex},
@@ -34,28 +34,33 @@ use stratum_apps::{
     },
 };
 
-// prevents get_available_port from ever returning the same port twice
-static UNIQUE_PORTS: Lazy<Mutex<HashSet<u16>>> = Lazy::new(|| Mutex::new(HashSet::new()));
+/// Ports reserved by [`get_available_address`], still BOUND, awaiting [`bind_listener`].
+///
+/// The old approach bound `127.0.0.1:0`, read the port, and dropped the listener — releasing
+/// the port before anything re-bound it. Between release and re-bind any other process could
+/// take it, and `bind_listener` then panicked on `expect("Impossible to listen on given
+/// address")`. That is #612: three `mock_roles` tests failing intermittently under the full
+/// workspace run, blocking `record-tests.sh` and therefore deploys. `cargo llvm-cov` widens
+/// the window enough to make it frequent (#408).
+///
+/// De-duplicating the port numbers (the previous `UNIQUE_PORTS` set) could not fix this: it
+/// only stopped THIS process handing the same port out twice, and the port was still
+/// unbound in the interval.
+///
+/// Holding the listener removes the interval entirely — the port is never free between being
+/// chosen and being used, so nothing can take it.
+static RESERVED: Lazy<Mutex<HashMap<SocketAddr, TcpListener>>> =
+    Lazy::new(|| Mutex::new(HashMap::new()));
 
+/// Reserve a free loopback address, keeping it bound until [`bind_listener`] claims it.
 pub fn get_available_address() -> SocketAddr {
-    let port = get_available_port();
-    SocketAddr::from(([127, 0, 0, 1], port))
-}
-
-fn get_available_port() -> u16 {
-    let mut unique_ports = UNIQUE_PORTS.lock().unwrap();
-
-    loop {
-        let port = TcpListener::bind("127.0.0.1:0")
-            .unwrap()
-            .local_addr()
-            .unwrap()
-            .port();
-        if !unique_ports.contains(&port) {
-            unique_ports.insert(port);
-            return port;
-        }
-    }
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind an ephemeral port");
+    let addr = listener.local_addr().expect("read the bound address");
+    RESERVED
+        .lock()
+        .expect("reserved-port registry")
+        .insert(addr, listener);
+    addr
 }
 pub async fn wait_for_client(listen_socket: SocketAddr) -> tokio::net::TcpStream {
     accept_one(bind_listener(listen_socket).await).await
@@ -71,10 +76,37 @@ pub async fn wait_for_client(listen_socket: SocketAddr) -> tokio::net::TcpStream
 ///
 /// The window is invisible on a fast machine and wide under `cargo llvm-cov`, which is exactly
 /// where the hang showed up: 5h38m in one test under instrumentation, 22 minutes without.
+/// Claim the listener [`get_available_address`] reserved for `listen_socket`, or bind fresh.
+///
+/// EVERY path that listens on a reserved address must go through this. A caller that binds
+/// the address itself will now FAIL, because the reservation still holds the port — which is
+/// exactly what happened to `Sniffer::start`, whose own `std::net::TcpListener::bind` broke
+/// the moment reservations started being held.
+///
+/// Returned non-blocking, ready for `tokio::net::TcpListener::from_std`.
+pub fn claim_listener(listen_socket: SocketAddr) -> TcpListener {
+    let reserved = RESERVED
+        .lock()
+        .expect("reserved-port registry")
+        .remove(&listen_socket);
+
+    let listener = match reserved {
+        Some(l) => l,
+        // Not reserved — an address the caller chose. Bind it directly; this path still races
+        // with the rest of the machine, which is why callers should use
+        // `get_available_address`.
+        None => TcpListener::bind(listen_socket).expect("Impossible to listen on given address"),
+    };
+
+    listener
+        .set_nonblocking(true)
+        .expect("set the listener non-blocking");
+    listener
+}
+
 pub async fn bind_listener(listen_socket: SocketAddr) -> tokio::net::TcpListener {
-    tokio::net::TcpListener::bind(listen_socket)
-        .await
-        .expect("Impossible to listen on given address")
+    tokio::net::TcpListener::from_std(claim_listener(listen_socket))
+        .expect("adopt the reserved listener")
 }
 
 /// Accept a single connection from an already-bound listener.
@@ -535,5 +567,56 @@ pub mod fs_utils {
             }
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod reserved_port_tests {
+    use super::*;
+
+    /// #612: the port must NEVER be unbound between being chosen and being used.
+    ///
+    /// The old helper bound `127.0.0.1:0`, read the port and dropped the listener, so the port
+    /// sat free until `bind_listener` re-bound it. Anything on the machine could take it in
+    /// that window, and `bind_listener` panicked when it did.
+    ///
+    /// This asserts the invariant directly: right after reserving, the address is already
+    /// bound, so an independent bind FAILS. Against the old implementation this test fails —
+    /// the port was free and the bind would succeed.
+    #[test]
+    fn a_reserved_address_is_already_bound_so_nothing_can_take_it() {
+        let addr = get_available_address();
+        assert!(
+            TcpListener::bind(addr).is_err(),
+            "reserved address {addr} was free — the race window is open"
+        );
+    }
+
+    /// And the reservation must be usable: `bind_listener` adopts it rather than re-binding.
+    #[tokio::test]
+    async fn bind_listener_adopts_the_reservation() {
+        let addr = get_available_address();
+        let listener = bind_listener(addr).await;
+        assert_eq!(
+            listener.local_addr().expect("local addr"),
+            addr,
+            "bind_listener must serve the address that was reserved"
+        );
+    }
+
+    /// Two reservations never collide, and neither is released by the other.
+    #[test]
+    fn reservations_are_distinct_and_both_held() {
+        let a = get_available_address();
+        let b = get_available_address();
+        assert_ne!(a, b, "two reservations returned the same address");
+        assert!(
+            TcpListener::bind(a).is_err(),
+            "first reservation was released"
+        );
+        assert!(
+            TcpListener::bind(b).is_err(),
+            "second reservation was released"
+        );
     }
 }


### PR DESCRIPTION
Closes #612.

## The race

`get_available_address` bound `127.0.0.1:0`, read the port the kernel assigned, then **dropped the listener** and returned the address. Between that drop and the eventual bind the port was free, so anything on the machine could take it — and `bind_listener` panicked with `Impossible to listen on given address` when something did.

The existing `UNIQUE_PORTS` set could not help here. It only stopped *this process* from handing out the same number twice; it said nothing about whether the port was still free, because during the interval it genuinely was not reserved by anyone.

## The fix

Keep the reservation. `get_available_address` retains the `TcpListener` in a registry keyed by address, and `claim_listener` hands that exact listener to the caller. There is no window in which the port is unbound, so there is nothing to race.

## What the first attempt got wrong

Closing the race did not fix the tests — the same three still failed, but at `sniffer.rs:126` instead of `utils.rs:77`. `Sniffer::start` did its own `TcpListener::bind` rather than going through `bind_listener`, so holding the reservation broke it. Both paths now go through `claim_listener`.

Worth recording because of how it presented: the failure became **deterministic** before it became fixed — 3/3 runs rather than intermittent. A flaky failure turning consistent means the mechanism changed, not necessarily that it was repaired.

## Tests

Three, encoding the invariant rather than attempting to reproduce a race:

- after reserving, an independent `bind` on that address **must fail** — this is the property the old code lacked
- `bind_listener` adopts the reservation rather than rebinding
- two reservations are distinct and both held simultaneously

The first fails against the previous implementation, which is what makes it a regression guard rather than a description.

## Verification

Six consecutive runs of the previously flaky suite:

```
run 1..6: test result: ok. 23 passed; 0 failed; finished in ~12.0s
```

Before the fix the same suite consistently reported `20 passed; 3 failed`.

## Scope note

This does **not** unblock a deploy gate. Since `7138b83a3` (#580) `record-tests.sh` compiles the sv2 targets with `--no-run`, so these tests have not been running in the gate. The value is the other way round: they are compile-only partly because they could not be trusted to run, and this removes one reason for that.
