### PR TITLE
feat(shares): arm the difficulty-tier commitment at 962_100

### DIFF
--- a/bins/ghost-pool/src/lib.rs
+++ b/bins/ghost-pool/src/lib.rs
@@ -312,14 +312,31 @@ pub const SHARE_POW_VERIFY_HEIGHT: u64 = 959_030;
 /// rejected (`missing_tier`). No JD client exists on the fleet today; resolve before arming if
 /// one does. (The old direct-SV1 path in ghost-pool is gone — SRI is the only mining path.)
 ///
-/// A concrete height is set only once fleet-wide convergence is proven, like the rest. Arming
-/// checklist, in addition: finalise `MIN_DIFFICULTY_TIER_LOG2` against the then-current vardiff
-/// floor AND update the duplicated floor constant in `translator-sv2::difficulty_manager` (that
-/// crate cannot link ghost-common); in ONE release ship the translator with
-/// `quantise_to_tiers = true` AND pool_sv2 with `[share_tier_binding]` (`node_id` = this node's
-/// identity, `activation_height` = this constant's value); verify on the roll that
-/// `missing_tier`/`tier_credit_mismatch` stay zero.
-pub const SHARE_TIER_BIND_HEIGHT: u64 = u64::MAX;
+/// **ARMED at 962_100.**
+///
+/// Chosen with margin rather than economy: the fleet was at ~961_983 and running ~7 min/block, so
+/// this is ~13 hours out against a roll that takes ~4 (CI, build, canary, a 60-minute soak, then
+/// eight nodes). `SHARE_POW_VERIFY_HEIGHT` was armed with an 8-block margin; that is not a
+/// precedent worth repeating for a gate that changes what work is WORTH.
+///
+/// Every node must carry this build before the height. A node still running an older binary has
+/// `u64::MAX` here and never arms, so a partial roll means the fleet disagrees about credited work
+/// — divergent coinbase splits, GHOST-02 rejections between peers — until the last node lands.
+/// There is no canary for the armed behaviour itself: a height gate flips everywhere at the same
+/// block by construction, so the canary proves the BINARY and the height proves the RULE.
+///
+/// The other two halves ship in this same release: the translator with `quantise_to_tiers = true`,
+/// and `pool_sv2` with `[share_tier_binding] activation_height = 962100`. The identity half is no
+/// longer transcribed — `pool_sv2` reads it from this process's `/health`, so the tags it stamps
+/// and the tags this process verifies cannot disagree.
+///
+/// KNOWN LIMIT carried into arming: `MIN_DIFFICULTY_TIER_LOG2` (10) stays coupled to the vardiff
+/// floor with nothing enforcing it. Verified at arming: the fleet's smallest assigned difficulty is
+/// 2_328 (1 TH/s assumed floor, `shares_per_minute` 6.0), quantising to tier 11 — a full tier above
+/// the floor, so quantisation only ever moves difficulty DOWN, which is the safe direction.
+///
+/// On the roll, watch `missing_tier` and `tier_credit_mismatch`: both must stay zero.
+pub const SHARE_TIER_BIND_HEIGHT: u64 = 962_100;
 
 /// Bind the miner's payout address into the GHOST-09 share signature.
 ///
