### PR TITLE
fix(ci): derive record-tests clippy from the workflow so it cannot drift (#626)

### DIFF
--- a/scripts/ci-clippy-args.sh
+++ b/scripts/ci-clippy-args.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+#
+# Print the EXACT clippy arguments the CI lint job runs, extracted from the workflow.
+#
+# `scripts/record-tests.sh` writes the `tested-` marker that `deploy-node.sh` requires, so a
+# green local gate is treated as "this commit is deployable". It used to run its own, weaker
+# clippy invocation (#626):
+#
+#     record-tests.sh   cargo clippy --workspace $EXCLUDES --all-targets
+#     ci.yml            cargo clippy $WORKSPACE_EXCLUDES --all-targets --all-features \
+#                         -- -D warnings -A clippy::derivable_impls ... (six allows)
+#
+# Two consequences. Without `--all-features`, feature-gated code — `zk-consensus`,
+# `mpc-ceremony`, `zk-production`, and there is a lot of it — was never linted locally.
+# Without `-D warnings`, clippy exits 0 on warnings, so the gate recorded success on a commit
+# CI would then reject. A commit could pass the deploy gate and turn main red.
+#
+# ## Why this parses the workflow instead of copying the flags
+#
+# Copying them creates two lists that must be kept in step by hand, and the whole defect in
+# #626 is that they drifted. Deriving the local gate FROM the workflow makes drift impossible
+# rather than merely detectable: change `ci.yml` and the local gate changes with it.
+#
+# The workflow is parsed with a real YAML loader, not grep. A `run:` written as a plain scalar
+# is folded onto one line and grep-based extraction of a multi-line command silently returns a
+# fragment — the same class of bug as the eaten line-continuations in
+# `check-workflow-scalars.sh` (#428).
+#
+# ## Failure is loud, never silent
+#
+# If the clippy step cannot be found, this exits non-zero and prints nothing. The caller MUST
+# treat that as a gate failure. Falling back to a hardcoded default is exactly how the local
+# gate came to disagree with CI in the first place: a silent fallback is indistinguishable from
+# agreement.
+#
+# Usage:
+#   scripts/ci-clippy-args.sh            # prints the argument string, exit 0
+#   eval "cargo clippy $(scripts/ci-clippy-args.sh)"
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+python3 - "$REPO_ROOT" <<'PY'
+import sys, os, glob
+
+try:
+    import yaml
+except ImportError:
+    sys.stderr.write("ci-clippy-args: PyYAML not installed — cannot verify the local gate "
+                     "matches CI. Install it rather than guessing the flags.\n")
+    sys.exit(2)
+
+root = sys.argv[1]
+
+# The env block carries WORKSPACE_EXCLUDES; the clippy command references it. Resolve the
+# reference rather than assuming its value, so an exclusion added in CI reaches the local gate.
+def expand(cmd, env):
+    for k, v in env.items():
+        cmd = cmd.replace("$" + k, str(v)).replace("${" + k + "}", str(v))
+    return cmd
+
+found = []
+for path in sorted(glob.glob(os.path.join(root, ".github/workflows/*.yml")) +
+                   glob.glob(os.path.join(root, ".github/workflows/*.yaml"))):
+    try:
+        with open(path) as fh:
+            doc = yaml.safe_load(fh)
+    except (yaml.YAMLError, OSError) as e:
+        sys.stderr.write(f"ci-clippy-args: cannot parse {path}: {e}\n")
+        sys.exit(2)
+    if not isinstance(doc, dict):
+        continue
+    top_env = doc.get("env") or {}
+    for _job_name, job in (doc.get("jobs") or {}).items():
+        if not isinstance(job, dict):
+            continue
+        env = {**top_env, **(job.get("env") or {})}
+        for step in (job.get("steps") or []):
+            if not isinstance(step, dict):
+                continue
+            run = step.get("run")
+            if not isinstance(run, str):
+                continue
+            step_env = {**env, **(step.get("env") or {})}
+            for line in run.splitlines():
+                s = line.strip()
+                # Only a real clippy invocation, not a comment mentioning one.
+                if s.startswith("cargo clippy ") or s == "cargo clippy":
+                    found.append((path, expand(s, step_env)))
+
+if not found:
+    sys.stderr.write("ci-clippy-args: no `cargo clippy` step found in .github/workflows. "
+                     "The local gate cannot be derived from CI — refusing to guess.\n")
+    sys.exit(1)
+
+# More than one would mean the local gate has to choose, and choosing wrongly is the bug this
+# exists to prevent. Make the ambiguity visible instead.
+if len({cmd for _p, cmd in found}) > 1:
+    sys.stderr.write("ci-clippy-args: multiple DIFFERENT clippy invocations in CI:\n")
+    for p, cmd in found:
+        sys.stderr.write(f"  {os.path.relpath(p, root)}: {cmd}\n")
+    sys.stderr.write("Resolve which one gates a deploy, or teach this script to pick.\n")
+    sys.exit(1)
+
+cmd = found[0][1]
+args = cmd[len("cargo clippy"):].strip()
+if not args:
+    sys.stderr.write("ci-clippy-args: clippy step has no arguments — refusing to proceed.\n")
+    sys.exit(1)
+print(args)
+PY

--- a/scripts/record-tests.sh
+++ b/scripts/record-tests.sh
@@ -93,7 +93,31 @@ run_gate() {
     echo "$out"
 }
 
-run_gate clippy cargo clippy --workspace $EXCLUDES --all-targets >/dev/null
+# #626: run clippy EXACTLY as CI runs it, by extracting the invocation from the workflow
+# rather than restating it here. This gate used to run
+#
+#     cargo clippy --workspace $EXCLUDES --all-targets
+#
+# against CI's
+#
+#     cargo clippy $WORKSPACE_EXCLUDES --all-targets --all-features -- -D warnings -A ...
+#
+# so feature-gated code (`zk-consensus`, `mpc-ceremony`, `zk-production`) was never linted
+# locally, and without `-D warnings` clippy exited 0 on warnings — `run_gate` recorded success
+# on a commit CI would reject, and the deploy gate passed it as tested.
+#
+# Deriving the flags makes drift impossible rather than merely detectable. If they cannot be
+# derived we FAIL: a hardcoded fallback would be indistinguishable from agreement, which is
+# how the two came apart in the first place.
+CI_CLIPPY_ARGS="$(scripts/ci-clippy-args.sh)" || {
+    echo "FAILED: cannot derive clippy flags from .github/workflows — refusing to record a \
+marker that claims CI-equivalence" >&2
+    exit 1
+}
+echo "==> clippy (exactly as CI runs it: $CI_CLIPPY_ARGS)"
+# Deliberate word-splitting: $CI_CLIPPY_ARGS is a flag list, not one argument.
+# shellcheck disable=SC2086
+run_gate clippy cargo clippy $CI_CLIPPY_ARGS >/dev/null
 run_gate "check (all targets, all features)" \
     cargo check --workspace $EXCLUDES --all-targets --all-features >/dev/null
 


### PR DESCRIPTION
Closes #626.

`record-tests.sh` writes the `tested-` marker that `deploy-node.sh` requires, so a green local gate is treated as *"this commit is deployable"*. Its clippy run was weaker than CI's:

```
record-tests.sh   cargo clippy --workspace $EXCLUDES --all-targets
ci.yml:93         cargo clippy $WORKSPACE_EXCLUDES --all-targets --all-features \
                    -- -D warnings -A clippy::derivable_impls ... (six allows)
```

## Demonstrated, not argued

With a `len_zero` warning introduced in `ghost-consensus`:

| invocation | clippy exit | `run_gate`'s `^error` grep | verdict |
|---|---|---|---|
| **old** (what the gate ran) | **0** | 0 matches | ✅ **records "tested"** |
| **new** (CI-exact) | **101** | — | ❌ fails |

**Both** of `run_gate`'s checks passed on the old invocation — the exit status *and* the `^error` grep — because without `-D warnings` a clippy warning is not an error and not a failure. So the deploy gate marked a commit deployable that CI would then reject.

## Why it derives instead of copying

Restating the flags here is what produced the drift. Deriving them from `ci.yml` makes drift **impossible** rather than merely detectable: change the workflow and the local gate changes with it. `WORKSPACE_EXCLUDES` is resolved from the workflow's `env` as well, so an exclusion added in CI reaches the local gate without anyone remembering to mirror it.

`scripts/ci-clippy-args.sh` parses the workflow with a real YAML loader rather than grep. A `run:` written as a plain scalar is folded onto one line, and grep-based extraction of a multi-line command silently returns a fragment — the same class of bug as the eaten line-continuations that kept Coverage red for six commits (#428, guarded by `check-workflow-scalars.sh`).

It **refuses rather than guesses** when the step is missing, unparseable, or ambiguous (more than one differing `cargo clippy` in the workflows), and `record-tests.sh` treats that refusal as a gate failure. A silent fallback to hardcoded flags would be indistinguishable from agreement — which is precisely how the two came apart.

## Scope

- The CI-exact invocation **passes clean on this tree**. The only output is the `proc-macro-error2` future-incompat note, which `ci.yml` documents as deliberately out of scope (it arrives via `ghost-cli -> tabled -> tabled_derive` and needs an upstream fix).
- This proves the **`-D warnings`** half. My probe sat in a feature-gated module, but that module is compiled anyway through another crate's feature selection, so the `--all-features` half is fixed here and not independently demonstrated.
- No production code changes; tooling only.

## Why now

Tomorrow's `PAYOUT_MEDIAN_ADOPTION` gate deploy depends on a `tested-` marker from this script. It will now be a marker that means what it claims.
