### PR TITLE
fix(solo): one fee model, local approval, one coinbase path (#592)

### DIFF
--- a/bins/ghost-pool/src/main.rs
+++ b/bins/ghost-pool/src/main.rs
@@ -7465,7 +7465,21 @@ async fn main() -> Result<()> {
         }
 
         // Broadcast the signed share proof to other nodes via P2P.
-        if let Err(e) = share_broadcast_tx.try_send(proof) {
+        //
+        // #592: never in solo mode. A solo node pays only its own operator and takes its own
+        // payout decision locally, so a share it broadcast would credit node rewards and enter
+        // peers' unpaid ledgers on the strength of work that no public round accounted for.
+        //
+        // This was previously safe only by accident — a solo node normally has no peers, so the
+        // broadcast went nowhere. That is a property of how solo happens to be deployed, not an
+        // invariant: `config/mainnet-solo.toml` says no seed nodes are *needed*, not that peers
+        // are forbidden. Suppress at the source so reachability cannot change the answer.
+        if rm_for_shares.is_solo_mode() {
+            tracing::trace!(
+                miner_id = %share.miner_id,
+                "Solo mode: share proof not broadcast (solo cannot touch the public ledger)"
+            );
+        } else if let Err(e) = share_broadcast_tx.try_send(proof) {
             tracing::warn!(error = %e, "Share broadcast channel full or closed");
         }
 

--- a/bins/ghost-pool/src/payout.rs
+++ b/bins/ghost-pool/src/payout.rs
@@ -687,10 +687,10 @@ pub struct BlockFoundData {
 
 /// Data for solo mining mode block found event
 ///
-/// In solo mode:
-/// - 99% of subsidy + ALL TX fees → solo_payout_address
-/// - 1% pool fee split between treasury and node pool per decay schedule
-/// - Hosting node participates in node reward pool
+/// Solo shares the single fee model with pool mode (#592); see
+/// [`ProposalCreator::create_solo_proposal`] for how the `COINBASE_FEE_SPLIT_HEIGHT` gate decides
+/// whether the 1% is levied on `subsidy + fees` or on the subsidy alone. The hosting node
+/// participates in the node reward pool in both regimes.
 #[derive(Debug, Clone)]
 pub struct SoloBlockFoundData {
     /// Round ID
@@ -708,7 +708,8 @@ pub struct SoloBlockFoundData {
     pub subsidy_sats: u64,
     /// PO4-M2: Treasury address snapshot taken at round start
     pub treasury_address_snapshot: Option<Vec<u8>>,
-    /// Transaction fees (satoshis) - ALL go to solo miner
+    /// Transaction fees (satoshis). Post-gate these are folded into the reward the 1% is levied
+    /// on and the remainder goes to the solo miner; pre-gate they go to the finder untouched.
     pub tx_fees_sats: u64,
     /// Node share distribution: (node_id, capability_shares)
     /// Hosting node is included in this list
@@ -1153,10 +1154,16 @@ impl PayoutProposalCreator {
 
     /// Create a solo mode payout proposal
     ///
-    /// Solo mode distribution:
-    /// - Solo miner: 99% of subsidy + ALL TX fees → solo_payout_address
-    /// - 1% pool fee → split between treasury and node pool per decay schedule
-    /// - Hosting node is included in node reward pool calculation
+    /// Solo uses the SAME fee model as pool mode (#592) — there is no solo-only regime. The split
+    /// follows the `COINBASE_FEE_SPLIT_HEIGHT` gate:
+    ///
+    /// - at/above the gate: 1% pool fee levied on `subsidy + fees`, solo miner keeps the other 99%
+    ///   of `subsidy + fees` → `solo_payout_address`
+    /// - below the gate (legacy): 1% levied on the subsidy alone, TX fees whole to the solo miner
+    ///
+    /// In both regimes the 1% is split treasury/node pool by the decay schedule, and the hosting
+    /// node is included in the node reward pool calculation. In solo the operator's own node *is*
+    /// the node pool, so that share returns to them — no special-casing is needed for it.
     pub fn create_solo_proposal(&self, data: SoloBlockFoundData) -> GhostResult<PayoutProposal> {
         // B-4/CFG-4/CFG-5: Validate block data (matching pool mode checks)
         self.validate_block_data(
@@ -1168,19 +1175,29 @@ impl PayoutProposalCreator {
 
         let now = chrono::Utc::now().timestamp() as u64;
 
-        // Calculate fee distribution using treasury decay schedule
-        // Note: In solo mode, TX fees are NOT included in pool fee calculation
-        // TX fees go 100% to solo miner, pool fee is only from subsidy
+        // #592: one fee model across all modes. This path used to pin the legacy regime — 1% levied
+        // on the subsidy alone, TX fees whole to the solo miner — by passing `0` fees to
+        // `FeeDistribution::calculate`. Above `COINBASE_FEE_SPLIT_HEIGHT` that disagrees with what
+        // every validator recomputes in `validate_proposal_split`, so a solo proposal was rejected
+        // even by a private mesh of the operator's own nodes. Derive the regime from the height
+        // exactly as the pool path does, so there is one split rule and no solo-only economics.
         // M-5 SECURITY: Use block_timestamp for deterministic decay calculation
-        let fee_dist = FeeDistribution::calculate(
+        let fee_split = data.block_height >= crate::coinbase_fee_split_height();
+        let fee_dist = FeeDistribution::calculate_at_height(
             data.subsidy_sats,
-            0, // TX fees not subject to pool fee in solo mode
+            data.tx_fees_sats,
             &data.treasury_state,
             data.block_timestamp,
+            fee_split,
         );
 
-        // Solo miner gets 99% of subsidy + ALL tx fees
-        let solo_miner_amount = fee_dist.miner_pool.saturating_add(data.tx_fees_sats);
+        // Post-gate the fees are already inside `miner_pool` (the 1% was levied on subsidy + fees)
+        // and `tx_fees_to_block_finder` is 0; pre-gate they sit outside it and go whole to the
+        // finder. Adding the field is therefore correct in both regimes without branching on the
+        // gate a second time.
+        let solo_miner_amount = fee_dist
+            .miner_pool
+            .saturating_add(fee_dist.tx_fees_to_block_finder);
 
         // H-01: Validate solo payout address before building payout entry
         self.validate_payout_address(data.solo_payout_address.as_bytes(), "solo miner")?;
@@ -4011,6 +4028,94 @@ mod tests {
             fee_dist.miner_pool as f64 / subsidy_sats as f64,
             0.99,
             "Miner should receive exactly 99% of subsidy"
+        );
+    }
+
+    /// Build solo block data at a chosen height. Everything except the height is fixed so the two
+    /// regimes below differ in exactly one input.
+    fn solo_data_at_height(block_height: u64) -> SoloBlockFoundData {
+        SoloBlockFoundData {
+            round_id: 7,
+            block_hash: [0xAB; 32],
+            block_height,
+            block_timestamp: chrono::Utc::now(),
+            // `ghost02_creator` is on Regtest, so the address must be too — `validate_payout_address`
+            // rejects a network mismatch before any fee arithmetic runs.
+            solo_payout_address: "bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080".to_string(),
+            subsidy_sats: 312_500_000,
+            treasury_address_snapshot: Some({
+                let mut addr = vec![0x51, 0x20];
+                addr.extend_from_slice(&[0xAA; 32]);
+                addr
+            }),
+            tx_fees_sats: 1_500_000,
+            node_shares: vec![([1u8; 32], 10)],
+            treasury_state: TreasuryState::new(),
+        }
+    }
+
+    /// #592: solo must use the SAME fee model as pool mode. This calls `create_solo_proposal` —
+    /// the two older `test_solo_mode_*` tests call `FeeDistribution::calculate` directly and then
+    /// recompute the solo sum in the test body, so they pass whatever the solo path does.
+    ///
+    /// Above the gate the 1% is levied on `subsidy + fees`. The previous implementation levied it
+    /// on the subsidy alone and added the fees whole, paying the solo miner 1% of the fees more
+    /// than every validator recomputes in `validate_proposal_split` — so this asserts the exact
+    /// figure rather than a bound.
+    #[test]
+    fn solo_uses_the_pool_fee_model_above_the_gate() {
+        let creator = ghost02_creator();
+        let data = solo_data_at_height(crate::coinbase_fee_split_height());
+
+        let subsidy = data.subsidy_sats;
+        let fees = data.tx_fees_sats;
+        let proposal = creator
+            .create_solo_proposal(data)
+            .expect("solo proposal at/above the gate");
+
+        // 1% of (312_500_000 + 1_500_000) = 3_140_000, so the miner keeps 310_860_000.
+        let total_reward = subsidy + fees;
+        let pool_fee = total_reward / 100;
+        assert_eq!(
+            proposal.miner_payouts[0].amount,
+            total_reward - pool_fee,
+            "solo miner must keep 99% of subsidy + fees above the gate"
+        );
+
+        // The pre-#592 figure, which must no longer be produced.
+        assert_ne!(
+            proposal.miner_payouts[0].amount,
+            (subsidy - subsidy / 100) + fees,
+            "solo must not levy the 1% on the subsidy alone above the gate"
+        );
+
+        // No satoshi may be created or lost across the whole coinbase.
+        let paid: u64 = proposal.miner_payouts.iter().map(|p| p.amount).sum::<u64>()
+            + proposal.node_payouts.iter().map(|p| p.amount).sum::<u64>()
+            + proposal.treasury_amount;
+        assert_eq!(
+            paid, total_reward,
+            "solo payouts must sum to subsidy + fees"
+        );
+    }
+
+    /// Below the gate the legacy regime is untouched: 1% on the subsidy alone, fees whole to the
+    /// finder. A mixed-version fleet must not split on coinbase construction.
+    #[test]
+    fn solo_keeps_the_legacy_model_below_the_gate() {
+        let creator = ghost02_creator();
+        let data = solo_data_at_height(crate::coinbase_fee_split_height() - 1);
+
+        let subsidy = data.subsidy_sats;
+        let fees = data.tx_fees_sats;
+        let proposal = creator
+            .create_solo_proposal(data)
+            .expect("solo proposal below the gate");
+
+        assert_eq!(
+            proposal.miner_payouts[0].amount,
+            (subsidy - subsidy / 100) + fees,
+            "below the gate the 1% is levied on the subsidy alone"
         );
     }
 

--- a/bins/ghost-pool/src/payout.rs
+++ b/bins/ghost-pool/src/payout.rs
@@ -688,7 +688,7 @@ pub struct BlockFoundData {
 /// Data for solo mining mode block found event
 ///
 /// Solo shares the single fee model with pool mode (#592); see
-/// [`ProposalCreator::create_solo_proposal`] for how the `COINBASE_FEE_SPLIT_HEIGHT` gate decides
+/// [`PayoutProposalCreator::create_solo_proposal`] for how the `COINBASE_FEE_SPLIT_HEIGHT` gate decides
 /// whether the 1% is levied on `subsidy + fees` or on the subsidy alone. The hosting node
 /// participates in the node reward pool in both regimes.
 #[derive(Debug, Clone)]
@@ -2270,37 +2270,35 @@ impl PayoutHandler {
         let proposal_hash = compute_proposal_hash(&proposal);
         proposal.proposal_hash = proposal_hash;
 
-        // Store proposal in template processor BEFORE submitting to consensus
+        // The proposal must be in the cache before it can be approved: `set_approved_payout`
+        // refuses a hash whose data it cannot find (MED-POOL-6).
         self.template_processor.store_proposal(proposal.clone());
 
-        // Submit to vote handler for BFT consensus
+        // #592: solo approves its own proposal instead of submitting it to BFT.
+        //
+        // A solo node has no mesh. The BFT pipeline requires `min_voters_for_bft`, which clamps to
+        // 4..=7, so a standalone node's proposal failed with `InsufficientVoters` every time — no
+        // coinbase commitment was ever approved, and `submitblock` then refused the block. Solo
+        // could not mine at all.
+        //
+        // There is nothing for consensus to protect here: solo contributes no shares to the public
+        // ledger and its coinbase pays only its own operator, so there is no other party whose
+        // funds a vote would be safeguarding. The proposal is built by the same
+        // `create_solo_proposal` under the same fee model as pool mode, and the coinbase is built
+        // from it by the same `build_coinbase_parts_with_payout_snapshot` — one construction path,
+        // no solo-specific economics.
+        //
+        // `set_approved_payout` also sets the M-28 coinbase commitment, which is what unblocks
+        // `submitblock`.
         info!(
             round_id = proposal.round_id,
             solo_payout = proposal.miner_payouts[0].amount,
             nodes = proposal.node_payouts.len(),
-            "Submitting solo mode payout proposal to consensus"
-        );
-
-        let returned_hash = self.vote_handler.handle_proposal(proposal)?;
-
-        // SECURITY: Verify hash matches - this catches implementation bugs where
-        // the vote handler modifies the proposal or computes the hash differently
-        if proposal_hash != returned_hash {
-            tracing::error!(
-                expected = %hex::encode(&proposal_hash[..8]),
-                actual = %hex::encode(&returned_hash[..8]),
-                "CRITICAL: Solo proposal hash mismatch between local computation and vote handler"
-            );
-            return Err(ghost_common::error::GhostError::HashMismatch {
-                expected: hex::encode(proposal_hash),
-                actual: hex::encode(returned_hash),
-            });
-        }
-
-        info!(
             hash = %hex::encode(&proposal_hash[..8]),
-            "Solo mode payout proposal submitted for voting"
+            "Solo mode: approving own payout proposal (no BFT — solo has no mesh)"
         );
+
+        self.template_processor.set_approved_payout(proposal_hash);
 
         Ok(proposal_hash)
     }

--- a/bins/ghost-pool/src/template.rs
+++ b/bins/ghost-pool/src/template.rs
@@ -153,7 +153,9 @@ pub struct TemplateConfig {
     /// Mining mode (PublicPool, PrivatePool, PrivateSolo)
     pub mining_mode: MiningMode,
     /// Solo payout address (required for PrivateSolo mode)
-    /// All rewards (99% subsidy + 100% tx fees) go to this address
+    ///
+    /// Solo uses the same fee model as pool mode (#592): above `COINBASE_FEE_SPLIT_HEIGHT` the 1%
+    /// pool fee is levied on `subsidy + fees` and this address receives the other 99%.
     pub solo_payout_address: Option<String>,
     /// Whether to enforce the finer per-field policy knobs during tx selection.
     ///
@@ -1477,205 +1479,6 @@ impl TemplateProcessor {
             outputs_serialized,
             outputs_count,
             adjusted_commitment,
-        ))
-    }
-
-    /// Build coinbase for solo mining mode
-    ///
-    /// Solo mode reward structure:
-    /// - Output 0: 99% subsidy + ALL TX fees → solo_payout_address
-    /// - Output 1: Treasury portion of 1% pool fee → treasury_address
-    /// - Output 2: Node pool portion of 1% pool fee → treasury_address (node pool)
-    /// - Output 3: Witness commitment (if SegWit)
-    ///
-    /// The 1% pool fee is split between treasury and node pool per decay schedule.
-    /// The hosting node participates in the node reward pool calculation.
-    ///
-    /// CRIT-10: Returns an error if any address is invalid.
-    /// This prevents creating blocks with unspendable outputs.
-    ///
-    /// Returns: (coinbase1, coinbase2, witness_data, outputs_serialized, outputs_count)
-    pub fn build_coinbase_solo_mode(
-        &self,
-        height: u64,
-        subsidy: u64,
-        tx_fees: u64,
-        treasury_amount: u64,
-        node_pool_amount: u64,
-        witness_commitment: &Option<String>,
-    ) -> Result<CoinbaseBuildResult, TemplateError> {
-        // Solo mode requires solo_payout_address to be configured
-        let solo_address = match self.config.solo_payout_address.as_ref() {
-            Some(addr) if !addr.is_empty() => addr,
-            _ => {
-                return Err(TemplateError::ConfigError(
-                    "solo_payout_address is required for solo mode".to_string(),
-                ));
-            }
-        };
-
-        // Calculate solo miner's share: 99% of subsidy + ALL tx fees
-        // The 1% pool fee (treasury_amount + node_pool_amount) comes from the caller
-        let miner_pool = subsidy
-            .saturating_sub(treasury_amount)
-            .saturating_sub(node_pool_amount);
-        let solo_miner_amount = miner_pool.saturating_add(tx_fees);
-
-        info!(
-            height = height,
-            subsidy = subsidy,
-            tx_fees = tx_fees,
-            solo_miner_amount = solo_miner_amount,
-            treasury = treasury_amount,
-            node_pool = node_pool_amount,
-            "Building solo mode coinbase"
-        );
-
-        // Build coinbase1 - NON-WITNESS format
-        let mut coinbase1 = Vec::new();
-
-        // Version (4 bytes, little-endian)
-        coinbase1.extend_from_slice(&2u32.to_le_bytes()); // Version 2 for BIP68
-
-        // Input count
-        coinbase1.push(0x01);
-
-        // Previous tx hash (all zeros for coinbase)
-        coinbase1.extend_from_slice(&[0u8; 32]);
-
-        // Previous output index (0xffffffff for coinbase)
-        coinbase1.extend_from_slice(&0xffffffffu32.to_le_bytes());
-
-        // Script sig: height then the pool tag. No payout commitment — this path builds no
-        // settleable payout. See coinbase_scriptsig.
-        let scriptsig = self.coinbase_scriptsig(height, None, 8)?;
-        coinbase1.push((scriptsig.len() + 8) as u8); // +8 for extranonce space
-        coinbase1.extend_from_slice(&scriptsig);
-
-        // Coinbase2: extranonce end + sequence + outputs + locktime
-        let mut coinbase2 = Vec::new();
-
-        // Sequence
-        coinbase2.extend_from_slice(&0xffffffffu32.to_le_bytes());
-
-        // Track witness commitment for WitnessData
-        let mut witness_data = WitnessData::default();
-
-        // Track serialized outputs for TDP
-        let mut outputs_serialized = Vec::new();
-
-        // Count outputs: solo miner + treasury (if > 0) + node pool (if > 0) + witness commitment
-        let mut output_count = 1; // solo miner always present
-        if treasury_amount > 0 {
-            output_count += 1;
-        }
-        if node_pool_amount > 0 {
-            output_count += 1;
-        }
-        if witness_commitment.is_some() {
-            output_count += 1;
-        }
-
-        self.encode_varint(&mut coinbase2, output_count);
-
-        // Output 0: Solo miner (99% subsidy + ALL tx fees)
-        // CRIT-10: Validate address and fail if invalid
-        coinbase2.extend_from_slice(&solo_miner_amount.to_le_bytes());
-        self.encode_address_script(&mut coinbase2, solo_address, "solo_miner")?;
-        outputs_serialized.extend_from_slice(&solo_miner_amount.to_le_bytes());
-        self.encode_address_script(&mut outputs_serialized, solo_address, "solo_miner_tdp")?;
-
-        // Output 1: Treasury (portion of 1% pool fee per decay schedule)
-        // CRIT-10: Validate treasury address and fail if invalid
-        // H-BTC-4: No silent fallbacks - require valid treasury address when amount > 0
-        if treasury_amount > 0 {
-            // H-BTC-4: Validate address BEFORE adding amount to buffer
-            if self.config.treasury_address.is_empty() {
-                error!(
-                    treasury_amount = treasury_amount,
-                    "H-BTC-4 SECURITY: Treasury amount specified ({} sats) but no treasury address configured. \
-                     This would create an unspendable output!",
-                    treasury_amount
-                );
-                return Err(TemplateError::ConfigError(format!(
-                    "H-BTC-4: Treasury amount {} sats specified but treasury_address is empty",
-                    treasury_amount
-                )));
-            }
-            let treasury_addr = self.config.treasury_address.address();
-            coinbase2.extend_from_slice(&treasury_amount.to_le_bytes());
-            self.encode_address_script(&mut coinbase2, treasury_addr, "treasury")?;
-            outputs_serialized.extend_from_slice(&treasury_amount.to_le_bytes());
-            self.encode_address_script(&mut outputs_serialized, treasury_addr, "treasury_tdp")?;
-        }
-
-        // Output 2: Node pool (portion of 1% pool fee per decay schedule)
-        // In solo mode, this typically goes to the hosting node (operator)
-        // For simplicity, we use treasury address as the destination (can be separate)
-        // CRIT-10: Validate node_pool address and fail if invalid
-        // H-BTC-4: No silent fallbacks - require valid address when amount > 0
-        if node_pool_amount > 0 {
-            // H-BTC-4: Validate address BEFORE adding amount to buffer
-            if self.config.treasury_address.is_empty() {
-                error!(
-                    node_pool_amount = node_pool_amount,
-                    "H-BTC-4 SECURITY: Node pool amount specified ({} sats) but no treasury address configured. \
-                     This would create an unspendable output!",
-                    node_pool_amount
-                );
-                return Err(TemplateError::ConfigError(format!(
-                    "H-BTC-4: Node pool amount {} sats specified but treasury_address is empty",
-                    node_pool_amount
-                )));
-            }
-            let treasury_addr = self.config.treasury_address.address();
-            coinbase2.extend_from_slice(&node_pool_amount.to_le_bytes());
-            self.encode_address_script(&mut coinbase2, treasury_addr, "node_pool")?;
-            outputs_serialized.extend_from_slice(&node_pool_amount.to_le_bytes());
-            self.encode_address_script(&mut outputs_serialized, treasury_addr, "node_pool_tdp")?;
-        }
-
-        // Output 3: Witness commitment (0-value OP_RETURN)
-        if let Some(commitment) = witness_commitment {
-            let commitment_bytes = hex::decode(commitment).map_err(|e| {
-                TemplateError::BlockAssemblyError(format!("Invalid witness commitment hex: {}", e))
-            })?;
-
-            if !validate_witness_commitment_script(&commitment_bytes) {
-                return Err(TemplateError::BlockAssemblyError(
-                    "Invalid witness commitment script structure".to_string(),
-                ));
-            }
-
-            coinbase2.extend_from_slice(&0u64.to_le_bytes()); // 0 value
-                                                              // L-10: Validate commitment length before casting to u8
-            if commitment_bytes.len() > 255 {
-                return Err(TemplateError::BlockAssemblyError(format!(
-                    "L-10: Witness commitment script too long: {} bytes (max 255)",
-                    commitment_bytes.len()
-                )));
-            }
-            coinbase2.push(commitment_bytes.len() as u8);
-            coinbase2.extend_from_slice(&commitment_bytes);
-            witness_data.commitment_script = Some(commitment_bytes.clone());
-            outputs_serialized.extend_from_slice(&0u64.to_le_bytes());
-            outputs_serialized.push(commitment_bytes.len() as u8);
-            outputs_serialized.extend_from_slice(&commitment_bytes);
-        }
-
-        // Locktime
-        coinbase2.extend_from_slice(&0u32.to_le_bytes());
-
-        // Witness nonce
-        witness_data.nonce = [0u8; 32];
-
-        Ok((
-            coinbase1,
-            coinbase2,
-            witness_data,
-            outputs_serialized,
-            output_count as u32,
-            None, // Solo mode has no payout proposal commitment
         ))
     }
 
@@ -3795,6 +3598,92 @@ mod tests {
         // coinbase2 should end with locktime (4 bytes), NOT witness data
         let len = coinbase2.len();
         assert_eq!(&coinbase2[len - 4..], &[0x00, 0x00, 0x00, 0x00]); // locktime = 0
+    }
+
+    /// #592: a solo node has no mesh, cannot reach `min_voters_for_bft`, and so approves its own
+    /// payout proposal locally instead of submitting it to BFT.
+    ///
+    /// This pins the property that made deleting `build_coinbase_solo_mode` safe: the ordinary
+    /// proposal-driven coinbase path serves a solo proposal with no solo-specific branch, and
+    /// produces the M-28 coinbase commitment. The deleted builder returned `None` for that
+    /// commitment — which is exactly why `submitblock` refused solo blocks.
+    #[test]
+    fn solo_proposal_builds_a_coinbase_through_the_shared_path() {
+        use ghost_common::types::PayoutEntry;
+
+        const SOLO_ADDR: &str = "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4";
+
+        let rpc = Arc::new(BitcoinRpc::new("127.0.0.1", 8332, "user", "pass").unwrap());
+        let processor = TemplateProcessor::new(
+            TemplateConfig {
+                pool_payout_address: SOLO_ADDR.to_string(),
+                mining_mode: MiningMode::PrivateSolo,
+                solo_payout_address: Some(SOLO_ADDR.to_string()),
+                ..Default::default()
+            },
+            rpc,
+            PolicyProfile::permissive(),
+            ReaperConfig::default(),
+        );
+
+        // Shaped exactly as `create_solo_proposal` builds one: a single Mining entry to the solo
+        // address, plus the 1% split into treasury and node pool.
+        let subsidy: u64 = 312_500_000;
+        let fees: u64 = 1_500_000;
+        let pool_fee = (subsidy + fees) / 100;
+        let solo_amount = (subsidy + fees) - pool_fee;
+        let treasury_amount = pool_fee / 2;
+        let node_amount = pool_fee - treasury_amount;
+
+        let proposal_hash = [0x5Au8; 32];
+        let proposal = PayoutProposal {
+            proposal_hash,
+            round_id: 1,
+            block_hash: [0xAB; 32],
+            block_height: 800_000,
+            proposer: [0x11; 32],
+            miner_payouts: vec![PayoutEntry {
+                address: SOLO_ADDR.as_bytes().to_vec(),
+                amount: solo_amount,
+                recipient_id: [0x22; 32],
+                payout_type: PayoutType::Mining,
+            }],
+            node_payouts: vec![PayoutEntry {
+                address: SOLO_ADDR.as_bytes().to_vec(),
+                amount: node_amount,
+                recipient_id: [0x33; 32],
+                payout_type: PayoutType::NodeReward,
+            }],
+            treasury_amount,
+            treasury_address: SOLO_ADDR.as_bytes().to_vec(),
+            tx_fees: fees,
+            subsidy,
+            timestamp: 0,
+            tx_fees_unallocated: 0,
+        };
+
+        // The solo path stores then approves locally — no vote handler involved.
+        processor.store_proposal(proposal);
+        processor.set_approved_payout(proposal_hash);
+
+        let (_c1, _c2, _witness, _outputs, outputs_count, commitment) = processor
+            .build_coinbase_parts_with_payout_snapshot(
+                800_000,
+                subsidy + fees,
+                &None,
+                Some(proposal_hash),
+            )
+            .expect("solo proposal must build a coinbase through the shared path");
+
+        assert!(
+            commitment.is_some(),
+            "solo must produce the M-28 coinbase commitment that submitblock requires — \
+             the deleted solo builder returned None here"
+        );
+        assert!(
+            outputs_count >= 2,
+            "expected at least the solo miner and treasury outputs, got {outputs_count}"
+        );
     }
 
     /// SEC-BLOCK-TEST-1: Test that header validation correctly rejects short headers


### PR DESCRIPTION
Closes #592.

`MiningMode::PrivateSolo` was config-complete and structurally non-functional. All three blockers are addressed.

## Blocker 2 — one fee model (commit 1)

`create_solo_proposal` pinned the **legacy** regime by passing `0` transaction fees to `FeeDistribution::calculate`, levying the 1% pool fee on the subsidy alone and adding the fees back whole.

Above `COINBASE_FEE_SPLIT_HEIGHT` the 1% is levied on `subsidy + fees`, and that is what every validator recomputes in `validate_proposal_split`. Solo therefore paid its miner 1% of the transaction fees more than the recompute expects — so a solo proposal was rejected **even by a private mesh of the operator's own nodes**.

The regime is now derived from the block height exactly as the pool path does. The miner's amount is `miner_pool + tx_fees_to_block_finder`, which is correct in both regimes without branching on the gate a second time. The legacy path below the gate is untouched, so a mixed-version fleet cannot split on coinbase construction.

## Blocker 1 — solo approves its own proposal (commit 2)

`handle_solo_block_found` submitted to `vote_handler.handle_proposal`, which requires `min_voters_for_bft` (clamped to 4..=7). A standalone solo node has no mesh, so every proposal failed with `InsufficientVoters`, no coinbase commitment was approved, and `submitblock` refused the block.

Nothing was being protected by that vote: solo contributes no shares to the public ledger and its coinbase pays only its own operator, so no other party's funds are at stake. It now calls `set_approved_payout` directly — which also sets the M-28 coinbase commitment that unblocks `submitblock`.

## Blocker 3 — `build_coinbase_solo_mode` deleted, not wired up (commit 2)

The recorded resolution (2026-07-31) said to wire it up. **The operator confirmed the change of approach after this PR's findings.**

The proposal-driven path already serves solo unchanged. `build_coinbase_parts_with_payout_snapshot` reads `miner_payouts`, `node_payouts` and `treasury_amount` off the proposal with **no mining-mode branch anywhere in it**, and `handle_solo_block_found` already stored the proposal before submitting it. Only the approval was missing.

Wiring up a second 199-line builder would have recreated, in the coinbase layer, exactly the divergence that caused blocker 2 in the payout layer — and the issue's own resolution gives the reason: *"divergent fee paths are where consensus bugs breed."* In the coinbase layer a divergence produces an **invalid block**, not merely a wrong payout.

Its closing `None` for the commitment was itself the bug — that is precisely the value `submitblock` rejects.

## Ledger isolation (commit 2)

The issue asked to *confirm* solo suppresses `ShareProof` broadcast. It did not — the broadcast was **unconditional**.

Solo takes its payout decision locally and pays only itself, so a share it broadcast would credit node rewards and enter peers' unpaid ledgers on work no public round accounted for. This was safe only because a solo node usually has no peers, which is a property of how solo happens to be deployed rather than an invariant: `config/mainnet-solo.toml` says no seed nodes are *needed*, not that peers are forbidden. Now suppressed at the source, so reachability cannot change the answer.

## Tests

Three new, all mutation-verified:

| test | mutant killed |
|---|---|
| `solo_uses_the_pool_fee_model_above_the_gate` | `fee_split = false` |
| `solo_keeps_the_legacy_model_below_the_gate` | `fee_split = true` |
| `solo_proposal_builds_a_coinbase_through_the_shared_path` | `payout_snapshot = None` |

The three existing `test_solo_mode_*` tests give **zero** coverage of any of this — they call `FeeDistribution::calculate` directly and recompute the solo sum in the test body, so they pass whatever the solo path does. Confirmed by mutation: all three stay green under both `fee_split` mutants.

`cargo test -p ghost-pool --lib`: 379 passed, 0 failed. fmt, clippy and workspace rustdoc (`-D warnings`, CI exclusions) all clean.

## What is not proven

No solo node has mined and submitted a block on a real chain. This is correct by construction and **unexercised end to end** — the remaining work on #592 is an actual mainnet or signet solo block, not more code.