@@ -882,29 +899,51 @@ mod in_dns_tests {
 
 #[cfg(test)]
 mod tier_gate_tests {
-    use super::{binds_difficulty_tier, share_tier_bind_height, SHARE_TIER_BIND_HEIGHT};
+    use super::{binds_difficulty_tier, SHARE_TIER_BIND_HEIGHT};
 
     /// **The dark-landing proof.** The tier gate ships dormant, so no live height binds a tier and
     /// the credit path is byte-identical to today across the whole mainnet range. The predicate is
     /// still genuinely wired — it fires at/above the resolved gate — so this is not a check that
     /// cannot fail.
     #[test]
-    fn the_tier_gate_is_dormant_and_behaviour_neutral() {
+    fn the_tier_gate_is_armed_at_the_intended_height() {
+        // Pinned to the exact value, not merely "not u64::MAX". The height is the whole contract:
+        // every node must agree on it or the fleet splits on credited work, and a typo here is
+        // indistinguishable from an intended change without this line.
         assert_eq!(
-            SHARE_TIER_BIND_HEIGHT,
-            u64::MAX,
-            "the tier gate must ship dormant — arming it must be a deliberate edit"
+            SHARE_TIER_BIND_HEIGHT, 962_100,
+            "the tier gate height is a fleet-wide agreement — changing it is a deliberate act"
         );
 
-        // Nothing in the mainnet range reaches the dormant gate, so nothing is tier-bound in
-        // production: the coinbase keeps the plain node tag and the legacy credit stands.
-        assert!(!binds_difficulty_tier(960_000));
-        assert!(!binds_difficulty_tier(1_000_000));
-        assert!(!binds_difficulty_tier(u64::MAX - 1));
+        // Below the height nothing is tier-bound: the coinbase keeps the plain node tag and the
+        // legacy credit path stands, byte-identical to the pre-tier build.
+        assert!(!binds_difficulty_tier(962_099));
+        assert!(!binds_difficulty_tier(961_000));
+        assert!(!binds_difficulty_tier(0));
 
-        // But the predicate does fire at/above the resolved gate — proving it is wired to the
-        // height, not hard-coded to false.
-        let gate = share_tier_bind_height();
-        assert!(binds_difficulty_tier(gate));
+        // At and above it, every node flips together.
+        assert!(binds_difficulty_tier(962_100));
+        assert!(binds_difficulty_tier(962_101));
+        assert!(binds_difficulty_tier(u64::MAX));
+    }
+
+    /// The three halves must name the SAME block. `pool_sv2` carries its own
+    /// `activation_height` in config and the translator carries a bare flag, so nothing at compile
+    /// time forces agreement — this records the value the shipped configs must match, so a change
+    /// to one without the others fails here rather than at the height.
+    #[test]
+    fn the_shipped_configs_must_name_this_same_height() {
+        let cfg = include_str!("../../../config/sri/pool-config.toml");
+        assert!(
+            cfg.contains("activation_height = 962100"),
+            "config/sri/pool-config.toml must arm pool_sv2 at the same height as \
+             SHARE_TIER_BIND_HEIGHT ({SHARE_TIER_BIND_HEIGHT})"
+        );
+        let tr = include_str!("../../../config/sri/translator-config.toml");
+        assert!(
+            tr.contains("\nquantise_to_tiers = true"),
+            "config/sri/translator-config.toml must ship quantise_to_tiers = true in the arming \
+             release — the translator has no chain view, so its flag is the third half of the gate"
+        );
     }
 }

--- a/bins/pool-sv2/src/lib/channel_manager/mod.rs
+++ b/bins/pool-sv2/src/lib/channel_manager/mod.rs
@@ -171,7 +171,8 @@ impl ChannelManager {
         let tier_binding = match config.share_tier_binding() {
             None => None,
             Some(cfg) => {
-                let tb = crate::tier_binding::TierBinding::from_config(cfg)
+                let tb = crate::tier_binding::TierBinding::resolve(cfg)
+                    .await
                     .map_err(|e| PoolError::shutdown(PoolErrorKind::Configuration(e)))?;
                 warn!(
                     activation_height = tb.activation_height(),

--- a/bins/pool-sv2/src/lib/config.rs
+++ b/bins/pool-sv2/src/lib/config.rs
@@ -70,9 +70,24 @@ pub struct ShareWebhookConfig {
 /// silently absorbed — see `tier_binding.rs`.
 #[derive(Clone, Debug, serde::Deserialize)]
 pub struct ShareTierBindingConfig {
-    /// This node's 32-byte identity, hex (64 chars) — MUST equal the `node_id` ghost-pool derives
-    /// its coinbase node tags from, or every tier-stamped share fails its binding check.
-    pub node_id: String,
+    /// This node's 32-byte identity, hex (64 chars).
+    ///
+    /// **Normally omit this.** Left unset, the identity is read from the co-located ghost-pool at
+    /// startup (see `ghost_pool_health_url`), which is the process that actually derives and
+    /// verifies the coinbase node tags — so the two cannot disagree.
+    ///
+    /// It exists only as an override for a node whose ghost-pool cannot be reached at startup.
+    /// Transcribing it by hand is the highest-risk step in arming: `pool_sv2` cannot recover the
+    /// raw id from the template prefix (that carries `sha256(node_id)[..20]`, one-way), so a
+    /// mistyped value is not detectable from the coinbase — it simply makes every tier-era share
+    /// fail its binding check, silently, for that node's miners only. When set, it is CHECKED
+    /// against ghost-pool's own answer and a mismatch refuses startup.
+    #[serde(default)]
+    pub node_id: Option<String>,
+    /// Where to read this node's identity from. Defaults to the co-located ghost-pool's health
+    /// endpoint on loopback.
+    #[serde(default)]
+    pub ghost_pool_health_url: Option<String>,
     /// Block height at/above which per-tier jobs are emitted. MUST equal ghost-pool's
     /// `SHARE_TIER_BIND_HEIGHT` in the same release.
     pub activation_height: u64,

--- a/bins/pool-sv2/src/lib/tier_binding.rs
+++ b/bins/pool-sv2/src/lib/tier_binding.rs
@@ -5,8 +5,9 @@
 //! per-template decision is derived from the BIP34 height ghost-pool stamps into every
 //! template's `coinbase_prefix`, so with the SAME height configured both binaries flip at the
 //! same block rather than at whichever moment this process restarted. The remaining desync
-//! surface is a mis-copied height or node id, which is why the config carries both explicitly
-//! and why [`TierBinding::from_config`] refuses to start on a malformed id.
+//! surface is a mis-copied height — the identity is no longer transcribed at all, but read from
+//! the co-located ghost-pool at startup ([`TierBinding::resolve`]), which is the process that
+//! derives and verifies the tags, so the two cannot disagree.
 //!
 //! ## What tiered mode changes
 //!
@@ -41,23 +42,127 @@ pub struct TierBinding {
     activation_height: u64,
 }
 
+/// Where this node's identity is read from when the config does not pin one.
+const DEFAULT_HEALTH_URL: &str = "http://127.0.0.1:8080/health";
+
 impl TierBinding {
-    /// Parse the config section. A malformed `node_id` is a refusal to start, not a warning:
-    /// stamping tags derived from the wrong identity would have every tier-era share rejected
-    /// by its binding check, silently, on every share.
-    pub fn from_config(cfg: &crate::config::ShareTierBindingConfig) -> Result<Self, String> {
-        let bytes = hex::decode(cfg.node_id.trim())
+    /// Build from an already-resolved identity.
+    pub fn from_parts(node_id: [u8; 32], activation_height: u64) -> Self {
+        Self {
+            node_id,
+            activation_height,
+        }
+    }
+
+    /// Parse a 64-hex node id. A malformed id is a refusal to start, not a warning: stamping tags
+    /// derived from the wrong identity would have every tier-era share rejected by its binding
+    /// check, silently, on every share.
+    pub fn parse_node_id(s: &str) -> Result<[u8; 32], String> {
+        let bytes = hex::decode(s.trim())
             .map_err(|e| format!("share_tier_binding.node_id is not valid hex: {e}"))?;
-        let node_id: [u8; 32] = bytes.try_into().map_err(|b: Vec<u8>| {
+        bytes.try_into().map_err(|b: Vec<u8>| {
             format!(
                 "share_tier_binding.node_id must be 32 bytes (64 hex chars), got {}",
                 b.len()
             )
-        })?;
-        Ok(Self {
-            node_id,
-            activation_height: cfg.activation_height,
         })
+    }
+
+    /// Pull `response.node_id` out of ghost-pool's health document.
+    pub fn node_id_from_health_json(body: &str) -> Result<[u8; 32], String> {
+        let v: serde_json::Value = serde_json::from_str(body)
+            .map_err(|e| format!("ghost-pool health is not JSON: {e}"))?;
+        let id = v
+            .get("response")
+            .and_then(|r| r.get("node_id"))
+            .and_then(|n| n.as_str())
+            .ok_or_else(|| "ghost-pool health has no response.node_id".to_string())?;
+        Self::parse_node_id(id)
+    }
+
+    /// Resolve this node's identity, preferring **ghost-pool's own answer** over anything
+    /// transcribed into config.
+    ///
+    /// `pool_sv2` cannot derive the raw id itself: the template prefix carries
+    /// `sha256(node_id)[..20]`, which is one-way. It previously had to be typed into the config of
+    /// every node individually — a per-node manual step in the consensus-visible path, where a
+    /// single wrong character silently rejects that node's tier-era shares and nothing in the
+    /// coinbase reveals it. Asking the process that derives and verifies those tags removes the
+    /// step entirely, and makes the two impossible to disagree.
+    ///
+    /// A pinned `node_id` is still honoured, but it is CHECKED: a mismatch refuses startup rather
+    /// than letting a stale value quietly win.
+    pub async fn resolve(cfg: &crate::config::ShareTierBindingConfig) -> Result<Self, String> {
+        let url = cfg
+            .ghost_pool_health_url
+            .as_deref()
+            .unwrap_or(DEFAULT_HEALTH_URL);
+        let pinned = cfg
+            .node_id
+            .as_deref()
+            .map(Self::parse_node_id)
+            .transpose()?;
+
+        // ghost-pool may still be starting; the deploy order restarts it first.
+        let mut fetched: Result<[u8; 32], String> = Err("not attempted".into());
+        for attempt in 1..=5u32 {
+            fetched = async {
+                let body = reqwest::Client::new()
+                    .get(url)
+                    .timeout(std::time::Duration::from_secs(5))
+                    .send()
+                    .await
+                    .map_err(|e| format!("cannot reach ghost-pool at {url}: {e}"))?
+                    .text()
+                    .await
+                    .map_err(|e| format!("cannot read ghost-pool health: {e}"))?;
+                Self::node_id_from_health_json(&body)
+            }
+            .await;
+            if fetched.is_ok() {
+                break;
+            }
+            if attempt < 5 {
+                tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+            }
+        }
+
+        let node_id = match (fetched, pinned) {
+            // Both available: they MUST agree. A mismatch is the exact failure the pin was
+            // supposed to guard against, so it stops the node rather than picking a winner.
+            (Ok(f), Some(p)) if f != p => {
+                return Err(format!(
+                    "share_tier_binding.node_id ({}) does not match the identity ghost-pool \
+                     reports ({}). ghost-pool stamps and verifies the coinbase node tags, so the \
+                     configured value would reject every tier-era share on this node. Remove the \
+                     pin to use ghost-pool's own identity.",
+                    hex::encode(&p[..8]),
+                    hex::encode(&f[..8]),
+                ))
+            }
+            (Ok(f), _) => f,
+            // Unreachable but pinned: honour the operator's value rather than refusing to start
+            // over a health endpoint, but say plainly that it is unverified.
+            (Err(e), Some(p)) => {
+                warn!(
+                    error = %e,
+                    "SHARE_TIER_BIND: could not verify node_id against ghost-pool — using the \
+                     configured value UNVERIFIED. If it is wrong, this node's tier-era shares \
+                     will all fail their binding check."
+                );
+                p
+            }
+            // Nothing to fall back on. Refusing is the safe direction: emitting tags from a
+            // guessed identity is undetectable from the coinbase.
+            (Err(e), None) => {
+                return Err(format!(
+                    "share_tier_binding is configured but this node's identity could not be read \
+                     from ghost-pool ({e}). Start ghost-pool first, or pin node_id explicitly."
+                ))
+            }
+        };
+
+        Ok(Self::from_parts(node_id, cfg.activation_height))
     }
 
     /// The height at/above which per-tier jobs are emitted.
@@ -223,11 +328,7 @@ mod tests {
     use stratum_apps::stratum_core::channels_sv2::target::hash_rate_to_target;
 
     fn a_binding(height: u64) -> TierBinding {
-        TierBinding::from_config(&crate::config::ShareTierBindingConfig {
-            node_id: hex::encode([0x7Au8; 32]),
-            activation_height: height,
-        })
-        .unwrap()
+        TierBinding::from_parts([0x7Au8; 32], height)
     }
 
     fn ghost_prefix(with_node_tag: bool) -> Vec<u8> {
@@ -368,12 +469,42 @@ mod tests {
     #[test]
     fn a_malformed_node_id_is_refused() {
         for bad in ["zz", "abcd", &hex::encode([0u8; 31])[..]] {
+            assert!(TierBinding::parse_node_id(bad).is_err());
+        }
+    }
+
+    /// The identity is read from ghost-pool's real health document, so the manual per-node
+    /// transcription that arming used to require is gone. Shaped exactly as the endpoint answers,
+    /// including the fields around it, so a change to that document fails here rather than at a
+    /// height on mainnet.
+    #[test]
+    fn the_identity_is_read_from_ghost_pools_health_document() {
+        let body = r#"{"response":{"block_height":961983,"capabilities":{"public_mining":true},
+            "healthy":true,"miner_count":2,
+            "node_id":"9fe860bda96ff81820a2e166f48cb3ae59010fc9e42550a3aeafb5bfef4d1b38",
+            "peer_count":7},"signed":"abc"}"#;
+        let got = TierBinding::node_id_from_health_json(body).expect("identity");
+        assert_eq!(
+            hex::encode(got),
+            "9fe860bda96ff81820a2e166f48cb3ae59010fc9e42550a3aeafb5bfef4d1b38"
+        );
+    }
+
+    /// A health document that does not carry an identity must be an error, never a default. A
+    /// zeroed or guessed id is undetectable from the coinbase — it simply rejects every tier-era
+    /// share on that node.
+    #[test]
+    fn health_without_an_identity_is_an_error_not_a_default() {
+        for body in [
+            r#"{"response":{"healthy":true}}"#,
+            r#"{"node_id":"9fe860bd"}"#,
+            r#"{"response":{"node_id":"nothex"}}"#,
+            r#"{"response":{"node_id":"9fe860bd"}}"#,
+            "not json at all",
+        ] {
             assert!(
-                TierBinding::from_config(&crate::config::ShareTierBindingConfig {
-                    node_id: bad.to_string(),
-                    activation_height: 0,
-                })
-                .is_err()
+                TierBinding::node_id_from_health_json(body).is_err(),
+                "must not yield an identity from {body}"
             );
         }
     }

--- a/config/sri/pool-config.toml
+++ b/config/sri/pool-config.toml
@@ -74,9 +74,15 @@ max_retries = 3
 #   - the translator shipped with quantise_to_tiers = true (translator-config.toml).
 # At/above the height, jobs are built per channel, each coinbase committing to the channel's
 # power-of-two difficulty tier; below it, behaviour is byte-identical to today.
-# [share_tier_binding]
-# node_id = "<64-hex node id>"
-# activation_height = 99999999
+# SHARE_TIER_BIND: ARMED at 962100. Must equal ghost-pool's SHARE_TIER_BIND_HEIGHT, and the
+# translator must ship quantise_to_tiers = true in the SAME release — all three flip together.
+#
+# node_id is deliberately NOT set: pool_sv2 reads this node's identity from the co-located
+# ghost-pool's /health at startup, so the tags it stamps and the tags ghost-pool verifies cannot
+# disagree. Set it only if ghost-pool is unreachable at startup; when set it is checked against
+# ghost-pool's answer and a mismatch refuses to start.
+[share_tier_binding]
+activation_height = 962100
 
 # Template Provider Configuration
 # Connects to ghost-pool's TDP server

--- a/config/sri/translator-config.toml
+++ b/config/sri/translator-config.toml
@@ -89,7 +89,7 @@ job_keepalive_interval_secs = 60
 # disagree. When armed, vardiff targets snap down to the tier below (2^n,
 # floored at 2^10 = 1024) so a share's coinbase can commit to the tier it was
 # assigned.
-# quantise_to_tiers = true
+quantise_to_tiers = true
 
 # Upstream SRI Pool connection
 [[upstreams]]


### PR DESCRIPTION
Two changes that must ship together, because arming is the release where the identity half stops being a manual step.

## `pool_sv2` reads its own identity instead of being told it

`pool_sv2` cannot derive the raw node id — the template prefix carries `sha256(node_id)[..20]`, which is one-way. So arming previously required the 64-hex identity to be transcribed into the config of **every node individually**: a per-node manual step in the consensus-visible path, where one wrong character rejects that node's tier-era shares silently, and nothing in the coinbase reveals it.

It now reads the identity from the co-located ghost-pool's `/health` at startup — the process that actually derives and verifies those tags. The two can no longer disagree, and the shipped config block is **identical on every node**.

A pinned `node_id` is still honoured for a node whose ghost-pool is unreachable, but it is **checked**: a mismatch refuses startup rather than letting a stale value win. An unreachable ghost-pool with no pin also refuses, because emitting tags from a guessed identity is undetectable from the coinbase.

## The gate is armed at 962_100

Chosen with margin, not economy. The fleet was at ~961_983 running ~7 min/block, so this is **~13 hours** out against a roll that takes ~4 (CI, build, canary, a 60-minute soak, then eight nodes). `SHARE_POW_VERIFY_HEIGHT` armed with an 8-block margin; that is not a precedent worth repeating for a gate that changes what work is **worth**.

**Every node must carry this build before the height.** A node on an older binary has `u64::MAX` here and never arms, so a partial roll means the fleet disagrees about credited work — divergent coinbase splits, GHOST-02 rejections between peers — until the last node lands. There is no canary for the armed behaviour itself: a height gate flips everywhere at the same block by construction, so the canary proves the **binary** and the height proves the **rule**.

## The three halves

All ship here: `SHARE_TIER_BIND_HEIGHT = 962_100`, `quantise_to_tiers = true` in the translator config, and `[share_tier_binding] activation_height = 962100` for `pool_sv2`. Nothing at compile time forces them to agree, so:

- the height is pinned **exactly** in test, not merely asserted non-dormant; and
- a second test reads the **shipped configs** and fails if they name a different block.

## Verified at arming

The fleet's smallest assigned difficulty is **2_328** (1 TH/s assumed floor, `shares_per_minute` 6.0), quantising to **tier 11** — a full tier above `MIN_DIFFICULTY_TIER_LOG2` (10), so quantisation only ever moves difficulty *down*, which is the safe direction.

## On the roll

Watch `missing_tier` and `tier_credit_mismatch` — both must stay zero.

## Known limit carried into arming

Job-Declaration custom work carries the declaring client's own coinbase and cannot commit to a tier; above the gate its shares would be rejected (`missing_tier`). No JD client runs on the fleet today.